### PR TITLE
Fix CI: pin cluster tests to primary runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
 
   cluster:
     name: Cluster Tests (2x MI300X)
-    runs-on: [self-hosted, mi300x]
+    runs-on: [self-hosted, mi300x, primary]
     needs: [build-and-test, fmt, clippy]
     # Only one cluster run at a time; cancel older runs on the same ref.
     concurrency:


### PR DESCRIPTION
## Summary
Pin the cluster test job to the `primary` label so it always runs on `mi300-runner`.

## Problem
Cluster tests require running on mi300 (primary) and SSH to mi300-2 (secondary). When GitHub Actions scheduled the job on `mi300-2-runner`, it failed because:
- `mi300-2` hostname couldn't be resolved (self-referencing)
- `~/spur/etc/stop-all.sh` didn't exist on mi300-2

## Fix
Added `primary` label to `mi300-runner` and changed `runs-on` from `[self-hosted, mi300x]` to `[self-hosted, mi300x, primary]` for the cluster test job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)