### PR TITLE
ci(clippy): deny unused code warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
             ${{ runner.os }}-cargo-clippy-
 
       - name: Clippy
-        run: cargo clippy --workspace --exclude spur-ffi --all-targets -- -W clippy::all
+        run: cargo clippy --workspace --exclude spur-ffi --all-targets -- -W clippy::all -D unused
 
   cluster:
     name: Cluster Tests (2x MI300X)


### PR DESCRIPTION
Add `-D unused` to the CI clippy invocation so that dead code, unused imports, unused variables, and other unused-item warnings are promoted to hard errors. This prevents unused code from silently accumulating in the codebase over time through AI written code (it tends to forget cleanup a lot).

The codebase was cleaned up in PRs #155 through #159, so the lint group passes cleanly today and this gate can now be enforced going forward.
