### PR TITLE
fix(spurctld): return error from snapshot_state instead of swallowing serde failures

### DIFF
--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1589,7 +1589,7 @@ impl StateMachineApply for ClusterManager {
         self.apply_operation(op);
     }
 
-    fn snapshot_state(&self) -> Vec<u8> {
+    fn snapshot_state(&self) -> Result<Vec<u8>, anyhow::Error> {
         let snap = ClusterSnapshot {
             jobs: self.jobs.read().values().cloned().collect(),
             nodes: self.nodes.read().values().cloned().collect(),
@@ -1598,7 +1598,7 @@ impl StateMachineApply for ClusterManager {
             license_pool: self.license_pool.read().clone(),
             hostname_aliases: self.hostname_aliases.read().clone(),
         };
-        serde_json::to_vec(&snap).unwrap_or_default()
+        serde_json::to_vec(&snap).map_err(Into::into)
     }
 
     fn restore_from_snapshot(&self, data: &[u8]) {
@@ -2125,7 +2125,7 @@ mod tests {
         register_node(&cm, "n1", 4, 8000);
         submit_and_wait(&cm, basic_spec("snap-job"));
 
-        let data = cm.snapshot_state();
+        let data = cm.snapshot_state().unwrap();
         assert!(!data.is_empty());
 
         // Create a fresh cluster and restore

--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -40,7 +40,7 @@ pub struct ClientResponse;
 /// Implemented by ClusterManager to avoid a circular dependency with SpurStore.
 pub trait StateMachineApply: Send + Sync {
     fn apply_operation(&self, op: &WalOperation);
-    fn snapshot_state(&self) -> Vec<u8>;
+    fn snapshot_state(&self) -> Result<Vec<u8>, anyhow::Error>;
     fn restore_from_snapshot(&self, data: &[u8]);
 }
 
@@ -209,7 +209,13 @@ impl RaftSnapshotBuilder<SpurTypeConfig> for Arc<SpurStore> {
     async fn build_snapshot(&mut self) -> Result<Snapshot<SpurTypeConfig>, StorageError<NodeId>> {
         let inner = self.inner.read();
 
-        let snapshot_data = self.applier.snapshot_state();
+        let snapshot_data = self.applier.snapshot_state().map_err(|e| {
+            StorageError::from_io_error(
+                openraft::ErrorSubject::Store,
+                openraft::ErrorVerb::Read,
+                std::io::Error::new(std::io::ErrorKind::Other, e),
+            )
+        })?;
 
         let snap_id = format!(
             "{}-{}",
@@ -659,8 +665,8 @@ mod tests {
     struct NoopApplier;
     impl StateMachineApply for NoopApplier {
         fn apply_operation(&self, _op: &WalOperation) {}
-        fn snapshot_state(&self) -> Vec<u8> {
-            Vec::new()
+        fn snapshot_state(&self) -> Result<Vec<u8>, anyhow::Error> {
+            Ok(Vec::new())
         }
         fn restore_from_snapshot(&self, _data: &[u8]) {}
     }


### PR DESCRIPTION
`snapshot_state()` used `unwrap_or_default()` on the serde result, which silently returns empty bytes if serialization fails. That empty blob gets persisted as the Raft snapshot, and after log compaction the cluster restores to a blank state with no way to recover.

Changed `StateMachineApply::snapshot_state` to return `Result<Vec<u8>>` and propagated the error as a `StorageError` in `build_snapshot`, so the Raft layer sees the failure and retries instead of persisting a corrupt snapshot.