### PR TITLE
Fix K8s pod rank (#69) and node state reset (#70)

### DIFF
--- a/crates/spur-k8s/src/agent.rs
+++ b/crates/spur-k8s/src/agent.rs
@@ -87,19 +87,13 @@ impl SlurmAgent for VirtualAgent {
             }
         }
 
-        // Compute node rank from peer_nodes
-        let node_rank = if !target_node.is_empty() {
-            peer_nodes
-                .iter()
-                .position(|p| {
-                    // peer_nodes contains addr:port strings; target_node is a hostname.
-                    // Try matching by checking if the peer starts with the target_node.
-                    p.starts_with(&target_node)
-                })
-                .unwrap_or(0) as u32
-        } else {
-            0
-        };
+        // Compute node rank from task_offset.
+        // Issue #69: peer_nodes contains addr:port strings (e.g., "10.0.0.1:6818")
+        // while target_node is a hostname — starts_with matching never worked,
+        // causing all pods to get rank 0. Instead, derive rank from task_offset
+        // which is incremented per-node by the dispatcher.
+        let tasks_per_node = spec.tasks_per_node.max(1);
+        let node_rank = req.task_offset / tasks_per_node;
 
         // Build env vars
         let mut env_vars: Vec<EnvVar> = vec![

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -676,6 +676,29 @@ impl ClusterManager {
             }
         };
 
+        // Issue #70: If node is already registered, update its connection
+        // info and resources but PRESERVE its current state and allocations.
+        // The K8s node watcher re-registers nodes on every Apply event, which
+        // was resetting Allocated/Mixed nodes back to Idle.
+        {
+            let mut nodes = self.nodes.write();
+            if let Some(existing) = nodes.get_mut(&effective_name) {
+                // Update connection info and resources, keep state + allocations
+                existing.total_resources = resources.clone();
+                existing.address = Some(address.clone());
+                existing.port = port;
+                existing.source = source;
+                if !wg_pubkey.is_empty() {
+                    existing.wg_pubkey = Some(wg_pubkey);
+                }
+                existing.version = Some(version);
+                existing.last_heartbeat = Some(Utc::now());
+                debug!(node = %effective_name, state = ?existing.state, "node re-registered (state preserved)");
+                return;
+            }
+        }
+
+        // First-time registration: create new node with Idle state
         let mut node = Node::new(effective_name.clone(), resources.clone());
         node.state = NodeState::Idle;
         node.source = source;


### PR DESCRIPTION
## Summary
- **#69**: All pods got rank 0 because `peer_nodes` (addr:port) never matched `target_node` (hostname). Now derives rank from `task_offset / tasks_per_node`.
- **#70**: Node state always showed idle because `register_node()` set `state=Idle` unconditionally, and the K8s node watcher re-registers on every Apply event. Now preserves state for already-registered nodes.

## Test plan
- [x] 778 tests pass
- [ ] CI green (fmt, clippy, build-and-test, cluster, K8s)
- [ ] K8s multi-node SpurJob: pods show correct SPUR_NODE_RANK (0, 1)
- [ ] Node state shows Allocated/Mixed when jobs are running

Closes #69, #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)