### PR TITLE
Add PID + mount namespace isolation with GPU device restriction (#99 PR 2/6)

### DIFF
--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -34,6 +34,8 @@ struct TrackedJob {
     stdout_path: String,
     /// Stderr path for output streaming.
     stderr_path: String,
+    /// Whether this job has a PID namespace (for nsenter flags).
+    has_pid_namespace: bool,
 }
 
 pub struct AgentService {
@@ -615,6 +617,7 @@ impl SlurmAgent for AgentService {
                         allocation: alloc_result,
                         stdout_path,
                         stderr_path,
+                        has_pid_namespace: nix::unistd::geteuid().is_root(),
                     },
                 );
                 info!(job_id, gpus = ?gpu_devices, "job launched successfully");
@@ -721,9 +724,19 @@ impl SlurmAgent for AgentService {
             "exec into running job"
         );
 
-        // Use nsenter to enter the job's mount namespace and run the command
+        // Use nsenter to enter the job's namespace(s) and run the command
+        let has_pid_ns = {
+            let jobs = self.running.lock().await;
+            jobs.get(&req.job_id)
+                .map(|j| j.has_pid_namespace)
+                .unwrap_or(false)
+        };
         let mut cmd = tokio::process::Command::new("nsenter");
-        cmd.args(["--target", &pid.to_string(), "--mount", "--"]);
+        cmd.arg("--target").arg(pid.to_string()).arg("--mount");
+        if has_pid_ns {
+            cmd.arg("--pid");
+        }
+        cmd.arg("--");
         cmd.arg(&req.command[0]);
         for arg in &req.command[1..] {
             cmd.arg(arg);

--- a/crates/spurd/src/container.rs
+++ b/crates/spurd/src/container.rs
@@ -441,7 +441,7 @@ mkdir -p {rootfs}{home}
     script.push_str(&format!(
         r#"
 if [ "$(id -u)" = "0" ]; then
-  exec unshare --mount bash -c '
+  exec unshare --mount --pid --fork bash -c '
 set -e
 ROOTFS="{rootfs}"
 

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -272,9 +272,53 @@ pub async fn launch_job(
     env.insert("VECLIB_MAXIMUM_THREADS".into(), cpus.to_string());
     env.insert("NUMEXPR_NUM_THREADS".into(), cpus.to_string());
 
+    // Issue #99: If root, wrap job with namespace isolation.
+    let use_namespaces = nix::unistd::geteuid().is_root();
+    let (launch_cmd, launch_args) = if use_namespaces {
+        let wrapper_path = PathBuf::from(work_dir).join(format!(".spur_ns_{}.sh", job_id));
+        let gpu_mounts = gpu_devices
+            .iter()
+            .map(|id| {
+                format!(
+                    "if [ -e /host_dev/dri/renderD{r} ]; then\n  touch /dev/dri/renderD{r}\n  mount --bind /host_dev/dri/renderD{r} /dev/dri/renderD{r}\nfi\n",
+                    r = 128 + id,
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("");
+
+        let wrapper = format!(
+            "#!/bin/bash\nset -e\nmount -t proc proc /proc 2>/dev/null || true\nmount -t tmpfs tmpfs /tmp 2>/dev/null || true\nmount -t tmpfs tmpfs /dev/shm 2>/dev/null || true\nif [ -d /dev/dri ]; then\n  mkdir -p /host_dev/dri\n  mount --bind /dev/dri /host_dev/dri 2>/dev/null || true\n  mount -t tmpfs tmpfs /dev/dri 2>/dev/null || true\n  mkdir -p /dev/dri\n{gpu_mounts}fi\nexec /bin/bash {script}\n",
+            gpu_mounts = gpu_mounts,
+            script = script_path.display(),
+        );
+        tokio::fs::write(&wrapper_path, &wrapper).await?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&wrapper_path, std::fs::Permissions::from_mode(0o755))?;
+        }
+        debug!(job_id, "namespace isolation wrapper created");
+        (
+            "/usr/bin/unshare".to_string(),
+            vec![
+                "--pid".into(),
+                "--mount".into(),
+                "--fork".into(),
+                "/bin/bash".into(),
+                wrapper_path.to_string_lossy().to_string(),
+            ],
+        )
+    } else {
+        (
+            "/bin/bash".to_string(),
+            vec![script_path.to_string_lossy().to_string()],
+        )
+    };
+
     // Launch the process
-    let mut cmd = Command::new("/bin/bash");
-    cmd.arg(&script_path)
+    let mut cmd = Command::new(&launch_cmd);
+    cmd.args(&launch_args)
         .current_dir(work_dir)
         .envs(&env)
         .stdout(stdout_file.into_std().await)
@@ -282,7 +326,6 @@ pub async fn launch_job(
         .stdin(Stdio::null());
 
     // Issue #99: Run job as the submitting user (not root).
-    // Requires spurd to run as root. Non-root spurd skips setuid.
     if uid > 0 && nix::unistd::geteuid().is_root() {
         use std::os::unix::process::CommandExt;
         cmd.uid(uid);


### PR DESCRIPTION
## Summary
Second PR in the isolation series (#99). Adds PID and mount namespace isolation for both bare-metal and container execution paths.

## Changes
- **PID namespace**: `unshare --pid --fork` — jobs see only their own processes
- **Mount namespace**: Private `/tmp`, `/dev/shm` per job; GPU `/dev/dri` restricted to allocated devices via selective bind-mount
- **Container path**: Added `--pid --fork` to existing `unshare --mount` in container.rs
- **Bare-metal path**: New namespace wrapper script in executor.rs
- **TrackedJob**: `has_pid_namespace` flag for correct nsenter behavior in exec_in_job

## GPU access verification
- Only allocated `renderD*` devices bind-mounted into private `/dev/dri`
- `/dev/kfd` preserved for AMD GPU access
- Unallocated GPU devices not visible in job's mount namespace

## Addresses
- spur-cloud #5 (process visibility)
- spur-cloud #11 (who shows host info)
- spur-cloud #4, #7 (partial — private /tmp prevents shared state)

## Test plan
- [ ] Job with PID namespace: `ps aux` shows only job processes (not host)
- [ ] Job with mount namespace: `ls /tmp` is empty (private tmpfs, not host)
- [ ] GPU device restriction: `ls /dev/dri/` inside 1-GPU job shows only 1 renderD device
- [ ] **GPU access after setuid** (per @shiv-tyagi): non-root user with `video`/`render` group can access `/dev/kfd` and `/dev/dri/renderD*`. PR #100 needs `initgroups()` to inherit supplementary groups — without it, setuid to a non-root UID loses `video`/`render` group membership and GPU device access fails with EACCES.
- [ ] Attach to namespaced job: `nsenter --mount --pid` enters correct namespaces
- [ ] Container path: `ps aux` inside container shows only container processes
- [ ] `who` command inside job: only shows current session (not host users)
- [ ] rocm-smi inside namespaced job: shows only allocated GPU
- [ ] HIP runtime test: `hipGetDeviceCount` returns correct count inside namespace
- [x] Full test suite passes (0 failures)

## Note on supplementary groups
As @shiv-tyagi pointed out, `Command::uid().gid()` sets primary UID/GID but does NOT set supplementary groups. GPU devices are typically `root:video` or `root:render`. PR #100 (setuid PR) needs to call `initgroups(username, gid)` in `pre_exec` to ensure the job process inherits `video`, `render`, and other groups. Without this, GPU access will fail for non-root users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)