### PR TITLE
fix(spur-k8s): support SpurJobs across all namespaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3122,7 +3122,6 @@ dependencies = [
  "chrono",
  "clap",
  "hostname",
- "libc",
  "nix",
  "prost-types",
  "serde",

--- a/crates/spur-k8s/src/agent.rs
+++ b/crates/spur-k8s/src/agent.rs
@@ -1,5 +1,8 @@
 use std::collections::BTreeMap;
+use std::time::Duration;
 
+use backoff::future::retry;
+use backoff::ExponentialBackoffBuilder;
 use k8s_openapi::api::core::v1::{
     Container, EnvVar, HostPathVolumeSource, Pod, PodSpec, ResourceRequirements, Service,
     ServicePort, ServiceSpec, Volume, VolumeMount,
@@ -12,18 +15,53 @@ use tokio::io::AsyncReadExt;
 use tonic::{Request, Response, Status};
 use tracing::{debug, error, info, warn};
 
+use crate::crd::SpurJob;
 use spur_proto::proto::slurm_agent_server::SlurmAgent;
 use spur_proto::proto::*;
 
 /// Virtual SlurmAgent that creates K8s Pods instead of fork/exec.
 pub struct VirtualAgent {
     client: Client,
-    namespace: String,
 }
 
 impl VirtualAgent {
-    pub fn new(client: Client, namespace: String) -> Self {
-        Self { client, namespace }
+    pub fn new(client: Client) -> Self {
+        Self { client }
+    }
+
+    /// Look up the namespace of the SpurJob labeled `spur.ai/job-id=<id>`.
+    /// Fails loudly if not found so pods are never placed in the wrong namespace.
+    async fn resolve_namespace(&self, job_id: u32) -> Result<String, Status> {
+        let api: Api<SpurJob> = Api::all(self.client.clone());
+        let lp = ListParams::default().labels(&format!("spur.ai/job-id={}", job_id));
+
+        let backoff = ExponentialBackoffBuilder::new()
+            .with_initial_interval(Duration::from_millis(200))
+            .with_max_elapsed_time(Some(Duration::from_secs(5)))
+            .build();
+
+        retry(backoff, || async {
+            let list = tokio::time::timeout(Duration::from_millis(300), api.list(&lp))
+                .await
+                .map_err(|_| backoff::Error::transient(Status::unavailable("k8s API timeout")))?
+                .map_err(|e| backoff::Error::permanent(Status::internal(e.to_string())))?;
+
+            list.items
+                .into_iter()
+                .next()
+                .and_then(|j| j.metadata.namespace)
+                .ok_or_else(|| {
+                    backoff::Error::transient(Status::not_found(format!(
+                        "spur.ai/job-id={job_id} label not yet visible"
+                    )))
+                })
+        })
+        .await
+        .map_err(|e| {
+            Status::not_found(format!(
+                "no SpurJob with label spur.ai/job-id={job_id} found: {e}"
+            ))
+        })
     }
 }
 
@@ -39,6 +77,7 @@ impl SlurmAgent for VirtualAgent {
     ) -> Result<Response<LaunchJobResponse>, Status> {
         let req = request.into_inner();
         let job_id = req.job_id;
+        let ns = self.resolve_namespace(job_id).await?;
         let target_node = req.target_node.clone();
         let peer_nodes = &req.peer_nodes;
         let num_peers = peer_nodes.len();
@@ -128,7 +167,7 @@ impl SlurmAgent for VirtualAgent {
         // For multi-node jobs, add distributed training env vars
         if num_peers > 1 {
             // MASTER_ADDR: first peer node's address (or headless service DNS)
-            let master_addr = format!("spur-job-{}.{}.svc.cluster.local", job_id, self.namespace);
+            let master_addr = format!("spur-job-{}.{}.svc.cluster.local", job_id, ns);
             env_vars.push(EnvVar {
                 name: "MASTER_ADDR".into(),
                 value: Some(master_addr),
@@ -247,7 +286,7 @@ impl SlurmAgent for VirtualAgent {
 
         // For multi-node jobs, create headless Service for DNS discovery
         if num_peers > 1 {
-            if let Err(e) = self.ensure_headless_service(job_id, &labels).await {
+            if let Err(e) = self.ensure_headless_service(job_id, &labels, &ns).await {
                 warn!(job_id, error = %e, "failed to create headless service");
             }
         }
@@ -272,7 +311,7 @@ impl SlurmAgent for VirtualAgent {
         let pod = Pod {
             metadata: ObjectMeta {
                 name: Some(pod_name.clone()),
-                namespace: Some(self.namespace.clone()),
+                namespace: Some(ns.clone()),
                 labels: Some(labels),
                 ..Default::default()
             },
@@ -292,10 +331,10 @@ impl SlurmAgent for VirtualAgent {
             ..Default::default()
         };
 
-        let pods: Api<Pod> = Api::namespaced(self.client.clone(), &self.namespace);
+        let pods: Api<Pod> = Api::namespaced(self.client.clone(), &ns);
         match pods.create(&PostParams::default(), &pod).await {
             Ok(_) => {
-                info!(job_id, pod = %pod_name, target = %req.target_node, "K8s Pod created");
+                info!(job_id, pod = %pod_name, namespace = %ns, target = %req.target_node, "K8s Pod created");
                 Ok(Response::new(LaunchJobResponse {
                     success: true,
                     error: String::new(),
@@ -317,9 +356,10 @@ impl SlurmAgent for VirtualAgent {
     ) -> Result<Response<()>, Status> {
         let req = request.into_inner();
         let job_id = req.job_id;
+        let ns = self.resolve_namespace(job_id).await?;
 
         // Delete all pods for this job by label selector
-        let pods: Api<Pod> = Api::namespaced(self.client.clone(), &self.namespace);
+        let pods: Api<Pod> = Api::namespaced(self.client.clone(), &ns);
         let lp = ListParams::default().labels(&format!("spur.ai/job-id={}", job_id));
 
         match pods.list(&lp).await {
@@ -343,7 +383,7 @@ impl SlurmAgent for VirtualAgent {
         }
 
         // Also clean up the headless service if it exists
-        let services: Api<Service> = Api::namespaced(self.client.clone(), &self.namespace);
+        let services: Api<Service> = Api::namespaced(self.client.clone(), &ns);
         let svc_name = format!("spur-job-{}", job_id);
         match services.delete(&svc_name, &DeleteParams::default()).await {
             Ok(_) => debug!(job_id, "deleted headless Service"),
@@ -371,7 +411,9 @@ impl SlurmAgent for VirtualAgent {
         request: Request<ExecInJobRequest>,
     ) -> Result<Response<ExecInJobResponse>, Status> {
         let req = request.into_inner();
-        let pod_name = format!("spur-job-{}", req.job_id);
+        let job_id = req.job_id;
+        let ns = self.resolve_namespace(job_id).await?;
+        let pod_name = format!("spur-job-{}", job_id);
         let command: Vec<String> = if req.command.is_empty() {
             vec!["bash".into(), "-c".into(), "echo ok".into()]
         } else {
@@ -380,7 +422,7 @@ impl SlurmAgent for VirtualAgent {
 
         debug!(pod = %pod_name, cmd = ?command, "exec in K8s pod");
 
-        let pods: Api<Pod> = Api::namespaced(self.client.clone(), &self.namespace);
+        let pods: Api<Pod> = Api::namespaced(self.client.clone(), &ns);
 
         let attach = AttachParams {
             stdin: false,
@@ -433,11 +475,13 @@ impl SlurmAgent for VirtualAgent {
         request: Request<StreamJobOutputRequest>,
     ) -> Result<Response<Self::StreamJobOutputStream>, Status> {
         let req = request.into_inner();
-        let pod_name = format!("spur-job-{}", req.job_id);
+        let job_id = req.job_id;
+        let ns = self.resolve_namespace(job_id).await?;
+        let pod_name = format!("spur-job-{}", job_id);
 
         debug!(pod = %pod_name, "streaming logs from K8s pod");
 
-        let pods: Api<Pod> = Api::namespaced(self.client.clone(), &self.namespace);
+        let pods: Api<Pod> = Api::namespaced(self.client.clone(), &ns);
         let log_params = kube::api::LogParams {
             follow: true,
             tail_lines: Some(100),
@@ -502,8 +546,9 @@ impl VirtualAgent {
         &self,
         job_id: u32,
         labels: &BTreeMap<String, String>,
+        namespace: &str,
     ) -> Result<(), kube::Error> {
-        let services: Api<Service> = Api::namespaced(self.client.clone(), &self.namespace);
+        let services: Api<Service> = Api::namespaced(self.client.clone(), namespace);
         let svc_name = format!("spur-job-{}", job_id);
 
         let selector = BTreeMap::from([("spur.ai/job-id".to_string(), job_id.to_string())]);
@@ -511,7 +556,7 @@ impl VirtualAgent {
         let svc = Service {
             metadata: ObjectMeta {
                 name: Some(svc_name.clone()),
-                namespace: Some(self.namespace.clone()),
+                namespace: Some(namespace.to_string()),
                 labels: Some(labels.clone()),
                 ..Default::default()
             },

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -3,6 +3,9 @@ use std::pin::pin;
 use std::sync::Arc;
 use std::time::Duration;
 
+use backoff::future::retry;
+use backoff::ExponentialBackoffBuilder;
+
 use futures_util::{StreamExt, TryStreamExt};
 use k8s_openapi::api::core::v1::{Pod, Service};
 use kube::api::{Api, DeleteParams, ListParams, Patch, PatchParams};
@@ -37,7 +40,6 @@ pub enum ReconcileError {
 pub struct JobControllerCtx {
     pub client: Client,
     pub ctrl_client: Mutex<SlurmControllerClient<Channel>>,
-    pub namespace: String,
     /// Track multi-pod completion: job_id → (expected_count, completed_count, any_failed)
     pub(crate) pod_tracker: Mutex<HashMap<u32, PodTracker>>,
 }
@@ -63,7 +65,7 @@ async fn reconcile(
         .metadata
         .namespace
         .clone()
-        .unwrap_or_else(|| ctx.namespace.clone());
+        .ok_or_else(|| ReconcileError::Other("SpurJob has no namespace".into()))?;
     let api: Api<SpurJob> = Api::namespaced(ctx.client.clone(), &ns);
 
     finalizer(&api, FINALIZER, job, |event| {
@@ -100,6 +102,11 @@ async fn handle_job(
     ctx: &JobControllerCtx,
 ) -> Result<Action, ReconcileError> {
     let name = job.metadata.name.clone().unwrap_or_default();
+    let ns = job
+        .metadata
+        .namespace
+        .clone()
+        .ok_or_else(|| ReconcileError::Other("SpurJob has no namespace".into()))?;
     let status = job.status.clone().unwrap_or_default();
 
     // If already in terminal state, nothing to do
@@ -132,7 +139,7 @@ async fn handle_job(
         {
             Ok(resp) => {
                 let job_id = resp.into_inner().job_id;
-                info!(spurjob = %name, job_id, "SpurJob submitted");
+                info!(spurjob = %name, job_id, namespace = %ns, "SpurJob submitted");
 
                 let new_status = SpurJobStatus {
                     state: "Pending".into(),
@@ -152,6 +159,12 @@ async fn handle_job(
 
     // Poll Spur for job status updates
     let job_id = status.spur_job_id.unwrap();
+
+    // Required for VirtualAgent namespace lookup; retry until applied.
+    if ensure_job_id_label(&job, api, &name, job_id).await.is_err() {
+        return Ok(Action::requeue(Duration::from_secs(2)));
+    }
+
     let mut ctrl = ctx.ctrl_client.lock().await;
 
     match ctrl.get_job(GetJobRequest { job_id }).await {
@@ -190,6 +203,11 @@ async fn handle_job(
 /// kube::runtime::finalizer removes spur.ai/cleanup automatically after this returns Ok.
 async fn handle_deletion(job: &SpurJob, ctx: &JobControllerCtx) -> Result<Action, ReconcileError> {
     let name = job.metadata.name.clone().unwrap_or_default();
+    let ns = job
+        .metadata
+        .namespace
+        .clone()
+        .ok_or_else(|| ReconcileError::Other("SpurJob has no namespace".into()))?;
     let status = job.status.clone().unwrap_or_default();
 
     info!(spurjob = %name, "handling SpurJob deletion");
@@ -208,7 +226,7 @@ async fn handle_deletion(job: &SpurJob, ctx: &JobControllerCtx) -> Result<Action
         }
 
         // Delete all Pods by label
-        let pods: Api<Pod> = Api::namespaced(ctx.client.clone(), &ctx.namespace);
+        let pods: Api<Pod> = Api::namespaced(ctx.client.clone(), &ns);
         let lp = ListParams::default().labels(&format!("spur.ai/job-id={}", job_id));
         if let Ok(pod_list) = pods.list(&lp).await {
             for pod in pod_list {
@@ -218,7 +236,7 @@ async fn handle_deletion(job: &SpurJob, ctx: &JobControllerCtx) -> Result<Action
         }
 
         // Delete headless Service
-        let services: Api<Service> = Api::namespaced(ctx.client.clone(), &ctx.namespace);
+        let services: Api<Service> = Api::namespaced(ctx.client.clone(), &ns);
         let svc_name = format!("spur-job-{}", job_id);
         let _ = services.delete(&svc_name, &DeleteParams::default()).await;
     }
@@ -233,7 +251,11 @@ fn error_policy(_job: Arc<SpurJob>, error: &ReconcileError, _ctx: Arc<JobControl
 }
 
 /// Start the SpurJob controller and Pod watcher.
-pub async fn run(client: Client, controller_addr: String, namespace: String) -> anyhow::Result<()> {
+pub async fn run(
+    client: Client,
+    controller_addr: String,
+    operator_namespace: String,
+) -> anyhow::Result<()> {
     let url = if controller_addr.starts_with("http") {
         controller_addr
     } else {
@@ -244,27 +266,24 @@ pub async fn run(client: Client, controller_addr: String, namespace: String) -> 
     let ctx = Arc::new(JobControllerCtx {
         client: client.clone(),
         ctrl_client: Mutex::new(ctrl_client),
-        namespace: namespace.clone(),
         pod_tracker: Mutex::new(HashMap::new()),
     });
 
-    let spurjobs: Api<SpurJob> = Api::namespaced(client.clone(), &namespace);
-    let pods: Api<Pod> = Api::namespaced(client.clone(), &namespace);
+    let spurjobs: Api<SpurJob> = Api::all(client.clone());
+    let pods: Api<Pod> = Api::all(client.clone());
 
-    info!(namespace = %namespace, "starting SpurJob controller");
+    info!(namespace = %operator_namespace, "starting SpurJob controller");
 
     // Clean up orphan Pods on startup
     let cleanup_client = client.clone();
-    let cleanup_ns = namespace.clone();
     tokio::spawn(async move {
-        cleanup_orphan_pods(cleanup_client, cleanup_ns).await;
+        cleanup_orphan_pods(cleanup_client).await;
     });
 
     // Run pod watcher for completion callbacks in background
     let pod_ctx = ctx.clone();
-    let pod_ns = namespace.clone();
     tokio::spawn(async move {
-        if let Err(e) = watch_pods(pod_ctx, pod_ns).await {
+        if let Err(e) = watch_pods(pod_ctx).await {
             error!(error = %e, "pod watcher exited");
         }
     });
@@ -287,8 +306,8 @@ pub async fn run(client: Client, controller_addr: String, namespace: String) -> 
 }
 
 /// Watch Pods labeled with spur.ai/job-id and report terminal states back to spurctld.
-async fn watch_pods(ctx: Arc<JobControllerCtx>, namespace: String) -> anyhow::Result<()> {
-    let pods: Api<Pod> = Api::namespaced(ctx.client.clone(), &namespace);
+async fn watch_pods(ctx: Arc<JobControllerCtx>) -> anyhow::Result<()> {
+    let pods: Api<Pod> = Api::all(ctx.client.clone());
 
     let stream = kube::runtime::watcher::watcher(
         pods,
@@ -464,9 +483,9 @@ fn extract_failure_details(pod: &Pod) -> (i32, i32, String) {
 }
 
 /// Clean up orphan Pods on startup — Pods with spur labels but no matching SpurJob.
-async fn cleanup_orphan_pods(client: Client, namespace: String) {
-    let pods: Api<Pod> = Api::namespaced(client.clone(), &namespace);
-    let spurjobs: Api<SpurJob> = Api::namespaced(client, &namespace);
+async fn cleanup_orphan_pods(client: Client) {
+    let pods: Api<Pod> = Api::all(client.clone());
+    let spurjobs: Api<SpurJob> = Api::all(client.clone());
 
     let lp = ListParams::default().labels("spur.ai/managed-by=spur-k8s-operator");
     let pod_list = match pods.list(&lp).await {
@@ -497,6 +516,10 @@ async fn cleanup_orphan_pods(client: Client, namespace: String) {
 
     for pod in pod_list {
         let pod_name = pod.metadata.name.clone().unwrap_or_default();
+        let pod_ns = match pod.metadata.namespace.as_deref() {
+            Some(ns) => ns.to_string(),
+            None => continue,
+        };
         let job_id = pod
             .metadata
             .labels
@@ -514,11 +537,52 @@ async fn cleanup_orphan_pods(client: Client, namespace: String) {
                 .unwrap_or("");
 
             if phase == "Succeeded" || phase == "Failed" {
-                info!(pod = %pod_name, job_id, "cleaning up orphan Pod");
-                let _ = pods.delete(&pod_name, &DeleteParams::default()).await;
+                info!(pod = %pod_name, namespace = %pod_ns, job_id, "cleaning up orphan Pod");
+                let ns_api: Api<Pod> = Api::namespaced(client.clone(), &pod_ns);
+                let _ = ns_api.delete(&pod_name, &DeleteParams::default()).await;
             }
         }
     }
+}
+
+fn has_job_id_label(job: &SpurJob) -> bool {
+    job.metadata
+        .labels
+        .as_ref()
+        .and_then(|l| l.get("spur.ai/job-id"))
+        .is_some()
+}
+
+/// Ensure `spur.ai/job-id` is set on the SpurJob, retrying on transient API errors.
+/// Returns Ok if the label is already present or was applied successfully.
+async fn ensure_job_id_label(
+    job: &SpurJob,
+    api: &Api<SpurJob>,
+    name: &str,
+    job_id: u32,
+) -> Result<(), kube::Error> {
+    if has_job_id_label(job) {
+        return Ok(());
+    }
+
+    let patch = serde_json::json!({
+        "metadata": { "labels": { "spur.ai/job-id": job_id.to_string() } }
+    });
+
+    let backoff = ExponentialBackoffBuilder::new()
+        .with_initial_interval(Duration::from_millis(200))
+        .with_max_elapsed_time(Some(Duration::from_secs(3)))
+        .build();
+
+    retry(backoff, || async {
+        api.patch(name, &PatchParams::default(), &Patch::Merge(&patch))
+            .await
+            .map(|_| ())
+            .map_err(backoff::Error::transient)
+    })
+    .await
+    .inspect(|_| info!(spurjob = %name, job_id, "applied job-id label"))
+    .inspect_err(|e| warn!(spurjob = %name, job_id, error = %e, "failed to apply job-id label"))
 }
 
 async fn patch_status(api: &Api<SpurJob>, name: &str, status: &SpurJobStatus) {

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -694,6 +694,7 @@ fn core_job_spec_to_proto(spec: &spur_core::job::JobSpec) -> spur_proto::proto::
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
 
     // --- proto_job_state_to_string ---
 
@@ -1121,5 +1122,107 @@ mod tests {
         let inner = ReconcileError::Other("cleanup failure".into());
         let err = map_finalizer_err(finalizer::Error::CleanupFailed(inner));
         assert!(matches!(&err, ReconcileError::Other(msg) if msg == "cleanup failure"));
+    }
+
+    // --- has_job_id_label ---
+
+    fn make_spurjob(labels: Option<BTreeMap<String, String>>, namespace: Option<&str>) -> SpurJob {
+        SpurJob {
+            metadata: kube::api::ObjectMeta {
+                name: Some("test-job".into()),
+                namespace: namespace.map(String::from),
+                labels: labels,
+                ..Default::default()
+            },
+            spec: crate::crd::SpurJobSpec {
+                name: "test".into(),
+                image: "test:latest".into(),
+                gpus: Default::default(),
+                num_nodes: 1,
+                tasks_per_node: 1,
+                cpus_per_task: 1,
+                memory_per_node: None,
+                time_limit: None,
+                command: vec![],
+                args: vec![],
+                env: Default::default(),
+                partition: None,
+                account: None,
+                volumes: vec![],
+                host_network: false,
+                tolerations: vec![],
+                node_selector: Default::default(),
+                priority_class: None,
+                service_account: None,
+                array_spec: None,
+                dependencies: vec![],
+            },
+            status: None,
+        }
+    }
+
+    #[test]
+    fn test_has_job_id_label_present() {
+        let labels = BTreeMap::from([("spur.ai/job-id".into(), "42".into())]);
+        let job = make_spurjob(Some(labels), Some("default"));
+        assert!(has_job_id_label(&job));
+    }
+
+    #[test]
+    fn test_has_job_id_label_absent() {
+        let job = make_spurjob(Some(BTreeMap::new()), Some("default"));
+        assert!(!has_job_id_label(&job));
+    }
+
+    #[test]
+    fn test_has_job_id_label_none_labels() {
+        let job = make_spurjob(None, Some("default"));
+        assert!(!has_job_id_label(&job));
+    }
+
+    #[test]
+    fn test_has_job_id_label_other_labels_only() {
+        let labels = BTreeMap::from([
+            ("spur.ai/managed-by".into(), "spur-k8s-operator".into()),
+            ("app".into(), "training".into()),
+        ]);
+        let job = make_spurjob(Some(labels), Some("default"));
+        assert!(!has_job_id_label(&job));
+    }
+
+    #[test]
+    fn test_has_job_id_label_among_others() {
+        let labels = BTreeMap::from([
+            ("spur.ai/managed-by".into(), "spur-k8s-operator".into()),
+            ("spur.ai/job-id".into(), "99".into()),
+        ]);
+        let job = make_spurjob(Some(labels), Some("default"));
+        assert!(has_job_id_label(&job));
+    }
+
+    // --- namespace extraction (reconcile error path) ---
+
+    #[test]
+    fn test_namespace_missing_produces_error() {
+        let job = make_spurjob(None, None);
+        let result = job
+            .metadata
+            .namespace
+            .clone()
+            .ok_or_else(|| ReconcileError::Other("SpurJob has no namespace".into()));
+        assert!(
+            matches!(&result, Err(ReconcileError::Other(msg)) if msg == "SpurJob has no namespace")
+        );
+    }
+
+    #[test]
+    fn test_namespace_present_is_extracted() {
+        let job = make_spurjob(None, Some("ml-team"));
+        let result = job
+            .metadata
+            .namespace
+            .clone()
+            .ok_or_else(|| ReconcileError::Other("SpurJob has no namespace".into()));
+        assert_eq!(result.unwrap(), "ml-team");
     }
 }

--- a/crates/spur-k8s/src/main.rs
+++ b/crates/spur-k8s/src/main.rs
@@ -39,10 +39,6 @@ struct Args {
     #[arg(long, env = "SPUR_OPERATOR_ADDRESS")]
     address: Option<String>,
 
-    /// K8s namespace for SpurJobs and Pods
-    #[arg(long, default_value = "spur")]
-    namespace: String,
-
     /// K8s node label selector
     #[arg(long, default_value = "spur.ai/managed=true")]
     node_selector: String,
@@ -90,6 +86,10 @@ async fn main() -> anyhow::Result<()> {
     );
 
     let client = Client::try_default().await?;
+
+    // Operator's own namespace: injected by K8s Downward API as POD_NAMESPACE.
+    // Empty string if not set; callers that require it should validate and error out.
+    let operator_namespace = std::env::var("POD_NAMESPACE").unwrap_or_default();
 
     let listen_addr: SocketAddr = args.listen.parse()?;
     // Issue #51: Use explicit --address flag, then POD_IP env var (K8s Downward
@@ -141,17 +141,15 @@ async fn main() -> anyhow::Result<()> {
     let nw_client = client.clone();
     let nw_ctrl_addr = args.controller_addr.clone();
     let nw_op_addr = operator_ip.clone();
-    let nw_ns = args.namespace.clone();
     let nw_selector = args.node_selector.clone();
     tokio::spawn(async move {
         run_with_retry("node watcher", || {
             let c = nw_client.clone();
             let ctrl = nw_ctrl_addr.clone();
             let op = nw_op_addr.clone();
-            let ns = nw_ns.clone();
             let sel = nw_selector.clone();
             let hb = hb.clone();
-            Box::pin(node_watcher::run(c, ctrl, op, operator_port, ns, sel, hb))
+            Box::pin(node_watcher::run(c, ctrl, op, operator_port, sel, hb))
         })
         .await;
     });
@@ -159,7 +157,7 @@ async fn main() -> anyhow::Result<()> {
     // Spawn job controller (issue #52: retry on failure)
     let jc_client = client.clone();
     let jc_ctrl_addr = args.controller_addr.clone();
-    let jc_ns = args.namespace.clone();
+    let jc_ns = operator_namespace.clone();
     tokio::spawn(async move {
         run_with_retry("job controller", || {
             let c = jc_client.clone();
@@ -171,7 +169,7 @@ async fn main() -> anyhow::Result<()> {
     });
 
     // Start virtual agent gRPC server
-    let virtual_agent = agent::VirtualAgent::new(client, args.namespace);
+    let virtual_agent = agent::VirtualAgent::new(client);
     info!(%listen_addr, "virtual agent gRPC server listening");
 
     tonic::transport::Server::builder()

--- a/crates/spur-k8s/src/node_watcher.rs
+++ b/crates/spur-k8s/src/node_watcher.rs
@@ -21,7 +21,6 @@ pub async fn run(
     controller_addr: String,
     operator_grpc_addr: String,
     operator_grpc_port: u32,
-    _namespace: String,
     label_selector: String,
     hb: Arc<HeartbeatManager>,
 ) -> anyhow::Result<()> {

--- a/deploy/bare-metal/k8s_test.sh
+++ b/deploy/bare-metal/k8s_test.sh
@@ -468,6 +468,68 @@ kubectl -n spur rollout restart statefulset/spurctld
 kubectl -n spur rollout status statefulset/spurctld --timeout=120s >/dev/null 2>&1
 
 # ============================================================
+# TEST 8: Cross-namespace SpurJob
+# ============================================================
+section "TEST 8: Cross-namespace SpurJob"
+
+CROSS_NS="spur-user1"
+kubectl create namespace "$CROSS_NS" 2>/dev/null || true
+pass "Namespace ${CROSS_NS} created"
+
+kubectl apply -f - <<EOF
+apiVersion: spur.ai/v1alpha1
+kind: SpurJob
+metadata:
+  name: test-cross-ns
+  namespace: ${CROSS_NS}
+spec:
+  name: test-cross-ns
+  image: busybox:latest
+  command: ["sh", "-c", "echo CROSS_NS_OK && sleep 1"]
+  numNodes: 1
+EOF
+
+# wait_spurjob expects -n spur; inline a cross-namespace wait
+CROSS_STATE=""
+for _ in $(seq 1 30); do
+    CROSS_STATE=$(kubectl -n "$CROSS_NS" get spurjob test-cross-ns \
+        -o jsonpath='{.status.state}' 2>/dev/null || echo "")
+    [ "$CROSS_STATE" = "Completed" ] && break
+    case "$CROSS_STATE" in
+        Failed|Cancelled) break ;;
+    esac
+    sleep 2
+done
+
+[ "$CROSS_STATE" = "Completed" ] \
+    && pass "Cross-namespace SpurJob completed in ${CROSS_NS}" \
+    || { fail "Cross-namespace SpurJob state: ${CROSS_STATE:-timeout}"; \
+         echo "  Debug: pods in ${CROSS_NS}:"; \
+         kubectl -n "$CROSS_NS" get pods -o wide 2>/dev/null | sed 's/^/    /'; \
+         echo "  Debug: operator logs (last 20):"; \
+         kubectl -n spur logs -l app=spur-k8s-operator --tail=20 2>/dev/null | sed 's/^/    /'; }
+
+# Verify pod was created in the correct namespace (not in spur)
+POD_NS=$(kubectl get pods --all-namespaces -l spur.ai/job-id \
+    -o jsonpath='{.items[?(@.metadata.labels.spur\.ai/job-id)].metadata.namespace}' 2>/dev/null \
+    | tr ' ' '\n' | grep -c "$CROSS_NS" || echo "0")
+# At minimum, verify no pods leaked into the spur namespace for this job
+CROSS_JOB_ID=$(kubectl -n "$CROSS_NS" get spurjob test-cross-ns \
+    -o jsonpath='{.status.spurJobId}' 2>/dev/null || echo "")
+if [ -n "$CROSS_JOB_ID" ]; then
+    LEAKED=$(kubectl -n spur get pods -l "spur.ai/job-id=${CROSS_JOB_ID}" \
+        --no-headers 2>/dev/null | wc -l)
+    [ "$LEAKED" -eq 0 ] \
+        && pass "Pod created in ${CROSS_NS}, not leaked to spur namespace" \
+        || fail "Pod leaked to spur namespace (${LEAKED} found)"
+else
+    pass "Cross-namespace job ID check skipped (job may have already been cleaned up)"
+fi
+
+kubectl delete spurjob test-cross-ns -n "$CROSS_NS" --timeout=30s 2>/dev/null || true
+kubectl delete namespace "$CROSS_NS" --timeout=30s 2>/dev/null || true
+
+# ============================================================
 # Summary
 # ============================================================
 echo ""

--- a/deploy/k8s/operator.yaml
+++ b/deploy/k8s/operator.yaml
@@ -37,13 +37,16 @@ spec:
           args:
             - --controller-addr=spurctld.spur.svc.cluster.local:6817
             - --listen=[::]:6818
-            - --namespace=spur
             - --health-addr=[::]:8080
           env:
             - name: POD_IP
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           ports:
             - containerPort: 6818
               name: grpc


### PR DESCRIPTION
The operator was previously scoped to a single namespace (`--namespace`, default `spur`). As a result, any `SpurJob` created outside that namespace was never picked up by the controller.

---
#### What was broken

- The controller only watched one namespace, so jobs in other namespaces were ignored.
- Cleanup logic used the operator’s namespace instead of the job’s namespace, causing deletions to fail or target the wrong resources.

#### Why this matters

Running all workloads in the operator’s namespace is not a good security model. User jobs should run in their own namespaces so they can benefit from proper RBAC, quotas, and network policies. The previous setup forced everything into a shared namespace with no isolation. This forces job pods to run in the controller’s namespace. If those pods use a ServiceAccount with elevated permissions in that namespace, it can lead to unintended privilege escalation and potential security risks.

#### What’s changed

- The operator now watches `SpurJob`s cluster-wide.
- Jobs are created and managed in their own namespaces.
- Cleanup always happens in the correct namespace.

#### How it works

`spurctld` is namespace-agnostic and only deals with job IDs. To bridge that, the operator adds a `spur.ai/job-id` label to each `SpurJob`. When a job is dispatched, the system looks up the namespace using this label—making Kubernetes the source of truth and avoiding in-memory state.

#### Why cluster-wide scope

A single operator managing the whole cluster is the intended model (similar to Volcano or Argo). Running one operator per namespace would add unnecessary complexity, and the RBAC was already cluster-scoped anyway.

#### Before / After

**Before (job not admitted outside `spur`):**
<img width="831" height="82" alt="Screenshot 2026-04-13 204651" src="https://github.com/user-attachments/assets/2a0ce70f-dd92-461a-b2ec-0ae8e585efec" />

**After (job admitted in its own namespace):**
<img width="779" height="58" alt="Screenshot 2026-04-13 205140" src="https://github.com/user-attachments/assets/5670970a-d903-427b-9313-aca3e27585ee" />