### PR TITLE
Wire spurctld accounting notifications to spurdbd

### DIFF
--- a/crates/spurctld/src/accounting.rs
+++ b/crates/spurctld/src/accounting.rs
@@ -1,0 +1,72 @@
+use chrono::{DateTime, Utc};
+use tonic::transport::Channel;
+use tracing::warn;
+
+use spur_core::job::{JobId, JobState};
+use spur_core::resource::ResourceSet;
+use spur_proto::proto::slurm_accounting_client::SlurmAccountingClient;
+use spur_proto::proto::{RecordJobEndRequest, RecordJobStartRequest};
+
+use crate::server::{datetime_to_proto, job_state_to_proto, resource_to_proto};
+
+pub struct AccountingNotifier {
+    client: SlurmAccountingClient<Channel>,
+}
+
+impl AccountingNotifier {
+    pub async fn connect(host: &str) -> anyhow::Result<Self> {
+        let uri = if host.starts_with("http://") || host.starts_with("https://") {
+            host.to_string()
+        } else {
+            format!("http://{}", host)
+        };
+        let client = SlurmAccountingClient::connect(uri).await?;
+        Ok(Self { client })
+    }
+
+    pub fn notify_job_start(
+        &self,
+        job_id: JobId,
+        user: String,
+        account: String,
+        partition: String,
+        resources: &ResourceSet,
+        start_time: DateTime<Utc>,
+    ) {
+        let req = RecordJobStartRequest {
+            job_id,
+            user,
+            account,
+            partition,
+            resources: Some(resource_to_proto(resources)),
+            start_time: Some(datetime_to_proto(start_time)),
+        };
+        let mut client = self.client.clone();
+        tokio::spawn(async move {
+            if let Err(e) = client.record_job_start(req).await {
+                warn!(job_id, error = %e, "failed to record job start in accounting");
+            }
+        });
+    }
+
+    pub fn notify_job_end(
+        &self,
+        job_id: JobId,
+        state: JobState,
+        exit_code: i32,
+        end_time: DateTime<Utc>,
+    ) {
+        let req = RecordJobEndRequest {
+            job_id,
+            final_state: job_state_to_proto(state) as i32,
+            exit_code,
+            end_time: Some(datetime_to_proto(end_time)),
+        };
+        let mut client = self.client.clone();
+        tokio::spawn(async move {
+            if let Err(e) = client.record_job_end(req).await {
+                warn!(job_id, error = %e, "failed to record job end in accounting");
+            }
+        });
+    }
+}

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -17,6 +17,7 @@ use spur_core::resource::ResourceSet;
 use spur_core::step::{JobStep, StepState, STEP_BATCH};
 use spur_core::wal::WalOperation;
 
+use crate::accounting::AccountingNotifier;
 use crate::raft::{SpurRaft, StateMachineApply};
 
 /// Central cluster state manager.
@@ -34,6 +35,7 @@ pub struct ClusterManager {
     license_pool: RwLock<HashMap<String, u64>>,
     hostname_aliases: RwLock<HashMap<String, String>>,
     raft: RwLock<Option<SpurRaft>>,
+    accounting: RwLock<Option<AccountingNotifier>>,
 }
 
 impl ClusterManager {
@@ -52,6 +54,7 @@ impl ClusterManager {
             license_pool: RwLock::new(license_pool),
             hostname_aliases: RwLock::new(HashMap::new()),
             raft: RwLock::new(None),
+            accounting: RwLock::new(None),
         };
 
         info!("cluster manager initialized (state will be recovered via Raft)");
@@ -341,6 +344,17 @@ impl ClusterManager {
             self.send_notification(job_id, "BEGIN", &spec_for_notify);
         }
 
+        if let Some(ref notifier) = *self.accounting.read() {
+            notifier.notify_job_start(
+                job_id,
+                spec_for_notify.user.clone(),
+                spec_for_notify.account.clone().unwrap_or_default(),
+                spec_for_notify.partition.clone().unwrap_or_default(),
+                &resources,
+                Utc::now(),
+            );
+        }
+
         debug!(job_id, "job started");
         Ok(())
     }
@@ -385,6 +399,10 @@ impl ClusterManager {
             if is_failure && spec.mail_type.iter().any(|t| t == "FAIL" || t == "ALL") {
                 self.send_notification(job_id, "FAIL", &spec);
             }
+        }
+
+        if let Some(ref notifier) = *self.accounting.read() {
+            notifier.notify_job_end(job_id, state, exit_code, Utc::now());
         }
 
         let should_requeue = matches!(
@@ -1287,6 +1305,10 @@ impl ClusterManager {
 
     pub fn set_raft(&self, raft: SpurRaft) {
         *self.raft.write() = Some(raft);
+    }
+
+    pub fn set_accounting(&self, notifier: AccountingNotifier) {
+        *self.accounting.write() = Some(notifier);
     }
 
     /// Persist a mutation via Raft consensus. The apply callback

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -1,3 +1,4 @@
+mod accounting;
 mod cluster;
 mod raft;
 mod raft_server;
@@ -127,6 +128,24 @@ async fn main() -> anyhow::Result<()> {
 
     let raft_handle = Arc::new(handle);
     cluster.set_raft(raft_handle.raft.clone());
+
+    // Connect to accounting daemon (best-effort -- scheduling works without it)
+    match accounting::AccountingNotifier::connect(&config.accounting.host).await {
+        Ok(notifier) => {
+            cluster.set_accounting(notifier);
+            info!(
+                "accounting notifier connected to {}",
+                config.accounting.host
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                host = %config.accounting.host,
+                "failed to connect to accounting daemon; job history will not be recorded"
+            );
+        }
+    }
 
     // Start scheduler loop (only schedules when this node is Raft leader)
     let sched_cluster = cluster.clone();

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1171,7 +1171,9 @@ fn partition_to_proto(part: &spur_core::partition::Partition) -> PartitionInfo {
     }
 }
 
-fn resource_to_proto(r: &spur_core::resource::ResourceSet) -> spur_proto::proto::ResourceSet {
+pub(crate) fn resource_to_proto(
+    r: &spur_core::resource::ResourceSet,
+) -> spur_proto::proto::ResourceSet {
     spur_proto::proto::ResourceSet {
         cpus: r.cpus,
         memory_mb: r.memory_mb,
@@ -1200,7 +1202,7 @@ fn resource_to_proto(r: &spur_core::resource::ResourceSet) -> spur_proto::proto:
     }
 }
 
-fn job_state_to_proto(s: spur_core::job::JobState) -> spur_proto::proto::JobState {
+pub(crate) fn job_state_to_proto(s: spur_core::job::JobState) -> spur_proto::proto::JobState {
     match s {
         spur_core::job::JobState::Pending => spur_proto::proto::JobState::JobPending,
         spur_core::job::JobState::Running => spur_proto::proto::JobState::JobRunning,
@@ -1229,7 +1231,7 @@ fn node_state_to_proto(s: spur_core::node::NodeState) -> spur_proto::proto::Node
     }
 }
 
-fn datetime_to_proto(dt: chrono::DateTime<chrono::Utc>) -> prost_types::Timestamp {
+pub(crate) fn datetime_to_proto(dt: chrono::DateTime<chrono::Utc>) -> prost_types::Timestamp {
     prost_types::Timestamp {
         seconds: dt.timestamp(),
         nanos: dt.timestamp_subsec_nanos() as i32,

--- a/crates/spurdbd/src/db.rs
+++ b/crates/spurdbd/src/db.rs
@@ -16,7 +16,7 @@ pub async fn connect(database_url: &str) -> anyhow::Result<PgPool> {
 
 /// Run database migrations (create tables if they don't exist).
 pub async fn migrate(pool: &PgPool) -> anyhow::Result<()> {
-    sqlx::query(SCHEMA).execute(pool).await?;
+    sqlx::raw_sql(SCHEMA).execute(pool).await?;
     Ok(())
 }
 

--- a/crates/spurdbd/src/db.rs
+++ b/crates/spurdbd/src/db.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use sqlx::postgres::PgPoolOptions;
 use sqlx::{PgPool, Row};
-use tracing::info;
+use tracing::{info, warn};
 
 /// Connect to PostgreSQL and return a connection pool.
 pub async fn connect(database_url: &str) -> anyhow::Result<PgPool> {
@@ -167,7 +167,7 @@ pub async fn record_job_end(
     exit_code: i32,
     end_time: DateTime<Utc>,
 ) -> anyhow::Result<()> {
-    sqlx::query(
+    let result = sqlx::query(
         r#"
         UPDATE jobs SET state = $2, exit_code = $3, end_time = $4
         WHERE job_id = $1
@@ -180,7 +180,14 @@ pub async fn record_job_end(
     .execute(pool)
     .await?;
 
-    // Update usage table
+    if result.rows_affected() == 0 {
+        warn!(
+            job_id,
+            "RecordJobEnd for unknown job; start was likely missed"
+        );
+        return Ok(());
+    }
+
     update_usage(pool, job_id, end_time).await?;
 
     Ok(())


### PR DESCRIPTION
Fixes #126 

### Summary
- Fix spurdbd schema migration to use `raw_sql` for multi-statement DDL (previously crashed on startup with `--migrate`)
- Guard `record_job_end` against missing start rows — warn and skip usage accounting instead of silently updating zero rows
- Add `AccountingNotifier` to spurctld that sends best-effort `RecordJobStart`/`RecordJobEnd` gRPC calls to spurdbd after WAL proposals, so `sacct` returns actual job history
### Details
`spurctld` never called `spurdbd`, so the accounting database stayed empty and `sacct` always returned no results. This PR wires the two together:
- `AccountingNotifier` connects to `config.accounting.host` at startup and fires fire-and-forget RPCs from `start_job()` and `complete_job()`. Failures are logged but never block scheduling.
- On the `spurdbd` side, `record_job_end` now checks `rows_affected` — if the start was missed (e.g. spurdbd was down), it warns instead of silently skipping usage accounting on a nonexistent row.
- The migration fix (`sqlx::query` → `sqlx::raw_sql`) is a pre-existing bug surfaced during testing.
### Known limitations (follow-up PRs)
- `cancel_job` has its own code path and does not call `notify_job_end` yet
- `PREEMPTED`/`SUSPENDED` states map to `UNKNOWN` in spurdbd's state string conversion
- No reconnect if spurdbd starts after spurctld — requires spurctld restart
- No config flag to intentionally disable accounting
### Test plan
- [x] Submit job, verify `sacct` shows it with correct state and exit code
- [x] Submit failing job (`exit 42`), verify `sacct` shows FAILED with exit 42
- [x] Scale spurdbd to 0, submit job — job completes normally, spurctld logs warnings
- [x] Restart spurdbd with fresh DB, submit new job — recorded correctly
- [x] Verify `UPDATE 0` guard via direct psql for nonexistent job_id
- [x] All 44 existing tests pass (`cargo test -p spurctld -p spurdbd`)