### PR TITLE
fix: Resolve working dir against rootfs in non-root container fallback

### DIFF
--- a/crates/spurd/src/container.rs
+++ b/crates/spurd/src/container.rs
@@ -599,7 +599,7 @@ else
   export LD_LIBRARY_PATH="$ROOTFS/usr/lib:$ROOTFS/lib:$ROOTFS/usr/lib64:$ROOTFS/lib64:${{LD_LIBRARY_PATH:-}}"
   export SPUR_CONTAINER_ROOTFS="$ROOTFS"
   export HOME="{home}"
-  cd {workdir}
+  cd "$ROOTFS{workdir}"
   {entrypoint}/bin/bash $ROOTFS/tmp/spur_job_{job_id}.sh
 fi
 "#,

--- a/crates/spurd/src/container.rs
+++ b/crates/spurd/src/container.rs
@@ -1066,7 +1066,14 @@ mod tests {
         let rootfs = Path::new("/tmp/test-rootfs");
         let script = build_container_launch_script(&config, rootfs, "/tmp/inner.sh", 1).unwrap();
 
-        assert!(script.contains("cd /workspace"));
+        // Root branch: cd runs inside chroot so workdir is unqualified.
+        assert!(script.contains(r#"cd /workspace &&"#));
+        // Non-root fallback: no chroot, so cd must be prefixed with $ROOTFS
+        // so it resolves against the container rootfs, not the host filesystem.
+        // Regression test for: https://github.com/ROCm/spur/issues/136
+        assert!(script.contains(r#"cd "$ROOTFS/workspace""#));
+        // The old broken form must not appear in the non-root branch.
+        assert!(!script.contains("\n  cd /workspace\n"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #136

When spurd runs a containerized job as a non-root user, the working directory change now resolves against the container rootfs instead of the host filesystem. Previously, jobs would abort immediately with `cd: /workspace/Primus: No such file or directory` whenever the requested working directory existed inside the image but not on the host.

Before:

  /home/amd/.spur_job_3.sh: line 4: cd: /workspace/Primus: No such file or directory

Approach

The container launch script in build_container_launch_script() has two execution branches. The root branch uses chroot so the cd runs inside the container naturally. The non-root fallback cannot use chroot, so the working directory must be resolved manually by prepending $ROOTFS. The fix changes cd {workdir} to cd "$ROOTFS{workdir}" in the non-root branch, matching the effective behaviour of the chroot path.

Changes

spurd/src/container.rs — change `cd {workdir}` to `cd "$ROOTFS{workdir}"`
in the non-root container fallback branch of build_container_launch_script()

Test plan
- [x] Added unit tests
