### PR TITLE
fix(ci): run docker image build on github-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
 
   build-docker-image:
     name: Build Docker Image
-    runs-on: [self-hosted, mi300x]
+    runs-on: ubuntu-latest
     needs: [build-and-test, fmt, clippy]
     steps:
       - uses: actions/checkout@v4

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -16,9 +16,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 WORKDIR /build
 COPY . .
 
-# Build all workspace binaries in release mode.
-# Limit parallel jobs to avoid "too many open files" in constrained CI builders.
-RUN CARGO_BUILD_JOBS=4 cargo build --release \
+RUN cargo build --release \
     --bin spur \
     --bin spurctld \
     --bin spurd \


### PR DESCRIPTION
Github runners are exempted from Dockerhub pull limits. This also helps us avoid too many open file issue which we hit on self hosted runners.

This aims to fix intermittent docker image build failure issues.
<img width="1432" height="276" alt="image" src="https://github.com/user-attachments/assets/7fe1f1e7-ddff-485d-8e4b-0af9f4099ba8" />
