### PR TITLE
 fix(spurctld): use correct namespace when creating leader election Lease

### DIFF
--- a/crates/spurctld/src/leader_election.rs
+++ b/crates/spurctld/src/leader_election.rs
@@ -30,7 +30,7 @@ pub async fn acquire_lease(namespace: &str) -> anyhow::Result<()> {
 
     // Try to acquire the Lease in a loop
     loop {
-        match try_acquire(&leases, &identity).await {
+        match try_acquire(&leases, namespace, &identity).await {
             Ok(true) => {
                 info!("acquired leader Lease");
                 break;
@@ -56,7 +56,7 @@ pub async fn acquire_lease(namespace: &str) -> anyhow::Result<()> {
 }
 
 /// Try to create or update the Lease. Returns true if we became the leader.
-async fn try_acquire(leases: &Api<Lease>, identity: &str) -> anyhow::Result<bool> {
+async fn try_acquire(leases: &Api<Lease>, namespace: &str, identity: &str) -> anyhow::Result<bool> {
     let now = Utc::now();
     let now_micro = k8s_openapi::apimachinery::pkg::apis::meta::v1::MicroTime(now);
 
@@ -104,7 +104,7 @@ async fn try_acquire(leases: &Api<Lease>, identity: &str) -> anyhow::Result<bool
             let lease = Lease {
                 metadata: ObjectMeta {
                     name: Some(LEASE_NAME.into()),
-                    namespace: Some(leases.resource_url().to_string()),
+                    namespace: Some(namespace.into()),
                     ..Default::default()
                 },
                 spec: Some(k8s_openapi::api::coordination::v1::LeaseSpec {

--- a/deploy/bare-metal/k8s_test.sh
+++ b/deploy/bare-metal/k8s_test.sh
@@ -6,6 +6,7 @@
 #   - Operator health and node registration
 #   - Multi-node job coordination
 #   - Cancellation and failure detection
+#   - Leader election via K8s Lease
 #
 # Prerequisites:
 #   - Spur binaries at ~/spur/bin/ (from cluster job)
@@ -410,6 +411,61 @@ $ALL_DONE && pass "All 3 sequential SpurJobs completed"
 for i in 1 2 3; do
     kubectl delete spurjob "test-seq-${i}" -n spur --timeout=10s 2>/dev/null || true
 done
+
+# ============================================================
+# TEST 7: Leader election (K8s Lease)
+# ============================================================
+section "TEST 7: Leader election (K8s Lease)"
+
+# Remove any stale Lease from previous runs
+kubectl delete lease spurctld-leader -n spur 2>/dev/null || true
+
+# Save original args, then patch in leader election flags
+ORIG_ARGS=$(kubectl -n spur get statefulset spurctld \
+    -o jsonpath='{.spec.template.spec.containers[0].args}')
+
+kubectl -n spur patch statefulset spurctld --type json -p '[
+  {"op": "replace", "path": "/spec/template/spec/containers/0/args", "value": [
+    "--listen=[::]:6817",
+    "--config=/etc/spur/spur.conf",
+    "--enable-leader-election",
+    "--election-namespace=spur"
+  ]},
+  {"op": "replace", "path": "/spec/template/spec/containers/0/livenessProbe/initialDelaySeconds", "value": 300}
+]'
+
+# Trigger a proper rollout so the pod picks up the new template
+kubectl -n spur rollout restart statefulset/spurctld
+kubectl -n spur rollout status statefulset/spurctld --timeout=120s \
+    && pass "Controller ready with leader election" \
+    || { fail "Controller not ready with leader election"; \
+         echo "  Debug: spurctld logs (last 15):"; \
+         kubectl -n spur logs -l app=spurctld --tail=15 2>/dev/null | sed 's/^/    /'; }
+
+# Verify the Lease object was created and has a holder
+HOLDER=$(kubectl -n spur get lease spurctld-leader -o jsonpath='{.spec.holderIdentity}' 2>/dev/null || echo "")
+[ -n "$HOLDER" ] \
+    && pass "Leader Lease acquired by: $HOLDER" \
+    || fail "Leader Lease not found or has no holder"
+
+LEASE_NS=$(kubectl -n spur get lease spurctld-leader -o jsonpath='{.metadata.namespace}' 2>/dev/null || echo "")
+[ "$LEASE_NS" = "spur" ] \
+    && pass "Lease created in correct namespace" \
+    || fail "Lease namespace mismatch: expected 'spur', got '${LEASE_NS}'"
+
+# Verify spurctld logs show successful acquisition (no repeated errors)
+ERROR_COUNT=$(kubectl -n spur logs -l app=spurctld 2>/dev/null | grep -c "leader election error" || true)
+[ "$ERROR_COUNT" -eq 0 ] \
+    && pass "No leader election errors in logs" \
+    || fail "Found $ERROR_COUNT leader election errors in logs"
+
+# Restore original args and liveness probe
+kubectl -n spur patch statefulset spurctld --type json -p "[
+  {\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/args\", \"value\": ${ORIG_ARGS}},
+  {\"op\": \"replace\", \"path\": \"/spec/template/spec/containers/0/livenessProbe/initialDelaySeconds\", \"value\": 15}
+]"
+kubectl -n spur rollout restart statefulset/spurctld
+kubectl -n spur rollout status statefulset/spurctld --timeout=120s >/dev/null 2>&1
 
 # ============================================================
 # Summary


### PR DESCRIPTION
## Summary
- `try_acquire()` set the Lease `ObjectMeta.namespace` to `leases.resource_url()` which returns the full K8s API path (e.g. `/apis/coordination.k8s.io/v1/namespaces/spur/leases`) instead of just `"spur"`
- This caused a `400 BadRequest` ("the namespace of the provided object does not match the namespace sent on the request") on every Lease creation attempt, making leader election permanently broken on fresh deployments
- The bug was masked when a Lease already existed from a prior run (the PATCH/renew path doesn't include namespace in the body)

## Fix
Pass the namespace string through to `try_acquire()` and use it directly in the Lease `ObjectMeta` instead of calling `resource_url()`.

## Before (main branch)
spurctld stuck in infinite retry loop — never acquires leadership:
<img width="1031" height="62" alt="Screenshot 2026-04-14 122129" src="https://github.com/user-attachments/assets/77e9893d-a625-4715-a060-5ac3042e18d9" />

## After (this PR)
Lease created and acquired on first attempt:
<img width="873" height="65" alt="Screenshot 2026-04-14 123150" src="https://github.com/user-attachments/assets/6cba1c92-bfa5-4038-aa48-22b1017307c4" />

## Testing
- [x] All 776 unit tests pass (`cargo test`)
- [x] Bug reproduced on live 3-node K8s cluster (v1.33)
- [x] Fix verified on same cluster — Lease created, leader acquired, nodes registered
- [x] Added K8s integration test (TEST 7 in `k8s_test.sh`) that verifies:
  - Controller starts with `--enable-leader-election`
  - `spurctld-leader` Lease is created in the correct namespace
  - No leader election errors in logs
