### PR TITLE
fix(ci): decouple k8s tests from cluster job via docker image artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,24 +149,47 @@ jobs:
           ssh mi300-2 '~/spur/etc/stop-agent.sh' || true
           ~/spur/etc/stop-all.sh || true
 
-  k8s:
-    name: K8s Integration (2x MI300X)
+  build-docker-image:
+    name: Build Docker Image
     runs-on: [self-hosted, mi300x]
-    needs: cluster
+    needs: [build-and-test, fmt, clippy]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build container image
+        run: sg docker -c "docker build -f deploy/Dockerfile -t spur:ci ."
+
+      - name: Save image as artifact
+        run: sg docker -c "docker save spur:ci -o /tmp/spur-ci-image.tar"
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: spur-ci-image
+          path: /tmp/spur-ci-image.tar
+          retention-days: 1
+
+  k8s:
+    name: K8s Integration
+    runs-on: [self-hosted, mi300x]
+    needs: build-docker-image
     concurrency:
-      group: cluster-${{ github.ref }}
+      group: k8s-${{ github.ref }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
 
-      - name: Verify binaries from cluster job
-        run: |
-          for bin in spurctld spurd spur spur-k8s-operator; do
-            ls ~/spur/bin/${bin}
-          done
+      - name: Download CI image
+        uses: actions/download-artifact@v4
+        with:
+          name: spur-ci-image
+          path: /tmp
+
+      - name: Load CI image
+        run: sg docker -c "docker load -i /tmp/spur-ci-image.tar"
 
       - name: Run K8s integration tests
-        run: sg docker -c "bash deploy/bare-metal/k8s_test.sh"
+        run: sg docker -c "SPUR_CI_IMAGE=spur:ci bash deploy/bare-metal/k8s_test.sh"
 
       - name: Cleanup kind cluster
         if: always()

--- a/deploy/bare-metal/k8s_test.sh
+++ b/deploy/bare-metal/k8s_test.sh
@@ -8,19 +8,19 @@
 #   - Cancellation and failure detection
 #
 # Prerequisites:
-#   - Spur binaries at ~/spur/bin/ (from cluster job)
 #   - Docker installed
+#   - SPUR_CI_IMAGE set to a pre-built Spur container image (e.g. spur:ci)
 #
-# Usage: bash deploy/bare-metal/k8s_test.sh
+# Usage:
+#   SPUR_CI_IMAGE=spur:ci bash deploy/bare-metal/k8s_test.sh
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-SPUR_HOME="${HOME}/spur"
-SPUR_BIN="${SPUR_HOME}/bin"
 TOOLS_DIR="${HOME}/.local/bin"
 CLUSTER_NAME="spur-ci"
+SPUR_CI_IMAGE="${SPUR_CI_IMAGE:?SPUR_CI_IMAGE must be set to a Docker image (e.g. spur:ci)}"
 
 mkdir -p "${TOOLS_DIR}"
 export PATH="${TOOLS_DIR}:${PATH}"
@@ -73,12 +73,7 @@ if ! docker info >/dev/null 2>&1; then
     exit 0
 fi
 
-if [ ! -x "${SPUR_BIN}/spurctld" ]; then
-    echo "ERROR: Spur binaries not found at ${SPUR_BIN}"
-    exit 1
-fi
-
-pass "Docker and Spur binaries available"
+pass "Docker available"
 
 # ============================================================
 # Install tools (kind + kubectl)
@@ -137,27 +132,14 @@ done
 pass "Worker nodes labeled for Spur"
 
 # ============================================================
-# Build and load container image
+# Load container image into kind
 # ============================================================
-section "Build Spur container image"
+section "Load Spur container image"
 
-BUILD_DIR=$(mktemp -d)
-
-cat > "${BUILD_DIR}/Dockerfile" <<'DOCKERFILE'
-FROM ubuntu:22.04
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates util-linux curl && rm -rf /var/lib/apt/lists/*
-COPY bin/ /usr/local/bin/
-DOCKERFILE
-
-mkdir -p "${BUILD_DIR}/bin"
-for b in spur spurctld spurd spurdbd spurrestd spur-k8s-operator; do
-    cp "${SPUR_BIN}/${b}" "${BUILD_DIR}/bin/"
-done
-
-docker build -t spur:ci "${BUILD_DIR}" \
-    && pass "Container image built" \
-    || fail "Container image build failed"
+echo "  Source image: ${SPUR_CI_IMAGE}"
+if [ "$SPUR_CI_IMAGE" != "spur:ci" ]; then
+    docker tag "$SPUR_CI_IMAGE" spur:ci
+fi
 
 kind load docker-image spur:ci --name "${CLUSTER_NAME}" \
     && pass "Image loaded into kind" \
@@ -169,15 +151,13 @@ kind load docker-image busybox:latest --name "${CLUSTER_NAME}" \
     && pass "busybox image loaded into kind" \
     || fail "busybox image load failed"
 
-rm -rf "${BUILD_DIR}"
-
 # ============================================================
 # Deploy Spur to K8s
 # ============================================================
 section "Deploy Spur to K8s"
 
 # Register SpurJob CRD
-"${SPUR_BIN}/spur-k8s-operator" generate-crd | kubectl apply -f - \
+docker run --rm spur:ci generate-crd | kubectl apply -f - \
     && pass "SpurJob CRD registered" \
     || fail "CRD registration failed"
 
@@ -224,9 +204,11 @@ kubectl -n spur wait --for=condition=Ready pod -l app=spurctld --timeout=120s \
     && pass "Controller pod ready" \
     || fail "Controller not ready"
 
-# Health check via exec into operator pod
+# Health check via a temporary busybox pod hitting the operator's pod IP
 OPERATOR_POD=$(kubectl -n spur get pod -l app=spur-k8s-operator -o jsonpath='{.items[0].metadata.name}')
-kubectl -n spur exec "$OPERATOR_POD" -- curl -sf http://localhost:8080/healthz >/dev/null 2>&1 \
+OPERATOR_IP=$(kubectl -n spur get pod "$OPERATOR_POD" -o jsonpath='{.status.podIP}')
+kubectl run healthcheck -n spur --image=busybox:latest --restart=Never --rm -i \
+    -- wget -qO- -T 5 "http://${OPERATOR_IP}:8080/healthz" >/dev/null 2>&1 \
     && pass "Operator /healthz OK" \
     || fail "Operator /healthz failed"
 


### PR DESCRIPTION
The k8s integration step assumed binaries from the cluster job would be at `~/spur/bin/` on the same runner. Both jobs running on the same runner back to back is not guaranteed like another job can come in between the two jobs, causing intermittent failures. (I experienced this lately)

Fix: add a build-docker-image job that builds via `deploy/Dockerfile`, uploads the image as an artifact, and the k8s job downloads and uses it. `k8s_test.sh` now requires SPUR_CI_IMAGE instead of host binaries.

This also means the docker image build is validated on every CI run.
