### PR TITLE
Fix resource isolation: thread limits + GPU hiding (#32)

### DIFF
--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -289,6 +289,10 @@ impl SlurmAgent for AgentService {
         env.insert("SPUR_JOB_ID".into(), job_id.to_string());
         env.insert("SPUR_TASK_OFFSET".into(), task_offset.to_string());
         env.insert("SPUR_NUM_NODES".into(), peer_nodes.len().to_string());
+        // Signal to executor that GRES was explicitly requested (for GPU hiding)
+        if !spec.gres.is_empty() {
+            env.insert("SPUR_GRES_REQUESTED".into(), "1".into());
+        }
         if !peer_nodes.is_empty() {
             env.insert("SPUR_PEER_NODES".into(), peer_nodes.join(","));
         }

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -248,10 +248,27 @@ pub async fn launch_job(
                 .join(","),
         );
     }
-    // Note: when gpu_devices is empty and no GRES was requested, we do NOT
-    // override GPU visibility — legacy jobs that don't specify --gres expect
-    // to see all GPUs. GPU hiding only happens when the allocation explicitly
-    // assigned specific devices (gpu_devices non-empty).
+    // When no GPUs are allocated but GRES was explicitly requested (gpu:0 or
+    // other GRES without gpu), hide all GPUs. When no GRES was requested at
+    // all, leave GPU visibility unchanged for backward compatibility.
+    // The caller (agent_server) should set SPUR_GRES_REQUESTED=1 when GRES is specified.
+    if gpu_devices.is_empty()
+        && env
+            .get("SPUR_GRES_REQUESTED")
+            .map(|v| v == "1")
+            .unwrap_or(false)
+    {
+        env.insert("ROCR_VISIBLE_DEVICES".into(), String::new());
+        env.insert("CUDA_VISIBLE_DEVICES".into(), String::new());
+    }
+
+    // Environment-based CPU/thread limiting — works even without cgroups.
+    // Well-behaved applications (OpenMP, MKL, PyTorch, etc.) read these.
+    env.insert("OMP_NUM_THREADS".into(), cpus.to_string());
+    env.insert("MKL_NUM_THREADS".into(), cpus.to_string());
+    env.insert("OPENBLAS_NUM_THREADS".into(), cpus.to_string());
+    env.insert("VECLIB_MAXIMUM_THREADS".into(), cpus.to_string());
+    env.insert("NUMEXPR_NUM_THREADS".into(), cpus.to_string());
 
     // Launch the process
     let mut cmd = Command::new("/bin/bash");


### PR DESCRIPTION
## Summary
1. **CPU**: Sets `OMP_NUM_THREADS`, `MKL_NUM_THREADS`, `OPENBLAS_NUM_THREADS` etc. to match `--cpus-per-task`. This makes `nproc`-aware apps respect the allocation even without root/cgroups.
2. **GPU**: Hides GPUs (`ROCR_VISIBLE_DEVICES=""`) when `--gres` is specified but no GPUs are allocated. Uses `SPUR_GRES_REQUESTED` env flag to distinguish from legacy jobs.

Fixes #32

## Test plan
- [x] `cargo build` — clean
- [x] `cargo test` — all tests pass
- [ ] CI cluster tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)