### PR TITLE
Add [isolation] config section for job isolation layers (#99 PR 5/6)

### DIFF
--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -65,6 +65,10 @@ pub struct SlurmConfig {
     #[serde(default)]
     pub topology: Option<crate::topology::TopologyConfig>,
 
+    /// Job isolation configuration.
+    #[serde(default)]
+    pub isolation: IsolationConfig,
+
     /// Cluster-wide license pool, e.g., {"fluent": 20, "comsol": 5}.
     #[serde(default)]
     pub licenses: HashMap<String, u64>,
@@ -400,6 +404,50 @@ pub struct NotificationConfig {
     pub smtp_command: Option<String>,
     /// From address for notification emails, e.g., "spur@cluster.local".
     pub from_address: Option<String>,
+}
+
+/// Job isolation configuration for bare-metal and container jobs.
+///
+/// Each layer operates independently and degrades gracefully when the
+/// kernel doesn't support it or spurd isn't running as root.
+///
+/// Example:
+/// ```toml
+/// [isolation]
+/// setuid = true       # Run jobs as submitting user (requires root)
+/// namespaces = true   # PID + mount namespace isolation
+/// seccomp = true      # syscall whitelist (blocks ptrace, mount, bpf)
+/// landlock = true     # filesystem access control (kernel 5.13+)
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IsolationConfig {
+    /// Run jobs as the submitting user's UID/GID (requires root spurd).
+    #[serde(default = "default_true_fn")]
+    pub setuid: bool,
+    /// PID + mount namespace isolation (requires root).
+    #[serde(default = "default_true_fn")]
+    pub namespaces: bool,
+    /// seccomp-BPF syscall filter (kernel 3.5+).
+    #[serde(default = "default_true_fn")]
+    pub seccomp: bool,
+    /// Landlock filesystem access control (kernel 5.13+, bare-metal only).
+    #[serde(default = "default_true_fn")]
+    pub landlock: bool,
+}
+
+fn default_true_fn() -> bool {
+    true
+}
+
+impl Default for IsolationConfig {
+    fn default() -> Self {
+        Self {
+            setuid: true,
+            namespaces: true,
+            seccomp: true,
+            landlock: true,
+        }
+    }
 }
 
 /// Federation configuration for multi-cluster job routing.

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1677,6 +1677,7 @@ mod tests {
             power: Default::default(),
             federation: Default::default(),
             topology: None,
+            isolation: Default::default(),
             licenses: HashMap::new(),
         }
     }

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -176,6 +176,7 @@ fn default_config() -> spur_core::config::SlurmConfig {
         power: Default::default(),
         federation: Default::default(),
         topology: None,
+        isolation: Default::default(),
         licenses: std::collections::HashMap::new(),
     }
 }


### PR DESCRIPTION
## Summary
Fifth PR in the isolation series (#99). Adds configurable `[isolation]` section to spur.conf.

## Config
```toml
[isolation]
setuid = true       # Run jobs as submitting user
namespaces = true   # PID + mount namespace isolation
seccomp = true      # syscall whitelist
landlock = true     # filesystem access control
```

All enabled by default. Operators can disable specific layers for debugging or compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)