### PR TITLE
ci: unpin container tests from main node

### DIFF
--- a/deploy/bare-metal/cluster_test.sh
+++ b/deploy/bare-metal/cluster_test.sh
@@ -1004,9 +1004,8 @@ ctest_ship() {
     done
 }
 
-# Submit a container job pinned to the controller node (mi300).
 ctest_sbatch() {
-    "${SPUR}/sbatch" --container-image="$CTEST_IMG" -w mi300 "$@" 2>/dev/null | awk '{print $NF}'
+    "${SPUR}/sbatch" --container-image="$CTEST_IMG" "$@" 2>/dev/null | awk '{print $NF}'
 }
 
 # Check exit code of a completed job


### PR DESCRIPTION
Remove mi300 node pin from container tests to verify container jobs run on any node.

The issue was a gid mismatch on the CI nodes, and the failure was expected behaviour.

This is in continuation of #167.

