### PR TITLE
fix(spurd): improve container init error reporting

### DIFF
--- a/crates/spurd/src/container.rs
+++ b/crates/spurd/src/container.rs
@@ -1147,7 +1147,7 @@ pub fn container_init(
             .context("unshare(CLONE_NEWNS | CLONE_NEWPID)")?;
     } else {
         setup_user_namespace(config.uid, config.gid)
-            .context("user namespace required for rootless containers — check that unprivileged user namespaces are enabled (sysctl kernel.unprivileged_userns_clone=1)")?;
+            .context("rootless container setup failed while setting up user namespace")?;
     }
 
     set_mount_propagation_private()?;

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -717,7 +717,7 @@ async fn launch_container_job(
             let hook_env = match crate::container::container_init(config, &rootfs) {
                 Ok(env) => env,
                 Err(e) => {
-                    let msg = format!("E:{}", e);
+                    let msg = format!("E:{:#}", e);
                     unsafe {
                         libc::write(ready_w, msg.as_ptr() as *const _, msg.len());
                     }


### PR DESCRIPTION
Use {:#} instead of {} when formatting the anyhow error from container_init so the full error chain (including the actual syscall failure) is propagated through the sync pipe. Previously only the outermost context was shown, hiding the root cause.

Also replace the misleading context message that pointed at a specific sysctl as the fix — the failure could be any of unshare, uid_map, setgroups, or gid_map.
