### PR TITLE
fix(spur-k8s): stop leaking memory in /readyz on every failed probe

### DIFF
--- a/crates/spur-k8s/src/health.rs
+++ b/crates/spur-k8s/src/health.rs
@@ -61,7 +61,7 @@ async fn readyz(State(state): State<Arc<HealthState>>) -> impl IntoResponse {
 
     if k8s_ok && ctrl_ok {
         debug!("readyz: ok");
-        (StatusCode::OK, "ok")
+        (StatusCode::OK, "ok".to_string())
     } else {
         let mut reasons = Vec::new();
         if !k8s_ok {
@@ -70,10 +70,7 @@ async fn readyz(State(state): State<Arc<HealthState>>) -> impl IntoResponse {
         if !ctrl_ok {
             reasons.push("spurctld-unreachable");
         }
-        (
-            StatusCode::SERVICE_UNAVAILABLE,
-            reasons.join(",").leak() as &'static str,
-        )
+        (StatusCode::SERVICE_UNAVAILABLE, reasons.join(","))
     }
 }
 


### PR DESCRIPTION
It seems like .leak() was used to convert a runtime-built String into a &'static str to align with the success arm's type. This resulted in a permanent memory leak on every probe failure. Both arms now return (StatusCode, String), which axum handles identically and prevents the leak.