### PR TITLE
ci: run k8s tests against a real cluster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,21 +155,109 @@ jobs:
     name: Build Docker Image
     runs-on: ubuntu-latest
     needs: [build-and-test, fmt, clippy]
+    outputs:
+      image_tag: ${{ steps.tag.outputs.value }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build container image
-        run: sg docker -c "docker build -f deploy/Dockerfile -t spur:ci ."
+      - name: Set image tag
+        id: tag
+        run: echo "value=${{ secrets.REGISTRY }}/spur:${{ github.sha }}" >> $GITHUB_OUTPUT
 
-      - name: Save image as artifact
-        run: sg docker -c "docker save spur:ci -o /tmp/spur-ci-image.tar"
-
-      - name: Upload image artifact
-        uses: actions/upload-artifact@v4
+      - name: Log in to registry
+        if: github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
         with:
-          name: spur-ci-image
-          path: /tmp/spur-ci-image.tar
-          retention-days: 1
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: deploy/Dockerfile
+          push: ${{ github.ref == 'refs/heads/main' }}
+          tags: |
+            ${{ secrets.REGISTRY }}/spur:${{ github.sha }}
+            ${{ secrets.REGISTRY }}/spur:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+
+  test-k8s:
+    name: Test on Kubernetes
+    runs-on: [self-hosted, amd-aac02-rocm]
+    needs: build-docker-image
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Patch image tag in manifests
+        env:
+          IMAGE_TAG: ${{ needs.build-docker-image.outputs.image_tag }}
+        run: |
+          find deploy/k8s -name '*.yaml' | xargs sed -i \
+            "s|image: spur:latest|image: ${IMAGE_TAG}|g"
+
+      - name: Rebuild CRD generator
+        run: |
+          source ~/.cargo/env
+          cargo build --release --bin spur-k8s-operator
+
+      - name: Deploy to Kubernetes
+        env:
+          IMAGE_TAG: ${{ needs.build-docker-image.outputs.image_tag }}
+          KUBECONFIG: /home/amd/.kube/config
+        run: |
+          set -euo pipefail
+          kubectl config use-context kubernetes-admin@kubernetes
+
+          echo "==> 1. Namespace"
+          kubectl apply -f deploy/k8s/namespace.yaml
+
+          echo "==> 2. RBAC"
+          kubectl apply -f deploy/k8s/rbac.yaml
+
+          echo "==> 3. SpurJob CRD"
+          ./target/release/spur-k8s-operator generate-crd | kubectl apply -f -
+
+          echo "==> 4. ConfigMap"
+          kubectl apply -f deploy/k8s/configmap.yaml
+
+          echo "==> 5. Accounting daemon"
+          kubectl apply -f deploy/k8s/spurdbd.yaml
+
+          echo "==> 6. Controller + PDB"
+          kubectl apply -f deploy/k8s/spurctld.yaml
+          kubectl apply -f deploy/k8s/pdb.yaml
+          kubectl rollout status statefulset/spurctld -n spur --timeout=180s
+
+          echo "==> 7. REST API"
+          kubectl apply -f deploy/k8s/spurrestd.yaml
+
+          echo "==> 8. Operator"
+          kubectl apply -f deploy/k8s/operator.yaml
+          kubectl rollout status deployment/spur-k8s-operator -n spur --timeout=120s
+
+          echo "==> Done. Current state:"
+          kubectl get all -n spur
+
+          echo "==> Verify: Raft leader election"
+          kubectl logs -n spur spurctld-0 | grep -i leader || echo "No leader log yet"
+
+          echo "==> Verify: Operator node registration"
+          kubectl logs -n spur deploy/spur-k8s-operator | grep -i register || echo "No registration log yet"
+
+          echo "==> Verify: Health checks"
+          kubectl port-forward -n spur deploy/spur-k8s-operator 8080:8080 &
+          PF_PID=$!
+          sleep 3
+          curl -sf http://localhost:8080/healthz && echo "healthz OK" || echo "healthz FAILED"
+          curl -sf http://localhost:8080/readyz && echo "readyz OK" || echo "readyz FAILED"
+          kill $PF_PID
 
   k8s:
     name: K8s Integration
@@ -181,17 +269,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download CI image
-        uses: actions/download-artifact@v4
-        with:
-          name: spur-ci-image
-          path: /tmp
-
-      - name: Load CI image
-        run: sg docker -c "docker load -i /tmp/spur-ci-image.tar"
-
       - name: Run K8s integration tests
-        run: sg docker -c "SPUR_CI_IMAGE=spur:ci bash deploy/bare-metal/k8s_test.sh"
+        run: SPUR_CI_IMAGE=${{ needs.build-docker-image.outputs.image_tag }} bash deploy/bare-metal/k8s_test.sh
 
       - name: Cleanup kind cluster
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,10 +162,9 @@ jobs:
 
       - name: Set image tag
         id: tag
-        run: echo "value=${{ secrets.REGISTRY }}/spur:${{ github.sha }}" >> $GITHUB_OUTPUT
+        run: echo "value=${{ secrets.REGISTRY }}/spur:${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to registry
-        if: github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -179,101 +178,109 @@ jobs:
         with:
           context: .
           file: deploy/Dockerfile
-          push: ${{ github.ref == 'refs/heads/main' }}
-          tags: |
-            ${{ secrets.REGISTRY }}/spur:${{ github.sha }}
-            ${{ secrets.REGISTRY }}/spur:latest
+          push: true
+          tags: ${{ steps.tag.outputs.value }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-
-  test-k8s:
-    name: Test on Kubernetes
+  k8s-integration:
+    name: K8s Integration
     runs-on: [self-hosted, amd-aac02-rocm]
     needs: build-docker-image
-    if: github.ref == 'refs/heads/main'
+    concurrency:
+      group: k8s-integration
+      cancel-in-progress: true
+    env:
+      KUBECONFIG: /home/amd/.kube/config
+      SPUR_TEST_NS: spur-ci-${{ github.run_id }}
+      SPUR_CI_IMAGE: ${{ secrets.REGISTRY }}/spur:${{ github.sha }}
+      RUST_LOG: info
     steps:
       - uses: actions/checkout@v4
 
-      - name: Patch image tag in manifests
-        env:
-          IMAGE_TAG: ${{ needs.build-docker-image.outputs.image_tag }}
-        run: |
-          find deploy/k8s -name '*.yaml' | xargs sed -i \
-            "s|image: spur:latest|image: ${IMAGE_TAG}|g"
+      - name: Select kubectl context
+        run: kubectl config use-context kubernetes-admin@kubernetes
 
-      - name: Rebuild CRD generator
-        run: |
-          source ~/.cargo/env
-          cargo build --release --bin spur-k8s-operator
-
-      - name: Deploy to Kubernetes
-        env:
-          IMAGE_TAG: ${{ needs.build-docker-image.outputs.image_tag }}
-          KUBECONFIG: /home/amd/.kube/config
+      - name: Remove leftover spur-ci namespaces
         run: |
           set -euo pipefail
-          kubectl config use-context kubernetes-admin@kubernetes
+          leftover=$(kubectl get ns -o jsonpath='{.items[*].metadata.name}' \
+            | tr ' ' '\n' | grep '^spur-ci-' || true)
+          if [ -z "$leftover" ]; then
+            echo "No leftover spur-ci namespaces"
+            exit 0
+          fi
+          echo "Deleting leftover spur-ci namespaces (cluster-scoped operator/RBAC contention):"
+          echo "$leftover"
+          for ns in $leftover; do
+            kubectl delete ns "$ns" --ignore-not-found --wait=false
+          done
+          deadline=$((SECONDS + 120))
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            remaining=$(kubectl get ns -o jsonpath='{.items[*].metadata.name}' \
+              | tr ' ' '\n' | grep '^spur-ci-' || true)
+            if [ -z "$remaining" ]; then
+              echo "All spur-ci namespaces removed"
+              exit 0
+            fi
+            echo "Waiting for namespaces to terminate: $remaining"
+            sleep 5
+          done
+          echo "ERROR: timed out after 2m waiting for spur-ci namespace deletion:"
+          kubectl get ns -o wide $(echo "$remaining" | tr '\n' ' ')
+          exit 1
 
-          echo "==> 1. Namespace"
-          kubectl apply -f deploy/k8s/namespace.yaml
+      - name: Clean cluster-scoped Spur RBAC (pre)
+        run: |
+          set -euo pipefail
+          kubectl delete clusterrolebinding spur-operator --ignore-not-found
+          kubectl delete clusterrole spur-operator --ignore-not-found
 
-          echo "==> 2. RBAC"
-          kubectl apply -f deploy/k8s/rbac.yaml
+      - name: Create test namespace
+        run: |
+          kubectl create namespace "$SPUR_TEST_NS" \
+            --dry-run=client -o yaml | kubectl apply -f -
 
-          echo "==> 3. SpurJob CRD"
-          ./target/release/spur-k8s-operator generate-crd | kubectl apply -f -
+      - name: Create registry pull secret
+        env:
+          REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          kubectl create secret docker-registry regcred \
+            --docker-server="https://index.docker.io/v1/" \
+            --docker-username="$REGISTRY_USERNAME" \
+            --docker-password="$REGISTRY_PASSWORD" \
+            -n "$SPUR_TEST_NS" \
+            --dry-run=client -o yaml | kubectl apply -f -
+          kubectl patch serviceaccount default -n "$SPUR_TEST_NS" \
+            -p '{"imagePullSecrets": [{"name": "regcred"}]}'
 
-          echo "==> 4. ConfigMap"
-          kubectl apply -f deploy/k8s/configmap.yaml
-
-          echo "==> 5. Accounting daemon"
-          kubectl apply -f deploy/k8s/spurdbd.yaml
-
-          echo "==> 6. Controller + PDB"
-          kubectl apply -f deploy/k8s/spurctld.yaml
-          kubectl apply -f deploy/k8s/pdb.yaml
-          kubectl rollout status statefulset/spurctld -n spur --timeout=180s
-
-          echo "==> 7. REST API"
-          kubectl apply -f deploy/k8s/spurrestd.yaml
-
-          echo "==> 8. Operator"
-          kubectl apply -f deploy/k8s/operator.yaml
-          kubectl rollout status deployment/spur-k8s-operator -n spur --timeout=120s
-
-          echo "==> Done. Current state:"
-          kubectl get all -n spur
-
-          echo "==> Verify: Raft leader election"
-          kubectl logs -n spur spurctld-0 | grep -i leader || echo "No leader log yet"
-
-          echo "==> Verify: Operator node registration"
-          kubectl logs -n spur deploy/spur-k8s-operator | grep -i register || echo "No registration log yet"
-
-          echo "==> Verify: Health checks"
-          kubectl port-forward -n spur deploy/spur-k8s-operator 8080:8080 &
-          PF_PID=$!
-          sleep 3
-          curl -sf http://localhost:8080/healthz && echo "healthz OK" || echo "healthz FAILED"
-          curl -sf http://localhost:8080/readyz && echo "readyz OK" || echo "readyz FAILED"
-          kill $PF_PID
-
-  k8s:
-    name: K8s Integration
-    runs-on: [self-hosted, mi300x]
-    needs: build-docker-image
-    concurrency:
-      group: k8s-${{ github.ref }}
-      cancel-in-progress: true
-    steps:
-      - uses: actions/checkout@v4
+      - name: Verify cluster can pull CI image
+        run: |
+          set -euo pipefail
+          kubectl run image-pull-check \
+            --namespace="$SPUR_TEST_NS" \
+            --image="$SPUR_CI_IMAGE" \
+            --restart=Never \
+            --command -- sleep 30
+          if ! kubectl wait --namespace="$SPUR_TEST_NS" \
+            --for=condition=Ready pod/image-pull-check --timeout=120s; then
+            echo "ERROR: cluster failed to pull $SPUR_CI_IMAGE"
+            kubectl describe pod image-pull-check -n "$SPUR_TEST_NS" || true
+            kubectl get events -n "$SPUR_TEST_NS" --sort-by='.lastTimestamp' | tail -30 || true
+            exit 1
+          fi
+          kubectl delete pod image-pull-check -n "$SPUR_TEST_NS" --ignore-not-found --wait=true
 
       - name: Run K8s integration tests
-        run: SPUR_CI_IMAGE=${{ needs.build-docker-image.outputs.image_tag }} bash deploy/bare-metal/k8s_test.sh
+        run: bash deploy/bare-metal/k8s_test.sh
 
-      - name: Cleanup kind cluster
+      - name: Cleanup test resources
         if: always()
         run: |
-          export PATH="$HOME/.local/bin:$PATH"
-          sg docker -c "kind delete cluster --name spur-ci" 2>/dev/null || true
+          set -euo pipefail
+          kubectl delete namespace "$SPUR_TEST_NS" --ignore-not-found --timeout=120s || true
+          kubectl delete clusterrolebinding spur-operator --ignore-not-found
+          kubectl delete clusterrole spur-operator --ignore-not-found
+          kubectl delete crd spurjobs.spur.ai --ignore-not-found --timeout=120s || true

--- a/deploy/bare-metal/k8s_test.sh
+++ b/deploy/bare-metal/k8s_test.sh
@@ -1,30 +1,20 @@
 #!/bin/bash
-# Spur K8s Integration Tests using kind (Kubernetes in Docker)
+# Spur K8s Integration Tests
 #
-# Validates the full K8s deployment path:
-#   - SpurJob CRD lifecycle (create → schedule → run → complete)
-#   - Operator health and node registration
-#   - Multi-node job coordination
-#   - Cancellation and failure detection
-#   - Leader election via K8s Lease
+# Runs against an existing K8s cluster. The CI workflow creates the
+# namespace, registry secret, and handles cleanup; this script deploys Spur
+# components and runs the test suite.
 #
-# Prerequisites:
-#   - Docker installed
-#   - SPUR_CI_IMAGE set to a pre-built Spur container image (e.g. spur:ci)
-#
-# Usage:
-#   SPUR_CI_IMAGE=spur:ci bash deploy/bare-metal/k8s_test.sh
+# Environment:
+#   SPUR_CI_IMAGE   (required) Container image for spurctld + operator
+#   SPUR_TEST_NS    (required) Namespace for test resources
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
-TOOLS_DIR="${HOME}/.local/bin"
-CLUSTER_NAME="spur-ci"
-SPUR_CI_IMAGE="${SPUR_CI_IMAGE:?SPUR_CI_IMAGE must be set to a Docker image (e.g. spur:ci)}"
-
-mkdir -p "${TOOLS_DIR}"
-export PATH="${TOOLS_DIR}:${PATH}"
+SPUR_CI_IMAGE="${SPUR_CI_IMAGE:?SPUR_CI_IMAGE must be set to a container image}"
+SPUR_NS="${SPUR_TEST_NS:?SPUR_TEST_NS must be set to the test namespace}"
 
 PASS=0
 FAIL=0
@@ -35,12 +25,13 @@ fail() { TOTAL=$((TOTAL + 1)); FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
 section() { echo ""; echo "=== $1 ==="; }
 
 wait_spurjob() {
-    local name="$1"
-    local want="$2"
-    local timeout="${3:-60}"
+    local ns="$1"
+    local name="$2"
+    local want="$3"
+    local timeout="${4:-60}"
     local state=""
     for _ in $(seq 1 $((timeout / 2))); do
-        state=$(kubectl -n spur get spurjob "$name" -o jsonpath='{.status.state}' 2>/dev/null || echo "")
+        state=$(kubectl -n "$ns" get spurjob "$name" -o jsonpath='{.status.state}' 2>/dev/null || echo "")
         [ "$state" = "$want" ] && echo "$state" && return 0
         case "$state" in
             Completed|Failed|Cancelled)
@@ -55,8 +46,7 @@ wait_spurjob() {
 cleanup() {
     echo ""
     echo "=== Cleanup ==="
-    kind delete cluster --name "${CLUSTER_NAME}" 2>/dev/null || true
-    echo "  kind cluster removed"
+    echo "  CI workflow handles namespace deletion"
 }
 
 # ============================================================
@@ -64,115 +54,62 @@ cleanup() {
 # ============================================================
 section "Prerequisites"
 
-if ! command -v docker &>/dev/null; then
-    echo "SKIP: Docker not installed"
-    exit 0
-fi
-
-if ! docker info >/dev/null 2>&1; then
-    echo "SKIP: Docker daemon not accessible (add runner user to docker group: sudo usermod -aG docker \$USER)"
-    exit 0
-fi
-
-pass "Docker available"
-
-# ============================================================
-# Install tools (kind + kubectl)
-# ============================================================
-section "Install tools"
-
-if ! command -v kind &>/dev/null; then
-    KIND_VER=$(curl -fsSL https://api.github.com/repos/kubernetes-sigs/kind/releases/latest \
-        | grep '"tag_name"' | head -1 | cut -d'"' -f4)
-    echo "  Installing kind ${KIND_VER}..."
-    curl -fsSL -o "${TOOLS_DIR}/kind" \
-        "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VER}/kind-linux-amd64"
-    chmod +x "${TOOLS_DIR}/kind"
-fi
-pass "kind $(kind version)"
+echo "  Namespace: ${SPUR_NS}"
+echo "  Image: ${SPUR_CI_IMAGE}"
 
 if ! command -v kubectl &>/dev/null; then
-    KUBECTL_VER=$(curl -fsSL https://dl.k8s.io/release/stable.txt)
-    echo "  Installing kubectl ${KUBECTL_VER}..."
-    curl -fsSL -o "${TOOLS_DIR}/kubectl" \
-        "https://dl.k8s.io/release/${KUBECTL_VER}/bin/linux/amd64/kubectl"
-    chmod +x "${TOOLS_DIR}/kubectl"
+    echo "FAIL: kubectl not found"
+    exit 1
 fi
-pass "kubectl $(kubectl version --client -o json 2>/dev/null | grep gitVersion | cut -d'"' -f4)"
+pass "kubectl available"
 
-# ============================================================
-# Create kind cluster (control-plane + 2 workers)
-# ============================================================
-section "Create kind cluster"
-
-# Clean up previous cluster
-kind delete cluster --name "${CLUSTER_NAME}" 2>/dev/null || true
+kubectl get nodes >/dev/null 2>&1 \
+    && pass "Cluster reachable" \
+    || { echo "FAIL: cannot reach cluster"; exit 1; }
 
 trap cleanup EXIT
-
-kind create cluster --name "${CLUSTER_NAME}" --config=- <<'EOF'
-kind: Cluster
-apiVersion: kind.x-k8s.io/v1alpha4
-nodes:
-  - role: control-plane
-  - role: worker
-  - role: worker
-EOF
-
-kubectl wait --for=condition=Ready node --all --timeout=120s \
-    && pass "Kind cluster ready (3 nodes)" \
-    || fail "Kind cluster not ready"
-
-echo "  Nodes:"
-kubectl get nodes
-
-# Label worker nodes for Spur operator
-for node in $(kubectl get nodes -l '!node-role.kubernetes.io/control-plane' -o jsonpath='{.items[*].metadata.name}'); do
-    kubectl label node "$node" spur.ai/managed=true --overwrite
-done
-pass "Worker nodes labeled for Spur"
-
-# ============================================================
-# Load container image into kind
-# ============================================================
-section "Load Spur container image"
-
-echo "  Source image: ${SPUR_CI_IMAGE}"
-if [ "$SPUR_CI_IMAGE" != "spur:ci" ]; then
-    docker tag "$SPUR_CI_IMAGE" spur:ci
-fi
-
-kind load docker-image spur:ci --name "${CLUSTER_NAME}" \
-    && pass "Image loaded into kind" \
-    || fail "Image load failed"
-
-# Pre-load busybox for SpurJob pods (avoids Docker Hub pull issues in CI)
-docker pull busybox:latest
-kind load docker-image busybox:latest --name "${CLUSTER_NAME}" \
-    && pass "busybox image loaded into kind" \
-    || fail "busybox image load failed"
 
 # ============================================================
 # Deploy Spur to K8s
 # ============================================================
 section "Deploy Spur to K8s"
 
-# Register SpurJob CRD
-docker run --rm spur:ci generate-crd | kubectl apply -f - \
+# Helper: patch namespace and DNS in YAML when not using the default "spur" ns
+patch_ns() {
+    if [ "$SPUR_NS" = "spur" ]; then
+        cat
+    else
+        sed "s|namespace: spur|namespace: ${SPUR_NS}|g" \
+        | sed "s|\.spur\.svc\.cluster\.local|.${SPUR_NS}.svc.cluster.local|g"
+    fi
+}
+
+# Register SpurJob CRD via a temporary pod
+kubectl run crd-gen --namespace="$SPUR_NS" \
+    --image="$SPUR_CI_IMAGE" --restart=Never \
+    --command -- spur-k8s-operator generate-crd
+kubectl wait --namespace="$SPUR_NS" --for=jsonpath='{.status.phase}'=Succeeded pod/crd-gen --timeout=120s
+kubectl logs crd-gen -n "$SPUR_NS" | kubectl apply -f - \
     && pass "SpurJob CRD registered" \
     || fail "CRD registration failed"
+kubectl delete pod crd-gen -n "$SPUR_NS" --ignore-not-found 2>/dev/null || true
 
-# Namespace + RBAC
-kubectl apply -f "${REPO_ROOT}/deploy/k8s/namespace.yaml"
-kubectl apply -f "${REPO_ROOT}/deploy/k8s/rbac.yaml"
+# RBAC (namespace is already created by the CI workflow)
+sed "s|namespace: spur|namespace: ${SPUR_NS}|g" "${REPO_ROOT}/deploy/k8s/rbac.yaml" \
+    | kubectl apply -f -
+
+# Attach registry pull secret to the spur-operator SA so spurctld/operator
+# pods can pull from the CI registry (regcred is created by the CI workflow).
+kubectl patch serviceaccount spur-operator -n "$SPUR_NS" \
+    -p '{"imagePullSecrets": [{"name": "regcred"}]}' 2>/dev/null || true
 
 # CI-specific config (no accounting, fast scheduler)
-kubectl apply -f - <<'EOF'
+kubectl apply -f - <<EOF
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: spur-config
-  namespace: spur
+  namespace: ${SPUR_NS}
 data:
   spur.conf: |
     cluster_name = "k8s-ci"
@@ -191,46 +128,47 @@ data:
 EOF
 
 # Deploy controller + operator with CI image.
-# Patch spurctld to 1 replica for CI (single-node Raft self-elects;
-# no peers config needed).
-sed 's|spur:latest|spur:ci|g' "${REPO_ROOT}/deploy/k8s/spurctld.yaml" \
+# Patch spurctld to 1 replica for CI (single-node Raft self-elects).
+sed "s|spur:latest|${SPUR_CI_IMAGE}|g" "${REPO_ROOT}/deploy/k8s/spurctld.yaml" \
     | sed 's|replicas: 3|replicas: 1|g' \
+    | patch_ns \
     | kubectl apply -f -
-sed 's|spur:latest|spur:ci|g' "${REPO_ROOT}/deploy/k8s/operator.yaml" \
+sed "s|spur:latest|${SPUR_CI_IMAGE}|g" "${REPO_ROOT}/deploy/k8s/operator.yaml" \
+    | patch_ns \
     | kubectl apply -f -
 
 # Wait for pods to be ready
-kubectl -n spur wait --for=condition=Available deployment/spur-k8s-operator --timeout=120s \
+kubectl -n "$SPUR_NS" wait --for=condition=Available deployment/spur-k8s-operator --timeout=120s \
     && pass "Operator deployment ready" \
     || fail "Operator not ready"
 
-kubectl -n spur wait --for=condition=Ready pod -l app=spurctld --timeout=120s \
+kubectl -n "$SPUR_NS" wait --for=condition=Ready pod -l app=spurctld --timeout=120s \
     && pass "Controller pod ready" \
     || fail "Controller not ready"
 
 # Health check via a temporary busybox pod hitting the operator's pod IP
-OPERATOR_POD=$(kubectl -n spur get pod -l app=spur-k8s-operator -o jsonpath='{.items[0].metadata.name}')
-OPERATOR_IP=$(kubectl -n spur get pod "$OPERATOR_POD" -o jsonpath='{.status.podIP}')
-kubectl run healthcheck -n spur --image=busybox:latest --restart=Never --rm -i \
+OPERATOR_POD=$(kubectl -n "$SPUR_NS" get pod -l app=spur-k8s-operator -o jsonpath='{.items[0].metadata.name}')
+OPERATOR_IP=$(kubectl -n "$SPUR_NS" get pod "$OPERATOR_POD" -o jsonpath='{.status.podIP}')
+kubectl run healthcheck -n "$SPUR_NS" --image=busybox:latest --restart=Never --rm -i \
     -- wget -qO- -T 5 "http://${OPERATOR_IP}:8080/healthz" >/dev/null 2>&1 \
     && pass "Operator /healthz OK" \
     || fail "Operator /healthz failed"
 
 # Show what the operator sees
 echo "  Operator logs (last 10 lines):"
-kubectl -n spur logs "$OPERATOR_POD" --tail=10 2>/dev/null | sed 's/^/    /'
+kubectl -n "$SPUR_NS" logs "$OPERATOR_POD" --tail=10 2>/dev/null | sed 's/^/    /'
 
 # ============================================================
 # TEST 1: Simple SpurJob
 # ============================================================
 section "TEST 1: Simple SpurJob"
 
-kubectl apply -f - <<'EOF'
+kubectl apply -f - <<EOF
 apiVersion: spur.ai/v1alpha1
 kind: SpurJob
 metadata:
   name: test-simple
-  namespace: spur
+  namespace: ${SPUR_NS}
 spec:
   name: test-simple
   image: busybox:latest
@@ -238,87 +176,87 @@ spec:
   numNodes: 1
 EOF
 
-STATE=$(wait_spurjob test-simple Completed 60) \
+STATE=$(wait_spurjob "$SPUR_NS" test-simple Completed 60) \
     && pass "Simple SpurJob completed" \
     || { fail "Simple SpurJob state: $STATE"; \
-         echo "  Debug: pods in spur namespace:"; \
-         kubectl -n spur get pods -o wide 2>/dev/null | sed 's/^/    /'; \
+         echo "  Debug: pods in ${SPUR_NS} namespace:"; \
+         kubectl -n "$SPUR_NS" get pods -o wide 2>/dev/null | sed 's/^/    /'; \
          echo "  Debug: operator logs (last 20):"; \
-         kubectl -n spur logs -l app=spur-k8s-operator --tail=20 2>/dev/null | sed 's/^/    /'; }
+         kubectl -n "$SPUR_NS" logs -l app=spur-k8s-operator --tail=20 2>/dev/null | sed 's/^/    /'; }
 
-JOB_ID=$(kubectl -n spur get spurjob test-simple -o jsonpath='{.status.spurJobId}' 2>/dev/null)
+JOB_ID=$(kubectl -n "$SPUR_NS" get spurjob test-simple -o jsonpath='{.status.spurJobId}' 2>/dev/null)
 [ -n "$JOB_ID" ] \
     && pass "Spur assigned job ID: $JOB_ID" \
     || fail "No Spur job ID assigned"
 
-kubectl delete spurjob test-simple -n spur --timeout=30s 2>/dev/null || true
+kubectl delete spurjob test-simple -n "$SPUR_NS" --timeout=30s 2>/dev/null || true
 
 # ============================================================
 # TEST 2: SpurJob with environment variables
 # ============================================================
 section "TEST 2: SpurJob with environment variables"
 
-kubectl apply -f - <<'EOF'
+kubectl apply -f - <<EOF
 apiVersion: spur.ai/v1alpha1
 kind: SpurJob
 metadata:
   name: test-env
-  namespace: spur
+  namespace: ${SPUR_NS}
 spec:
   name: test-env
   image: busybox:latest
-  command: ["sh", "-c", "echo job=$SPUR_JOB_ID custom=$CUSTOM_VAR"]
+  command: ["sh", "-c", "echo job=\$SPUR_JOB_ID custom=\$CUSTOM_VAR"]
   numNodes: 1
   env:
     CUSTOM_VAR: "spur-ci-test"
 EOF
 
-STATE=$(wait_spurjob test-env Completed 60) \
+STATE=$(wait_spurjob "$SPUR_NS" test-env Completed 60) \
     && pass "Env var SpurJob completed" \
     || fail "Env var SpurJob state: $STATE"
 
-kubectl delete spurjob test-env -n spur --timeout=30s 2>/dev/null || true
+kubectl delete spurjob test-env -n "$SPUR_NS" --timeout=30s 2>/dev/null || true
 
 # ============================================================
 # TEST 3: Multi-node SpurJob (2 nodes)
 # ============================================================
 section "TEST 3: Multi-node SpurJob"
 
-kubectl apply -f - <<'EOF'
+kubectl apply -f - <<EOF
 apiVersion: spur.ai/v1alpha1
 kind: SpurJob
 metadata:
   name: test-multinode
-  namespace: spur
+  namespace: ${SPUR_NS}
 spec:
   name: test-multinode
   image: busybox:latest
-  command: ["sh", "-c", "echo rank=$SPUR_NODE_RANK nodes=$SPUR_NUM_NODES host=$(hostname)"]
+  command: ["sh", "-c", "echo rank=\$SPUR_NODE_RANK nodes=\$SPUR_NUM_NODES host=\$(hostname)"]
   numNodes: 2
 EOF
 
-STATE=$(wait_spurjob test-multinode Completed 90) \
+STATE=$(wait_spurjob "$SPUR_NS" test-multinode Completed 90) \
     && pass "Multi-node SpurJob completed" \
     || fail "Multi-node SpurJob state: $STATE"
 
-NODES=$(kubectl -n spur get spurjob test-multinode -o jsonpath='{.status.assignedNodes}' 2>/dev/null || echo "")
+NODES=$(kubectl -n "$SPUR_NS" get spurjob test-multinode -o jsonpath='{.status.assignedNodes}' 2>/dev/null || echo "")
 [ -n "$NODES" ] && [ "$NODES" != "[]" ] \
     && pass "Multi-node job assigned nodes: $NODES" \
     || pass "Multi-node job completed (node tracking optional)"
 
-kubectl delete spurjob test-multinode -n spur --timeout=30s 2>/dev/null || true
+kubectl delete spurjob test-multinode -n "$SPUR_NS" --timeout=30s 2>/dev/null || true
 
 # ============================================================
 # TEST 4: SpurJob cancellation
 # ============================================================
 section "TEST 4: SpurJob cancellation"
 
-kubectl apply -f - <<'EOF'
+kubectl apply -f - <<EOF
 apiVersion: spur.ai/v1alpha1
 kind: SpurJob
 metadata:
   name: test-cancel
-  namespace: spur
+  namespace: ${SPUR_NS}
 spec:
   name: test-cancel
   image: busybox:latest
@@ -330,11 +268,11 @@ EOF
 sleep 8
 
 # Delete the SpurJob
-kubectl delete spurjob test-cancel -n spur --timeout=30s
+kubectl delete spurjob test-cancel -n "$SPUR_NS" --timeout=30s
 
 # Verify pods are cleaned up
 sleep 5
-REMAINING=$(kubectl -n spur get pods 2>/dev/null | grep -c "test-cancel" || true)
+REMAINING=$(kubectl -n "$SPUR_NS" get pods 2>/dev/null | grep -c "test-cancel" || true)
 [ "$REMAINING" -eq 0 ] \
     && pass "Cancelled SpurJob pods cleaned up" \
     || fail "Pods still present after cancel ($REMAINING remaining)"
@@ -344,12 +282,12 @@ REMAINING=$(kubectl -n spur get pods 2>/dev/null | grep -c "test-cancel" || true
 # ============================================================
 section "TEST 5: SpurJob failure detection"
 
-kubectl apply -f - <<'EOF'
+kubectl apply -f - <<EOF
 apiVersion: spur.ai/v1alpha1
 kind: SpurJob
 metadata:
   name: test-fail
-  namespace: spur
+  namespace: ${SPUR_NS}
 spec:
   name: test-fail
   image: busybox:latest
@@ -357,11 +295,11 @@ spec:
   numNodes: 1
 EOF
 
-STATE=$(wait_spurjob test-fail Failed 60) \
+STATE=$(wait_spurjob "$SPUR_NS" test-fail Failed 60) \
     && pass "Failed SpurJob detected" \
     || fail "Failed SpurJob state: $STATE"
 
-kubectl delete spurjob test-fail -n spur --timeout=30s 2>/dev/null || true
+kubectl delete spurjob test-fail -n "$SPUR_NS" --timeout=30s 2>/dev/null || true
 
 # ============================================================
 # TEST 6: Sequential SpurJobs (scheduler queue)
@@ -374,7 +312,7 @@ apiVersion: spur.ai/v1alpha1
 kind: SpurJob
 metadata:
   name: test-seq-${i}
-  namespace: spur
+  namespace: ${SPUR_NS}
 spec:
   name: test-seq-${i}
   image: busybox:latest
@@ -385,7 +323,7 @@ done
 
 ALL_DONE=true
 for i in 1 2 3; do
-    STATE=$(wait_spurjob "test-seq-${i}" Completed 60) || true
+    STATE=$(wait_spurjob "$SPUR_NS" "test-seq-${i}" Completed 60) || true
     if [ "$STATE" != "Completed" ]; then
         ALL_DONE=false
         fail "Sequential job ${i} state: $STATE"
@@ -394,7 +332,7 @@ done
 $ALL_DONE && pass "All 3 sequential SpurJobs completed"
 
 for i in 1 2 3; do
-    kubectl delete spurjob "test-seq-${i}" -n spur --timeout=10s 2>/dev/null || true
+    kubectl delete spurjob "test-seq-${i}" -n "$SPUR_NS" --timeout=10s 2>/dev/null || true
 done
 
 # ============================================================
@@ -402,7 +340,7 @@ done
 # ============================================================
 section "TEST 7: Single-node Raft mode (no peers configured)"
 
-kubectl -n spur get pods -l app=spurctld -o jsonpath='{.items[0].status.phase}' 2>/dev/null | grep -q "Running" \
+kubectl -n "$SPUR_NS" get pods -l app=spurctld -o jsonpath='{.items[0].status.phase}' 2>/dev/null | grep -q "Running" \
     && pass "Controller pod is Running in single-node Raft mode" \
     || fail "Controller pod not in Running state"
 
@@ -411,7 +349,7 @@ kubectl -n spur get pods -l app=spurctld -o jsonpath='{.items[0].status.phase}' 
 # ============================================================
 section "TEST 8: Cross-namespace SpurJob"
 
-CROSS_NS="spur-user1"
+CROSS_NS="${SPUR_NS}-user1"
 kubectl create namespace "$CROSS_NS" 2>/dev/null || true
 pass "Namespace ${CROSS_NS} created"
 
@@ -428,17 +366,8 @@ spec:
   numNodes: 1
 EOF
 
-# wait_spurjob expects -n spur; inline a cross-namespace wait
-CROSS_STATE=""
-for _ in $(seq 1 30); do
-    CROSS_STATE=$(kubectl -n "$CROSS_NS" get spurjob test-cross-ns \
-        -o jsonpath='{.status.state}' 2>/dev/null || echo "")
-    [ "$CROSS_STATE" = "Completed" ] && break
-    case "$CROSS_STATE" in
-        Failed|Cancelled) break ;;
-    esac
-    sleep 2
-done
+CROSS_STATE=$(wait_spurjob "$CROSS_NS" test-cross-ns Completed 60) \
+    && true || true
 
 [ "$CROSS_STATE" = "Completed" ] \
     && pass "Cross-namespace SpurJob completed in ${CROSS_NS}" \
@@ -446,21 +375,17 @@ done
          echo "  Debug: pods in ${CROSS_NS}:"; \
          kubectl -n "$CROSS_NS" get pods -o wide 2>/dev/null | sed 's/^/    /'; \
          echo "  Debug: operator logs (last 20):"; \
-         kubectl -n spur logs -l app=spur-k8s-operator --tail=20 2>/dev/null | sed 's/^/    /'; }
+         kubectl -n "$SPUR_NS" logs -l app=spur-k8s-operator --tail=20 2>/dev/null | sed 's/^/    /'; }
 
-# Verify pod was created in the correct namespace (not in spur)
-POD_NS=$(kubectl get pods --all-namespaces -l spur.ai/job-id \
-    -o jsonpath='{.items[?(@.metadata.labels.spur\.ai/job-id)].metadata.namespace}' 2>/dev/null \
-    | tr ' ' '\n' | grep -c "$CROSS_NS" || echo "0")
-# At minimum, verify no pods leaked into the spur namespace for this job
+# Verify no pods leaked into the system namespace for this job
 CROSS_JOB_ID=$(kubectl -n "$CROSS_NS" get spurjob test-cross-ns \
     -o jsonpath='{.status.spurJobId}' 2>/dev/null || echo "")
 if [ -n "$CROSS_JOB_ID" ]; then
-    LEAKED=$(kubectl -n spur get pods -l "spur.ai/job-id=${CROSS_JOB_ID}" \
+    LEAKED=$(kubectl -n "$SPUR_NS" get pods -l "spur.ai/job-id=${CROSS_JOB_ID}" \
         --no-headers 2>/dev/null | wc -l)
     [ "$LEAKED" -eq 0 ] \
-        && pass "Pod created in ${CROSS_NS}, not leaked to spur namespace" \
-        || fail "Pod leaked to spur namespace (${LEAKED} found)"
+        && pass "Pod created in ${CROSS_NS}, not leaked to ${SPUR_NS} namespace" \
+        || fail "Pod leaked to ${SPUR_NS} namespace (${LEAKED} found)"
 else
     pass "Cross-namespace job ID check skipped (job may have already been cleaned up)"
 fi
@@ -474,27 +399,27 @@ kubectl delete namespace "$CROSS_NS" --timeout=30s 2>/dev/null || true
 section "TEST 9: Raft HA cluster setup"
 
 # Tear down single-node controller
-kubectl -n spur delete statefulset spurctld --timeout=30s 2>/dev/null || true
-kubectl -n spur delete svc spurctld --timeout=10s 2>/dev/null || true
+kubectl -n "$SPUR_NS" delete statefulset spurctld --timeout=30s 2>/dev/null || true
+kubectl -n "$SPUR_NS" delete svc spurctld --timeout=10s 2>/dev/null || true
 for pvc in spool-spurctld-0 spool-spurctld-1 spool-spurctld-2; do
-    kubectl -n spur delete pvc "$pvc" --timeout=10s 2>/dev/null || true
+    kubectl -n "$SPUR_NS" delete pvc "$pvc" --timeout=10s 2>/dev/null || true
 done
 sleep 5
 
-kubectl apply -f - <<'RAFTCFG'
+kubectl apply -f - <<EOF
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: spur-config
-  namespace: spur
+  namespace: ${SPUR_NS}
 data:
   spur.conf: |
     cluster_name = "k8s-ci-raft"
     [controller]
     peers = [
-      "spurctld-0.spurctld.spur.svc.cluster.local:6821",
-      "spurctld-1.spurctld.spur.svc.cluster.local:6821",
-      "spurctld-2.spurctld.spur.svc.cluster.local:6821",
+      "spurctld-0.spurctld.${SPUR_NS}.svc.cluster.local:6821",
+      "spurctld-1.spurctld.${SPUR_NS}.svc.cluster.local:6821",
+      "spurctld-2.spurctld.${SPUR_NS}.svc.cluster.local:6821",
     ]
     [scheduler]
     interval_secs = 1
@@ -506,22 +431,23 @@ data:
     nodes = "ALL"
     max_time = "1h"
     default_time = "10m"
-RAFTCFG
+EOF
 
-sed 's|spur:latest|spur:ci|g' "${REPO_ROOT}/deploy/k8s/spurctld.yaml" \
+sed "s|spur:latest|${SPUR_CI_IMAGE}|g" "${REPO_ROOT}/deploy/k8s/spurctld.yaml" \
+    | patch_ns \
     | kubectl apply -f -
 
 echo "  Waiting for 3-replica Raft cluster..."
 sleep 45
-kubectl -n spur wait --for=condition=Ready pod -l app=spurctld --timeout=120s 2>/dev/null
+kubectl -n "$SPUR_NS" wait --for=condition=Ready pod -l app=spurctld --timeout=120s 2>/dev/null
 
 # Voter initialization restart
-kubectl -n spur delete pod spurctld-0 spurctld-1 spurctld-2 --grace-period=5 2>/dev/null || true
+kubectl -n "$SPUR_NS" delete pod spurctld-0 spurctld-1 spurctld-2 --grace-period=5 2>/dev/null || true
 sleep 35
-kubectl -n spur wait --for=condition=Ready pod -l app=spurctld --timeout=120s 2>/dev/null
+kubectl -n "$SPUR_NS" wait --for=condition=Ready pod -l app=spurctld --timeout=120s 2>/dev/null
 sleep 10
 
-RUNNING=$(kubectl -n spur get pods -l app=spurctld --field-selector=status.phase=Running --no-headers 2>/dev/null | wc -l)
+RUNNING=$(kubectl -n "$SPUR_NS" get pods -l app=spurctld --field-selector=status.phase=Running --no-headers 2>/dev/null | wc -l)
 [ "$RUNNING" -eq 3 ] \
     && pass "3-replica Raft cluster deployed" \
     || fail "Expected 3 running pods, got $RUNNING"
@@ -534,7 +460,7 @@ section "TEST 10: Raft leader election"
 LEADER_FOUND=false
 for attempt in $(seq 1 10); do
     for i in 0 1 2; do
-        VOTE=$(kubectl -n spur exec spurctld-$i -- cat /var/spool/spur/raft/vote.json 2>/dev/null || echo "")
+        VOTE=$(kubectl -n "$SPUR_NS" exec spurctld-$i -- cat /var/spool/spur/raft/vote.json 2>/dev/null || echo "")
         if echo "$VOTE" | grep -q '"committed":true'; then
             LEADER_FOUND=true
             pass "Committed vote found on spurctld-$i"
@@ -550,14 +476,14 @@ $LEADER_FOUND || fail "No committed leader vote after 30s"
 # ============================================================
 section "TEST 11: Raft state replication"
 
-BOUND=$(kubectl -n spur get pvc --no-headers 2>/dev/null | grep -c Bound || true)
+BOUND=$(kubectl -n "$SPUR_NS" get pvc --no-headers 2>/dev/null | grep -c Bound || true)
 [ "$BOUND" -ge 3 ] \
     && pass "All 3 PVCs bound" \
     || fail "Only $BOUND PVCs bound"
 
 ALL_HAVE_LOGS=true
 for i in 0 1 2; do
-    LC=$(kubectl -n spur exec spurctld-$i -- ls /var/spool/spur/raft/log/ 2>/dev/null | wc -l || echo "0")
+    LC=$(kubectl -n "$SPUR_NS" exec spurctld-$i -- ls /var/spool/spur/raft/log/ 2>/dev/null | wc -l || echo "0")
     [ "$LC" -eq 0 ] && ALL_HAVE_LOGS=false
 done
 $ALL_HAVE_LOGS \
@@ -569,16 +495,16 @@ $ALL_HAVE_LOGS \
 # ============================================================
 section "TEST 12: Raft failover recovery"
 
-kubectl -n spur delete pod spurctld-0 --grace-period=0 --force 2>/dev/null || true
+kubectl -n "$SPUR_NS" delete pod spurctld-0 --grace-period=0 --force 2>/dev/null || true
 sleep 20
-kubectl -n spur wait --for=condition=Ready pod/spurctld-0 --timeout=60s 2>/dev/null
+kubectl -n "$SPUR_NS" wait --for=condition=Ready pod/spurctld-0 --timeout=60s 2>/dev/null
 
-PODS_READY=$(kubectl -n spur get pods -l app=spurctld --field-selector=status.phase=Running --no-headers 2>/dev/null | wc -l)
+PODS_READY=$(kubectl -n "$SPUR_NS" get pods -l app=spurctld --field-selector=status.phase=Running --no-headers 2>/dev/null | wc -l)
 [ "$PODS_READY" -eq 3 ] \
     && pass "Cluster recovered after pod kill (3 pods running)" \
     || fail "Cluster not fully recovered ($PODS_READY pods running)"
 
-VOTE_AFTER=$(kubectl -n spur exec spurctld-0 -- cat /var/spool/spur/raft/vote.json 2>/dev/null || echo "")
+VOTE_AFTER=$(kubectl -n "$SPUR_NS" exec spurctld-0 -- cat /var/spool/spur/raft/vote.json 2>/dev/null || echo "")
 echo "$VOTE_AFTER" | grep -q '"committed":true' \
     && pass "Restarted pod recovered Raft state from PVC" \
     || fail "Restarted pod has no committed vote"
@@ -590,12 +516,12 @@ section "TEST 13: Raft state survives leader failover"
 
 # Submit a job to populate Raft state, then kill the leader.
 # After recovery, verify the job ID is still known (state was replicated).
-kubectl apply -f - <<'EOF'
+kubectl apply -f - <<EOF
 apiVersion: spur.ai/v1alpha1
 kind: SpurJob
 metadata:
   name: test-failover-state
-  namespace: spur
+  namespace: ${SPUR_NS}
 spec:
   name: test-failover-state
   image: busybox:latest
@@ -604,7 +530,7 @@ spec:
 EOF
 
 sleep 8
-JOB_ID_BEFORE=$(kubectl -n spur get spurjob test-failover-state \
+JOB_ID_BEFORE=$(kubectl -n "$SPUR_NS" get spurjob test-failover-state \
     -o jsonpath='{.status.spurJobId}' 2>/dev/null || echo "")
 [ -n "$JOB_ID_BEFORE" ] \
     && pass "Job submitted before failover (job_id=$JOB_ID_BEFORE)" \
@@ -613,11 +539,11 @@ JOB_ID_BEFORE=$(kubectl -n spur get spurjob test-failover-state \
 # Find and kill the current leader
 LEADER_POD=""
 for i in 0 1 2; do
-    IS_LEADER=$(kubectl -n spur exec spurctld-$i -- \
+    IS_LEADER=$(kubectl -n "$SPUR_NS" exec spurctld-$i -- \
         cat /var/spool/spur/raft/vote.json 2>/dev/null \
         | grep -o '"node_id":[0-9]*' | head -1 | grep -o '[0-9]*' || echo "")
     MY_ID=$((i + 1))
-    COMMITTED=$(kubectl -n spur exec spurctld-$i -- \
+    COMMITTED=$(kubectl -n "$SPUR_NS" exec spurctld-$i -- \
         cat /var/spool/spur/raft/vote.json 2>/dev/null \
         | grep -c '"committed":true' || echo "0")
     if [ "$IS_LEADER" = "$MY_ID" ] && [ "$COMMITTED" = "1" ]; then
@@ -627,15 +553,15 @@ for i in 0 1 2; do
 done
 [ -z "$LEADER_POD" ] && LEADER_POD="spurctld-0"
 echo "  Killing leader: $LEADER_POD"
-kubectl -n spur delete pod "$LEADER_POD" --grace-period=0 --force 2>/dev/null || true
+kubectl -n "$SPUR_NS" delete pod "$LEADER_POD" --grace-period=0 --force 2>/dev/null || true
 
 sleep 25
-kubectl -n spur wait --for=condition=Ready pod -l app=spurctld --timeout=60s 2>/dev/null
+kubectl -n "$SPUR_NS" wait --for=condition=Ready pod -l app=spurctld --timeout=60s 2>/dev/null
 
 # The key assertion: job ID should be the same after leader failover.
 # The job may have ended as Completed or Failed depending on pod lifecycle,
 # but the Raft-replicated state (job ID, job existence) must survive.
-JOB_ID_AFTER=$(kubectl -n spur get spurjob test-failover-state \
+JOB_ID_AFTER=$(kubectl -n "$SPUR_NS" get spurjob test-failover-state \
     -o jsonpath='{.status.spurJobId}' 2>/dev/null || echo "")
 [ "$JOB_ID_BEFORE" = "$JOB_ID_AFTER" ] \
     && pass "Job ID consistent across failover ($JOB_ID_AFTER)" \
@@ -644,7 +570,7 @@ JOB_ID_AFTER=$(kubectl -n spur get spurjob test-failover-state \
 # Verify new leader was elected
 NEW_LEADER_FOUND=false
 for i in 0 1 2; do
-    COMMITTED=$(kubectl -n spur exec spurctld-$i -- \
+    COMMITTED=$(kubectl -n "$SPUR_NS" exec spurctld-$i -- \
         cat /var/spool/spur/raft/vote.json 2>/dev/null \
         | grep -c '"committed":true' || echo "0")
     if [ "$COMMITTED" = "1" ]; then
@@ -655,7 +581,7 @@ for i in 0 1 2; do
 done
 $NEW_LEADER_FOUND || fail "No committed vote found after failover"
 
-kubectl delete spurjob test-failover-state -n spur --timeout=30s 2>/dev/null || true
+kubectl delete spurjob test-failover-state -n "$SPUR_NS" --timeout=30s 2>/dev/null || true
 
 # ============================================================
 # TEST 14: New leader accepts writes after failover
@@ -664,12 +590,12 @@ section "TEST 14: New leader accepts writes after failover"
 
 # After the leader kill in test 13, the cluster should have a new leader.
 # Submit a new job and verify it gets a job ID (proves writes work).
-kubectl apply -f - <<'EOF'
+kubectl apply -f - <<EOF
 apiVersion: spur.ai/v1alpha1
 kind: SpurJob
 metadata:
   name: test-post-failover
-  namespace: spur
+  namespace: ${SPUR_NS}
 spec:
   name: test-post-failover
   image: busybox:latest
@@ -678,7 +604,7 @@ spec:
 EOF
 
 sleep 10
-POST_JOB_ID=$(kubectl -n spur get spurjob test-post-failover \
+POST_JOB_ID=$(kubectl -n "$SPUR_NS" get spurjob test-post-failover \
     -o jsonpath='{.status.spurJobId}' 2>/dev/null || echo "")
 [ -n "$POST_JOB_ID" ] \
     && pass "New job accepted after failover (job_id=$POST_JOB_ID)" \
@@ -691,7 +617,7 @@ if [ -n "$POST_JOB_ID" ] && [ -n "$JOB_ID_BEFORE" ]; then
         || fail "Job ID sequence broken ($POST_JOB_ID <= $JOB_ID_BEFORE)"
 fi
 
-kubectl delete spurjob test-post-failover -n spur --timeout=30s 2>/dev/null || true
+kubectl delete spurjob test-post-failover -n "$SPUR_NS" --timeout=30s 2>/dev/null || true
 
 # ============================================================
 # TEST 15: Raft log replication and node recovery
@@ -702,7 +628,7 @@ section "TEST 15: Raft log replication and node recovery"
 MIN_LOGS=999999
 MAX_LOGS=0
 for i in 0 1 2; do
-    LC=$(kubectl -n spur exec spurctld-$i -- \
+    LC=$(kubectl -n "$SPUR_NS" exec spurctld-$i -- \
         ls /var/spool/spur/raft/log/ 2>/dev/null | wc -l || echo "0")
     [ "$LC" -lt "$MIN_LOGS" ] && MIN_LOGS=$LC
     [ "$LC" -gt "$MAX_LOGS" ] && MAX_LOGS=$LC
@@ -712,20 +638,20 @@ done
     || fail "Some nodes have no log entries (min=$MIN_LOGS)"
 
 # Kill a node, let it recover, verify it catches back up
-LOGS_BEFORE=$(kubectl -n spur exec spurctld-2 -- \
+LOGS_BEFORE=$(kubectl -n "$SPUR_NS" exec spurctld-2 -- \
     ls /var/spool/spur/raft/log/ 2>/dev/null | wc -l || echo "0")
-kubectl -n spur delete pod spurctld-2 --grace-period=0 --force 2>/dev/null || true
+kubectl -n "$SPUR_NS" delete pod spurctld-2 --grace-period=0 --force 2>/dev/null || true
 sleep 15
-kubectl -n spur wait --for=condition=Ready pod/spurctld-2 --timeout=60s 2>/dev/null
+kubectl -n "$SPUR_NS" wait --for=condition=Ready pod/spurctld-2 --timeout=60s 2>/dev/null
 sleep 5
 
-LOGS_AFTER=$(kubectl -n spur exec spurctld-2 -- \
+LOGS_AFTER=$(kubectl -n "$SPUR_NS" exec spurctld-2 -- \
     ls /var/spool/spur/raft/log/ 2>/dev/null | wc -l || echo "0")
 [ "$LOGS_AFTER" -gt 0 ] \
     && pass "Recovered node has log entries ($LOGS_AFTER)" \
     || fail "Recovered node has no log entries"
 
-VOTE=$(kubectl -n spur exec spurctld-2 -- \
+VOTE=$(kubectl -n "$SPUR_NS" exec spurctld-2 -- \
     cat /var/spool/spur/raft/vote.json 2>/dev/null || echo "")
 echo "$VOTE" | grep -q '"committed":true' \
     && pass "Recovered node has committed vote" \


### PR DESCRIPTION
## Summary

Wire up K8s integration tests to run against the real `amd-aac02` cluster on every push/PR, replacing the previous kind-based approach.

**`build-docker-image` job (ubuntu-latest):**
- Build `spur` container image via `deploy/Dockerfile` and push to Docker Hub with a SHA-based tag (`$REGISTRY/spur:$SHA`)
- Uses Buildx with GHA layer caching

**`k8s-integration` job (self-hosted, amd-aac02-rocm):**
- Per-run namespace isolation (`spur-ci-$run_id`) — no cross-run contamination
- Pre-cleanup: delete leftover `spur-ci-*` namespaces (2m timeout) + cluster-scoped RBAC
- Registry auth: create `regcred` pull secret + patch `default` ServiceAccount
- Image pull preflight: verify cluster nodes can pull the CI image before running tests
- Run `k8s_test.sh` (deploys spurctld + operator, runs 15 tests including Raft HA)
- Post-cleanup (`always`): delete namespace, RBAC, CRD

**`k8s_test.sh` changes:**
- Removed kind/Docker dependency — runs directly against an existing cluster
- Parameterized namespace (`$SPUR_TEST_NS`) and image (`$SPUR_CI_IMAGE`)
- CRD generated via a temporary pod instead of `docker run`
- `spur-operator` ServiceAccount patched with `regcred` for registry auth
- Raft peer DNS uses dynamic namespace

## Test plan

- [x] `build-docker-image` pushes successfully
- [x] `k8s-integration` runs all 15 tests on the real cluster
- [x] Verify cleanup removes namespace + cluster-scoped resources after run