### PR TITLE
Fix missing protobuf well-known types in Docker build

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -7,7 +7,7 @@ ARG PROTOC_VERSION=25.1
 RUN yum install -y unzip && yum clean all && \
     curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" \
         -o /tmp/protoc.zip && \
-    unzip -o /tmp/protoc.zip -d /usr/local bin/protoc && \
+    unzip -o /tmp/protoc.zip -d /usr/local && \
     rm /tmp/protoc.zip
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable


### PR DESCRIPTION
The docker build was failing with the following error,

```
31.24   Error: Custom { kind: Other, error: "protoc failed: google/protobuf/timestamp.proto: File not found.\ngoogle/protobuf/duration.proto: File not found.\ngoogle/protobuf/empty.proto: File not found.\nslurm.proto:5:1: Import \"google/protobuf/timestamp.proto\" was not found or had errors.\nslurm.proto:6:1: Import \"google/protobuf/duration.proto\" was not found or had errors.\nslurm.proto:7:1: Import \"google/protobuf/empty.proto\" was not found or had errors.\nslurm.proto:85:3: \"google.protobuf.Duration\" is not defined.\nslurm.proto:86:3: \"google.protobuf.Duration\" is not defined.\nslurm.proto:110:3: \"google.protobuf.Timestamp\" is not defined.\nslurm.proto:111:3: \"google.protobuf.Timestamp\" is not defined.\nslurm.proto:145:3: \"google.protobuf.Timestamp\" is not defined.\nslurm.proto:146:3: \"google.protobuf.Timestamp\" is not defined.\nslurm.proto:147:3: \"google.protobuf.Timestamp\" is not defined.\nslurm.proto:148:3: \"google.protobuf.Duration\" is not defined.\nslurm.proto:149:3: \"google.protobuf.Duration\" is not defined.\nslurm.proto:185:3: \"google.protobuf.Timestamp\" is not defined.\nslurm.proto:186:3: \"google.protobuf.Timestamp\" is not defined.\nslurm.proto:187:3: \"google.protobuf.Timestamp\" is not defined.\nslurm.proto:199:3: \"google.protobuf.Duration\" is not defined.\nslurm.proto:200:3: \"google.protobuf.Duration\" is not defined.\nslurm.proto:337:12: \"google.protobuf.Duration\" is not defined.\nslurm.proto:373:3: \"google.protobuf.Timestamp\" is not defined.\nslurm.proto:476:3: \"google.protobuf.Timestamp\" is not defined.\nslurm.proto:483:3: \"google.protobuf.Timestamp\" is not defined.\nslurm.proto:489:3: \"google.protobuf.Timestamp\" is not defined.\nslurm.proto:490:3: \"google.protobuf.Timestamp\" is not defined.\nslurm.proto:502:3: \"google.protobuf.Timestamp\" is not defined.\nslurm.proto:225:44: \"google.protobuf.Empty\" is not defined.\nslurm.proto:226:44: \"google.protobuf.Empty\" is not defined.\nslurm.proto:231:46: \"google.protobuf.Empty\" is not defined.\nslurm.proto:241:12: \"google.protobuf.Empty\" is not defined.\nslurm.proto:248:56: \"google.protobuf.Empty\" is not defined.\nslurm.proto:251:60: \"google.protobuf.Empty\" is not defined.\nslurm.proto:252:60: \"google.protobuf.Empty\" is not defined.\nslurm.proto:253:60: \"google.protobuf.Empty\" is not defined.\nslurm.proto:264:49: \"google.protobuf.Empty\" is not defined.\nslurm.proto:265:24: \"google.protobuf.Empty\" is not defined.\nslurm.proto:275:54: \"google.protobuf.Empty\" is not defined.\nslurm.proto:276:50: \"google.protobuf.Empty\" is not defined.\nslurm.proto:281:52: \"google.protobuf.Empty\" is not defined.\nslurm.proto:282:52: \"google.protobuf.Empty\" is not defined.\nslurm.proto:286:40: \"google.protobuf.Empty\" is not defined.\nslurm.proto:287:46: \"google.protobuf.Empty\" is not defined.\nslurm.proto:291:44: \"google.protobuf.Empty\" is not defined.\nslurm.proto:292:44: \"google.protobuf.Empty\" is not defined.\n" }
31.24 warning: build failed, waiting for other jobs to finish...
------
Dockerfile:20
--------------------
  19 |     # Build all workspace binaries in release mode
  20 | >>> RUN cargo build --release \
  21 | >>>     --bin spur \
  22 | >>>     --bin spurctld \
  23 | >>>     --bin spurd \
  24 | >>>     --bin spurdbd \
  25 | >>>     --bin spurrestd \
  26 | >>>     --bin spur-k8s-operator
  27 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c cargo build --release     --bin spur     --bin spurctld     --bin spurd     --bin spurdbd     --bin spurrestd     --bin spur-k8s-operator" did not complete successfully: exit code: 101

```

It is because protoc could not find standard Google Protocol Buffer definitions (like timestamp.proto, duration.proto, and empty.proto).

The root cause was that our protoc installation step only extracted the bin/protoc executable from the zip archive, skipping the include/ directory where these standard library .proto files reside.

This PR updates the unzip command in the Dockerfile to extract the entire contents of the Protobuf zip into /usr/local, rather than just the binary. 

I have verified that the build works fine with these changes.