### PR TITLE
refactor(spur-net): use base64 crate for registry auth encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3302,6 +3302,7 @@ name = "spur-net"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "base64",
  "bytes",
  "flate2",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ flate2 = "1"
 tar = "0.4"
 semver = "1"
 sha2 = "0.10"
+base64 = "0.22"
 
 # Internal
 spur-update = { path = "crates/spur-update" }

--- a/crates/spur-net/Cargo.toml
+++ b/crates/spur-net/Cargo.toml
@@ -15,3 +15,4 @@ futures-util = { workspace = true }
 flate2 = { workspace = true }
 tar = { workspace = true }
 bytes = { workspace = true }
+base64 = { workspace = true }

--- a/crates/spur-net/src/oci.rs
+++ b/crates/spur-net/src/oci.rs
@@ -15,6 +15,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use flate2::read::GzDecoder;
 use reqwest::header::{ACCEPT, AUTHORIZATION};
 use serde::Deserialize;
@@ -416,6 +417,12 @@ fn parse_netrc(content: &str, registry: &str) -> Option<RegistryCredentials> {
     None
 }
 
+/// Decode the `auth` field from Docker `config.json` (standard Base64 of `user:password`).
+fn decode_registry_auth_b64(s: &str) -> Option<String> {
+    let bytes = STANDARD.decode(s.trim()).ok()?;
+    String::from_utf8(bytes).ok()
+}
+
 fn load_docker_config_auth(registry: &str) -> Option<RegistryCredentials> {
     let docker_config = if let Ok(home) = std::env::var("HOME") {
         PathBuf::from(home).join(".docker/config.json")
@@ -441,7 +448,7 @@ fn load_docker_config_auth(registry: &str) -> Option<RegistryCredentials> {
     for key in keys_to_try {
         if let Some(entry) = auths.get(key) {
             if let Some(auth_b64) = entry.get("auth").and_then(|a| a.as_str()) {
-                let decoded = base64_decode(auth_b64)?;
+                let decoded = decode_registry_auth_b64(auth_b64)?;
                 let (user, pass) = decoded.split_once(':')?;
                 return Some(RegistryCredentials {
                     username: user.to_string(),
@@ -452,38 +459,6 @@ fn load_docker_config_auth(registry: &str) -> Option<RegistryCredentials> {
     }
 
     None
-}
-
-fn base64_decode(input: &str) -> Option<String> {
-    // Simple base64 decode without pulling in a crate
-    let input = input.trim();
-    let bytes: Vec<u8> = input
-        .bytes()
-        .filter_map(|b| match b {
-            b'A'..=b'Z' => Some(b - b'A'),
-            b'a'..=b'z' => Some(b - b'a' + 26),
-            b'0'..=b'9' => Some(b - b'0' + 52),
-            b'+' => Some(62),
-            b'/' => Some(63),
-            b'=' => None,
-            _ => None,
-        })
-        .collect();
-
-    let mut result = Vec::new();
-    for chunk in bytes.chunks(4) {
-        if chunk.len() >= 2 {
-            result.push((chunk[0] << 2) | (chunk[1] >> 4));
-        }
-        if chunk.len() >= 3 {
-            result.push((chunk[1] << 4) | (chunk[2] >> 2));
-        }
-        if chunk.len() >= 4 {
-            result.push((chunk[2] << 6) | chunk[3]);
-        }
-    }
-
-    String::from_utf8(result).ok()
 }
 
 /// Get an auth token from the registry.
@@ -525,7 +500,7 @@ async fn get_auth_token(
         write!(
             basic,
             "Basic {}",
-            encode_basic_auth(&creds.username, &creds.password)
+            STANDARD.encode(format!("{}:{}", creds.username, creds.password))
         )
         .ok();
         return Ok(Some(basic));
@@ -533,32 +508,6 @@ async fn get_auth_token(
 
     // Try anonymous access
     Ok(None)
-}
-
-fn encode_basic_auth(user: &str, pass: &str) -> String {
-    let input = format!("{}:{}", user, pass);
-    let mut result = String::new();
-    let b64_chars = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let bytes = input.as_bytes();
-    for chunk in bytes.chunks(3) {
-        let b0 = chunk[0] as u32;
-        let b1 = if chunk.len() > 1 { chunk[1] as u32 } else { 0 };
-        let b2 = if chunk.len() > 2 { chunk[2] as u32 } else { 0 };
-        let triple = (b0 << 16) | (b1 << 8) | b2;
-        result.push(b64_chars[((triple >> 18) & 0x3F) as usize] as char);
-        result.push(b64_chars[((triple >> 12) & 0x3F) as usize] as char);
-        if chunk.len() > 1 {
-            result.push(b64_chars[((triple >> 6) & 0x3F) as usize] as char);
-        } else {
-            result.push('=');
-        }
-        if chunk.len() > 2 {
-            result.push(b64_chars[(triple & 0x3F) as usize] as char);
-        } else {
-            result.push('=');
-        }
-    }
-    result
 }
 
 /// Resolve a manifest list (multi-arch) to a single amd64/linux manifest.
@@ -688,7 +637,49 @@ pub fn sanitize_name(name: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use base64::{engine::general_purpose::STANDARD, Engine as _};
+
     use super::*;
+
+    #[test]
+    fn test_decode_registry_auth_b64_valid() {
+        // echo -n 'alice:secret' | base64 -w0
+        let decoded = super::decode_registry_auth_b64("YWxpY2U6c2VjcmV0").expect("decode");
+        assert_eq!(decoded, "alice:secret");
+        let (u, p) = decoded.split_once(':').unwrap();
+        assert_eq!(u, "alice");
+        assert_eq!(p, "secret");
+    }
+
+    #[test]
+    fn test_decode_registry_auth_b64_trims_whitespace() {
+        assert_eq!(
+            super::decode_registry_auth_b64("  YWxpY2U6c2VjcmV0  ").as_deref(),
+            Some("alice:secret")
+        );
+    }
+
+    #[test]
+    fn test_decode_registry_auth_b64_invalid_characters() {
+        assert!(super::decode_registry_auth_b64("YWxpY2U6c2VjcmV0!!!").is_none());
+    }
+
+    #[test]
+    fn test_decode_registry_auth_b64_truncated() {
+        assert!(super::decode_registry_auth_b64("YWxpY2U6c2V").is_none());
+    }
+
+    #[test]
+    fn test_decode_registry_auth_b64_rejects_nonstandard_alphabet() {
+        assert!(super::decode_registry_auth_b64("Y_WxpY2U6c2VjcmV0").is_none());
+    }
+
+    #[test]
+    fn test_registry_auth_b64_roundtrip() {
+        let cred = "myuser:mypassword";
+        let enc = STANDARD.encode(cred);
+        assert_eq!(super::decode_registry_auth_b64(&enc).as_deref(), Some(cred));
+    }
 
     #[test]
     fn test_parse_dockerhub_official() {


### PR DESCRIPTION
Replace hand-written Base64 in OCI registry credential paths with the standard base64 0.22 engine (RFC 4648 STANDARD). Docker config.json auth decoding and non-Docker-Hub Basic auth now use strict decode/encode.

Add decode_registry_auth_b64 helper and unit tests for valid input, whitespace trim, invalid or truncated blobs, non-standard alphabet, and encode/decode roundtrip.

## Motivation
spur-net implemented Docker config.json auth decoding and non–Docker Hub registry Basic auth using hand-written Base64 routines. That duplicated well-tested library behavior, was harder to audit, and accepted malformed input more leniently than a standards-based decoder. This change routes those paths through the maintained base64 crate so behavior matches common registry tooling and is easier to keep correct.

## Technical Details

- Added base64 0.22 as a workspace dependency and a direct dependency of spur-net ([Cargo.toml](vscode-file://vscode-app/c:/Users/sgopinath/AppData/Local/Programs/cursor/resources/app/out/vs/code/electron-sandbox/workbench/Cargo.toml), [crates/spur-net/Cargo.toml](vscode-file://vscode-app/c:/Users/sgopinath/AppData/Local/Programs/cursor/resources/app/out/vs/code/electron-sandbox/workbench/crates/spur-net/Cargo.toml)); [Cargo.lock](vscode-file://vscode-app/c:/Users/sgopinath/AppData/Local/Programs/cursor/resources/app/out/vs/code/electron-sandbox/workbench/Cargo.lock) updated accordingly.
- In [crates/spur-net/src/oci.rs](vscode-file://vscode-app/c:/Users/sgopinath/AppData/Local/Programs/cursor/resources/app/out/vs/code/electron-sandbox/workbench/crates/spur-net/src/oci.rs):
    - Introduced decode_registry_auth_b64, which decodes trimmed input with general_purpose::STANDARD and returns None on decode or non–UTF-8 failure. load_docker_config_auth uses it instead of the removed custom decoder.
    - Non–Docker Hub creds in get_auth_token now use STANDARD.encode on the user:password string for the Basic … payload (replacing the custom encoder).
- Behavior change: invalid characters, bad padding, or non-standard alphabet (for example URL-safe - / _ under the standard engine) now fail decode and surface as missing credentials, instead of being partially ignored by the old implementation.

## Test Plan
- cargo test -p spur-net (covers new oci unit tests: valid blob, trim, invalid/truncated input, non-standard alphabet, encode/decode roundtrip).
- cargo test (full workspace; requires protoc on the host, same as CI’s protobuf-compiler step).
- cargo fmt --all --check
- cargo clippy --workspace --exclude spur-ffi --all-targets -- -W clippy::all -D unused (CI-aligned; note spur-net may still emit pre-existing Clippy warnings unrelated to this change if the job is run with stricter flags locally).

## Scope / Out of Scope
- In scope: OCI/registry credential Base64 only in spur-net oci.rs.
- Out of scope: Docker Hub token request path (reqwest::basic_auth), URL-safe Base64 support, and any change to image pull logic beyond auth string encoding/decoding.
