### PR TITLE
Add UID/GID enforcement, pids.max, and OOM isolation (#99 PR 1/6)

### DIFF
--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -597,6 +597,8 @@ impl SlurmAgent for AgentService {
             &cpu_ids,
             (*self.spank).as_ref(),
             open_mode,
+            spec.uid,
+            spec.gid,
         )
         .await
         {

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -110,6 +110,8 @@ pub async fn launch_job(
     cpu_ids: &[u32],
     spank: Option<&SpankHost>,
     open_mode: Option<&str>,
+    uid: u32,
+    gid: u32,
 ) -> anyhow::Result<RunningJob> {
     info!(job_id, work_dir, "launching job");
 
@@ -279,6 +281,15 @@ pub async fn launch_job(
         .stderr(stderr_file.into_std().await)
         .stdin(Stdio::null());
 
+    // Issue #99: Run job as the submitting user (not root).
+    // Requires spurd to run as root. Non-root spurd skips setuid.
+    if uid > 0 && nix::unistd::geteuid().is_root() {
+        use std::os::unix::process::CommandExt;
+        cmd.uid(uid);
+        cmd.gid(gid);
+        debug!(job_id, uid, gid, "job will run as non-root user");
+    }
+
     // If cgroup is set up, launch via cgexec or write PID to cgroup
     let child = cmd.spawn().context("failed to spawn job process")?;
 
@@ -340,6 +351,17 @@ fn setup_cgroup(
         if let Err(e) = std::fs::write(cgroup_path.join("memory.max"), memory_bytes.to_string()) {
             warn!(job_id, error = %e, "failed to set memory.max");
         }
+    }
+
+    // OOM isolation: kill entire cgroup on OOM, not a random process
+    if let Err(e) = std::fs::write(cgroup_path.join("memory.oom.group"), "1") {
+        warn!(job_id, error = %e, "failed to set memory.oom.group");
+    }
+
+    // Fork bomb protection: limit total processes per job
+    let max_pids = (cpus as u64 * 256).max(1024);
+    if let Err(e) = std::fs::write(cgroup_path.join("pids.max"), max_pids.to_string()) {
+        warn!(job_id, error = %e, "failed to set pids.max");
     }
 
     // Pin to specific CPU cores via cpuset


### PR DESCRIPTION
## Summary
First PR in the bare-metal job isolation series (#99). Adds three foundational cgroup + process controls.

## Changes
1. **setuid/setgid** — Jobs run as submitting user's UID/GID (not root). `Command::uid()/gid()` when spurd is root; graceful skip otherwise.
2. **pids.max** — Fork bomb protection. Limits processes per job to `max(cpus*256, 1024)`.
3. **memory.oom.group** — OOM kills entire job cgroup, not random process.

Works with both bare-metal and container (Enroot-like) paths — cgroup setup happens before process spawn in both cases.

## Isolation series roadmap
1. **This PR**: setuid + pids.max + OOM
2. Device cgroup (GPU enforcement at kernel level)
3. PID + mount namespace
4. seccomp-BPF syscall filter (from AXIS)
5. Landlock filesystem restrictions (from AXIS)
6. Config + CLI integration

## Test plan
- [x] Full test suite passes (0 failures)
- [ ] CI cluster test: submit job as non-root user, verify GPU access works
- [ ] Fork bomb test: `:(){ :|:& };:` → pids.max kills cgroup

🤖 Generated with [Claude Code](https://claude.com/claude-code)