### PR TITLE
Show reserved nodes as "resv" in sinfo and spur health

### DIFF
--- a/crates/spur-cli/src/sinfo.rs
+++ b/crates/spur-cli/src/sinfo.rs
@@ -104,10 +104,11 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     Ok(())
 }
 
-fn group_nodes_by_state<'a>(nodes: &[&'a NodeInfo]) -> Vec<(i32, Vec<&'a NodeInfo>)> {
-    let mut groups: BTreeMap<i32, Vec<&'a NodeInfo>> = BTreeMap::new();
+fn group_nodes_by_display_state<'a>(nodes: &[&'a NodeInfo]) -> Vec<(String, Vec<&'a NodeInfo>)> {
+    let mut groups: BTreeMap<String, Vec<&'a NodeInfo>> = BTreeMap::new();
     for node in nodes {
-        groups.entry(node.state).or_default().push(node);
+        let key = effective_state_str(node);
+        groups.entry(key).or_default().push(node);
     }
     groups.into_iter().collect()
 }
@@ -130,7 +131,7 @@ fn render_sinfo_output(
     } else {
         for part in partitions {
             let part_nodes: Vec<_> = nodes.iter().filter(|n| n.partition == part.name).collect();
-            let state_groups = group_nodes_by_state(&part_nodes);
+            let state_groups = group_nodes_by_display_state(&part_nodes);
 
             if state_groups.is_empty() {
                 let row = format_engine::format_row(fields, &|spec| {
@@ -159,7 +160,7 @@ fn resolve_node_field(
     match spec {
         'N' | 'n' => node.name.clone(),
         'P' | 'R' => node.partition.clone(),
-        't' | 'T' => node_state_str(node.state),
+        't' | 'T' => effective_state_str(node),
         'c' => {
             if let Some(ref r) = node.total_resources {
                 r.cpus.to_string()
@@ -249,7 +250,7 @@ fn resolve_partition_field(
             if nodes.is_empty() {
                 "idle".into()
             } else {
-                node_state_str(nodes[0].state)
+                effective_state_str(nodes[0])
             }
         }
         'N' => {
@@ -268,8 +269,13 @@ fn resolve_partition_field(
     }
 }
 
-fn node_state_str(state: i32) -> String {
-    match state {
+fn effective_state_str(node: &NodeInfo) -> String {
+    if !node.active_reservation.is_empty()
+        && node.state == spur_proto::proto::NodeState::NodeIdle as i32
+    {
+        return "resv".into();
+    }
+    match node.state {
         0 => "idle",
         1 => "alloc",
         2 => "mix",
@@ -277,6 +283,8 @@ fn node_state_str(state: i32) -> String {
         4 => "drain",
         5 => "drng",
         6 => "err",
+        7 => "unk",
+        8 => "susp",
         _ => "unk",
     }
     .into()
@@ -313,7 +321,7 @@ mod tests {
     }
 
     #[test]
-    fn test_group_nodes_by_state_mixed() {
+    fn test_group_nodes_by_display_state_mixed() {
         let nodes = vec![
             make_node("n1", NodeState::NodeIdle, "p"),
             make_node("n2", NodeState::NodeIdle, "p"),
@@ -321,36 +329,36 @@ mod tests {
             make_node("n4", NodeState::NodeDrain, "p"),
         ];
         let refs: Vec<&NodeInfo> = nodes.iter().collect();
-        let groups = group_nodes_by_state(&refs);
+        let groups = group_nodes_by_display_state(&refs);
 
         assert_eq!(groups.len(), 3);
-        // BTreeMap ordering: idle(0), down(3), drain(4)
-        assert_eq!(groups[0].0, NodeState::NodeIdle as i32);
-        assert_eq!(groups[0].1.len(), 2);
-        assert_eq!(groups[1].0, NodeState::NodeDown as i32);
+        // BTreeMap ordering: alphabetical — "down", "drain", "idle"
+        assert_eq!(groups[0].0, "down");
+        assert_eq!(groups[0].1.len(), 1);
+        assert_eq!(groups[1].0, "drain");
         assert_eq!(groups[1].1.len(), 1);
-        assert_eq!(groups[2].0, NodeState::NodeDrain as i32);
-        assert_eq!(groups[2].1.len(), 1);
+        assert_eq!(groups[2].0, "idle");
+        assert_eq!(groups[2].1.len(), 2);
     }
 
     #[test]
-    fn test_group_nodes_by_state_all_same() {
+    fn test_group_nodes_by_display_state_all_same() {
         let nodes = vec![
             make_node("n1", NodeState::NodeIdle, "p"),
             make_node("n2", NodeState::NodeIdle, "p"),
             make_node("n3", NodeState::NodeIdle, "p"),
         ];
         let refs: Vec<&NodeInfo> = nodes.iter().collect();
-        let groups = group_nodes_by_state(&refs);
+        let groups = group_nodes_by_display_state(&refs);
 
         assert_eq!(groups.len(), 1);
-        assert_eq!(groups[0].0, NodeState::NodeIdle as i32);
+        assert_eq!(groups[0].0, "idle");
         assert_eq!(groups[0].1.len(), 3);
     }
 
     #[test]
-    fn test_group_nodes_by_state_empty() {
-        let groups = group_nodes_by_state(&[]);
+    fn test_group_nodes_by_display_state_empty() {
+        let groups = group_nodes_by_display_state(&[]);
         assert!(groups.is_empty());
     }
 
@@ -371,46 +379,39 @@ mod tests {
             2,
             "expected 2 rows (idle + down), got: {lines:?}"
         );
+
+        let idle_line = lines
+            .iter()
+            .find(|l| l.contains("idle"))
+            .expect("no idle row");
         assert!(
-            lines[0].contains("idle"),
-            "first row should be idle: {}",
-            lines[0]
+            idle_line.contains("2"),
+            "idle row should show 2 nodes: {idle_line}"
         );
         assert!(
-            lines[0].contains("2"),
-            "idle row should show 2 nodes: {}",
-            lines[0]
+            idle_line.contains("n1"),
+            "idle row should list n1: {idle_line}"
         );
         assert!(
-            lines[0].contains("n1"),
-            "idle row should list n1: {}",
-            lines[0]
+            idle_line.contains("n2"),
+            "idle row should list n2: {idle_line}"
         );
         assert!(
-            lines[0].contains("n2"),
-            "idle row should list n2: {}",
-            lines[0]
-        );
-        assert!(
-            !lines[0].contains("n3"),
-            "idle row should not list n3: {}",
-            lines[0]
+            !idle_line.contains("n3"),
+            "idle row should not list n3: {idle_line}"
         );
 
+        let down_line = lines
+            .iter()
+            .find(|l| l.contains("down"))
+            .expect("no down row");
         assert!(
-            lines[1].contains("down"),
-            "second row should be down: {}",
-            lines[1]
+            down_line.contains("1"),
+            "down row should show 1 node: {down_line}"
         );
         assert!(
-            lines[1].contains("1"),
-            "down row should show 1 node: {}",
-            lines[1]
-        );
-        assert!(
-            lines[1].contains("n3"),
-            "down row should list n3: {}",
-            lines[1]
+            down_line.contains("n3"),
+            "down row should list n3: {down_line}"
         );
     }
 
@@ -461,5 +462,147 @@ mod tests {
         assert!(lines[0].contains("idle"));
         assert!(lines[1].contains("n2"));
         assert!(lines[1].contains("down"));
+    }
+
+    // --- effective_state_str tests ---
+
+    fn make_reserved_node(
+        name: &str,
+        state: NodeState,
+        partition: &str,
+        reservation: &str,
+    ) -> NodeInfo {
+        let mut n = make_node(name, state, partition);
+        n.active_reservation = reservation.into();
+        n
+    }
+
+    #[test]
+    fn test_effective_state_idle_reserved() {
+        let node = make_reserved_node("n1", NodeState::NodeIdle, "p", "maint");
+        assert_eq!(effective_state_str(&node), "resv");
+    }
+
+    #[test]
+    fn test_effective_state_alloc_reserved() {
+        let node = make_reserved_node("n1", NodeState::NodeAllocated, "p", "maint");
+        assert_eq!(effective_state_str(&node), "alloc");
+    }
+
+    #[test]
+    fn test_effective_state_mixed_reserved() {
+        let node = make_reserved_node("n1", NodeState::NodeMixed, "p", "maint");
+        assert_eq!(effective_state_str(&node), "mix");
+    }
+
+    #[test]
+    fn test_effective_state_all_base_states() {
+        let cases = [
+            (NodeState::NodeIdle, "idle"),
+            (NodeState::NodeAllocated, "alloc"),
+            (NodeState::NodeMixed, "mix"),
+            (NodeState::NodeDown, "down"),
+            (NodeState::NodeDrain, "drain"),
+            (NodeState::NodeDraining, "drng"),
+            (NodeState::NodeError, "err"),
+            (NodeState::NodeUnknown, "unk"),
+            (NodeState::NodeSuspended, "susp"),
+        ];
+        for (state, expected) in cases {
+            let node = make_node("n1", state, "p");
+            assert_eq!(
+                effective_state_str(&node),
+                expected,
+                "state {:?} should display as {}",
+                state,
+                expected
+            );
+        }
+    }
+
+    // --- grouping tests ---
+
+    #[test]
+    fn test_group_separates_reserved_idle_from_idle() {
+        let nodes = vec![
+            make_node("n1", NodeState::NodeIdle, "p"),
+            make_node("n2", NodeState::NodeIdle, "p"),
+            make_reserved_node("n3", NodeState::NodeIdle, "p", "maint"),
+        ];
+        let refs: Vec<&NodeInfo> = nodes.iter().collect();
+        let groups = group_nodes_by_display_state(&refs);
+
+        assert_eq!(groups.len(), 2, "expected idle + resv groups: {groups:?}");
+        assert_eq!(groups[0].0, "idle");
+        assert_eq!(groups[0].1.len(), 2);
+        assert_eq!(groups[1].0, "resv");
+        assert_eq!(groups[1].1.len(), 1);
+    }
+
+    #[test]
+    fn test_group_alloc_reserved_stays_with_alloc() {
+        let nodes = vec![
+            make_node("n1", NodeState::NodeAllocated, "p"),
+            make_reserved_node("n2", NodeState::NodeAllocated, "p", "maint"),
+        ];
+        let refs: Vec<&NodeInfo> = nodes.iter().collect();
+        let groups = group_nodes_by_display_state(&refs);
+
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].0, "alloc");
+        assert_eq!(groups[0].1.len(), 2);
+    }
+
+    // --- render integration tests ---
+
+    #[test]
+    fn test_render_reserved_and_idle_rows() {
+        let fields = default_fields();
+        let partitions = vec![make_partition("default", true)];
+        let nodes = vec![
+            make_node("n1", NodeState::NodeIdle, "default"),
+            make_node("n2", NodeState::NodeIdle, "default"),
+            make_reserved_node("n3", NodeState::NodeIdle, "default", "maint"),
+        ];
+
+        let lines = render_sinfo_output(&fields, &partitions, &nodes, false);
+        assert_eq!(
+            lines.len(),
+            2,
+            "expected 2 rows (idle + resv), got: {lines:?}"
+        );
+
+        let idle_line = lines
+            .iter()
+            .find(|l| l.contains("idle"))
+            .expect("no idle row");
+        assert!(idle_line.contains("n1"), "idle row should list n1");
+        assert!(idle_line.contains("n2"), "idle row should list n2");
+        assert!(!idle_line.contains("n3"), "idle row should not list n3");
+
+        let resv_line = lines
+            .iter()
+            .find(|l| l.contains("resv"))
+            .expect("no resv row");
+        assert!(resv_line.contains("n3"), "resv row should list n3");
+        assert!(!resv_line.contains("n1"), "resv row should not list n1");
+    }
+
+    #[test]
+    fn test_render_node_oriented_reserved() {
+        let fields =
+            format_engine::parse_format("%#N %.6D %#P %.11T", &format_engine::sinfo_header);
+        let partitions = vec![make_partition("batch", true)];
+        let nodes = vec![
+            make_node("n1", NodeState::NodeIdle, "batch"),
+            make_reserved_node("n2", NodeState::NodeIdle, "batch", "maint"),
+        ];
+
+        let lines = render_sinfo_output(&fields, &partitions, &nodes, true);
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("n1"));
+        assert!(lines[0].contains("idle"));
+        assert!(lines[1].contains("n2"));
+        assert!(lines[1].contains("resv"));
     }
 }

--- a/crates/spur-cli/src/smd.rs
+++ b/crates/spur-cli/src/smd.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
-use spur_proto::proto::{GetNodesRequest, NodeState};
+use spur_proto::proto::{GetNodesRequest, NodeInfo, NodeState};
 
 /// Node health monitoring daemon.
 ///
@@ -63,7 +63,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
 
         let mut unhealthy_count = 0u32;
         for node in &nodes {
-            let state_str = node_state_str(node.state);
+            let state_str = node_state_str(node);
             let is_unhealthy = node.state == NodeState::NodeDown as i32
                 || node.state == NodeState::NodeError as i32
                 || node.state == NodeState::NodeDrain as i32;
@@ -104,8 +104,11 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     Ok(())
 }
 
-fn node_state_str(state: i32) -> &'static str {
-    match state {
+fn node_state_str(node: &NodeInfo) -> &'static str {
+    if !node.active_reservation.is_empty() && node.state == NodeState::NodeIdle as i32 {
+        return "resv";
+    }
+    match node.state {
         0 => "idle",
         1 => "alloc",
         2 => "mix",
@@ -116,5 +119,43 @@ fn node_state_str(state: i32) -> &'static str {
         7 => "unk",
         8 => "susp",
         _ => "???",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_node(name: &str, state: NodeState, reservation: &str) -> NodeInfo {
+        NodeInfo {
+            name: name.into(),
+            state: state as i32,
+            active_reservation: reservation.into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_smd_state_reserved() {
+        let node = make_node("n1", NodeState::NodeIdle, "maint");
+        assert_eq!(node_state_str(&node), "resv");
+    }
+
+    #[test]
+    fn test_smd_state_alloc_reserved() {
+        let node = make_node("n1", NodeState::NodeAllocated, "maint");
+        assert_eq!(node_state_str(&node), "alloc");
+    }
+
+    #[test]
+    fn test_smd_state_idle_no_reservation() {
+        let node = make_node("n1", NodeState::NodeIdle, "");
+        assert_eq!(node_state_str(&node), "idle");
+    }
+
+    #[test]
+    fn test_smd_state_down() {
+        let node = make_node("n1", NodeState::NodeDown, "");
+        assert_eq!(node_state_str(&node), "DOWN");
     }
 }

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -2,10 +2,12 @@ use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use chrono::{DateTime, Utc};
 use tokio::sync::Mutex;
 use tonic::metadata::MetadataValue;
 use tonic::{Request, Response, Status};
 
+use spur_core::reservation::Reservation;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::slurm_controller_server::{SlurmController, SlurmControllerServer};
 use spur_proto::proto::*;
@@ -285,7 +287,9 @@ impl SlurmController for ControllerService {
 
         let _req = request.into_inner();
         let nodes = self.cluster.get_nodes();
-        let proto_nodes: Vec<NodeInfo> = nodes.iter().map(node_to_proto).collect();
+        let mut proto_nodes: Vec<NodeInfo> = nodes.iter().map(node_to_proto).collect();
+        let reservations = self.cluster.get_reservations();
+        annotate_nodes_with_reservations(&mut proto_nodes, &reservations, Utc::now());
         Ok(Response::new(GetNodesResponse { nodes: proto_nodes }))
     }
 
@@ -308,7 +312,14 @@ impl SlurmController for ControllerService {
             .cluster
             .get_node(&name)
             .ok_or_else(|| Status::not_found(format!("node {} not found", name)))?;
-        Ok(Response::new(node_to_proto(&node)))
+        let mut proto_node = node_to_proto(&node);
+        let reservations = self.cluster.get_reservations();
+        annotate_nodes_with_reservations(
+            std::slice::from_mut(&mut proto_node),
+            &reservations,
+            Utc::now(),
+        );
+        Ok(Response::new(proto_node))
     }
 
     async fn update_node(
@@ -1143,6 +1154,7 @@ fn node_to_proto(node: &spur_core::node::Node) -> NodeInfo {
         last_busy: node.last_busy.map(datetime_to_proto),
         slurmd_start_time: node.agent_start_time.map(datetime_to_proto),
         switch_name: node.switch_name.clone().unwrap_or_default(),
+        active_reservation: String::new(),
     }
 }
 
@@ -1238,5 +1250,108 @@ pub(crate) fn datetime_to_proto(dt: chrono::DateTime<chrono::Utc>) -> prost_type
     prost_types::Timestamp {
         seconds: dt.timestamp(),
         nanos: dt.timestamp_subsec_nanos() as i32,
+    }
+}
+
+fn annotate_nodes_with_reservations(
+    nodes: &mut [NodeInfo],
+    reservations: &[Reservation],
+    now: DateTime<Utc>,
+) {
+    for node_info in nodes.iter_mut() {
+        for res in reservations {
+            if res.is_active(now) && res.covers_node(&node_info.name) {
+                node_info.active_reservation = res.name.clone();
+                break;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    fn make_node_info(name: &str) -> NodeInfo {
+        NodeInfo {
+            name: name.into(),
+            ..Default::default()
+        }
+    }
+
+    fn make_reservation(
+        name: &str,
+        nodes: &[&str],
+        start_offset_hours: i64,
+        end_offset_hours: i64,
+    ) -> Reservation {
+        let now = Utc::now();
+        Reservation {
+            name: name.into(),
+            start_time: now + Duration::hours(start_offset_hours),
+            end_time: now + Duration::hours(end_offset_hours),
+            nodes: nodes.iter().map(|s| s.to_string()).collect(),
+            accounts: Vec::new(),
+            users: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn test_annotate_no_reservations() {
+        let mut nodes = vec![make_node_info("n1"), make_node_info("n2")];
+        annotate_nodes_with_reservations(&mut nodes, &[], Utc::now());
+        assert!(nodes[0].active_reservation.is_empty());
+        assert!(nodes[1].active_reservation.is_empty());
+    }
+
+    #[test]
+    fn test_annotate_active_reservation() {
+        let mut nodes = vec![make_node_info("n1"), make_node_info("n2")];
+        let reservations = vec![make_reservation("maint", &["n1"], -1, 1)];
+        annotate_nodes_with_reservations(&mut nodes, &reservations, Utc::now());
+        assert_eq!(nodes[0].active_reservation, "maint");
+        assert!(nodes[1].active_reservation.is_empty());
+    }
+
+    #[test]
+    fn test_annotate_expired_reservation() {
+        let mut nodes = vec![make_node_info("n1")];
+        let reservations = vec![make_reservation("old", &["n1"], -3, -1)];
+        annotate_nodes_with_reservations(&mut nodes, &reservations, Utc::now());
+        assert!(nodes[0].active_reservation.is_empty());
+    }
+
+    #[test]
+    fn test_annotate_future_reservation() {
+        let mut nodes = vec![make_node_info("n1")];
+        let reservations = vec![make_reservation("future", &["n1"], 1, 3)];
+        annotate_nodes_with_reservations(&mut nodes, &reservations, Utc::now());
+        assert!(nodes[0].active_reservation.is_empty());
+    }
+
+    #[test]
+    fn test_annotate_partial_coverage() {
+        let mut nodes = vec![
+            make_node_info("n1"),
+            make_node_info("n2"),
+            make_node_info("n3"),
+        ];
+        let reservations = vec![make_reservation("gpu-resv", &["n1", "n3"], -1, 1)];
+        annotate_nodes_with_reservations(&mut nodes, &reservations, Utc::now());
+        assert_eq!(nodes[0].active_reservation, "gpu-resv");
+        assert!(nodes[1].active_reservation.is_empty());
+        assert_eq!(nodes[2].active_reservation, "gpu-resv");
+    }
+
+    #[test]
+    fn test_annotate_multiple_reservations_first_wins() {
+        let mut nodes = vec![make_node_info("n1")];
+        let reservations = vec![
+            make_reservation("first", &["n1"], -1, 1),
+            make_reservation("second", &["n1"], -1, 1),
+        ];
+        annotate_nodes_with_reservations(&mut nodes, &reservations, Utc::now());
+        assert_eq!(nodes[0].active_reservation, "first");
     }
 }

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -195,6 +195,8 @@ message NodeInfo {
   google.protobuf.Timestamp slurmd_start_time = 32;
 
   string switch_name = 40;   // Leaf switch from topology config
+
+  string active_reservation = 50;
 }
 
 message PartitionInfo {


### PR DESCRIPTION
Fixes #135 

When a node belongs to an active reservation but has no running jobs, `spur info` and `spur health` now display its state as `resv` instead of `idle`, matching Slurm's `sinfo` behavior. This lets users see at a glance why their jobs are not scheduling on those nodes.

Before:

    PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
    default*    up   infinite      3   idle k8s-worker1,k8s-worker2,k8s-worker3

After (with reservation on k8s-worker3):

    PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
    default*    up   infinite      2   idle k8s-worker1,k8s-worker2
    default*    up   infinite      1   resv k8s-worker3

## Approach

Following Slurm's model, `RESERVED` is treated as a display-time flag rather than a new base state. An `active_reservation` string field is added to the proto `NodeInfo` message. The controller populates it at `GetNodes`/`GetNode` response time by cross-referencing active reservations. The CLI overrides the displayed state to `resv` only when the base state is idle — reserved nodes that are allocated or mixed still show `alloc`/`mix`.

## Changes

- **proto/slurm.proto** — add `string active_reservation = 50` to `NodeInfo`
- **spurctld/server.rs** — extract `annotate_nodes_with_reservations()` pure function, call from `get_nodes` and `get_node` handlers
- **spur-cli/sinfo.rs** — replace `node_state_str` with `effective_state_str`, rename grouping to `group_nodes_by_display_state` keyed on display string, fix missing unknown/suspended state mappings
- **spur-cli/smd.rs** — update `node_state_str` to show `resv` for idle reserved nodes

## Test plan

- [x] 20 new unit tests across 3 crates (annotate logic, effective state string, grouping, render integration, smd display)
- [x] All 220 existing tests pass
- [x] End-to-end verified on K8s testbed: create reservation → `spur info` shows `resv` → delete reservation → returns to `idle`