### PR TITLE
Add release workflow and curl-pipe-bash installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v0.1.0)"
+        required: true
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build release binaries
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install protobuf compiler
+        run: sudo apt-get install -y protobuf-compiler
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-release-
+
+      - name: Build release
+        run: cargo build --release
+
+      - name: Package binaries
+        run: |
+          VERSION="${GITHUB_REF_NAME:-${{ github.event.inputs.tag }}}"
+          DIST="spur-${VERSION}-linux-amd64"
+          mkdir -p "${DIST}/bin"
+          for bin in spur spurctld spurd spurdbd spurrestd; do
+            cp "target/release/${bin}" "${DIST}/bin/"
+          done
+
+          # Create Slurm-compat symlinks
+          cd "${DIST}/bin"
+          for cmd in sbatch srun squeue scancel sinfo sacct scontrol; do
+            ln -s spur "${cmd}"
+          done
+          cd ../..
+
+          # Include config + deploy examples
+          mkdir -p "${DIST}/etc"
+          cp deploy/bare-metal/spur.conf "${DIST}/etc/spur.conf.example"
+
+          tar czf "${DIST}.tar.gz" "${DIST}"
+          sha256sum "${DIST}.tar.gz" > "${DIST}.tar.gz.sha256"
+          echo "DIST=${DIST}" >> "$GITHUB_ENV"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: spur-linux-amd64
+          path: |
+            spur-*.tar.gz
+            spur-*.tar.gz.sha256
+
+  release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: spur-linux-amd64
+
+      - name: Determine tag
+        id: tag
+        run: echo "tag=${GITHUB_REF_NAME:-${{ github.event.inputs.tag }}}" >> "$GITHUB_OUTPUT"
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          gh release create "${TAG}" \
+            --title "Spur ${TAG}" \
+            --generate-notes \
+            spur-*.tar.gz spur-*.tar.gz.sha256

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Install Spur — Slurm-compatible HPC job scheduler
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/powderluv/spur/main/install.sh | bash
+#
+#   # Or install a specific version:
+#   curl -fsSL https://raw.githubusercontent.com/powderluv/spur/main/install.sh | bash -s -- v0.1.0
+#
+#   # Or install to a custom directory:
+#   curl -fsSL https://raw.githubusercontent.com/powderluv/spur/main/install.sh | INSTALL_DIR=/opt/spur/bin bash
+
+set -euo pipefail
+
+REPO="powderluv/spur"
+INSTALL_DIR="${INSTALL_DIR:-${HOME}/.local/bin}"
+VERSION="${1:-latest}"
+
+log()  { echo "==> $*"; }
+err()  { echo "ERROR: $*" >&2; exit 1; }
+
+# --- Platform check ---
+OS=$(uname -s)
+ARCH=$(uname -m)
+[ "$OS" = "Linux" ] || err "Spur currently supports Linux only (got ${OS})"
+[ "$ARCH" = "x86_64" ] || err "Spur currently supports x86_64 only (got ${ARCH})"
+
+# --- Resolve version ---
+if [ "$VERSION" = "latest" ]; then
+    log "Fetching latest release..."
+    VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+        | grep '"tag_name"' | head -1 | cut -d'"' -f4) \
+        || err "No releases found. Create one with: gh release create v0.1.0"
+fi
+log "Installing Spur ${VERSION}"
+
+# --- Download ---
+TARBALL="spur-${VERSION}-linux-amd64.tar.gz"
+URL="https://github.com/${REPO}/releases/download/${VERSION}/${TARBALL}"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+log "Downloading ${URL}..."
+curl -fSL -o "${TMPDIR}/${TARBALL}" "${URL}" \
+    || err "Download failed. Check that release ${VERSION} exists at https://github.com/${REPO}/releases"
+
+# --- Verify checksum if available ---
+SHA_URL="${URL}.sha256"
+if curl -fsSL -o "${TMPDIR}/${TARBALL}.sha256" "${SHA_URL}" 2>/dev/null; then
+    log "Verifying checksum..."
+    (cd "${TMPDIR}" && sha256sum -c "${TARBALL}.sha256") || err "Checksum mismatch"
+fi
+
+# --- Extract ---
+log "Extracting..."
+tar xzf "${TMPDIR}/${TARBALL}" -C "${TMPDIR}"
+
+# --- Install ---
+mkdir -p "${INSTALL_DIR}"
+EXTRACTED="${TMPDIR}/spur-${VERSION}-linux-amd64"
+cp -f "${EXTRACTED}"/bin/* "${INSTALL_DIR}/"
+chmod +x "${INSTALL_DIR}/spur" "${INSTALL_DIR}/spurctld" "${INSTALL_DIR}/spurd" \
+         "${INSTALL_DIR}/spurdbd" "${INSTALL_DIR}/spurrestd"
+
+# --- Verify ---
+if ! "${INSTALL_DIR}/spur" --version >/dev/null 2>&1; then
+    # Binary exists but --version may not be implemented yet
+    if [ -x "${INSTALL_DIR}/spur" ]; then
+        log "Binaries installed (version flag not yet supported)"
+    else
+        err "Installation verification failed"
+    fi
+fi
+
+# --- PATH hint ---
+log "Installed to ${INSTALL_DIR}/"
+log "Binaries: spur, spurctld, spurd, spurdbd, spurrestd"
+log "Symlinks: sbatch, srun, squeue, scancel, sinfo, sacct, scontrol"
+
+if ! echo "$PATH" | tr ':' '\n' | grep -qx "${INSTALL_DIR}"; then
+    echo ""
+    echo "Add to your PATH:"
+    echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+    echo ""
+    echo "Or add to ~/.bashrc:"
+    echo "  echo 'export PATH=\"${INSTALL_DIR}:\$PATH\"' >> ~/.bashrc"
+fi
+
+log "Done."


### PR DESCRIPTION
## Summary
- Adds GitHub Actions release workflow that builds release binaries on tag push
- Adds one-line install script for deploying Spur without Rust

## Install with:
```bash
curl -fsSL https://raw.githubusercontent.com/powderluv/spur/main/install.sh | bash
```

## Test plan
- [ ] Merge PR
- [ ] Tag with `v0.1.0` to trigger release build
- [ ] Verify install script works: `curl ... | bash`

🤖 Generated with [Claude Code](https://claude.com/claude-code)