### PR TITLE
fix(spur-tests): remove unused imports and variables

### DIFF
--- a/crates/spur-tests/src/harness.rs
+++ b/crates/spur-tests/src/harness.rs
@@ -3,12 +3,10 @@
 //! Provides helpers for standing up test clusters, submitting jobs,
 //! and asserting state transitions.
 
-use std::collections::HashMap;
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::Arc;
 
 use spur_core::config::SlurmConfig;
-use spur_core::job::{Job, JobId, JobSpec, JobState};
+use spur_core::job::{Job, JobSpec, JobState};
 use spur_core::node::{Node, NodeState};
 use spur_core::partition::{Partition, PartitionState};
 use spur_core::resource::ResourceSet;

--- a/crates/spur-tests/src/t07_sched.rs
+++ b/crates/spur-tests/src/t07_sched.rs
@@ -9,7 +9,6 @@ mod tests {
     use chrono::{Duration, Utc};
     use spur_core::job::*;
     use spur_core::node::*;
-    use spur_core::partition::*;
     use spur_core::resource::*;
     use spur_sched::backfill::BackfillScheduler;
     use spur_sched::timeline::NodeTimeline;

--- a/crates/spur-tests/src/t39_gpu.rs
+++ b/crates/spur-tests/src/t39_gpu.rs
@@ -218,7 +218,7 @@ mod tests {
             ..Default::default()
         }];
 
-        let mut job = Job::new(
+        let job = Job::new(
             1,
             JobSpec {
                 name: "test".into(),


### PR DESCRIPTION
Drop unused HashMap, Arc, JobId, and partition imports from the test harness and scheduler tests. Mark job binding as immutable in GPU test.
