### PR TITLE
Add K8s pod options: hostNetwork, privileged, hostIPC, shmSize, extraResources (#85, #86, #87, #88)

### DIFF
--- a/crates/spur-cli/src/sbatch.rs
+++ b/crates/spur-cli/src/sbatch.rs
@@ -621,6 +621,11 @@ pub async fn main_with_args(cli_args: Vec<String>) -> Result<()> {
             }),
         spread_job: args.spread_job,
         topology: args.topology.clone().unwrap_or_default(),
+        host_network: false,
+        privileged: false,
+        host_ipc: false,
+        shm_size: String::new(),
+        extra_resources: std::collections::HashMap::new(),
         open_mode: args.open_mode.unwrap_or_default(),
     };
 

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -210,6 +210,18 @@ pub struct JobSpec {
     /// "block" (keep within one rack). None = default (no topology preference).
     pub topology: Option<String>,
 
+    // Kubernetes pod options
+    /// Enable host networking for the pod (for RDMA/NCCL).
+    pub host_network: bool,
+    /// Run container in privileged mode.
+    pub privileged: bool,
+    /// Enable host IPC namespace sharing (for NCCL shared memory).
+    pub host_ipc: bool,
+    /// Shared memory size (e.g., "64Gi"). Mounted as emptyDir at /dev/shm.
+    pub shm_size: Option<String>,
+    /// Extra device plugin resources (e.g., {"rdma/devices": "1"}).
+    pub extra_resources: std::collections::HashMap<String, String>,
+
     // Output mode
     /// How to open stdout/stderr files: "truncate" (default) or "append".
     pub open_mode: Option<String>,
@@ -272,6 +284,11 @@ impl Default for JobSpec {
             deadline: None,
             spread_job: false,
             topology: None,
+            host_network: false,
+            privileged: false,
+            host_ipc: false,
+            shm_size: None,
+            extra_resources: std::collections::HashMap::new(),
             open_mode: None,
         }
     }

--- a/crates/spur-k8s/src/agent.rs
+++ b/crates/spur-k8s/src/agent.rs
@@ -240,13 +240,38 @@ impl SlurmAgent for VirtualAgent {
         };
 
         // Parse container_mounts → volumes + volume_mounts
-        let (volumes, volume_mounts) = parse_mounts(&spec.container_mounts);
+        let (mut volumes, mut volume_mounts) = parse_mounts(&spec.container_mounts);
 
         // Set working_dir from work_dir or container_workdir
         let working_dir = if !spec.container_workdir.is_empty() {
             Some(spec.container_workdir.clone())
         } else if !spec.work_dir.is_empty() {
             Some(spec.work_dir.clone())
+        } else {
+            None
+        };
+
+        // Add extra device plugin resources (RDMA, MIG, etc.) — Issue #88
+        for (key, val) in &spec.extra_resources {
+            resource_requests.insert(key.clone(), Quantity(val.clone()));
+            resource_limits.insert(key.clone(), Quantity(val.clone()));
+        }
+
+        // Shared memory volume mount — Issue #87
+        if !spec.shm_size.is_empty() {
+            volume_mounts.push(k8s_openapi::api::core::v1::VolumeMount {
+                name: "dshm".into(),
+                mount_path: "/dev/shm".into(),
+                ..Default::default()
+            });
+        }
+
+        // Privileged mode / SecurityContext — Issue #86
+        let security_context = if spec.privileged {
+            Some(k8s_openapi::api::core::v1::SecurityContext {
+                privileged: Some(true),
+                ..Default::default()
+            })
         } else {
             None
         };
@@ -267,6 +292,7 @@ impl SlurmAgent for VirtualAgent {
                 limits: Some(resource_limits),
                 ..Default::default()
             }),
+            security_context,
             ..Default::default()
         };
 
@@ -315,18 +341,36 @@ impl SlurmAgent for VirtualAgent {
                 labels: Some(labels),
                 ..Default::default()
             },
-            spec: Some(PodSpec {
-                containers: vec![container],
-                restart_policy: Some("Never".into()),
-                node_name,
-                hostname,
-                subdomain,
-                volumes: if volumes.is_empty() {
-                    None
-                } else {
-                    Some(volumes)
-                },
-                ..Default::default()
+            spec: Some({
+                // Shared memory emptyDir volume — Issue #87
+                if !spec.shm_size.is_empty() {
+                    volumes.push(k8s_openapi::api::core::v1::Volume {
+                        name: "dshm".into(),
+                        empty_dir: Some(k8s_openapi::api::core::v1::EmptyDirVolumeSource {
+                            medium: Some("Memory".into()),
+                            size_limit: Some(Quantity(spec.shm_size.clone())),
+                        }),
+                        ..Default::default()
+                    });
+                }
+
+                PodSpec {
+                    containers: vec![container],
+                    restart_policy: Some("Never".into()),
+                    node_name,
+                    hostname,
+                    subdomain,
+                    volumes: if volumes.is_empty() {
+                        None
+                    } else {
+                        Some(volumes)
+                    },
+                    // Issue #85: host_network
+                    host_network: if spec.host_network { Some(true) } else { None },
+                    // Issue #87: host_ipc
+                    host_ipc: if spec.host_ipc { Some(true) } else { None },
+                    ..Default::default()
+                }
             }),
             ..Default::default()
         };

--- a/crates/spur-k8s/src/crd.rs
+++ b/crates/spur-k8s/src/crd.rs
@@ -76,6 +76,22 @@ pub struct SpurJobSpec {
     #[serde(default)]
     pub host_network: bool,
 
+    /// Run container in privileged mode.
+    #[serde(default)]
+    pub privileged: bool,
+
+    /// Enable host IPC namespace sharing (for NCCL shared memory).
+    #[serde(default)]
+    pub host_ipc: bool,
+
+    /// Shared memory size (e.g., "64Gi"). Mounted as emptyDir at /dev/shm.
+    #[serde(default)]
+    pub shm_size: Option<String>,
+
+    /// Extra device plugin resources (e.g., {"rdma/devices": "1"}).
+    #[serde(default)]
+    pub extra_resources: std::collections::HashMap<String, String>,
+
     /// K8s tolerations.
     #[serde(default)]
     pub tolerations: Vec<TolerationSpec>,
@@ -194,6 +210,11 @@ pub fn to_core_job_spec(spec: &SpurJobSpec, user: &str) -> spur_core::job::JobSp
         time_limit,
         dependency: spec.dependencies.clone(),
         array_spec: spec.array_spec.clone(),
+        host_network: spec.host_network,
+        privileged: spec.privileged,
+        host_ipc: spec.host_ipc,
+        shm_size: spec.shm_size.clone(),
+        extra_resources: spec.extra_resources.clone(),
         ..Default::default()
     }
 }
@@ -277,6 +298,10 @@ mod tests {
             account: None,
             volumes: vec![],
             host_network: false,
+            privileged: false,
+            host_ipc: false,
+            shm_size: None,
+            extra_resources: std::collections::HashMap::new(),
             tolerations: vec![],
             node_selector: Default::default(),
             priority_class: None,
@@ -408,6 +433,10 @@ mod tests {
             account: None,
             volumes: vec!["/data:/mnt/data:ro".into()],
             host_network: false,
+            privileged: false,
+            host_ipc: false,
+            shm_size: None,
+            extra_resources: std::collections::HashMap::new(),
             tolerations: vec![],
             node_selector: Default::default(),
             priority_class: None,
@@ -594,6 +623,10 @@ mod tests {
             account: Some("acct".into()),
             volumes: vec!["/data:/data".into()],
             host_network: true,
+            privileged: false,
+            host_ipc: false,
+            shm_size: None,
+            extra_resources: std::collections::HashMap::new(),
             tolerations: vec![TolerationSpec {
                 key: Some("spur.ai/gpu-node".into()),
                 operator: "Exists".into(),
@@ -659,6 +692,10 @@ mod tests {
                 "pvc:checkpoints:/checkpoints".into(),
             ],
             host_network: false,
+            privileged: false,
+            host_ipc: false,
+            shm_size: None,
+            extra_resources: std::collections::HashMap::new(),
             tolerations: vec![TolerationSpec {
                 key: Some("spur.ai/gpu-node".into()),
                 operator: "Exists".into(),

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -711,6 +711,11 @@ fn core_job_spec_to_proto(spec: &spur_core::job::JobSpec) -> spur_proto::proto::
         }),
         spread_job: spec.spread_job,
         topology: spec.topology.clone().unwrap_or_default(),
+        host_network: spec.host_network,
+        privileged: spec.privileged,
+        host_ipc: spec.host_ipc,
+        shm_size: spec.shm_size.clone().unwrap_or_default(),
+        extra_resources: spec.extra_resources.clone(),
         open_mode: spec.open_mode.clone().unwrap_or_default(),
     }
 }
@@ -1174,6 +1179,10 @@ mod tests {
                 account: None,
                 volumes: vec![],
                 host_network: false,
+                privileged: false,
+                host_ipc: false,
+                shm_size: None,
+                extra_resources: std::collections::HashMap::new(),
                 tolerations: vec![],
                 node_selector: Default::default(),
                 priority_class: None,

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -446,6 +446,11 @@ fn core_spec_to_proto(s: &spur_core::job::JobSpec) -> ProtoJobSpec {
         }),
         spread_job: s.spread_job,
         topology: s.topology.clone().unwrap_or_default(),
+        host_network: s.host_network,
+        privileged: s.privileged,
+        host_ipc: s.host_ipc,
+        shm_size: s.shm_size.clone().unwrap_or_default(),
+        extra_resources: s.extra_resources.clone(),
         open_mode: s.open_mode.clone().unwrap_or_default(),
     }
 }
@@ -527,6 +532,11 @@ async fn dispatch_to_agent(
         }),
         spread_job: spec.spread_job,
         topology: spec.topology.clone().unwrap_or_default(),
+        host_network: spec.host_network,
+        privileged: spec.privileged,
+        host_ipc: spec.host_ipc,
+        shm_size: spec.shm_size.clone().unwrap_or_default(),
+        extra_resources: spec.extra_resources.clone(),
         open_mode: spec.open_mode.clone().unwrap_or_default(),
     };
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -982,6 +982,15 @@ fn proto_to_job_spec(spec: JobSpec) -> Result<spur_core::job::JobSpec, Status> {
         } else {
             Some(spec.topology)
         },
+        host_network: spec.host_network,
+        privileged: spec.privileged,
+        host_ipc: spec.host_ipc,
+        shm_size: if spec.shm_size.is_empty() {
+            None
+        } else {
+            Some(spec.shm_size)
+        },
+        extra_resources: spec.extra_resources,
         open_mode: if spec.open_mode.is_empty() {
             None
         } else {

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -121,6 +121,13 @@ message JobSpec {
   string wckey = 64;
   bool interactive = 65;  // salloc interactive allocation
 
+  // Kubernetes pod options
+  bool host_network = 66;          // Enable host networking (RDMA/NCCL)
+  bool privileged = 67;            // Run in privileged mode
+  bool host_ipc = 68;              // Share host IPC namespace
+  string shm_size = 69;            // Shared memory size (e.g., "64Gi")
+  map<string, string> extra_resources = 80; // Custom device plugin resources
+
   // Container
   string container_image = 70;     // OCI image ref or squashfs path
   repeated string container_mounts = 71;  // "/src:/dst:ro" bind mounts


### PR DESCRIPTION
## Summary
Fixes #85, #86, #87, #88 — adds five K8s pod options required for GPU training workloads.

## Changes
Thread five new fields through the CRD → core JobSpec → proto → pod creation pipeline:

| Field | Issue | Pod Effect |
|-------|-------|-----------|
| `hostNetwork` | #85 | `PodSpec.host_network = true` |
| `privileged` | #86 | `Container.security_context.privileged = true` |
| `hostIpc` | #87 | `PodSpec.host_ipc = true` |
| `shmSize` | #87 | emptyDir volume at `/dev/shm` with sizeLimit |
| `extraResources` | #88 | Added to pod resource requests/limits (e.g., `rdma/devices: 1`) |

## Example SpurJob
```yaml
apiVersion: spur.ai/v1alpha1
kind: SpurJob
spec:
  image: nvcr.io/nvidia/pytorch:latest
  hostNetwork: true
  privileged: true
  hostIpc: true
  shmSize: "64Gi"
  extraResources:
    rdma/hca_shared_devices_a: "1"
  gpus:
    count: 8
    gpuType: mi300x
```

## Test plan
- [x] Full test suite passes (0 failures)
- [x] Existing CRD parse tests updated with new fields
- [ ] K8s integration: deploy SpurJob with hostNetwork=true, verify pod has host networking

@amd-vpenumal — these are the fields you requested. Please verify the CRD schema matches your expected usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)