### PR TITLE
K8s deployment fixes

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,8 +1,13 @@
 # Multi-stage build: one image with all Spur binaries
-FROM rust:1.82 AS builder
+FROM rust:1.94.1 AS builder
 
 WORKDIR /build
 COPY . .
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    protobuf-compiler \
+    libprotobuf-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # Build all workspace binaries in release mode
 RUN cargo build --release \

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -5,8 +5,7 @@ metadata:
   namespace: spur
 data:
   spur.conf: |
-    [cluster]
-    name = "spur-k8s"
+    cluster_name = "spur-k8s"
 
     [scheduler]
     interval_secs = 2
@@ -17,8 +16,10 @@ data:
     enabled = true
     address = "spurdbd.spur.svc.cluster.local:6819"
 
-    [partitions.default]
+    [[partitions]]
+    name = "default"
     state = "UP"
     default = true
+    nodes = "ALL"
     max_time = "7d"
     default_time = "1h"

--- a/deploy/k8s/operator.yaml
+++ b/deploy/k8s/operator.yaml
@@ -35,7 +35,6 @@ spec:
           image: spur:latest
           command: [spur-k8s-operator]
           args:
-            - run
             - --controller-addr=spurctld.spur.svc.cluster.local:6817
             - --listen=[::]:6818
             - --namespace=spur

--- a/deploy/k8s/spurctld.yaml
+++ b/deploy/k8s/spurctld.yaml
@@ -58,11 +58,13 @@ spec:
         - name: config
           configMap:
             name: spur-config
-  volumeClaimTemplates:
-    - metadata:
-        name: spool
-      spec:
-        accessModes: [ReadWriteOnce]
-        resources:
-          requests:
-            storage: 10Gi
+        - name: spool
+          emptyDir: {}
+  # volumeClaimTemplates:
+  #   - metadata:
+  #       name: spool
+  #     spec:
+  #       accessModes: [ReadWriteOnce]
+  #       resources:
+  #         requests:
+  #           storage: 10Gi

--- a/deploy/k8s/spurrestd.yaml
+++ b/deploy/k8s/spurrestd.yaml
@@ -33,7 +33,7 @@ spec:
           command: [spurrestd]
           args:
             - --listen=[::]:6820
-            - --controller=spurctld.spur.svc.cluster.local:6817
+            - --controller=http://spurctld.spur.svc.cluster.local:6817
           ports:
             - containerPort: 6820
               name: http


### PR DESCRIPTION
## Motivation

Fix several issues in the K8s deployment manifests and Dockerfile that prevented successful deployment to a production RKE2 cluster with AMD MI325X GPUs.

## Technical Details

- **Fix Dockerfile build**: Bumped `rust:1.82` to `rust:latest` (edition 2024 required by `redb` crate) and added `protobuf-compiler` + `libprotobuf-dev` to the builder stage
- **Fix configmap config syntax**: Changed `[partitions.default]` (TOML map) to `[[partitions]]` with `name = "default"` (TOML array-of-tables) to match `SlurmConfig` parser; replaced `[cluster] name = ...` with top-level `cluster_name = ...`; added required `nodes` field
- **Fix operator args ordering**: Removed `run` subcommand from args — `--controller-addr` and other flags are top-level clap args that must appear before any subcommand, and `run` is already the default
- **Simplify spool volume**: Replaced `volumeClaimTemplate` with `emptyDir` for the spurctld StatefulSet to avoid PVC provisioning issues on clusters with certain storage backends (e.g., Longhorn)
- **Fix spurrestd controller address**: Prepended `http://` to the `--controller` arg in `spurrestd.yaml` — spurrestd passes the address directly to tonic's `connect()` which requires a scheme

## Test Plan

- `docker build -f deploy/Dockerfile` completes successfully
- All manifests apply cleanly to an RKE2 cluster
- `spurctld` starts and runs the scheduler loop
- `spur-k8s-operator` connects to spurctld and registers GPU nodes
- `spurrestd` connects to spurctld without 500 errors
- `spur nodes` shows registered MI325X node with correct resources

## Test Result

Deployed to a single-node RKE2 cluster with AMD MI325X GPUs. All Spur control plane components (`spurctld`, `spur-k8s-operator`, `spurrestd`) start and communicate successfully. GPU node registered with correct CPU, memory, and GPU resources.