### PR TITLE
Fix test t50_106: test real RawModeGuard, not simulation (#111)

### DIFF
--- a/crates/spur-cli/src/sattach.rs
+++ b/crates/spur-cli/src/sattach.rs
@@ -219,20 +219,27 @@ async fn interactive_attach(
 /// - Keystrokes are forwarded immediately (no buffering until Enter)
 /// - Special keys (Ctrl-C, Ctrl-Z) are sent as bytes instead of signals
 /// - No local echo (the remote shell handles echo)
-struct RawModeGuard {
+/// RAII guard that sets the terminal to raw mode and restores it on drop.
+pub(crate) struct RawModeGuard {
+    fd: i32,
     original: libc::termios,
 }
 
 impl RawModeGuard {
-    fn enter() -> Result<Self> {
-        use std::mem::MaybeUninit;
+    /// Enter raw mode on stdin. Returns Err if stdin is not a TTY.
+    pub(crate) fn enter() -> Result<Self> {
         use std::os::unix::io::AsRawFd;
+        Self::enter_on_fd(std::io::stdin().as_raw_fd())
+    }
 
-        let fd = std::io::stdin().as_raw_fd();
+    /// Enter raw mode on a specific file descriptor.
+    /// Exposed for testing with explicit fds (pipes, ptys).
+    pub(crate) fn enter_on_fd(fd: i32) -> Result<Self> {
+        use std::mem::MaybeUninit;
 
-        // Check stdin is a TTY
+        // Check fd is a TTY
         if unsafe { libc::isatty(fd) } != 1 {
-            anyhow::bail!("stdin is not a TTY");
+            anyhow::bail!("fd {} is not a TTY", fd);
         }
 
         // Save original termios
@@ -249,15 +256,13 @@ impl RawModeGuard {
             anyhow::bail!("tcsetattr failed");
         }
 
-        Ok(Self { original })
+        Ok(Self { fd, original })
     }
 }
 
 impl Drop for RawModeGuard {
     fn drop(&mut self) {
-        use std::os::unix::io::AsRawFd;
-        let fd = std::io::stdin().as_raw_fd();
-        unsafe { libc::tcsetattr(fd, libc::TCSANOW, &self.original) };
+        unsafe { libc::tcsetattr(self.fd, libc::TCSANOW, &self.original) };
     }
 }
 
@@ -274,5 +279,33 @@ fn state_name(state: i32) -> &'static str {
         8 => "PREEMPTED",
         9 => "SUSPENDED",
         _ => "UNKNOWN",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_mode_fails_on_pipe() {
+        // Create a pipe — a non-TTY fd — and verify RawModeGuard::enter_on_fd
+        // returns Err. This tests the REAL RawModeGuard code, not a simulation.
+        // Works identically in CI, interactive terminal, and IDE.
+        let mut fds = [0i32; 2];
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+        let read_fd = fds[0];
+
+        let result = RawModeGuard::enter_on_fd(read_fd);
+        assert!(result.is_err(), "RawModeGuard should fail on a pipe fd");
+        let err_msg = format!("{}", result.err().unwrap());
+        assert!(
+            err_msg.contains("not a TTY"),
+            "error should mention TTY, got: {err_msg}"
+        );
+
+        unsafe {
+            libc::close(fds[0]);
+            libc::close(fds[1]);
+        }
     }
 }

--- a/crates/spur-tests/src/t50_core.rs
+++ b/crates/spur-tests/src/t50_core.rs
@@ -1374,15 +1374,12 @@ address = "http://peer-a:6817"
 
     #[test]
     fn t50_106_attach_raw_mode_is_nonfatal_for_pipes() {
-        // Issue #64: sattach enters raw terminal mode for interactive I/O.
-        // When stdin is a pipe (not a TTY), the raw mode setup should
-        // fail gracefully. Verify the libc::isatty check works.
-        // (The actual RawModeGuard is in spur-cli; here we verify the
-        // underlying principle that CI/test stdin is not a TTY.)
-        use std::os::unix::io::AsRawFd;
-        let fd = std::io::stdin().as_raw_fd();
-        let is_tty = unsafe { libc::isatty(fd) } == 1;
-        assert!(!is_tty, "expected stdin to be a pipe in test environment");
+        // Moved to spur-cli/src/sattach.rs::tests::raw_mode_fails_on_pipe
+        // which tests the REAL RawModeGuard::enter_on_fd() with an explicit
+        // pipe fd. See issue #111 — the old test simulated isatty() instead
+        // of calling the actual unit, and depended on the test runner env.
+        //
+        // This placeholder ensures the test ID isn't reused.
     }
 
     // ── Issue #65 (reopen of #56): pending reason uses available resources ──


### PR DESCRIPTION
## Summary
Fixes #111 — replaces the broken test with one that exercises the real `RawModeGuard` code.

## Problem
Old test simulated `isatty()` with raw libc calls instead of calling `RawModeGuard::enter()`. It depended on stdin being a pipe, so it failed on interactive terminals.

## Fix
- `RawModeGuard::enter_on_fd(fd)` — new `pub(crate)` method that takes an explicit fd
- Test creates a pipe (always non-TTY), passes it to `enter_on_fd()`, asserts `Err("not a TTY")`
- Works identically in CI, interactive terminal, and IDE

Per CLAUDE.md:
> Do not write tests that simulate a unit's behavior instead of calling the actual unit.
> Do not write tests that depend on the test runner's environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)