### PR TITLE
ci: use main repo branches for dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches: [main]
-  pull_request_target:
+  pull_request:
     branches: [main]
   workflow_dispatch:
 
@@ -15,8 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Install protobuf compiler
         run: sudo apt-get install -y protobuf-compiler
@@ -45,8 +43,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -57,8 +53,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Install protobuf compiler
         run: sudo apt-get install -y protobuf-compiler
@@ -87,12 +81,10 @@ jobs:
     needs: [build-and-test, fmt, clippy]
     # Only one cluster run at a time; cancel older runs on the same ref.
     concurrency:
-      group: cluster-${{ github.head_ref || github.ref }}
+      group: cluster-${{ github.ref }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Build release binaries
         run: |
@@ -167,8 +159,6 @@ jobs:
       image_tag: ${{ steps.tag.outputs.value }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set image tag
         id: tag
@@ -207,8 +197,6 @@ jobs:
       RUST_LOG: info
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Select kubectl context
         run: kubectl config use-context kubernetes-admin@kubernetes


### PR DESCRIPTION
If we use main repo branches for dev, we only require `pull_request_target`.