### PR TITLE
fix(spurd): prevent resource leak on force-kill cancel path

### DIFF
--- a/crates/spur-tests/src/bare_metal/single_node/lifecycle.rs
+++ b/crates/spur-tests/src/bare_metal/single_node/lifecycle.rs
@@ -6,7 +6,7 @@ mod tests {
 
     use crate::bare_metal::fixture::parse_job_id;
     use crate::bare_metal::single_node::fixture;
-    use crate::bare_metal::{job_state, wait_final_state, wait_job};
+    use crate::bare_metal::{assert_eventually, job_state, wait_final_state, wait_job};
 
     #[tokio::test]
     #[ignore]
@@ -35,6 +35,44 @@ mod tests {
             "expected cancelled, got {:?}",
             state
         );
+    }
+
+    /// After cancellation, the node must return to idle (resources released).
+    /// Regression test: the force-kill path previously removed the job from
+    /// the agent's tracking map without releasing allocations.
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn job_cancel_releases_resources() {
+        let f = fixture().await;
+        let script = f
+            .write_script(
+                "test-cancel-res.sh",
+                "#!/bin/bash\ntrap '' TERM\nsleep 300\n",
+            )
+            .await
+            .expect("script");
+
+        let sb = f
+            .sbatch(&["-J", "cancel-res", "-N", "1", &script])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+
+        tokio::time::sleep(Duration::from_secs(4)).await;
+        f.scancel(&job_id.to_string()).await.expect("scancel");
+
+        // Wait for SIGTERM grace (5s) + SIGKILL + monitor reap
+        assert_eventually(
+            Duration::from_secs(15),
+            Duration::from_secs(2),
+            "node should return to idle after cancel",
+            || async {
+                let info = f.sinfo().await.unwrap_or_default();
+                info.contains("idle") && !info.contains("mix") && !info.contains("alloc")
+            },
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2129,6 +2129,52 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancel_running_job_releases_resources() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        register_node(&cm, "worker1", 8, 16000);
+        let job_id = submit_and_wait(&cm, basic_spec("cancel-alloc"));
+
+        let resources = ResourceSet {
+            cpus: 2,
+            memory_mb: 4000,
+            ..Default::default()
+        };
+        cm.start_job(job_id, vec!["worker1".into()], resources)
+            .unwrap();
+        settle(&cm, job_id, JobState::Running);
+
+        let node = cm.get_node("worker1").unwrap();
+        assert_eq!(node.alloc_resources.cpus, 2);
+
+        cm.cancel_job(job_id, "testuser").unwrap();
+        settle(&cm, job_id, JobState::Cancelled);
+
+        let node = cm.get_node("worker1").unwrap();
+        assert_eq!(
+            node.alloc_resources.cpus, 0,
+            "resources must be freed after cancel"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn double_cancel_returns_error() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        let job_id = submit_and_wait(&cm, basic_spec("double-cancel"));
+        cm.cancel_job(job_id, "testuser").unwrap();
+        settle(&cm, job_id, JobState::Cancelled);
+
+        let result = cm.cancel_job(job_id, "testuser");
+        assert!(
+            result.is_err(),
+            "cancelling an already-cancelled job must fail"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn snapshot_and_restore() {
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1309,4 +1309,83 @@ mod tests {
         let observed_canonical = std::fs::canonicalize(resp.stdout.trim()).unwrap();
         assert_eq!(observed_canonical, tmp_canonical);
     }
+
+    /// Helper: poll until the job is removed from `running` (by the monitor).
+    async fn wait_job_reaped(svc: &AgentService, job_id: u32, timeout_ms: u64) -> bool {
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(timeout_ms);
+        while tokio::time::Instant::now() < deadline {
+            if svc.running.lock().await.get(&job_id).is_none() {
+                return true;
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+        }
+        false
+    }
+
+    #[tokio::test]
+    async fn graceful_cancel_sigterm_responsive() {
+        let svc = AgentService::new(test_reporter());
+        svc.start_monitor("http://127.0.0.1:1".into());
+
+        let job_id = 900;
+        svc.insert_test_job(job_id, TrackedJob::dummy(0)).await;
+
+        svc.graceful_cancel(job_id).await;
+
+        assert!(
+            wait_job_reaped(&svc, job_id, 5_000).await,
+            "monitor should reap SIGTERM-killed job within 5s"
+        );
+    }
+
+    #[tokio::test]
+    async fn graceful_cancel_escalates_to_sigkill() {
+        let svc = AgentService::new(test_reporter());
+        svc.start_monitor("http://127.0.0.1:1".into());
+
+        let job_id = 901;
+        let child = tokio::process::Command::new("/bin/sh")
+            .args(["-c", "trap '' TERM; while true; do sleep 1; done"])
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("failed to spawn SIGTERM-trapping process");
+        let tracked = TrackedJob {
+            job: executor::RunningJob::Managed {
+                child,
+                cgroup_path: None,
+            },
+            rootfs_mode: crate::container::RootfsMode::Extracted,
+            allocation: None,
+            stdout_path: "/dev/null".into(),
+            stderr_path: "/dev/null".into(),
+            has_pid_namespace: false,
+        };
+        svc.insert_test_job(job_id, tracked).await;
+
+        svc.graceful_cancel(job_id).await;
+
+        // 5s grace + up to 2s monitor tick + buffer
+        assert!(
+            wait_job_reaped(&svc, job_id, 10_000).await,
+            "monitor should reap job after SIGKILL escalation"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_explicit_signal_kills_job() {
+        let svc = AgentService::new(test_reporter());
+        svc.start_monitor("http://127.0.0.1:1".into());
+
+        let job_id = 902;
+        svc.insert_test_job(job_id, TrackedJob::dummy(0)).await;
+
+        svc.send_explicit_signal(job_id, 9).await; // SIGKILL
+
+        assert!(
+            wait_job_reaped(&svc, job_id, 5_000).await,
+            "monitor should reap SIGKILL'd job within 5s"
+        );
+    }
 }

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -658,37 +658,11 @@ impl SlurmAgent for AgentService {
     ) -> Result<Response<()>, Status> {
         let req = request.into_inner();
         let job_id = req.job_id;
-        let signal = req.signal;
 
-        {
-            let jobs = self.running.lock().await;
-            let Some(tracked) = jobs.get(&job_id) else {
-                return Ok(Response::new(()));
-            };
-
-            let sig = if signal > 0 {
-                info!(job_id, signal, "sending signal to job");
-                nix::sys::signal::Signal::try_from(signal)
-                    .unwrap_or(nix::sys::signal::Signal::SIGTERM)
-            } else {
-                info!(job_id, "graceful cancel: SIGTERM → 5s grace → SIGKILL");
-                nix::sys::signal::Signal::SIGTERM
-            };
-
-            let _ = tracked.job.kill_signal(sig);
-        }
-
-        if signal == 0 {
-            let running = self.running.clone();
-            tokio::spawn(async move {
-                tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
-                let mut jobs = running.lock().await;
-                if let Some(tracked) = jobs.get(&job_id) {
-                    info!(job_id, "grace period expired, sending SIGKILL");
-                    let _ = tracked.job.kill_signal(nix::sys::signal::Signal::SIGKILL);
-                    jobs.remove(&job_id);
-                }
-            });
+        if req.signal > 0 {
+            self.send_explicit_signal(job_id, req.signal).await;
+        } else {
+            self.graceful_cancel(job_id).await;
         }
 
         Ok(Response::new(()))
@@ -1107,6 +1081,41 @@ impl SlurmAgent for AgentService {
 }
 
 impl AgentService {
+    /// Send a user-specified signal to a running job.
+    async fn send_explicit_signal(&self, job_id: u32, signal: i32) {
+        let jobs = self.running.lock().await;
+        let Some(tracked) = jobs.get(&job_id) else {
+            return;
+        };
+        let sig =
+            nix::sys::signal::Signal::try_from(signal).unwrap_or(nix::sys::signal::Signal::SIGTERM);
+        info!(job_id, signal, "sending explicit signal to job");
+        let _ = tracked.job.kill_signal(sig);
+    }
+
+    /// SIGTERM now, escalate to SIGKILL after a 5-second grace period.
+    async fn graceful_cancel(&self, job_id: u32) {
+        {
+            let jobs = self.running.lock().await;
+            let Some(tracked) = jobs.get(&job_id) else {
+                return;
+            };
+            info!(job_id, "graceful cancel: SIGTERM → 5s grace → SIGKILL");
+            let _ = tracked.job.kill_signal(nix::sys::signal::Signal::SIGTERM);
+        }
+
+        let running = self.running.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+            let jobs = running.lock().await;
+            if let Some(tracked) = jobs.get(&job_id) {
+                info!(job_id, "grace period expired, sending SIGKILL");
+                let _ = tracked.job.kill_signal(nix::sys::signal::Signal::SIGKILL);
+                // Job stays in `running` and monitor loop reaps it and does full cleanup.
+            }
+        });
+    }
+
     /// Read environment variables from a running process via /proc.
     fn read_proc_env(pid: u32) -> Vec<(String, String)> {
         let path = format!("/proc/{}/environ", pid);


### PR DESCRIPTION
## Summary
The graceful cancel handler (`signal == 0`) sent SIGTERM, then after a 5s grace period sent SIGKILL and immediately removed the job from the `running` map. This bypassed the monitor loop's cleanup — GPU/CPU allocation release, cgroup teardown, rootfs cleanup, PMI shutdown, SPANK hooks, and completion reporting were all skipped. Over time, this caused nodes to appear fully allocated while no jobs were actually running.
### Changes
- Refactored `cancel_job` into two methods: `send_explicit_signal` (user-specified signal) and `graceful_cancel` (SIGTERM → 5s → SIGKILL), keeping each path self-contained
- Removed the `jobs.remove()` from the SIGKILL escalation task — the job stays in the `running` map so the monitor loop detects exit and performs full cleanup
- Added 3 agent unit tests: SIGTERM-responsive cancel, SIGKILL escalation with a SIGTERM-trapping process (regression test), and explicit signal delivery
- Added 2 controller unit tests: cancel of a running allocated job releases node resources, double cancel returns error
- Enhanced bare-metal E2E Test 7 with a node-idle assertion after scancel
## Test plan
- [x] `cargo test -p spurd -p spurctld` — all 141 tests pass
- [x] `cargo fmt --check --all` — clean
- [x] Bare-metal cluster: graceful cancel (SIGTERM kills process) — node returns to idle
- [x] Bare-metal cluster: force-kill cancel (SIGTERM trapped, SIGKILL escalation) — node returns to idle
- [x] Bare-metal cluster: explicit signal (`scancel -s 9`) — node returns to idle
- [x] Bare-metal cluster: double cancel — second cancel returns error, no crash
- [x] Bare-metal cluster: cancel already-completed job — returns error, cluster unaffected
- [x] Bare-metal cluster: multi-job cancel across nodes — all resources released
