### PR TITLE
Add secretEnv field to SpurJob CRD (#117)

### DIFF
--- a/crates/spur-k8s/src/agent.rs
+++ b/crates/spur-k8s/src/agent.rs
@@ -230,6 +230,36 @@ impl SlurmAgent for VirtualAgent {
             });
         }
 
+        // Issue #117: Inject secret env vars from SpurJob CRD's secretEnv field.
+        // These reference K8s Secrets and are injected as secretKeyRef, keeping
+        // secret values out of the SpurJob spec and Raft log.
+        {
+            let api: kube::Api<crate::crd::SpurJob> = kube::Api::all(self.client.clone());
+            let lp = kube::api::ListParams::default().labels(&format!("spur.ai/job-id={}", job_id));
+            if let Ok(list) = api.list(&lp).await {
+                if let Some(spurjob) = list.items.into_iter().next() {
+                    for (env_name, secret_ref) in &spurjob.spec.secret_env {
+                        if let Some((secret_name, secret_key)) = secret_ref.split_once('/') {
+                            env_vars.push(EnvVar {
+                                name: env_name.clone(),
+                                value_from: Some(k8s_openapi::api::core::v1::EnvVarSource {
+                                    secret_key_ref: Some(
+                                        k8s_openapi::api::core::v1::SecretKeySelector {
+                                            name: secret_name.to_string(),
+                                            key: secret_key.to_string(),
+                                            optional: Some(true),
+                                        },
+                                    ),
+                                    ..Default::default()
+                                }),
+                                ..Default::default()
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
         // Build command
         let command = if !spec.argv.is_empty() {
             Some(spec.argv.clone())

--- a/crates/spur-k8s/src/crd.rs
+++ b/crates/spur-k8s/src/crd.rs
@@ -60,6 +60,15 @@ pub struct SpurJobSpec {
     #[serde(default)]
     pub env: std::collections::HashMap<String, String>,
 
+    /// Environment variables from K8s Secrets.
+    /// Map of env var name → "secret-name/key" reference.
+    /// The operator injects these as secretKeyRef env vars into the pod,
+    /// keeping secrets out of the SpurJob spec.
+    ///
+    /// Example: `{"HF_TOKEN": "hf-creds/token", "API_KEY": "my-secret/api-key"}`
+    #[serde(default)]
+    pub secret_env: std::collections::HashMap<String, String>,
+
     /// Spur partition to submit to.
     #[serde(default)]
     pub partition: Option<String>,
@@ -302,6 +311,7 @@ mod tests {
             host_ipc: false,
             shm_size: None,
             extra_resources: std::collections::HashMap::new(),
+            secret_env: std::collections::HashMap::new(),
             tolerations: vec![],
             node_selector: Default::default(),
             priority_class: None,
@@ -437,6 +447,7 @@ mod tests {
             host_ipc: false,
             shm_size: None,
             extra_resources: std::collections::HashMap::new(),
+            secret_env: std::collections::HashMap::new(),
             tolerations: vec![],
             node_selector: Default::default(),
             priority_class: None,
@@ -627,6 +638,7 @@ mod tests {
             host_ipc: false,
             shm_size: None,
             extra_resources: std::collections::HashMap::new(),
+            secret_env: std::collections::HashMap::new(),
             tolerations: vec![TolerationSpec {
                 key: Some("spur.ai/gpu-node".into()),
                 operator: "Exists".into(),
@@ -696,6 +708,7 @@ mod tests {
             host_ipc: false,
             shm_size: None,
             extra_resources: std::collections::HashMap::new(),
+            secret_env: std::collections::HashMap::new(),
             tolerations: vec![TolerationSpec {
                 key: Some("spur.ai/gpu-node".into()),
                 operator: "Exists".into(),

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -1212,6 +1212,7 @@ mod tests {
                 host_ipc: false,
                 shm_size: None,
                 extra_resources: std::collections::HashMap::new(),
+                secret_env: std::collections::HashMap::new(),
                 tolerations: vec![],
                 node_selector: Default::default(),
                 priority_class: None,


### PR DESCRIPTION
## Summary
Fixes #117 — SpurJob CRD can now reference K8s Secrets as environment variables.

## Changes
- New `secretEnv` field on SpurJobSpec: `map<string, string>` where values are `"secret-name/key"`
- Agent reads `secretEnv` from SpurJob CRD and injects `secretKeyRef` env vars into the pod
- Secrets never appear in the SpurJob spec or Raft log

## Example
```yaml
apiVersion: spur.ai/v1alpha1
kind: SpurJob
spec:
  name: training
  image: pytorch:latest
  secretEnv:
    HF_TOKEN: "hf-creds/token"
    WANDB_API_KEY: "wandb/api-key"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)