### PR TITLE
fix(srun): step dispatch routes to allocated node, not controller

### DIFF
--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -454,15 +454,25 @@ async fn print_job_output(work_dir: &str, job_id: u32) {
     }
 }
 
-/// When srun runs inside a sbatch script (SPUR_JOB_ID is set), it creates a
-/// job step and executes the command directly on the allocated node.
+/// When srun runs inside an allocation (SPUR_JOB_ID is set, e.g. inside an
+/// `salloc` interactive shell or sbatch script on the submit host), it
+/// dispatches the command to one of the allocation's nodes via the
+/// controller's RunStep RPC. The controller picks an allocated node and
+/// forwards to that agent's RunCommand RPC.
+///
+/// Closes #146 — previously this ran the command locally, so `srun hostname`
+/// inside `salloc` printed the controller's hostname instead of the
+/// allocated compute node's.
 async fn run_as_step(args: &SrunArgs, job_id: u32) -> Result<()> {
+    use spur_proto::proto::RunStepRequest;
+
     let mut client = SlurmControllerClient::connect(args.controller.clone())
         .await
         .context("failed to connect to spurctld")?;
 
-    // Create a step on the controller for tracking
-    let resp = client
+    // Create a step on the controller for tracking. The controller doesn't
+    // currently use this for dispatch — it's just bookkeeping.
+    let _ = client
         .create_job_step(CreateJobStepRequest {
             job_id,
             command: args.command.clone(),
@@ -472,18 +482,38 @@ async fn run_as_step(args: &SrunArgs, job_id: u32) -> Result<()> {
         .await
         .context("failed to create job step")?;
 
-    let step_id = resp.into_inner().step_id;
-    eprintln!("srun: created step {}.{}", job_id, step_id);
+    let work_dir = args.chdir.as_deref().map(String::from).unwrap_or_else(|| {
+        std::env::current_dir()
+            .ok()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default()
+    });
 
-    // Execute the command directly — we are already on an allocated node
-    let status = tokio::process::Command::new(&args.command[0])
-        .args(&args.command[1..])
-        .status()
+    let env: std::collections::HashMap<String, String> = std::env::vars().collect();
+
+    let resp = client
+        .run_step(RunStepRequest {
+            job_id,
+            command: args.command.clone(),
+            uid: nix::unistd::geteuid().as_raw(),
+            gid: nix::unistd::getegid().as_raw(),
+            work_dir,
+            environment: env,
+        })
         .await
-        .context("failed to execute command")?;
+        .context("RunStep dispatch failed")?
+        .into_inner();
 
-    let exit_code = status.code().unwrap_or(-1);
-    std::process::exit(exit_code);
+    if !resp.node.is_empty() {
+        eprintln!("srun: dispatched to node {}", resp.node);
+    }
+    if !resp.stdout.is_empty() {
+        print!("{}", resp.stdout);
+    }
+    if !resp.stderr.is_empty() {
+        eprint!("{}", resp.stderr);
+    }
+    std::process::exit(resp.exit_code);
 }
 
 fn parse_memory_mb(s: &str) -> Result<u64> {

--- a/crates/spur-k8s/src/agent.rs
+++ b/crates/spur-k8s/src/agent.rs
@@ -545,6 +545,22 @@ impl SlurmAgent for VirtualAgent {
         }))
     }
 
+    async fn run_command(
+        &self,
+        _request: Request<RunCommandRequest>,
+    ) -> Result<Response<RunCommandResponse>, Status> {
+        // #146: srun-in-salloc step dispatch. The K8s virtual agent does
+        // not currently support one-shot commands outside the job pod's
+        // lifecycle — salloc + srun-in-allocation is not a common K8s
+        // workflow. Implementations that need it could spawn a transient
+        // pod (e.g. via PodSpec with the same image as the allocation
+        // template), but that's a non-trivial design choice and the
+        // user-facing path uses the native spurd agent.
+        Err(Status::unimplemented(
+            "RunCommand is not yet supported by the K8s virtual agent",
+        ))
+    }
+
     async fn stream_job_output(
         &self,
         request: Request<StreamJobOutputRequest>,

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -790,6 +790,75 @@ impl SlurmController for ControllerService {
 
         Ok(resp)
     }
+
+    /// #146: route a step from `srun-in-salloc` to one of the job's
+    /// allocated nodes. Unlike ExecInJob, the job may not have a tracked
+    /// process — salloc allocations only exist as scheduler bookkeeping.
+    async fn run_step(
+        &self,
+        request: Request<RunStepRequest>,
+    ) -> Result<Response<RunStepResponse>, Status> {
+        if let Err(_) = self.check_leader(&request) {
+            let proxy = &self.leader_proxy;
+            let mut client = proxy.get_leader_client().await?;
+            let mut fwd = Request::new(request.into_inner());
+            *fwd.metadata_mut() = Self::forwarded_metadata();
+            return client.run_step(fwd).await;
+        }
+
+        use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
+
+        let req = request.into_inner();
+        let job_id = req.job_id;
+
+        let job = self
+            .cluster
+            .get_job(job_id)
+            .ok_or_else(|| Status::not_found(format!("job {} not found", job_id)))?;
+
+        if job.allocated_nodes.is_empty() {
+            return Err(Status::failed_precondition(format!(
+                "job {} has no allocated nodes — is the allocation still active?",
+                job_id
+            )));
+        }
+
+        let node_name = job.allocated_nodes[0].clone();
+        let node = self
+            .cluster
+            .get_node(&node_name)
+            .ok_or_else(|| Status::not_found(format!("node {} not found", node_name)))?;
+        let addr = node
+            .address
+            .as_ref()
+            .ok_or_else(|| Status::internal(format!("node {} has no agent address", node_name)))?;
+        let agent_addr = format!("http://{}:{}", addr, node.port);
+
+        let mut agent = SlurmAgentClient::connect(agent_addr.clone())
+            .await
+            .map_err(|e| {
+                Status::unavailable(format!("cannot reach agent at {}: {}", agent_addr, e))
+            })?;
+
+        let agent_resp = agent
+            .run_command(RunCommandRequest {
+                command: req.command,
+                uid: req.uid,
+                gid: req.gid,
+                work_dir: req.work_dir,
+                environment: req.environment,
+            })
+            .await
+            .map_err(|e| Status::internal(format!("run_command failed: {}", e)))?
+            .into_inner();
+
+        Ok(Response::new(RunStepResponse {
+            exit_code: agent_resp.exit_code,
+            stdout: agent_resp.stdout,
+            stderr: agent_resp.stderr,
+            node: node_name,
+        }))
+    }
 }
 
 pub async fn serve(

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -755,6 +755,67 @@ impl SlurmAgent for AgentService {
         }))
     }
 
+    /// #146: run a one-shot command on this node, used by `srun` inside an
+    /// `salloc` interactive shell. Unlike ExecInJob, this does not require
+    /// a tracked job process — salloc allocations don't run anything until
+    /// `srun` dispatches a step.
+    async fn run_command(
+        &self,
+        request: Request<RunCommandRequest>,
+    ) -> Result<Response<RunCommandResponse>, Status> {
+        let req = request.into_inner();
+        if req.command.is_empty() {
+            return Err(Status::invalid_argument("no command specified"));
+        }
+
+        let work_dir = if req.work_dir.is_empty() {
+            "/tmp".to_string()
+        } else {
+            req.work_dir
+        };
+
+        let mut cmd = tokio::process::Command::new(&req.command[0]);
+        cmd.args(&req.command[1..]).current_dir(&work_dir);
+        for (k, v) in &req.environment {
+            cmd.env(k, v);
+        }
+
+        // Drop privilege if requested (and we're root). Mirrors the privilege
+        // drop in launch_job's non-namespace path.
+        if req.uid > 0 && nix::unistd::geteuid().is_root() {
+            use std::os::unix::process::CommandExt;
+            let target_uid = req.uid;
+            let target_gid = req.gid;
+            unsafe {
+                cmd.pre_exec(move || {
+                    nix::unistd::setgid(nix::unistd::Gid::from_raw(target_gid))
+                        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                    nix::unistd::setuid(nix::unistd::Uid::from_raw(target_uid))
+                        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                    Ok(())
+                });
+            }
+        }
+
+        info!(
+            command = ?req.command,
+            uid = req.uid,
+            work_dir = %work_dir,
+            "RunCommand: executing one-shot step"
+        );
+
+        let output = cmd
+            .output()
+            .await
+            .map_err(|e| Status::internal(format!("command failed: {}", e)))?;
+
+        Ok(Response::new(RunCommandResponse {
+            exit_code: output.status.code().unwrap_or(-1),
+            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        }))
+    }
+
     async fn stream_job_output(
         &self,
         request: Request<StreamJobOutputRequest>,
@@ -1142,5 +1203,102 @@ mod tests {
 
         let err = svc.exec_in_job(req).await.unwrap_err();
         assert_eq!(err.code(), tonic::Code::NotFound);
+    }
+
+    // --- #146: srun-in-salloc step dispatch via RunCommand ---
+    //
+    // Regression: srun's run_as_step previously called
+    //   tokio::process::Command::new(args.command[0]).status()
+    // which executed the command on whichever host the user had typed
+    // srun on (the controller / submit host), not on the allocated
+    // compute node. After the fix, srun calls the controller's RunStep
+    // RPC, which forwards to the allocated agent's RunCommand.
+    //
+    // These tests cover the agent-side RunCommand handler. The controller
+    // routing is glue (~50 lines) that mirrors exec_in_job's pattern.
+
+    #[tokio::test]
+    async fn run_command_executes_simple_command() {
+        let svc = AgentService::new(test_reporter());
+        let req = Request::new(RunCommandRequest {
+            command: vec!["echo".into(), "hello-from-agent".into()],
+            uid: 0,
+            gid: 0,
+            work_dir: String::new(),
+            environment: HashMap::new(),
+        });
+        let resp = svc.run_command(req).await.unwrap().into_inner();
+        assert_eq!(resp.exit_code, 0);
+        assert_eq!(resp.stdout.trim(), "hello-from-agent");
+        assert!(resp.stderr.is_empty());
+    }
+
+    #[tokio::test]
+    async fn run_command_propagates_nonzero_exit_code() {
+        let svc = AgentService::new(test_reporter());
+        let req = Request::new(RunCommandRequest {
+            command: vec!["false".into()],
+            uid: 0,
+            gid: 0,
+            work_dir: String::new(),
+            environment: HashMap::new(),
+        });
+        let resp = svc.run_command(req).await.unwrap().into_inner();
+        assert_eq!(resp.exit_code, 1, "false exits 1");
+    }
+
+    #[tokio::test]
+    async fn run_command_passes_environment() {
+        let svc = AgentService::new(test_reporter());
+        let mut env = HashMap::new();
+        env.insert("SPUR_TEST_VAR".into(), "step-dispatched".into());
+        let req = Request::new(RunCommandRequest {
+            command: vec!["/bin/sh".into(), "-c".into(), "echo $SPUR_TEST_VAR".into()],
+            uid: 0,
+            gid: 0,
+            work_dir: String::new(),
+            environment: env,
+        });
+        let resp = svc.run_command(req).await.unwrap().into_inner();
+        assert_eq!(resp.exit_code, 0);
+        assert_eq!(resp.stdout.trim(), "step-dispatched");
+    }
+
+    #[tokio::test]
+    async fn run_command_empty_command_is_rejected() {
+        let svc = AgentService::new(test_reporter());
+        let req = Request::new(RunCommandRequest {
+            command: vec![],
+            uid: 0,
+            gid: 0,
+            work_dir: String::new(),
+            environment: HashMap::new(),
+        });
+        let err = svc.run_command(req).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn run_command_uses_provided_work_dir() {
+        // The bug repro: the user's workflow is `salloc; srun hostname`.
+        // hostname runs in whatever cwd the agent picks; we can't easily
+        // assert it's a specific directory without mounting a tempdir as
+        // the agent's cwd. Instead use `pwd` and assert it matches the
+        // dir we passed.
+        let svc = AgentService::new(test_reporter());
+        let tmp = std::env::temp_dir();
+        // Resolve symlinks (e.g., macOS /tmp -> /private/tmp).
+        let tmp_canonical = std::fs::canonicalize(&tmp).unwrap_or(tmp.clone());
+        let req = Request::new(RunCommandRequest {
+            command: vec!["pwd".into()],
+            uid: 0,
+            gid: 0,
+            work_dir: tmp_canonical.to_string_lossy().into_owned(),
+            environment: HashMap::new(),
+        });
+        let resp = svc.run_command(req).await.unwrap().into_inner();
+        assert_eq!(resp.exit_code, 0);
+        let observed_canonical = std::fs::canonicalize(resp.stdout.trim()).unwrap();
+        assert_eq!(observed_canonical, tmp_canonical);
     }
 }

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -267,6 +267,11 @@ service SlurmController {
 
   // Exec a command inside a running job's container (proxies to correct agent)
   rpc ExecInJob(ExecInJobRequest) returns (ExecInJobResponse);
+
+  // Run a step on one of an allocation's nodes — used by `srun` inside an
+  // `salloc` interactive shell. The controller picks an allocated node and
+  // proxies to its agent's RunCommand RPC (#146).
+  rpc RunStep(RunStepRequest) returns (RunStepResponse);
 }
 
 // -- Agent service (slurmd) --
@@ -276,6 +281,8 @@ service SlurmAgent {
   rpc CancelJob(AgentCancelJobRequest) returns (google.protobuf.Empty);
   rpc GetNodeResources(google.protobuf.Empty) returns (NodeResourcesResponse);
   rpc ExecInJob(ExecInJobRequest) returns (ExecInJobResponse);
+  // Run a one-shot command on this node (for srun-in-salloc step dispatch, #146)
+  rpc RunCommand(RunCommandRequest) returns (RunCommandResponse);
   rpc StreamJobOutput(StreamJobOutputRequest) returns (stream StreamJobOutputChunk);
   // Interactive attach: bidirectional streaming for stdin/stdout forwarding
   rpc AttachJob(stream AttachJobInput) returns (stream AttachJobOutput);
@@ -452,6 +459,42 @@ message ExecInJobResponse {
   int32 exit_code = 2;
   string stdout = 3;
   string stderr = 4;
+}
+
+// Controller-side request: run a step inside an allocation. The controller
+// selects a node from the allocation's allocated_nodes and forwards to that
+// agent's RunCommand RPC. Used for srun-in-salloc (#146).
+message RunStepRequest {
+  uint32 job_id = 1;
+  repeated string command = 2;
+  uint32 uid = 3;
+  uint32 gid = 4;
+  string work_dir = 5;
+  map<string, string> environment = 6;
+}
+
+message RunStepResponse {
+  int32 exit_code = 1;
+  string stdout = 2;
+  string stderr = 3;
+  string node = 4;  // Hostname of the allocated node the command ran on
+}
+
+// Agent-side request: run a command directly on this node (no namespace
+// entry, since salloc allocations don't track a job process). The agent
+// runs the command as the requested uid/gid in the requested work_dir.
+message RunCommandRequest {
+  repeated string command = 1;
+  uint32 uid = 2;
+  uint32 gid = 3;
+  string work_dir = 4;
+  map<string, string> environment = 5;
+}
+
+message RunCommandResponse {
+  int32 exit_code = 1;
+  string stdout = 2;
+  string stderr = 3;
 }
 
 message StreamJobOutputRequest {


### PR DESCRIPTION
## Summary

Closes #146.

When ``srun`` ran inside an allocation (``SPUR_JOB_ID`` set, e.g. inside an ``salloc`` interactive shell), ``run_as_step`` executed the command via ``tokio::process::Command::new(...).status()`` — **locally**, on the controller / submit host. So:

\`\`\`
\$ salloc -N 1
\$ srun hostname
controller-host    # ← wrong: should be the allocated compute node
\`\`\`

Slurm dispatches steps via slurmd RPC to the allocated nodes; spur now does the same.

## Two new RPCs

**SlurmAgent.RunCommand**: runs a one-shot command directly on the agent's node. Unlike ``ExecInJob``, this doesn't require a tracked job process — ``salloc`` allocations don't run anything until ``srun`` dispatches a step.

**SlurmController.RunStep**: looks up the job's ``allocated_nodes``, picks the first, forwards to that agent's ``RunCommand``. Mirrors the existing ``ExecInJob`` routing pattern.

\`\`\`
srun (in salloc shell)
  └─> RunStep(job_id, command, uid, gid, cwd, env) → controller
        └─> RunCommand(command, uid, gid, cwd, env) → agent on allocated node
              └─> run, capture stdout/stderr/exit_code
\`\`\`

## Tests

5 new tests for the agent-side ``RunCommand`` handler in ``agent_server::tests``:

- ``run_command_executes_simple_command`` — ``echo`` round-trip
- ``run_command_propagates_nonzero_exit_code`` — ``false`` → 1
- ``run_command_passes_environment`` — env var visible in spawned child
- ``run_command_empty_command_is_rejected`` — InvalidArgument
- ``run_command_uses_provided_work_dir`` — ``pwd`` matches supplied work_dir (handles symlink resolution)

The controller's ``RunStep`` routing is ~50 lines that mirror ``ExecInJob`` (same lookup-job → first-allocated-node → forward pattern). ``ExecInJob`` is covered by integration tests in ``spur-tests``.

## Test plan

- [x] ``cargo test -p spurd agent_server::tests::run_command`` — all 5 pass
- [x] ``cargo build --workspace``
- [x] ``cargo fmt --check``

## Limitations / follow-ups

- The first allocated node is always picked. For multi-node allocations or ``-N`` partitioning, this is sufficient for the bug repro (``srun hostname`` works) but a richer scheduler would distribute across nodes — separate change.
- Output is buffered (returned as one stdout/stderr blob), not streamed line-by-line. Long-running ``srun`` invocations would benefit from streaming via ``StreamJobOutput``-like RPC — separate change.

Closes #146