### PR TITLE
fix(spur-k8s): send periodic heartbeats so virtual nodes don't go DOWN

### DIFF
--- a/crates/spur-k8s/src/heartbeat.rs
+++ b/crates/spur-k8s/src/heartbeat.rs
@@ -1,0 +1,205 @@
+use std::collections::HashMap;
+
+use tokio::sync::RwLock;
+use tonic::Code;
+use tracing::{debug, info, warn};
+
+use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
+use spur_proto::proto::{GetNodeRequest, RegisterAgentRequest};
+
+// Matches spurctld's check_node_health(90) timeout and spurd's 30 s interval.
+const INTERVAL_SECS: u64 = 30;
+
+/// Tracks the set of active K8s nodes and sends periodic `GetNode` heartbeats
+/// to spurctld on their behalf, mirroring what `spurd`'s `reporter::heartbeat_loop`
+/// does for bare-metal nodes.
+///
+/// `node_watcher` holds an `Arc<HeartbeatManager>` and calls `track`/`untrack`
+/// as nodes appear and disappear; the heartbeat task calls `run` under
+/// `retry::run_with_retry`.
+pub struct HeartbeatManager {
+    registry: RwLock<HashMap<String, RegisterAgentRequest>>,
+    controller_addr: String,
+}
+
+impl HeartbeatManager {
+    pub fn new(controller_addr: String) -> Self {
+        Self {
+            registry: RwLock::new(HashMap::new()),
+            controller_addr,
+        }
+    }
+
+    /// Add or update a node in the tracked set.
+    pub async fn track(&self, name: String, req: RegisterAgentRequest) {
+        self.registry.write().await.insert(name, req);
+    }
+
+    /// Remove a node from the tracked set. Safe to call for unknown names.
+    pub async fn untrack(&self, name: &str) {
+        self.registry.write().await.remove(name);
+    }
+
+    /// Send `GetNode` pings to spurctld for every tracked node.
+    pub async fn run(&self) -> anyhow::Result<()> {
+        let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(INTERVAL_SECS));
+        loop {
+            interval.tick().await;
+
+            let names: Vec<String> = self.registry.read().await.keys().cloned().collect();
+            if names.is_empty() {
+                continue;
+            }
+
+            match connect(&self.controller_addr).await {
+                Ok(mut client) => {
+                    for name in &names {
+                        match client.get_node(GetNodeRequest { name: name.clone() }).await {
+                            Ok(_) => debug!(node = %name, "heartbeat sent"),
+                            // spurctld restarted and lost state — re-register immediately.
+                            Err(e) if e.code() == Code::NotFound => {
+                                let req = self.registry.read().await.get(name).cloned();
+                                if let Some(req) = req {
+                                    match client.register_agent(req).await {
+                                        Ok(_) => {
+                                            info!(node = %name, "K8s node re-registered with spurctld");
+                                        }
+                                        Err(e) => {
+                                            warn!(node = %name, error = %e, "re-registration failed");
+                                        }
+                                    }
+                                }
+                            }
+                            Err(e) => warn!(node = %name, error = %e, "heartbeat failed"),
+                        }
+                    }
+                }
+                Err(e) => warn!(error = %e, "heartbeat: failed to connect to spurctld"),
+            }
+        }
+    }
+}
+
+async fn connect(addr: &str) -> anyhow::Result<SlurmControllerClient<tonic::transport::Channel>> {
+    let url = if addr.starts_with("http") {
+        addr.to_string()
+    } else {
+        format!("http://{}", addr)
+    };
+    Ok(SlurmControllerClient::connect(url).await?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_req(hostname: &str) -> RegisterAgentRequest {
+        RegisterAgentRequest {
+            hostname: hostname.into(),
+            resources: None,
+            version: "test".into(),
+            address: "127.0.0.1".into(),
+            port: 6818,
+            wg_pubkey: String::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_new_registry_is_empty() {
+        let hb = HeartbeatManager::new("http://localhost:6817".into());
+        assert!(hb.registry.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_track_adds_node() {
+        let hb = HeartbeatManager::new("http://localhost:6817".into());
+        hb.track("node-1".into(), make_req("node-1")).await;
+        assert!(hb.registry.read().await.contains_key("node-1"));
+    }
+
+    #[tokio::test]
+    async fn test_untrack_removes_node() {
+        let hb = HeartbeatManager::new("http://localhost:6817".into());
+        hb.track("node-1".into(), make_req("node-1")).await;
+        hb.untrack("node-1").await;
+        assert!(hb.registry.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_untrack_unknown_name_is_safe() {
+        let hb = HeartbeatManager::new("http://localhost:6817".into());
+        hb.untrack("does-not-exist").await;
+        assert!(hb.registry.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_track_idempotent_updates_entry() {
+        let hb = HeartbeatManager::new("http://localhost:6817".into());
+        hb.track("node-1".into(), make_req("node-1")).await;
+
+        let mut updated = make_req("node-1");
+        updated.address = "10.0.0.1".into();
+        hb.track("node-1".into(), updated).await;
+
+        let guard = hb.registry.read().await;
+        assert_eq!(guard.len(), 1);
+        assert_eq!(guard["node-1"].address, "10.0.0.1");
+    }
+
+    #[tokio::test]
+    async fn test_multiple_nodes_tracked_independently() {
+        let hb = HeartbeatManager::new("http://localhost:6817".into());
+        hb.track("node-1".into(), make_req("node-1")).await;
+        hb.track("node-2".into(), make_req("node-2")).await;
+        hb.track("node-3".into(), make_req("node-3")).await;
+        assert_eq!(hb.registry.read().await.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_untrack_one_of_many_leaves_others() {
+        let hb = HeartbeatManager::new("http://localhost:6817".into());
+        hb.track("node-1".into(), make_req("node-1")).await;
+        hb.track("node-2".into(), make_req("node-2")).await;
+        hb.untrack("node-1").await;
+
+        let guard = hb.registry.read().await;
+        assert_eq!(guard.len(), 1);
+        assert!(!guard.contains_key("node-1"));
+        assert!(guard.contains_key("node-2"));
+    }
+
+    #[tokio::test]
+    async fn test_track_after_untrack_re_adds_node() {
+        let hb = HeartbeatManager::new("http://localhost:6817".into());
+        hb.track("node-1".into(), make_req("node-1")).await;
+        hb.untrack("node-1").await;
+        hb.track("node-1".into(), make_req("node-1")).await;
+
+        assert_eq!(hb.registry.read().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_untrack_all_leaves_empty_registry() {
+        let hb = HeartbeatManager::new("http://localhost:6817".into());
+        hb.track("node-1".into(), make_req("node-1")).await;
+        hb.track("node-2".into(), make_req("node-2")).await;
+        hb.untrack("node-1").await;
+        hb.untrack("node-2").await;
+        assert!(hb.registry.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_register_req_preserved_for_reregistration() {
+        let hb = HeartbeatManager::new("http://localhost:6817".into());
+        let req = make_req("node-1");
+        hb.track("node-1".into(), req.clone()).await;
+        hb.track("node-2".into(), make_req("node-2")).await;
+        hb.untrack("node-2").await;
+
+        let guard = hb.registry.read().await;
+        let stored = guard.get("node-1").expect("node-1 must still be tracked");
+        assert_eq!(stored.hostname, req.hostname);
+        assert_eq!(stored.address, req.address);
+        assert_eq!(stored.port, req.port);
+    }
+}

--- a/crates/spur-k8s/src/lib.rs
+++ b/crates/spur-k8s/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod agent;
 pub mod crd;
 pub mod health;
+pub mod heartbeat;
 pub mod job_controller;
 pub mod node_watcher;

--- a/crates/spur-k8s/src/main.rs
+++ b/crates/spur-k8s/src/main.rs
@@ -1,6 +1,7 @@
 mod agent;
 mod crd;
 mod health;
+mod heartbeat;
 mod job_controller;
 mod node_watcher;
 
@@ -119,7 +120,22 @@ async fn main() -> anyhow::Result<()> {
         .await;
     });
 
-    // Spawn node watcher (issue #52: retry on failure)
+    // HeartbeatManager is created once so tracked nodes survive watcher restarts.
+    let hb = std::sync::Arc::new(heartbeat::HeartbeatManager::new(
+        args.controller_addr.clone(),
+    ));
+
+    // Spawn heartbeat sender.
+    let hb_task = hb.clone();
+    tokio::spawn(async move {
+        run_with_retry("node heartbeat", || {
+            let h = hb_task.clone();
+            Box::pin(async move { h.run().await })
+        })
+        .await;
+    });
+
+    // Spawn node watcher — only calls hb.track / hb.untrack, never sends pings.
     let nw_client = client.clone();
     let nw_ctrl_addr = args.controller_addr.clone();
     let nw_op_addr = operator_ip.clone();
@@ -132,7 +148,8 @@ async fn main() -> anyhow::Result<()> {
             let op = nw_op_addr.clone();
             let ns = nw_ns.clone();
             let sel = nw_selector.clone();
-            Box::pin(node_watcher::run(c, ctrl, op, operator_port, ns, sel))
+            let hb = hb.clone();
+            Box::pin(node_watcher::run(c, ctrl, op, operator_port, ns, sel, hb))
         })
         .await;
     });

--- a/crates/spur-k8s/src/node_watcher.rs
+++ b/crates/spur-k8s/src/node_watcher.rs
@@ -1,4 +1,5 @@
 use std::pin::pin;
+use std::sync::Arc;
 
 use futures_util::TryStreamExt;
 use k8s_openapi::api::core::v1::Node as K8sNode;
@@ -11,9 +12,10 @@ use tracing::{debug, error, info, warn};
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{RegisterAgentRequest, ResourceSet, UpdateNodeRequest};
 
-/// Watch K8s nodes with the `spur.ai/managed=true` label and register them
-/// with spurctld as virtual nodes. The operator's own gRPC address is used
-/// as the agent endpoint so that dispatch hits our virtual agent.
+use crate::heartbeat::HeartbeatManager;
+
+/// Watch K8s nodes matching `label_selector`, register them with spurctld, and
+/// keep `hb` in sync so the heartbeat task knows which nodes to ping.
 pub async fn run(
     client: Client,
     controller_addr: String,
@@ -21,6 +23,7 @@ pub async fn run(
     operator_grpc_port: u32,
     _namespace: String,
     label_selector: String,
+    hb: Arc<HeartbeatManager>,
 ) -> anyhow::Result<()> {
     let nodes: Api<K8sNode> = Api::all(client);
 
@@ -39,6 +42,7 @@ pub async fn run(
                 // Check if node is not-ready via taints
                 if is_node_not_ready(&node) {
                     warn!(node = %name, "K8s node has NotReady taint, marking DOWN");
+                    hb.untrack(&name).await;
                     let req = UpdateNodeRequest {
                         name: name.clone(),
                         state: Some(3), // NODE_DOWN
@@ -63,14 +67,18 @@ pub async fn run(
                     wg_pubkey: String::new(),
                 };
 
-                match ctrl_client.register_agent(req).await {
-                    Ok(_) => debug!(node = %name, "K8s node registered with spurctld"),
+                match ctrl_client.register_agent(req.clone()).await {
+                    Ok(_) => {
+                        debug!(node = %name, "K8s node registered with spurctld");
+                        hb.track(name, req).await;
+                    }
                     Err(e) => error!(node = %name, error = %e, "failed to register K8s node"),
                 }
             }
             Event::Delete(node) => {
                 let name = node.metadata.name.clone().unwrap_or_default();
                 warn!(node = %name, "K8s node deleted, marking DOWN");
+                hb.untrack(&name).await;
 
                 let req = UpdateNodeRequest {
                     name: name.clone(),


### PR DESCRIPTION
While testing spur on a K8s cluster, I noticed nodes would flip to DOWN a couple of minutes after the operator started with no real failure on the cluster side.

<img width="1187" height="258" alt="Screenshot 2026-04-10 022138" src="https://github.com/user-attachments/assets/dd0fab7c-3c9e-4f93-ba7d-d254be499c4e" />

Turned out the operator registered K8s nodes with spurctld once at startup but never sent periodic heartbeats. spurctld's 90-second node health check has no heartbeat to refresh, so it marks them DOWN.

The PR fixes the issue with the following changes:-
- `heartbeat.rs`: new HeartbeatManager that tracks active nodes and pings spurctld every 30 seconds via GetNode — matching what spurd does for bare-metal nodes. On NotFound (e.g. spurctld restarted and lost state), it automatically re-registers the node from the stored RegisterAgentRequest, no operator restart needed.
- `node_watcher.rs`: stripped of heartbeat logic; now only calls hb.track() / hb.untrack() on K8s node events.
- `main.rs`: spawns HeartbeatManager::run and node_watcher::run as independent run_with_retry tasks so the heartbeat task survives watcher restarts and retains the node registry across them.

I have verified on a k8s cluster that the nodes stayed idle continuously; after a manual spurctld restart, both nodes self-healed and re-registered themselves within one 30-second interval with no intervention.

This PR also includes relevant tests as well.

Please review. Thanks in advance!