### PR TITLE
Centralized node state machine with auto-recovery and K8s dedup

### DIFF
--- a/crates/spur-core/src/node.rs
+++ b/crates/spur-core/src/node.rs
@@ -18,7 +18,65 @@ pub enum NodeState {
     Suspended,
 }
 
+/// Events that drive node state transitions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NodeEvent {
+    /// First-time registration via WAL.
+    Register,
+    /// No heartbeat received within the health-check threshold.
+    HeartbeatTimeout,
+    /// Heartbeat resumed on a previously-timed-out node.
+    HeartbeatRecovered,
+    /// Admin or API explicitly requests a target state.
+    AdminSetState(NodeState),
+    /// Power management suspended the node.
+    PowerSuspend,
+    /// Power management resumed the node.
+    PowerResume,
+}
+
 impl NodeState {
+    /// Centralized transition table. Returns the new state if the transition
+    /// is valid, `None` if the current state should be preserved.
+    ///
+    /// When `admin_locked` is true, auto-recovery (HeartbeatRecovered) is
+    /// suppressed — only an explicit admin action can clear the state.
+    pub fn transition(&self, event: &NodeEvent, admin_locked: bool) -> Option<NodeState> {
+        match (self, event) {
+            // --- Registration ---
+            (NodeState::Unknown, NodeEvent::Register) => Some(NodeState::Idle),
+            (_, NodeEvent::Register) => None,
+
+            // --- Heartbeat liveness (symmetric pair) ---
+            (NodeState::Down | NodeState::Drain, NodeEvent::HeartbeatTimeout) => None,
+            (_, NodeEvent::HeartbeatTimeout) => Some(NodeState::Down),
+
+            (NodeState::Down | NodeState::Error, NodeEvent::HeartbeatRecovered)
+                if !admin_locked =>
+            {
+                Some(NodeState::Idle)
+            }
+            (_, NodeEvent::HeartbeatRecovered) => None,
+
+            // --- Power management ---
+            (_, NodeEvent::PowerSuspend) => Some(NodeState::Suspended),
+            (NodeState::Suspended, NodeEvent::PowerResume) => Some(NodeState::Idle),
+            (_, NodeEvent::PowerResume) => None,
+
+            // --- Admin / API ---
+            (_, NodeEvent::AdminSetState(target)) => Some(*target),
+        }
+    }
+
+    /// Whether this is an operator-managed hold state that allocation-driven
+    /// transitions (Idle/Mixed/Allocated) must not override.
+    pub fn is_admin_hold(&self) -> bool {
+        matches!(
+            self,
+            Self::Down | Self::Drain | Self::Draining | Self::Error | Self::Suspended
+        )
+    }
+
     pub fn display(&self) -> &'static str {
         match self {
             Self::Idle => "idle",
@@ -81,6 +139,12 @@ pub struct Node {
     pub name: String,
     pub state: NodeState,
     pub state_reason: Option<String>,
+    /// When true, the current state was set by an operator (admin API, drain,
+    /// etc.) and auto-recovery is suppressed. Only an explicit admin action
+    /// can clear it. Automatically-set states (heartbeat timeout) leave this
+    /// false so the node can self-heal when the agent reconnects.
+    #[serde(default)]
+    pub admin_locked: bool,
     pub partitions: Vec<String>,
     /// Where this node comes from (bare-metal or K8s).
     #[serde(default)]
@@ -129,6 +193,7 @@ impl Node {
             name,
             state: NodeState::Unknown,
             state_reason: None,
+            admin_locked: false,
             partitions: Vec::new(),
             source: NodeSource::default(),
             total_resources: resources,
@@ -163,13 +228,8 @@ impl Node {
 
     /// Update state based on allocation level.
     pub fn update_state_from_alloc(&mut self) {
-        if self.state == NodeState::Down
-            || self.state == NodeState::Drain
-            || self.state == NodeState::Draining
-            || self.state == NodeState::Error
-            || self.state == NodeState::Suspended
-        {
-            return; // Don't override admin states
+        if self.state.is_admin_hold() {
+            return;
         }
 
         if self.alloc_resources.cpus == 0 && self.alloc_resources.gpus.is_empty() {
@@ -178,6 +238,185 @@ impl Node {
             self.state = NodeState::Allocated;
         } else {
             self.state = NodeState::Mixed;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALL_STATES: &[NodeState] = &[
+        NodeState::Idle,
+        NodeState::Allocated,
+        NodeState::Mixed,
+        NodeState::Down,
+        NodeState::Drain,
+        NodeState::Draining,
+        NodeState::Error,
+        NodeState::Unknown,
+        NodeState::Suspended,
+    ];
+
+    #[test]
+    fn register_from_unknown_yields_idle() {
+        assert_eq!(
+            NodeState::Unknown.transition(&NodeEvent::Register, false),
+            Some(NodeState::Idle),
+        );
+    }
+
+    #[test]
+    fn register_from_non_unknown_is_noop() {
+        for &s in ALL_STATES.iter().filter(|s| **s != NodeState::Unknown) {
+            assert_eq!(
+                s.transition(&NodeEvent::Register, false),
+                None,
+                "from {s:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn heartbeat_recovered_auto_downed() {
+        assert_eq!(
+            NodeState::Down.transition(&NodeEvent::HeartbeatRecovered, false),
+            Some(NodeState::Idle),
+        );
+        assert_eq!(
+            NodeState::Error.transition(&NodeEvent::HeartbeatRecovered, false),
+            Some(NodeState::Idle),
+        );
+    }
+
+    #[test]
+    fn heartbeat_recovered_blocked_by_admin_lock() {
+        assert_eq!(
+            NodeState::Down.transition(&NodeEvent::HeartbeatRecovered, true),
+            None,
+        );
+        assert_eq!(
+            NodeState::Error.transition(&NodeEvent::HeartbeatRecovered, true),
+            None,
+        );
+    }
+
+    #[test]
+    fn heartbeat_recovered_noop_for_live_and_admin_states() {
+        let preserved = [
+            NodeState::Idle,
+            NodeState::Allocated,
+            NodeState::Mixed,
+            NodeState::Drain,
+            NodeState::Draining,
+            NodeState::Suspended,
+            NodeState::Unknown,
+        ];
+        for &s in &preserved {
+            assert_eq!(
+                s.transition(&NodeEvent::HeartbeatRecovered, false),
+                None,
+                "from {s:?}"
+            );
+            assert_eq!(
+                s.transition(&NodeEvent::HeartbeatRecovered, true),
+                None,
+                "from {s:?} (locked)"
+            );
+        }
+    }
+
+    #[test]
+    fn heartbeat_timeout_marks_down() {
+        let should_go_down = [
+            NodeState::Idle,
+            NodeState::Allocated,
+            NodeState::Mixed,
+            NodeState::Draining,
+            NodeState::Error,
+            NodeState::Unknown,
+            NodeState::Suspended,
+        ];
+        for &s in &should_go_down {
+            assert_eq!(
+                s.transition(&NodeEvent::HeartbeatTimeout, false),
+                Some(NodeState::Down),
+                "from {s:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn heartbeat_timeout_noop_for_down_and_drain() {
+        assert_eq!(
+            NodeState::Down.transition(&NodeEvent::HeartbeatTimeout, false),
+            None
+        );
+        assert_eq!(
+            NodeState::Drain.transition(&NodeEvent::HeartbeatTimeout, false),
+            None
+        );
+    }
+
+    #[test]
+    fn admin_can_force_any_state() {
+        for &from in ALL_STATES {
+            for &to in ALL_STATES {
+                assert_eq!(
+                    from.transition(&NodeEvent::AdminSetState(to), false),
+                    Some(to),
+                    "admin {from:?} -> {to:?}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn power_suspend_from_any_state() {
+        for &s in ALL_STATES {
+            assert_eq!(
+                s.transition(&NodeEvent::PowerSuspend, false),
+                Some(NodeState::Suspended),
+                "from {s:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn power_resume_only_from_suspended() {
+        assert_eq!(
+            NodeState::Suspended.transition(&NodeEvent::PowerResume, false),
+            Some(NodeState::Idle),
+        );
+        for &s in ALL_STATES.iter().filter(|s| **s != NodeState::Suspended) {
+            assert_eq!(
+                s.transition(&NodeEvent::PowerResume, false),
+                None,
+                "from {s:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn admin_hold_states() {
+        let holds = [
+            NodeState::Down,
+            NodeState::Drain,
+            NodeState::Draining,
+            NodeState::Error,
+            NodeState::Suspended,
+        ];
+        let non_holds = [
+            NodeState::Idle,
+            NodeState::Allocated,
+            NodeState::Mixed,
+            NodeState::Unknown,
+        ];
+        for &s in &holds {
+            assert!(s.is_admin_hold(), "{s:?} should be admin hold");
+        }
+        for &s in &non_holds {
+            assert!(!s.is_admin_hold(), "{s:?} should not be admin hold");
         }
     }
 }

--- a/crates/spur-core/src/resource.rs
+++ b/crates/spur-core/src/resource.rs
@@ -10,7 +10,7 @@ pub enum GpuLinkType {
 }
 
 /// A single GPU resource.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GpuResource {
     pub device_id: u32,
     pub gpu_type: String,
@@ -20,7 +20,7 @@ pub struct GpuResource {
 }
 
 /// A set of compute resources (node-level or job-level).
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ResourceSet {
     pub cpus: u32,
     pub memory_mb: u64,

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -4,6 +4,10 @@ use crate::job::{JobId, JobSpec, JobState};
 use crate::node::NodeState;
 use crate::resource::ResourceSet;
 
+fn default_port() -> u16 {
+    6818
+}
+
 /// All state-mutating operations that get logged to the Raft log.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum WalOperation {
@@ -38,12 +42,28 @@ pub enum WalOperation {
         name: String,
         resources: ResourceSet,
         address: String,
+        #[serde(default = "default_port")]
+        port: u16,
+        #[serde(default)]
+        wg_pubkey: String,
+        #[serde(default)]
+        version: String,
+    },
+    NodeUpdate {
+        name: String,
+        resources: ResourceSet,
+        address: String,
+        port: u16,
+        wg_pubkey: String,
+        version: String,
     },
     NodeStateChange {
         name: String,
         old_state: NodeState,
         new_state: NodeState,
         reason: Option<String>,
+        #[serde(default)]
+        admin_locked: bool,
     },
     NodeHeartbeat {
         name: String,

--- a/crates/spur-k8s/src/node_watcher.rs
+++ b/crates/spur-k8s/src/node_watcher.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 use std::pin::pin;
 use std::sync::Arc;
 
@@ -10,9 +12,79 @@ use tonic::transport::Channel;
 use tracing::{debug, error, info, warn};
 
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
-use spur_proto::proto::{RegisterAgentRequest, ResourceSet, UpdateNodeRequest};
+use spur_proto::proto::{NodeState, RegisterAgentRequest, ResourceSet, UpdateNodeRequest};
 
 use crate::heartbeat::HeartbeatManager;
+
+/// Tracks the taint state of a K8s node and whether spurctld has been notified.
+/// On every taint transition, `synced` flips to false and the operator retries
+/// until spurctld acknowledges the state change.
+struct NodeTaintState {
+    tainted: bool,
+    synced: bool,
+}
+
+/// Resource fingerprint — purely about compute resources, not health/taints.
+#[derive(Hash, PartialEq, Eq)]
+struct NodeFingerprint {
+    cpus: u32,
+    memory_mb: u64,
+    gpu_count: u32,
+    gpu_type: String,
+    gpu_memory_mb: u64,
+    gpu_link_type: i32,
+}
+
+fn fingerprint(resources: &ResourceSet) -> u64 {
+    let fp = NodeFingerprint {
+        cpus: resources.cpus,
+        memory_mb: resources.memory_mb,
+        gpu_count: resources.gpus.len() as u32,
+        gpu_type: resources
+            .gpus
+            .first()
+            .map(|g| g.gpu_type.clone())
+            .unwrap_or_default(),
+        gpu_memory_mb: resources.gpus.first().map(|g| g.memory_mb).unwrap_or(0),
+        gpu_link_type: resources.gpus.first().map(|g| g.link_type).unwrap_or(0),
+    };
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    fp.hash(&mut hasher);
+    hasher.finish()
+}
+
+async fn sync_taint_state(
+    name: &str,
+    entry: &mut NodeTaintState,
+    client: &mut SlurmControllerClient<Channel>,
+) {
+    let (state, reason) = if entry.tainted {
+        (NodeState::NodeDown as i32, Some("K8s node NotReady".into()))
+    } else {
+        (NodeState::NodeIdle as i32, None)
+    };
+
+    let req = UpdateNodeRequest {
+        name: name.into(),
+        state: Some(state),
+        reason,
+    };
+
+    match client.update_node(req).await {
+        Ok(_) => {
+            entry.synced = true;
+            if entry.tainted {
+                warn!(node = %name, "K8s node marked DOWN (NotReady taint)");
+            } else {
+                info!(node = %name, "K8s node resumed (NotReady taint removed)");
+            }
+        }
+        Err(e) => {
+            let action = if entry.tainted { "mark DOWN" } else { "resume" };
+            error!(node = %name, error = %e, "failed to {action}, will retry");
+        }
+    }
+}
 
 /// Watch K8s nodes matching `label_selector`, register them with spurctld, and
 /// keep `hb` in sync so the heartbeat task knows which nodes to ping.
@@ -29,6 +101,8 @@ pub async fn run(
     info!(selector = %label_selector, "starting K8s node watcher");
 
     let mut ctrl_client = connect_controller(&controller_addr).await?;
+    let mut fingerprints: HashMap<String, u64> = HashMap::new();
+    let mut taint_states: HashMap<String, NodeTaintState> = HashMap::new();
 
     let stream = watcher::watcher(nodes, watcher::Config::default().labels(&label_selector));
     let mut stream = pin!(stream);
@@ -37,51 +111,60 @@ pub async fn run(
         match event {
             Event::Apply(node) | Event::InitApply(node) => {
                 let name = node.metadata.name.clone().unwrap_or_default();
-
-                // Check if node is not-ready via taints
-                if is_node_not_ready(&node) {
-                    warn!(node = %name, "K8s node has NotReady taint, marking DOWN");
-                    hb.untrack(&name).await;
-                    let req = UpdateNodeRequest {
-                        name: name.clone(),
-                        state: Some(3), // NODE_DOWN
-                        reason: Some("K8s node NotReady".into()),
-                    };
-                    if let Err(e) = ctrl_client.update_node(req).await {
-                        error!(node = %name, error = %e, "failed to mark node DOWN");
-                    }
-                    continue;
-                }
-
+                let tainted = is_node_not_ready(&node);
                 let resources = extract_resources(&node);
 
-                info!(node = %name, cpus = resources.cpus, memory_mb = resources.memory_mb, gpus = resources.gpus.len(), "registering K8s node");
+                let fp = fingerprint(&resources);
 
-                let req = RegisterAgentRequest {
-                    hostname: name.clone(),
-                    resources: Some(resources),
-                    version: "spur-k8s-operator".into(),
-                    address: operator_grpc_addr.clone(),
-                    port: operator_grpc_port,
-                    wg_pubkey: String::new(),
-                };
+                if fingerprints.get(&name) != Some(&fp) {
+                    fingerprints.insert(name.clone(), fp);
 
-                match ctrl_client.register_agent(req.clone()).await {
-                    Ok(_) => {
-                        debug!(node = %name, "K8s node registered with spurctld");
-                        hb.track(name, req).await;
+                    info!(node = %name, cpus = resources.cpus, memory_mb = resources.memory_mb, gpus = resources.gpus.len(), "registering K8s node");
+
+                    let req = RegisterAgentRequest {
+                        hostname: name.clone(),
+                        resources: Some(resources),
+                        version: "spur-k8s-operator".into(),
+                        address: operator_grpc_addr.clone(),
+                        port: operator_grpc_port,
+                        wg_pubkey: String::new(),
+                    };
+
+                    match ctrl_client.register_agent(req.clone()).await {
+                        Ok(_) => {
+                            debug!(node = %name, "K8s node registered with spurctld");
+                            hb.track(name.clone(), req).await;
+                        }
+                        Err(e) => {
+                            error!(node = %name, error = %e, "failed to register K8s node")
+                        }
                     }
-                    Err(e) => error!(node = %name, error = %e, "failed to register K8s node"),
+                }
+
+                let entry = taint_states.entry(name.clone()).or_insert(NodeTaintState {
+                    tainted,
+                    synced: false,
+                });
+
+                if entry.tainted != tainted {
+                    entry.tainted = tainted;
+                    entry.synced = false;
+                }
+
+                if !entry.synced {
+                    sync_taint_state(&name, entry, &mut ctrl_client).await;
                 }
             }
             Event::Delete(node) => {
                 let name = node.metadata.name.clone().unwrap_or_default();
                 warn!(node = %name, "K8s node deleted, marking DOWN");
+                fingerprints.remove(&name);
+                taint_states.remove(&name);
                 hb.untrack(&name).await;
 
                 let req = UpdateNodeRequest {
                     name: name.clone(),
-                    state: Some(3), // NODE_DOWN
+                    state: Some(NodeState::NodeDown as i32),
                     reason: Some("K8s node removed".into()),
                 };
 
@@ -612,5 +695,58 @@ mod tests {
         assert_eq!(res.gpus[0].gpu_type, "mi250x");
         assert_eq!(res.gpus[0].memory_mb, 131072);
         assert_eq!(res.gpus[0].link_type, 1);
+    }
+
+    // --- Fingerprint tests ---
+
+    fn make_resources(cpus: u32, mem: u64, gpu_count: u32) -> ResourceSet {
+        let gpus: Vec<spur_proto::proto::GpuResource> = (0..gpu_count)
+            .map(|i| spur_proto::proto::GpuResource {
+                device_id: i,
+                gpu_type: "mi300x".into(),
+                memory_mb: 196608,
+                peer_gpus: vec![],
+                link_type: 1,
+            })
+            .collect();
+        ResourceSet {
+            cpus,
+            memory_mb: mem,
+            gpus,
+            generic: Default::default(),
+        }
+    }
+
+    #[test]
+    fn fingerprint_same_input_same_hash() {
+        let r = make_resources(64, 262144, 8);
+        assert_eq!(fingerprint(&r), fingerprint(&r));
+    }
+
+    #[test]
+    fn fingerprint_different_cpus() {
+        let r1 = make_resources(64, 262144, 8);
+        let r2 = make_resources(32, 262144, 8);
+        assert_ne!(fingerprint(&r1), fingerprint(&r2));
+    }
+
+    #[test]
+    fn fingerprint_different_memory() {
+        let r1 = make_resources(64, 262144, 8);
+        let r2 = make_resources(64, 131072, 8);
+        assert_ne!(fingerprint(&r1), fingerprint(&r2));
+    }
+
+    #[test]
+    fn fingerprint_different_gpu_count() {
+        let r1 = make_resources(64, 262144, 8);
+        let r2 = make_resources(64, 262144, 4);
+        assert_ne!(fingerprint(&r1), fingerprint(&r2));
+    }
+
+    #[test]
+    fn fingerprint_no_gpus() {
+        let r = make_resources(4, 8000, 0);
+        assert_eq!(fingerprint(&r), fingerprint(&r));
     }
 }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2,14 +2,14 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::atomic::{AtomicU32, Ordering};
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use parking_lot::RwLock;
 use tracing::{debug, info, warn};
 
 use spur_core::accounting::{Qos, TresRecord, TresType};
 use spur_core::config::SlurmConfig;
 use spur_core::job::{Job, JobId, JobSpec, JobState, PendingReason};
-use spur_core::node::{Node, NodeSource, NodeState};
+use spur_core::node::{Node, NodeEvent, NodeSource, NodeState};
 use spur_core::partition::Partition;
 use spur_core::qos::{check_qos_limits, QosCheckResult};
 use spur_core::reservation::Reservation;
@@ -507,71 +507,45 @@ impl ClusterManager {
             }
         };
 
-        // Issue #70: If node is already registered, update its connection
-        // info and resources but PRESERVE its current state and allocations.
-        // The K8s node watcher re-registers nodes on every Apply event, which
-        // was resetting Allocated/Mixed nodes back to Idle.
-        //
-        // Issue #95: Exception — if a node is Down due to heartbeat timeout
-        // ("Not responding"), re-registration means the agent came back.
-        // Recover it to Idle so it can accept jobs again.
-        {
-            let mut nodes = self.nodes.write();
-            if let Some(existing) = nodes.get_mut(&effective_name) {
-                // Update connection info and resources, keep state + allocations
-                existing.total_resources = resources.clone();
-                existing.address = Some(address.clone());
-                existing.port = port;
-                existing.source = source;
-                if !wg_pubkey.is_empty() {
-                    existing.wg_pubkey = Some(wg_pubkey);
-                }
-                existing.version = Some(version);
-                existing.last_heartbeat = Some(Utc::now());
+        let action = {
+            let nodes = self.nodes.read();
+            evaluate_registration(nodes.get(&effective_name), &resources)
+        };
 
-                // Auto-recover from heartbeat-timeout Down state
-                if existing.state == NodeState::Down {
-                    let is_auto_down = existing
-                        .state_reason
-                        .as_deref()
-                        .map(|r| r == "Not responding")
-                        .unwrap_or(false);
-                    if is_auto_down {
-                        info!(
-                            node = %effective_name,
-                            "node re-registered after heartbeat timeout — recovering to Idle"
-                        );
-                        existing.state = NodeState::Idle;
-                        existing.state_reason = None;
-                    } else {
-                        debug!(node = %effective_name, state = ?existing.state, "node re-registered (admin Down preserved)");
-                    }
-                } else {
-                    debug!(node = %effective_name, state = ?existing.state, "node re-registered (state preserved)");
+        match action {
+            RegistrationAction::Skip => {
+                debug!(node = %effective_name, "node unchanged, skipping");
+            }
+            RegistrationAction::Update => {
+                self.propose(WalOperation::NodeUpdate {
+                    name: effective_name.clone(),
+                    resources,
+                    address,
+                    port,
+                    wg_pubkey,
+                    version,
+                });
+                if let Some(node) = self.nodes.write().get_mut(&effective_name) {
+                    node.source = source;
                 }
-                return;
+                info!(node = %effective_name, "node updated (resources changed)");
+            }
+            RegistrationAction::Register => {
+                self.propose(WalOperation::NodeRegister {
+                    name: effective_name.clone(),
+                    resources,
+                    address,
+                    port,
+                    wg_pubkey,
+                    version,
+                });
+                if let Some(node) = self.nodes.write().get_mut(&effective_name) {
+                    node.source = source;
+                    node.agent_start_time = Some(Utc::now());
+                }
+                info!(node = %effective_name, "node registered");
             }
         }
-
-        self.propose(WalOperation::NodeRegister {
-            name: effective_name.clone(),
-            resources,
-            address,
-        });
-
-        // Set ephemeral connection info not tracked by the WAL
-        if let Some(node) = self.nodes.write().get_mut(&effective_name) {
-            node.port = port;
-            node.source = source;
-            if !wg_pubkey.is_empty() {
-                node.wg_pubkey = Some(wg_pubkey);
-            }
-            node.version = Some(version);
-            node.agent_start_time = Some(Utc::now());
-            node.last_heartbeat = Some(Utc::now());
-        }
-
-        info!(node = %effective_name, "node registered");
     }
 
     /// Update node heartbeat data.
@@ -756,55 +730,75 @@ impl ClusterManager {
                 .get(name)
                 .ok_or_else(|| anyhow::anyhow!("node {} not found", name))?;
             let old = node.state;
-            let effective = if state == NodeState::Drain
+            let requested = old
+                .transition(&NodeEvent::AdminSetState(state), node.admin_locked)
+                .unwrap_or(state);
+            // Drain with active allocations becomes Draining
+            let effective = if requested == NodeState::Drain
                 && (node.alloc_resources.cpus > 0 || !node.alloc_resources.gpus.is_empty())
             {
                 NodeState::Draining
             } else {
-                state
+                requested
             };
             (old, effective)
         };
+
+        // Admin-initiated state changes that move into a hold state are
+        // locked so auto-recovery won't override the operator's intent.
+        // Resuming to Idle clears the lock.
+        let admin_locked = effective_state.is_admin_hold();
 
         self.propose(WalOperation::NodeStateChange {
             name: name.to_string(),
             old_state,
             new_state: effective_state,
             reason,
+            admin_locked,
         });
         info!(node = %name, old = ?old_state, new = ?effective_state, "node state updated");
         Ok(())
     }
 
-    /// Check for stale nodes (no heartbeat within timeout) and mark them DOWN.
+    /// Reconcile node liveness state with heartbeat data.
+    /// Marks stale nodes Down and recovers nodes whose heartbeat has resumed.
     pub fn check_node_health(&self, timeout_secs: u64) {
-        let now = Utc::now();
-        let threshold = chrono::Duration::seconds(timeout_secs as i64);
-
-        // Collect nodes that need to be marked DOWN (avoid holding write lock across propose)
-        let stale_nodes: Vec<(String, NodeState)> = {
+        let actions = {
             let nodes = self.nodes.read();
-            nodes
-                .values()
-                .filter(|n| {
-                    n.state != NodeState::Down
-                        && n.state != NodeState::Drain
-                        && n.last_heartbeat
-                            .map(|hb| now - hb > threshold)
-                            .unwrap_or(false)
-                })
-                .map(|n| (n.name.clone(), n.state))
-                .collect()
+            let refs: Vec<&Node> = nodes.values().collect();
+            evaluate_node_health(&refs, Utc::now(), timeout_secs)
         };
+        self.apply_health_actions(actions);
+    }
 
-        for (name, old_state) in stale_nodes {
-            warn!(node = %name, "node marked DOWN (heartbeat timeout)");
-            self.propose(WalOperation::NodeStateChange {
-                name,
-                old_state,
-                new_state: NodeState::Down,
-                reason: Some("Not responding".into()),
-            });
+    fn apply_health_actions(&self, actions: Vec<HealthAction>) {
+        for action in actions {
+            match action {
+                HealthAction::MarkDown {
+                    name,
+                    old_state,
+                    admin_locked,
+                } => {
+                    warn!(node = %name, "node marked DOWN (heartbeat timeout)");
+                    self.propose(WalOperation::NodeStateChange {
+                        name,
+                        old_state,
+                        new_state: NodeState::Down,
+                        reason: Some("Not responding".into()),
+                        admin_locked,
+                    });
+                }
+                HealthAction::Recover { name, old_state } => {
+                    info!(node = %name, "node recovered (heartbeat resumed)");
+                    self.propose(WalOperation::NodeStateChange {
+                        name,
+                        old_state,
+                        new_state: NodeState::Idle,
+                        reason: None,
+                        admin_locked: false,
+                    });
+                }
+            }
         }
     }
 
@@ -1490,10 +1484,24 @@ impl ClusterManager {
                 name,
                 resources,
                 address,
+                port,
+                wg_pubkey,
+                version,
             } => {
                 let mut node = Node::new(name.clone(), resources.clone());
                 node.address = Some(address.clone());
-                node.state = NodeState::Idle;
+                node.port = *port;
+                if !wg_pubkey.is_empty() {
+                    node.wg_pubkey = Some(wg_pubkey.clone());
+                }
+                if !version.is_empty() {
+                    node.version = Some(version.clone());
+                }
+                node.last_heartbeat = Some(Utc::now());
+                node.state = node
+                    .state
+                    .transition(&NodeEvent::Register, false)
+                    .unwrap_or(NodeState::Idle);
 
                 // Assign partitions from config
                 drop(nodes);
@@ -1529,15 +1537,38 @@ impl ClusterManager {
                 self.next_job_id.store(next_id, Ordering::Relaxed);
                 return;
             }
+            WalOperation::NodeUpdate {
+                name,
+                resources,
+                address,
+                port,
+                wg_pubkey,
+                version,
+            } => {
+                if let Some(node) = nodes.get_mut(name) {
+                    node.total_resources = resources.clone();
+                    node.address = Some(address.clone());
+                    node.port = *port;
+                    if !wg_pubkey.is_empty() {
+                        node.wg_pubkey = Some(wg_pubkey.clone());
+                    }
+                    if !version.is_empty() {
+                        node.version = Some(version.clone());
+                    }
+                    node.last_heartbeat = Some(Utc::now());
+                }
+            }
             WalOperation::NodeStateChange {
                 name,
                 new_state,
                 reason,
+                admin_locked,
                 ..
             } => {
                 if let Some(node) = nodes.get_mut(name) {
                     node.state = *new_state;
                     node.state_reason = reason.clone();
+                    node.admin_locked = *admin_locked;
                 }
             }
             WalOperation::NodeHeartbeat {
@@ -1634,6 +1665,77 @@ fn extract_license_requirements(spec: &JobSpec) -> HashMap<String, u64> {
         }
     }
     licenses
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum RegistrationAction {
+    Skip,
+    Update,
+    Register,
+}
+
+pub(crate) fn evaluate_registration(
+    existing: Option<&Node>,
+    incoming_resources: &ResourceSet,
+) -> RegistrationAction {
+    match existing {
+        None => RegistrationAction::Register,
+        Some(node) if node.total_resources != *incoming_resources => RegistrationAction::Update,
+        Some(_) => RegistrationAction::Skip,
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum HealthAction {
+    MarkDown {
+        name: String,
+        old_state: NodeState,
+        admin_locked: bool,
+    },
+    Recover {
+        name: String,
+        old_state: NodeState,
+    },
+}
+
+pub(crate) fn evaluate_node_health(
+    nodes: &[&Node],
+    now: DateTime<Utc>,
+    timeout_secs: u64,
+) -> Vec<HealthAction> {
+    let threshold = chrono::Duration::seconds(timeout_secs as i64);
+    let mut actions = Vec::new();
+
+    for node in nodes {
+        let Some(hb) = node.last_heartbeat else {
+            continue;
+        };
+        let stale = now - hb > threshold;
+
+        if stale {
+            if node
+                .state
+                .transition(&NodeEvent::HeartbeatTimeout, node.admin_locked)
+                .is_some()
+            {
+                actions.push(HealthAction::MarkDown {
+                    name: node.name.clone(),
+                    old_state: node.state,
+                    admin_locked: node.admin_locked,
+                });
+            }
+        } else if node
+            .state
+            .transition(&NodeEvent::HeartbeatRecovered, node.admin_locked)
+            .is_some()
+        {
+            actions.push(HealthAction::Recover {
+                name: node.name.clone(),
+                old_state: node.state,
+            });
+        }
+    }
+    actions
 }
 
 #[cfg(test)]
@@ -1883,6 +1985,9 @@ mod tests {
                 ..Default::default()
             },
             address: "10.0.0.1".into(),
+            port: 6818,
+            wg_pubkey: String::new(),
+            version: "1.0".into(),
         });
 
         let node = cm.get_node("gpu-node").unwrap();
@@ -1908,6 +2013,7 @@ mod tests {
             old_state: NodeState::Idle,
             new_state: NodeState::Drain,
             reason: Some("maintenance".into()),
+            admin_locked: true,
         });
 
         let node = cm.get_node("n1").unwrap();
@@ -2134,6 +2240,109 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn admin_drained_node_stays_locked_through_timeout_and_reregister() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "locked", 4, 8000);
+
+        // Give the node an allocation so Drain becomes Draining
+        let id = submit_and_wait(&cm, basic_spec("hold-job"));
+        cm.start_job(
+            id,
+            vec!["locked".into()],
+            ResourceSet {
+                cpus: 2,
+                memory_mb: 4000,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        settle(&cm, id, JobState::Running);
+
+        // Admin drains while job is running — becomes Draining (admin_locked)
+        cm.update_node_state("locked", NodeState::Drain, Some("hw swap".into()))
+            .unwrap();
+        wait_for("draining applied", || {
+            cm.get_node("locked")
+                .map_or(false, |n| n.state == NodeState::Draining)
+        });
+        assert!(cm.get_node("locked").unwrap().admin_locked);
+
+        // Heartbeat times out — Draining → Down, admin_locked preserved
+        if let Some(node) = cm.nodes.write().get_mut("locked") {
+            node.last_heartbeat = Some(Utc::now() - chrono::Duration::seconds(200));
+        }
+        cm.check_node_health(90);
+        wait_for("health check applied", || {
+            cm.get_node("locked")
+                .map_or(false, |n| n.state == NodeState::Down)
+        });
+        let node = cm.get_node("locked").unwrap();
+        assert_eq!(node.state, NodeState::Down);
+        assert!(
+            node.admin_locked,
+            "admin lock must survive heartbeat timeout"
+        );
+
+        // Agent reconnects — re-registration must NOT recover to Idle
+        cm.register_node(
+            "locked".into(),
+            ResourceSet {
+                cpus: 4,
+                memory_mb: 8000,
+                ..Default::default()
+            },
+            "127.0.0.1".into(),
+            6818,
+            String::new(),
+            "1.0".into(),
+            NodeSource::BareMetal,
+        );
+        let node = cm.get_node("locked").unwrap();
+        assert_eq!(
+            node.state,
+            NodeState::Down,
+            "admin-locked node must not auto-recover"
+        );
+        assert!(node.admin_locked);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn auto_downed_node_recovers_via_health_check() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "auto", 4, 8000);
+
+        // Heartbeat timeout — auto Down, admin_locked = false
+        if let Some(node) = cm.nodes.write().get_mut("auto") {
+            node.last_heartbeat = Some(Utc::now() - chrono::Duration::seconds(200));
+        }
+        cm.check_node_health(90);
+        wait_for("health check applied", || {
+            cm.get_node("auto")
+                .map_or(false, |n| n.state == NodeState::Down)
+        });
+        let node = cm.get_node("auto").unwrap();
+        assert!(!node.admin_locked, "auto-downed must not be admin_locked");
+
+        // Agent heartbeat resumes — refresh last_heartbeat
+        cm.update_heartbeat("auto", 50, 4000);
+
+        // Next health check cycle detects fresh heartbeat → recovers to Idle
+        cm.check_node_health(90);
+        wait_for("recovery applied", || {
+            cm.get_node("auto")
+                .map_or(false, |n| n.state == NodeState::Idle)
+        });
+        let node = cm.get_node("auto").unwrap();
+        assert_eq!(
+            node.state,
+            NodeState::Idle,
+            "auto-downed node must recover via health check"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn requeue_resets_fields_via_apply() {
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
@@ -2193,5 +2402,187 @@ mod tests {
         let node = cm.get_node("test-node").unwrap();
         assert!(!node.partitions.is_empty());
         assert_eq!(node.partitions[0], "default");
+    }
+
+    // --- Pure evaluate_node_health tests (no Raft needed) ---
+
+    fn make_health_node(
+        name: &str,
+        state: NodeState,
+        admin_locked: bool,
+        last_hb: Option<chrono::DateTime<Utc>>,
+    ) -> Node {
+        let mut node = Node::new(name.into(), ResourceSet::default());
+        node.state = state;
+        node.admin_locked = admin_locked;
+        node.last_heartbeat = last_hb;
+        node
+    }
+
+    #[test]
+    fn health_stale_idle_marks_down() {
+        let node = make_health_node(
+            "n1",
+            NodeState::Idle,
+            false,
+            Some(Utc::now() - chrono::Duration::seconds(200)),
+        );
+        let actions = super::evaluate_node_health(&[&node], Utc::now(), 90);
+        assert_eq!(
+            actions,
+            vec![super::HealthAction::MarkDown {
+                name: "n1".into(),
+                old_state: NodeState::Idle,
+                admin_locked: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn health_fresh_down_recovers() {
+        let node = make_health_node(
+            "n1",
+            NodeState::Down,
+            false,
+            Some(Utc::now() - chrono::Duration::seconds(10)),
+        );
+        let actions = super::evaluate_node_health(&[&node], Utc::now(), 90);
+        assert_eq!(
+            actions,
+            vec![super::HealthAction::Recover {
+                name: "n1".into(),
+                old_state: NodeState::Down,
+            }]
+        );
+    }
+
+    #[test]
+    fn health_admin_locked_down_no_recovery() {
+        let node = make_health_node(
+            "n1",
+            NodeState::Down,
+            true,
+            Some(Utc::now() - chrono::Duration::seconds(10)),
+        );
+        let actions = super::evaluate_node_health(&[&node], Utc::now(), 90);
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn health_drain_not_marked_down() {
+        let node = make_health_node(
+            "n1",
+            NodeState::Drain,
+            true,
+            Some(Utc::now() - chrono::Duration::seconds(200)),
+        );
+        let actions = super::evaluate_node_health(&[&node], Utc::now(), 90);
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn health_idle_fresh_no_action() {
+        let node = make_health_node(
+            "n1",
+            NodeState::Idle,
+            false,
+            Some(Utc::now() - chrono::Duration::seconds(10)),
+        );
+        let actions = super::evaluate_node_health(&[&node], Utc::now(), 90);
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn health_no_heartbeat_skipped() {
+        let node = make_health_node("n1", NodeState::Idle, false, None);
+        let actions = super::evaluate_node_health(&[&node], Utc::now(), 90);
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn health_mixed_actions() {
+        let stale = make_health_node(
+            "stale",
+            NodeState::Idle,
+            false,
+            Some(Utc::now() - chrono::Duration::seconds(200)),
+        );
+        let recovering = make_health_node(
+            "back",
+            NodeState::Down,
+            false,
+            Some(Utc::now() - chrono::Duration::seconds(10)),
+        );
+        let stable = make_health_node(
+            "ok",
+            NodeState::Idle,
+            false,
+            Some(Utc::now() - chrono::Duration::seconds(10)),
+        );
+        let actions = super::evaluate_node_health(&[&stale, &recovering, &stable], Utc::now(), 90);
+        assert_eq!(actions.len(), 2);
+        assert_eq!(
+            actions[0],
+            super::HealthAction::MarkDown {
+                name: "stale".into(),
+                old_state: NodeState::Idle,
+                admin_locked: false,
+            }
+        );
+        assert_eq!(
+            actions[1],
+            super::HealthAction::Recover {
+                name: "back".into(),
+                old_state: NodeState::Down,
+            }
+        );
+    }
+
+    // --- Pure evaluate_registration tests ---
+
+    #[test]
+    fn registration_new_node() {
+        let resources = ResourceSet {
+            cpus: 4,
+            memory_mb: 8000,
+            ..Default::default()
+        };
+        assert_eq!(
+            super::evaluate_registration(None, &resources),
+            super::RegistrationAction::Register,
+        );
+    }
+
+    #[test]
+    fn registration_unchanged_skip() {
+        let resources = ResourceSet {
+            cpus: 4,
+            memory_mb: 8000,
+            ..Default::default()
+        };
+        let node = Node::new("n1".into(), resources.clone());
+        assert_eq!(
+            super::evaluate_registration(Some(&node), &resources),
+            super::RegistrationAction::Skip,
+        );
+    }
+
+    #[test]
+    fn registration_resources_changed_update() {
+        let old = ResourceSet {
+            cpus: 4,
+            memory_mb: 8000,
+            ..Default::default()
+        };
+        let new = ResourceSet {
+            cpus: 8,
+            memory_mb: 16000,
+            ..Default::default()
+        };
+        let node = Node::new("n1".into(), old);
+        assert_eq!(
+            super::evaluate_registration(Some(&node), &new),
+            super::RegistrationAction::Update,
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Introduces a centralized `NodeState::transition()` function as the single source of truth for all node state transitions, replacing scattered `if` checks across the codebase.
- Adds `admin_locked` flag to `Node` to distinguish operator-set states (require explicit resume) from auto-detected states (heartbeat timeout), enabling safe auto-recovery.
- Decouples registration from liveness — `register_node` only handles identity and resources, `check_node_health` handles both directions (timeout → Down, heartbeat resumed → Idle), all Raft-replicated.
- Adds `NodeUpdate` WAL operation for resource changes and expands `NodeRegister` to be self-contained.
- Adds hash-based fingerprint dedup in the K8s node watcher, eliminating redundant `register_agent` RPCs from label/condition churn.
- Adds symmetric taint handling — operator now explicitly resumes nodes via `update_node(IDLE)` when NotReady taint is removed, with retry tracking.

Fixes #95. Supersedes #97.

## Test plan

- [x] 870 unit/integration tests passing
- [x] Pure `evaluate_node_health` tests cover all (state, heartbeat, admin_locked) combinations
- [x] Pure `evaluate_registration` tests cover skip/update/register paths
- [x] Fingerprint hash tests verify dedup correctness
- [x] Integration tests verify admin-locked nodes don't auto-recover and auto-downed nodes do
- [x] Deployed on test cluster — verified heartbeat timeout → Down → auto-recovery → Idle flow end-to-end
- [x] Verified K8s fingerprint dedup eliminates steady-state registration noise