### PR TITLE
Fix missing Protobuf well-known types in Dockerfile.manylinux

### DIFF
--- a/deploy/Dockerfile.manylinux
+++ b/deploy/Dockerfile.manylinux
@@ -16,7 +16,7 @@ ARG PROTOC_VERSION=25.1
 RUN yum install -y unzip && yum clean all && \
     curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" \
         -o /tmp/protoc.zip && \
-    unzip -o /tmp/protoc.zip -d /usr/local bin/protoc && \
+    unzip -o /tmp/protoc.zip -d /usr/local && \
     rm /tmp/protoc.zip && \
     protoc --version
 


### PR DESCRIPTION
I tried building the `Dockerfile.manylinux` image today. It failed with a similar error like that in #61.

This got missed in my previous PR because my fork was not updated with the latest commits which added this file.

This change should fix the issue. 