### PR TITLE
Rebrand to AI-native job scheduler

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -458,4 +458,4 @@ spur show node gpu-node-1
 - **Accounting:** Start `spurdbd` with PostgreSQL for job history and fair-share scheduling
 - **REST API:** Start `spurrestd` for HTTP access (Slurm-compatible `/slurm/v0.0.42/` endpoints)
 - **Prolog/Epilog:** Set `SPUR_PROLOG` / `SPUR_EPILOG` environment variables to run scripts before/after jobs
-- **Kubernetes:** K8s integration is planned for hybrid HPC+cloud scheduling
+- **Kubernetes:** K8s integration is planned for hybrid cloud+on-prem scheduling

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Install Spur — Slurm-compatible HPC job scheduler
+# Install Spur — AI-native job scheduler
 #
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/powderluv/spur/main/install.sh | bash


### PR DESCRIPTION
## Summary
- install.sh: "Slurm-compatible HPC job scheduler" → "AI-native job scheduler"
- quickstart.md: "hybrid HPC+cloud" → "hybrid cloud+on-prem"

README.md already says "AI-native" — this catches the remaining spots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)