### PR TITLE
fix(spur-k8s): handle 409 AlreadyExists in launch_job as success

### DIFF
--- a/crates/spur-k8s/src/agent.rs
+++ b/crates/spur-k8s/src/agent.rs
@@ -415,6 +415,13 @@ impl SlurmAgent for VirtualAgent {
                     error: String::new(),
                 }))
             }
+            Err(kube::Error::Api(e)) if e.code == 409 => {
+                info!(job_id, pod = %pod_name, namespace = %ns, target = %req.target_node, "K8s Pod already exists, treating as success");
+                Ok(Response::new(LaunchJobResponse {
+                    success: true,
+                    error: String::new(),
+                }))
+            }
             Err(e) => {
                 error!(job_id, error = %e, "failed to create K8s Pod");
                 Ok(Response::new(LaunchJobResponse {


### PR DESCRIPTION
`VirtualAgent::launch_job` treated all pod creation errors, including 409 AlreadyExists as hard failures. When all dispatches failed, the scheduler requeued the job back to Pending, which re-triggered dispatch with the same deterministic pod name, producing an infinite requeue loop at scheduler frequency.

Handle 409 the same way ensure_headless_service already does: treat the existing pod as a successful launch and let the pod watcher reconcile status. This matches the pattern used by Volcano and other K8s batch operators.
