### PR TITLE
fix(spurctld): refactor submit_array_job to avoid deadlock

### DIFF
--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -172,6 +172,12 @@ pub struct JobSpec {
 
     // Array
     pub array_spec: Option<String>,
+    #[serde(default)]
+    pub array_job_id: Option<JobId>,
+    #[serde(default)]
+    pub array_task_id: Option<u32>,
+    #[serde(default)]
+    pub array_max_concurrent: Option<u32>,
 
     // Flags
     pub requeue: bool,
@@ -262,6 +268,9 @@ impl Default for JobSpec {
             distribution: None,
             het_group: None,
             array_spec: None,
+            array_job_id: None,
+            array_task_id: None,
+            array_max_concurrent: None,
             requeue: false,
             exclusive: false,
             hold: false,
@@ -316,13 +325,6 @@ pub struct Job {
     #[serde(default)]
     pub requeue_count: u32,
 
-    // Array support
-    pub array_job_id: Option<JobId>,
-    pub array_task_id: Option<u32>,
-    /// Max concurrent tasks for this array (0 = unlimited).
-    #[serde(default)]
-    pub array_max_concurrent: Option<u32>,
-
     // Heterogeneous job support
     /// Links het job components to the first component's job ID.
     #[serde(default)]
@@ -362,9 +364,6 @@ impl Job {
             allocated_resources: None,
             exit_code: None,
             requeue_count: 0,
-            array_job_id: None,
-            array_task_id: None,
-            array_max_concurrent: None,
             het_job_id: None,
             het_group: None,
         }
@@ -392,9 +391,12 @@ impl Job {
         result = result.replace("%j", &self.job_id.to_string());
         result = result.replace("%J", &self.job_id.to_string());
         result = result.replace("%x", &self.spec.name);
-        if let Some(tid) = self.array_task_id {
+        if let Some(tid) = self.spec.array_task_id {
             result = result.replace("%a", &tid.to_string());
-            result = result.replace("%A", &self.array_job_id.unwrap_or(self.job_id).to_string());
+            result = result.replace(
+                "%A",
+                &self.spec.array_job_id.unwrap_or(self.job_id).to_string(),
+            );
         }
         if let Some(node) = self.allocated_nodes.first() {
             result = result.replace("%N", node);

--- a/crates/spur-tests/src/t28_arrays.rs
+++ b/crates/spur-tests/src/t28_arrays.rs
@@ -49,8 +49,8 @@ mod tests {
                 ..Default::default()
             },
         );
-        job.array_job_id = Some(100);
-        job.array_task_id = Some(5);
+        job.spec.array_job_id = Some(100);
+        job.spec.array_task_id = Some(5);
 
         assert_eq!(job.resolved_stdout(), "output_100_5.log");
     }
@@ -82,11 +82,11 @@ mod tests {
                 ..Default::default()
             },
         );
-        job.array_job_id = Some(200);
-        job.array_task_id = Some(42);
+        job.spec.array_job_id = Some(200);
+        job.spec.array_task_id = Some(42);
 
-        assert_eq!(job.array_job_id, Some(200));
-        assert_eq!(job.array_task_id, Some(42));
+        assert_eq!(job.spec.array_job_id, Some(200));
+        assert_eq!(job.spec.array_task_id, Some(42));
     }
 
     // ── T28.6: Array tasks are independent jobs ──────────────────
@@ -101,8 +101,8 @@ mod tests {
                 ..Default::default()
             },
         );
-        task1.array_job_id = Some(200);
-        task1.array_task_id = Some(0);
+        task1.spec.array_job_id = Some(200);
+        task1.spec.array_task_id = Some(0);
 
         let mut task2 = Job::new(
             202,
@@ -112,8 +112,8 @@ mod tests {
                 ..Default::default()
             },
         );
-        task2.array_job_id = Some(200);
-        task2.array_task_id = Some(1);
+        task2.spec.array_job_id = Some(200);
+        task2.spec.array_task_id = Some(1);
 
         // Transition task1 to running, task2 stays pending
         task1.transition(JobState::Running).unwrap();
@@ -154,8 +154,7 @@ mod tests {
     }
 
     #[test]
-    fn t28_10_array_max_concurrent_stored_on_job() {
-        // Verify array_max_concurrent field on Job struct
+    fn t28_10_array_max_concurrent_stored_on_spec() {
         let mut job = Job::new(
             300,
             JobSpec {
@@ -165,7 +164,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        job.array_max_concurrent = Some(5);
-        assert_eq!(job.array_max_concurrent, Some(5));
+        job.spec.array_max_concurrent = Some(5);
+        assert_eq!(job.spec.array_max_concurrent, Some(5));
     }
 }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -61,75 +61,26 @@ impl ClusterManager {
 
     /// Submit a new job. If it has an array spec, expand into individual tasks.
     pub fn submit_job(&self, mut spec: JobSpec) -> anyhow::Result<JobId> {
-        // If no partition specified, assign the default partition.
-        if spec.partition.is_none() {
-            let partitions = self.partitions.read();
-            if let Some(default_part) = partitions.iter().find(|p| p.is_default) {
-                spec.partition = Some(default_part.name.clone());
-            } else if let Some(first) = partitions.first() {
-                spec.partition = Some(first.name.clone());
-            }
-        }
-
-        // Validate partition constraints before accepting the job
+        apply_default_partition(&mut spec, &self.partitions.read());
         self.validate_partition(&spec)?;
 
-        // Check for array job
-        if let Some(ref array_spec) = spec.array_spec {
-            return self.submit_array_job(spec.clone(), array_spec);
-        }
-
         let job_id = self.next_job_id.fetch_add(1, Ordering::SeqCst);
+        let specs = expand_job_specs(spec, job_id)?;
 
-        self.propose(WalOperation::JobSubmit {
-            job_id,
-            spec: spec.clone(),
-        })?;
-
-        info!(job_id, name = %spec.name, user = %spec.user, "job submitted");
-        Ok(job_id)
-    }
-
-    /// Submit an array job — expands the spec into individual task jobs.
-    fn submit_array_job(&self, spec: JobSpec, array_spec_str: &str) -> anyhow::Result<JobId> {
-        use spur_core::array::parse_array_spec;
-
-        let array = parse_array_spec(array_spec_str)
-            .map_err(|e| anyhow::anyhow!("invalid array spec: {}", e))?;
-
-        let array_job_id = self.next_job_id.fetch_add(1, Ordering::SeqCst);
-        let mut jobs = self.jobs.write();
-
-        info!(
-            array_job_id,
-            tasks = array.task_ids.len(),
-            max_concurrent = array.max_concurrent,
-            name = %spec.name,
-            "array job submitted"
-        );
-
-        for &task_id in &array.task_ids {
-            let task_job_id = self.next_job_id.fetch_add(1, Ordering::SeqCst);
-            let mut task_spec = spec.clone();
-            task_spec.array_spec = None; // Don't recurse
-
+        for task_spec in specs {
+            let task_id = if task_spec.array_job_id.is_some() {
+                self.next_job_id.fetch_add(1, Ordering::SeqCst)
+            } else {
+                job_id
+            };
             self.propose(WalOperation::JobSubmit {
-                job_id: task_job_id,
-                spec: task_spec.clone(),
+                job_id: task_id,
+                spec: task_spec,
             })?;
-
-            let mut job = Job::new(task_job_id, task_spec);
-            job.array_job_id = Some(array_job_id);
-            job.array_task_id = Some(task_id);
-            if array.max_concurrent > 0 {
-                job.array_max_concurrent = Some(array.max_concurrent);
-            }
-
-            jobs.insert(task_job_id, job);
         }
 
-        // Return the array job ID (first task IDs are array_job_id + 1, +2, ...)
-        Ok(array_job_id)
+        info!(job_id, "job submitted");
+        Ok(job_id)
     }
 
     /// Validate partition constraints: access control and node limits.
@@ -877,7 +828,7 @@ impl ClusterManager {
             let mut counts = std::collections::HashMap::new();
             for j in jobs.values() {
                 if j.state == JobState::Running {
-                    if let Some(aid) = j.array_job_id {
+                    if let Some(aid) = j.spec.array_job_id {
                         *counts.entry(aid).or_insert(0) += 1;
                     }
                 }
@@ -885,7 +836,7 @@ impl ClusterManager {
             counts
         };
         pending.retain(|job| {
-            if let (Some(aid), Some(max)) = (job.array_job_id, job.array_max_concurrent) {
+            if let (Some(aid), Some(max)) = (job.spec.array_job_id, job.spec.array_max_concurrent) {
                 let running = running_array_counts.get(&aid).copied().unwrap_or(0);
                 if running >= max {
                     return false; // Throttled — too many siblings running
@@ -1724,6 +1675,47 @@ pub(crate) fn evaluate_node_health(
     actions
 }
 
+fn apply_default_partition(spec: &mut JobSpec, partitions: &[Partition]) {
+    if spec.partition.is_none() {
+        if let Some(default_part) = partitions.iter().find(|p| p.is_default) {
+            spec.partition = Some(default_part.name.clone());
+        } else if let Some(first) = partitions.first() {
+            spec.partition = Some(first.name.clone());
+        }
+    }
+}
+
+/// Expand a job spec into one or more submittable specs. For non-array jobs,
+/// returns the spec unchanged. For array jobs, returns N task specs with
+/// array metadata populated and `array_spec` cleared.
+fn expand_job_specs(spec: JobSpec, parent_job_id: JobId) -> anyhow::Result<Vec<JobSpec>> {
+    let Some(ref array_spec_str) = spec.array_spec else {
+        return Ok(vec![spec]);
+    };
+
+    let array = spur_core::array::parse_array_spec(array_spec_str)
+        .map_err(|e| anyhow::anyhow!("invalid array spec: {}", e))?;
+
+    let max_concurrent = if array.max_concurrent > 0 {
+        Some(array.max_concurrent)
+    } else {
+        None
+    };
+
+    Ok(array
+        .task_ids
+        .iter()
+        .map(|&task_id| {
+            let mut task_spec = spec.clone();
+            task_spec.array_spec = None;
+            task_spec.array_job_id = Some(parent_job_id);
+            task_spec.array_task_id = Some(task_id);
+            task_spec.array_max_concurrent = max_concurrent;
+            task_spec
+        })
+        .collect())
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -2522,5 +2514,100 @@ mod tests {
             super::evaluate_registration(Some(&node), &new),
             super::RegistrationAction::Update,
         );
+    }
+
+    // --- expand_job_specs tests ---
+
+    #[test]
+    fn expand_non_array_returns_single_spec() {
+        let spec = basic_spec("simple");
+        let result = super::expand_job_specs(spec, 1).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "simple");
+        assert!(result[0].array_job_id.is_none());
+        assert!(result[0].array_task_id.is_none());
+        assert!(result[0].array_max_concurrent.is_none());
+    }
+
+    #[test]
+    fn expand_array_with_throttle() {
+        let mut spec = basic_spec("arr");
+        spec.array_spec = Some("0-4%2".into());
+        let result = super::expand_job_specs(spec, 10).unwrap();
+        assert_eq!(result.len(), 5);
+        for (i, s) in result.iter().enumerate() {
+            assert_eq!(s.array_job_id, Some(10));
+            assert_eq!(s.array_task_id, Some(i as u32));
+            assert_eq!(s.array_max_concurrent, Some(2));
+            assert!(s.array_spec.is_none());
+            assert_eq!(s.name, "arr");
+        }
+    }
+
+    #[test]
+    fn expand_array_without_throttle() {
+        let mut spec = basic_spec("arr");
+        spec.array_spec = Some("0-4".into());
+        let result = super::expand_job_specs(spec, 5).unwrap();
+        assert_eq!(result.len(), 5);
+        for s in &result {
+            assert_eq!(s.array_job_id, Some(5));
+            assert!(s.array_max_concurrent.is_none());
+        }
+    }
+
+    #[test]
+    fn expand_array_invalid_spec_errors() {
+        let mut spec = basic_spec("bad");
+        spec.array_spec = Some("10-5".into());
+        assert!(super::expand_job_specs(spec, 1).is_err());
+    }
+
+    // --- apply_default_partition tests ---
+
+    #[test]
+    fn apply_default_partition_picks_default() {
+        let mut spec = basic_spec("j");
+        spec.partition = None;
+        let partitions = vec![
+            Partition {
+                name: "other".into(),
+                is_default: false,
+                ..Default::default()
+            },
+            Partition {
+                name: "gpu".into(),
+                is_default: true,
+                ..Default::default()
+            },
+        ];
+        super::apply_default_partition(&mut spec, &partitions);
+        assert_eq!(spec.partition.as_deref(), Some("gpu"));
+    }
+
+    #[test]
+    fn apply_default_partition_falls_back_to_first() {
+        let mut spec = basic_spec("j");
+        spec.partition = None;
+        let partitions = vec![Partition {
+            name: "batch".into(),
+            is_default: false,
+            ..Default::default()
+        }];
+        super::apply_default_partition(&mut spec, &partitions);
+        assert_eq!(spec.partition.as_deref(), Some("batch"));
+    }
+
+    #[test]
+    fn apply_default_partition_noop_when_set() {
+        let mut spec = basic_spec("j");
+        spec.partition = Some("mypart".into());
+        let partitions = vec![Partition {
+            name: "default".into(),
+            is_default: true,
+            ..Default::default()
+        }];
+        super::apply_default_partition(&mut spec, &partitions);
+        assert_eq!(spec.partition.as_deref(), Some("mypart"));
     }
 }

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -935,6 +935,9 @@ fn proto_to_job_spec(spec: JobSpec) -> Result<spur_core::job::JobSpec, Status> {
         } else {
             Some(spec.array_spec)
         },
+        array_job_id: None,
+        array_task_id: None,
+        array_max_concurrent: None,
         requeue: spec.requeue,
         exclusive: spec.exclusive,
         hold: spec.hold,
@@ -1119,8 +1122,8 @@ fn job_to_proto(job: &spur_core::job::Job) -> JobInfo {
         resources: job.allocated_resources.as_ref().map(resource_to_proto),
         priority: job.priority,
         qos: job.spec.qos.clone().unwrap_or_default(),
-        array_job_id: job.array_job_id.unwrap_or(0),
-        array_task_id: job.array_task_id.unwrap_or(0),
+        array_job_id: job.spec.array_job_id.unwrap_or(0),
+        array_task_id: job.spec.array_task_id.unwrap_or(0),
     }
 }
 


### PR DESCRIPTION
submit_array_job held self.jobs.write() while calling self.propose(), which re-acquires the same lock in apply_operation leading to a deadlock.

Consolidate into a single submit_job using pure helpers:
- apply_default_partition: assigns default partition
- expand_job_specs: expands array spec into per-task JobSpecs

Additional fixes:
- Array metadata (array_job_id, array_task_id, array_max_concurrent) now flows through the WAL via JobSpec, making it durable across Raft replay and snapshot restore
- Eliminates double-insert where apply_operation overwrote the manually-enriched job, losing array metadata
- Removes redundant array fields from Job struct (single source of truth in job.spec)
- Adds unit tests for both helpers

Made-with: Cursor