### PR TITLE
chore: bump workspace version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3215,7 +3215,7 @@ dependencies = [
 
 [[package]]
 name = "spur-cli"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -3241,7 +3241,7 @@ dependencies = [
 
 [[package]]
 name = "spur-core"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3261,7 +3261,7 @@ dependencies = [
 
 [[package]]
 name = "spur-ffi"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "prost-types",
  "spur-core",
@@ -3272,7 +3272,7 @@ dependencies = [
 
 [[package]]
 name = "spur-k8s"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3299,7 +3299,7 @@ dependencies = [
 
 [[package]]
 name = "spur-net"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "spur-proto"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "prost",
  "prost-types",
@@ -3326,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "spur-sched"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "spur-core",
@@ -3335,7 +3335,7 @@ dependencies = [
 
 [[package]]
 name = "spur-spank"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "libloading",
@@ -3346,7 +3346,7 @@ dependencies = [
 
 [[package]]
 name = "spur-tests"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3369,7 +3369,7 @@ dependencies = [
 
 [[package]]
 name = "spur-update"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "spurctld"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "spurd"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3437,7 +3437,7 @@ dependencies = [
 
 [[package]]
 name = "spurdbd"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3457,7 +3457,7 @@ dependencies = [
 
 [[package]]
 name = "spurrestd"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/ROCm/spur"


### PR DESCRIPTION
## Summary

Bumps the Rust workspace version `0.1.0 → 0.3.0` to align with the upcoming `v0.3.0` release tag. Last tagged release was `v0.2.2`; the workspace version had not been bumped before so this is a catch-up.

Cargo.lock is regenerated for all workspace crates (spurctld, spurd, spur-cli, spur-update, spur-core, spur-spank, spur-k8s, spur-tests, spurdbd, spurrestd).

## Changes since v0.2.2

- Feature: auto-update startup check + CLI self-update (#119)
- Feature: SpurJob `secretEnv` field (#117)
- Fix: namespace `unshare: EPERM` for non-root jobs (#128)
- Fix: spurctld accounting wiring (#129)
- Fix: sinfo grouping by node state (#127)
- Fix: snapshot_state error propagation (#124)
- Fix: array-job submit deadlock (#122)
- Fix: Raft propose error propagation (#121)
- Fix: exec_in_job double mutex deadlock (#120)
- Cargo.lock sync (#123)

## Test plan

- [x] `cargo check --workspace` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)