### PR TITLE
chore(deps): drop unused utoipa workspace dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ tonic-build = "0.12"
 
 # REST API
 axum = { version = "0.7", features = ["json"] }
-utoipa = { version = "4", features = ["axum_extras"] }
 tower = "0.4"
 tower-http = { version = "0.5", features = ["cors", "trace"] }
 


### PR DESCRIPTION
No crate in the workspace references utoipa; remove it from workspace deps.
