### PR TITLE
test(spur-tests): add bare-metal E2E test suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2076,6 +2076,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssh"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d534c4bfecb0ed71dea4db444a5922a294d15cf40e700548f27295e1feb0ef18"
+dependencies = [
+ "libc",
+ "once_cell",
+ "shell-escape",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3151,6 +3165,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-escape"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3397,6 +3417,7 @@ dependencies = [
  "jsonwebtoken",
  "k8s-openapi",
  "kube",
+ "openssh",
  "predicates",
  "prost-types",
  "reqwest",

--- a/crates/spur-tests/Cargo.toml
+++ b/crates/spur-tests/Cargo.toml
@@ -29,6 +29,7 @@ assert_cmd = "2"
 predicates = "3"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 jsonwebtoken.workspace = true
+openssh = { version = "0.11", default-features = false, features = ["process-mux"] }
 
 [dev-dependencies]
 serial_test = "3.4.0"

--- a/crates/spur-tests/src/bare_metal/config.rs
+++ b/crates/spur-tests/src/bare_metal/config.rs
@@ -1,0 +1,110 @@
+use std::path::PathBuf;
+
+use anyhow::{bail, Result};
+
+/// Bare-metal test configuration from environment variables.
+#[derive(Debug, Clone)]
+pub struct TestConfig {
+    pub nodes: Vec<String>,
+    pub binaries_dir: PathBuf,
+    pub ssh_key: Option<PathBuf>,
+    pub ssh_user: String,
+}
+
+impl TestConfig {
+    pub fn from_env() -> Result<Self> {
+        let nodes = std::env::var("SPUR_TEST_BM_NODES")
+            .unwrap_or_else(|_| "localhost".into())
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>();
+
+        if nodes.is_empty() {
+            bail!("SPUR_TEST_BM_NODES must list at least one host");
+        }
+
+        let binaries_dir = std::env::var("SPUR_TEST_BM_BINARIES_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| {
+                PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                    .parent()
+                    .and_then(|p| p.parent())
+                    .map(|p| p.join("target/release"))
+                    .unwrap_or_else(|| PathBuf::from("target/release"))
+            });
+
+        let ssh_key = std::env::var("SPUR_TEST_BM_SSH_KEY")
+            .ok()
+            .map(PathBuf::from)
+            .filter(|p| !p.as_os_str().is_empty());
+
+        let ssh_user = std::env::var("SPUR_TEST_BM_SSH_USER").unwrap_or_else(|_| {
+            std::env::var("USER")
+                .or_else(|_| std::env::var("LOGNAME"))
+                .unwrap_or_else(|_| "root".into())
+        });
+
+        Ok(Self {
+            nodes,
+            binaries_dir,
+            ssh_key,
+            ssh_user,
+        })
+    }
+
+    pub fn binary_path(&self, name: &str) -> PathBuf {
+        self.binaries_dir.join(name)
+    }
+
+    pub fn validate_binaries(&self) -> Result<()> {
+        for name in ["spurctld", "spurd", "spur"] {
+            let path = self.binary_path(name);
+            if !path.is_file() {
+                bail!(
+                    "missing binary {} (set SPUR_TEST_BM_BINARIES_DIR or run cargo build --release)",
+                    path.display()
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Override remote work directory. In CI, set via workflow env to a
+/// deterministic path based on run ID. Locally, leave unset — the fixture
+/// generates `/tmp/spur-bm-{pid}-{timestamp}` automatically.
+pub fn remote_dir_override() -> Option<String> {
+    std::env::var("SPUR_TEST_BM_REMOTE_DIR")
+        .ok()
+        .filter(|s| !s.is_empty())
+}
+
+/// Derive a unique remote directory path for this test run.
+/// Mirrors the K8s namespace pattern (`spur-ci-{pid}-{ts}`).
+pub fn default_remote_dir() -> String {
+    let pid = std::process::id();
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    format!("/tmp/spur-bm-{pid}-{ts}")
+}
+
+pub fn controller_port() -> u16 {
+    std::env::var("SPUR_TEST_BM_CONTROLLER_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(6817)
+}
+
+pub fn agent_port() -> u16 {
+    std::env::var("SPUR_TEST_BM_AGENT_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(6818)
+}
+
+pub fn resolve_controller_url(host: &str) -> String {
+    format!("http://{}:{}", host, controller_port())
+}

--- a/crates/spur-tests/src/bare_metal/fixture.rs
+++ b/crates/spur-tests/src/bare_metal/fixture.rs
@@ -1,0 +1,726 @@
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{bail, Result};
+use tracing::info;
+
+use super::config::{
+    agent_port, controller_port, default_remote_dir, remote_dir_override, resolve_controller_url,
+    TestConfig,
+};
+use super::ssh::SshNode;
+
+const BM_BINARIES: [&str; 3] = ["spurctld", "spurd", "spur"];
+
+/// Deployed bare-metal cluster for E2E tests.
+pub struct BareMetalFixture {
+    pub config: TestConfig,
+    pub nodes: Vec<SshNode>,
+    pub node_names: Vec<String>,
+    pub remote_dir: String,
+    pub controller_addr: String,
+    pub bin_dir: String,
+    pub etc_dir: String,
+    pub state_dir: String,
+    pub log_dir: String,
+    pub ssh_user: String,
+}
+
+impl BareMetalFixture {
+    pub async fn deploy(config: TestConfig) -> Result<Self> {
+        config.validate_binaries()?;
+        info!("deploy: validated binaries");
+
+        let ssh_key = config.ssh_key.as_deref();
+        let mut nodes = Vec::new();
+        let mut node_names = Vec::new();
+
+        for host in &config.nodes {
+            info!(host, "connecting via SSH");
+            let node = SshNode::connect(host, &config.ssh_user, ssh_key).await?;
+            info!(host, "killing stale processes");
+            node.kill_processes("spurctld").await?;
+            node.kill_processes("spurd").await?;
+            nodes.push(node);
+        }
+
+        let remote_dir = remote_dir_override().unwrap_or_else(default_remote_dir);
+        info!(remote_dir, "remote workdir");
+
+        let bin_dir = format!("{remote_dir}/bin");
+        let etc_dir = format!("{remote_dir}/etc");
+        let state_dir = format!("{remote_dir}/state");
+        let log_dir = format!("{remote_dir}/log");
+
+        info!("creating directories on all nodes");
+        for node in &nodes {
+            node.rm_rf(&remote_dir).await?;
+            node.mkdir_p(&remote_dir).await?;
+            node.mkdir_p(&bin_dir).await?;
+            node.mkdir_p(&etc_dir).await?;
+            node.mkdir_p(&state_dir).await?;
+            node.mkdir_p(&log_dir).await?;
+        }
+
+        for name in BM_BINARIES {
+            info!(name, "uploading binary to all nodes");
+            let local = config.binary_path(name);
+            for node in &nodes {
+                let remote = format!("{bin_dir}/{name}");
+                node.scp_to(&local, &remote).await?;
+                node.exec(&format!("chmod +x '{remote}'")).await?;
+            }
+        }
+
+        info!("creating CLI symlinks");
+        for node in &nodes {
+            node.exec(&format!(
+                "cd '{bin_dir}' && for cmd in sbatch srun squeue scancel sinfo scontrol; do ln -sf spur $cmd 2>/dev/null || true; done"
+            ))
+            .await?;
+        }
+
+        for node in &nodes {
+            let name = node
+                .exec("hostname -s")
+                .await
+                .unwrap_or_else(|_| node.host.clone())
+                .trim()
+                .to_string();
+            node_names.push(name);
+        }
+
+        let controller_host = &config.nodes[0];
+        let controller_addr = if controller_host == "localhost" || controller_host == "127.0.0.1" {
+            format!("http://127.0.0.1:{}", controller_port())
+        } else {
+            resolve_controller_url(controller_host)
+        };
+
+        info!("writing spur.conf");
+        let spur_conf = generate_spur_conf(&node_names);
+        nodes[0]
+            .write_remote_file(&format!("{etc_dir}/spur.conf"), spur_conf.as_bytes())
+            .await?;
+
+        info!(node = %node_names[0], "starting spurctld");
+        let listen = format!("[::]:{}", controller_port());
+        let ctld_cmd = format!(
+            "nohup '{bin_dir}/spurctld' -f '{etc_dir}/spur.conf' \
+             --listen '{listen}' --state-dir '{state_dir}' --log-level info -D \
+             > '{log_dir}/spurctld.log' 2>&1 & echo $!"
+        );
+        let ctld_pid = nodes[0].exec(&ctld_cmd).await?;
+        info!(pid = ctld_pid.trim(), "spurctld started");
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        for (i, node) in nodes.iter().enumerate() {
+            let hostname = &node_names[i];
+            let ctrl = controller_addr.clone();
+            let address = if node.host == "localhost" || node.host == "127.0.0.1" {
+                "127.0.0.1".to_string()
+            } else {
+                node.host.clone()
+            };
+            let agent_listen = format!("0.0.0.0:{}", agent_port());
+            info!(hostname, "starting spurd");
+            let spurd_cmd = format!(
+                "nohup '{bin_dir}/spurd' --controller '{ctrl}' --listen '{agent_listen}' \
+                 --hostname '{hostname}' --address '{address}' --log-level info -D \
+                 > '{log_dir}/spurd.log' 2>&1 & echo $!"
+            );
+            let spurd_pid = node.exec(&spurd_cmd).await?;
+            info!(hostname, pid = spurd_pid.trim(), "spurd started");
+        }
+
+        let fixture = Self {
+            config: config.clone(),
+            nodes,
+            node_names,
+            remote_dir: remote_dir.clone(),
+            controller_addr,
+            bin_dir: bin_dir.clone(),
+            etc_dir,
+            state_dir,
+            log_dir,
+            ssh_user: config.ssh_user.clone(),
+        };
+
+        info!("waiting for all nodes to become idle");
+        fixture.wait_all_idle(Duration::from_secs(120)).await?;
+        info!(nodes = ?fixture.node_names, "bare-metal cluster ready");
+        Ok(fixture)
+    }
+
+    pub fn controller(&self) -> &SshNode {
+        &self.nodes[0]
+    }
+
+    pub fn node_by_name(&self, name: &str) -> Option<&SshNode> {
+        self.node_names
+            .iter()
+            .position(|n| n == name)
+            .map(|i| &self.nodes[i])
+    }
+
+    pub async fn cli(&self, args: &[&str]) -> Result<String> {
+        if args.is_empty() {
+            bail!("cli requires at least one argument");
+        }
+        let mut cmd = format!(
+            "SPUR_CONTROLLER_ADDR='{}' PATH='{}':$PATH",
+            self.controller_addr, self.bin_dir
+        );
+        cmd.push(' ');
+        cmd.push_str(&format!("'{}/{}'", self.bin_dir, args[0]));
+        for arg in &args[1..] {
+            cmd.push(' ');
+            cmd.push_str(&shell_escape(arg));
+        }
+        self.controller().exec(&cmd).await
+    }
+
+    pub async fn sbatch(&self, args: &[&str]) -> Result<String> {
+        let mut a = vec!["sbatch"];
+        a.extend(args);
+        self.cli(&a).await
+    }
+
+    pub async fn squeue_all(&self) -> Result<String> {
+        self.cli(&["squeue", "-t", "all"]).await
+    }
+
+    pub async fn sinfo(&self) -> Result<String> {
+        self.cli(&["sinfo"]).await
+    }
+
+    pub async fn scancel(&self, job_id: &str) -> Result<String> {
+        self.cli(&["scancel", job_id]).await
+    }
+
+    pub async fn scontrol_release(&self, job_id: &str) -> Result<String> {
+        self.cli(&["scontrol", "release", job_id]).await
+    }
+
+    pub async fn write_script(&self, name: &str, body: &str) -> Result<String> {
+        let path = format!("{}/{}", self.remote_dir, name);
+        self.controller()
+            .write_remote_file(&path, body.as_bytes())
+            .await?;
+        self.controller()
+            .exec(&format!("chmod +x '{path}'"))
+            .await?;
+        Ok(path)
+    }
+
+    pub async fn job_stdout_path(&self, job_id: u32) -> Option<String> {
+        let out = self
+            .cli(&["scontrol", "show", "job", &job_id.to_string()])
+            .await
+            .ok()?;
+        for token in out.split_whitespace() {
+            if let Some(path) = token.strip_prefix("StdOut=") {
+                if !path.is_empty() {
+                    return Some(path.to_string());
+                }
+            }
+        }
+        None
+    }
+
+    pub async fn read_job_output(&self, job_id: u32) -> Result<String> {
+        if let Some(path) = self.job_stdout_path(job_id).await {
+            let content = self.read_output_on_any_node(&path).await?;
+            if !content.trim().is_empty() {
+                return Ok(content);
+            }
+        }
+        Ok(String::new())
+    }
+
+    pub async fn read_output_on_any_node(&self, path: &str) -> Result<String> {
+        if let Ok(content) = self.controller().read_remote_file(path).await {
+            if !content.trim().is_empty() {
+                return Ok(content);
+            }
+        }
+        for node in self.nodes.iter().skip(1) {
+            if let Ok(content) = node.read_remote_file(path).await {
+                if !content.trim().is_empty() {
+                    return Ok(content);
+                }
+            }
+        }
+        Ok(String::new())
+    }
+
+    pub fn cluster_is_ready(&self, sinfo_output: &str) -> bool {
+        let all_registered = self
+            .node_names
+            .iter()
+            .all(|name| sinfo_output.contains(name));
+        if !all_registered {
+            return false;
+        }
+        for line in sinfo_output.lines() {
+            if !line.contains("idle") {
+                continue;
+            }
+            let fields: Vec<&str> = line.split_whitespace().collect();
+            for window in fields.windows(2) {
+                if window[1] == "idle" {
+                    if let Ok(n) = window[0].parse::<usize>() {
+                        return n >= self.node_names.len();
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    pub async fn wait_all_idle(&self, timeout: Duration) -> Result<()> {
+        let start = std::time::Instant::now();
+        loop {
+            let out = self.sinfo().await.unwrap_or_default();
+            if self.cluster_is_ready(&out) {
+                return Ok(());
+            }
+            if start.elapsed() > timeout {
+                bail!(
+                    "timeout waiting for {} idle nodes; sinfo:\n{out}",
+                    self.node_names.len()
+                );
+            }
+            tokio::time::sleep(Duration::from_secs(2)).await;
+        }
+    }
+
+    pub async fn teardown(&self) -> Result<()> {
+        for node in &self.nodes {
+            node.kill_processes("spurctld").await?;
+            node.kill_processes("spurd").await?;
+            node.rm_rf(&self.remote_dir).await?;
+        }
+        info!("bare-metal cluster torn down");
+        Ok(())
+    }
+
+    pub async fn ship_file_to_all_agents(&self, local: &Path, remote_name: &str) -> Result<()> {
+        for node in &self.nodes {
+            let remote = format!("{}/{}", self.remote_dir, remote_name);
+            node.scp_to(local, &remote).await?;
+        }
+        Ok(())
+    }
+
+    pub async fn ship_bytes_to_all_agents(&self, remote_name: &str, data: &[u8]) -> Result<()> {
+        for node in &self.nodes {
+            let remote = format!("{}/{}", self.remote_dir, remote_name);
+            node.write_remote_file(&remote, data).await?;
+        }
+        Ok(())
+    }
+
+    /// Verify that at least `min_nodes` agents have visible GPU hardware.
+    /// Panics with a diagnostic message if the check fails.
+    pub async fn gpu_preflight(&self, min_nodes: usize) {
+        let mut gpu_nodes = Vec::new();
+        for (i, node) in self.nodes.iter().enumerate() {
+            let probe = node
+                .exec_allow_fail(
+                    "{ ls /dev/kfd 2>/dev/null && echo HAS_GPU; } || \
+                     { nvidia-smi -L 2>/dev/null && echo HAS_GPU; } || \
+                     echo NO_GPU",
+                )
+                .await
+                .unwrap_or_default();
+            if probe.contains("HAS_GPU") {
+                gpu_nodes.push(self.node_names[i].as_str());
+            }
+        }
+        assert!(
+            gpu_nodes.len() >= min_nodes,
+            "GPU preflight failed: need {min_nodes} GPU node(s), found {} ({:?}). \
+             Are you running these tests on a cluster without GPUs?",
+            gpu_nodes.len(),
+            gpu_nodes
+        );
+    }
+
+    /// Ship GPU test assets to all agents: Python scripts, HIP source,
+    /// compiled gpu_test binary, ephemeral venv with PyTorch, and generated
+    /// job wrapper scripts that activate the venv.
+    pub async fn ship_gpu_assets(&self) {
+        let deploy = bare_metal_deploy_dir();
+        let rd = &self.remote_dir;
+
+        // Ship Python test scripts
+        for name in ["distributed_test.py", "inference_test.py"] {
+            let local = deploy.join(name);
+            if local.is_file() {
+                self.ship_file_to_all_agents(&local, name)
+                    .await
+                    .expect(name);
+            }
+        }
+
+        // Generate job wrappers that point to the ephemeral venv + remote_dir
+        let dist_wrapper = format!(
+            "#!/bin/bash\nsource '{rd}/venv/bin/activate'\nexec python3 '{rd}/distributed_test.py'\n"
+        );
+        self.ship_bytes_to_all_agents("distributed_job.sh", dist_wrapper.as_bytes())
+            .await
+            .expect("distributed_job.sh");
+        for node in &self.nodes {
+            let _ = node
+                .exec(&format!("chmod +x '{rd}/distributed_job.sh'"))
+                .await;
+        }
+
+        let infer_wrapper = format!(
+            "#!/bin/bash\nsource '{rd}/venv/bin/activate'\nexec python3 '{rd}/inference_test.py'\n"
+        );
+        self.ship_bytes_to_all_agents("inference_job.sh", infer_wrapper.as_bytes())
+            .await
+            .expect("inference_job.sh");
+        for node in &self.nodes {
+            let _ = node
+                .exec(&format!("chmod +x '{rd}/inference_job.sh'"))
+                .await;
+        }
+
+        // Compile HIP gpu_test binary if source and toolchain are available
+        let hip = deploy.join("gpu_test.hip");
+        if hip.is_file() {
+            self.ship_file_to_all_agents(&hip, "gpu_test.hip")
+                .await
+                .ok();
+            for node in &self.nodes {
+                let remote_src = format!("{rd}/gpu_test.hip");
+                let _ = node
+                    .exec(&format!(
+                        "command -v hipcc >/dev/null && \
+                         hipcc -o '{rd}/gpu_test' '{remote_src}' 2>/dev/null || true"
+                    ))
+                    .await;
+            }
+        }
+
+        // Create ephemeral venv with PyTorch on each node
+        let torch_index = std::env::var("SPUR_TEST_BM_TORCH_INDEX")
+            .unwrap_or_else(|_| "https://download.pytorch.org/whl/rocm6.3".into());
+        for (i, node) in self.nodes.iter().enumerate() {
+            let name = &self.node_names[i];
+            info!(name, "creating GPU venv");
+            node.exec(&format!("python3 -m venv '{rd}/venv'"))
+                .await
+                .unwrap_or_else(|e| {
+                    panic!("venv creation failed on {name} — is python3-venv installed? {e}")
+                });
+            info!(name, "installing torch");
+            node.exec(&format!(
+                "'{rd}/venv/bin/pip' install --quiet torch --index-url '{torch_index}'"
+            ))
+            .await
+            .unwrap_or_else(|e| panic!("pip install torch failed on {name}: {e}"));
+        }
+    }
+
+    /// Collect diagnostic info for a failed job (scontrol, sinfo, squeue,
+    /// stdout, controller and agent logs). Best-effort — never fails.
+    pub async fn debug_job(&self, job_id: u32) -> String {
+        let mut d = format!("=== DEBUG job {job_id} ===\n");
+
+        if let Ok(info) = self
+            .cli(&["scontrol", "show", "job", &job_id.to_string()])
+            .await
+        {
+            d.push_str("scontrol show job:\n");
+            d.push_str(&info);
+            d.push('\n');
+        }
+
+        if let Ok(info) = self.sinfo().await {
+            d.push_str("sinfo:\n");
+            d.push_str(&info);
+            d.push('\n');
+        }
+
+        if let Ok(info) = self.squeue_all().await {
+            d.push_str("squeue:\n");
+            d.push_str(&info);
+            d.push('\n');
+        }
+
+        if let Some(path) = self.job_stdout_path(job_id).await {
+            let content = self
+                .read_output_on_any_node(&path)
+                .await
+                .unwrap_or_default();
+            if !content.trim().is_empty() {
+                d.push_str(&format!("stdout ({path}):\n"));
+                d.push_str(&content);
+                d.push('\n');
+            }
+        }
+
+        let ctrl_log = format!("{}/spurctld.log", self.log_dir);
+        if let Ok(log) = self
+            .controller()
+            .exec_allow_fail(&format!("tail -30 '{ctrl_log}'"))
+            .await
+        {
+            d.push_str(&format!(
+                "spurctld.log on {} (last 30 lines):\n",
+                self.node_names[0]
+            ));
+            d.push_str(&log);
+            d.push('\n');
+        }
+
+        for (i, node) in self.nodes.iter().enumerate() {
+            let agent_log = format!("{}/spurd.log", self.log_dir);
+            if let Ok(log) = node
+                .exec_allow_fail(&format!("tail -15 '{agent_log}'"))
+                .await
+            {
+                d.push_str(&format!(
+                    "spurd.log on {} (last 15 lines):\n",
+                    self.node_names[i]
+                ));
+                d.push_str(&log);
+                d.push('\n');
+            }
+        }
+
+        d
+    }
+
+    /// Read output for a given path from **all** nodes and return combined text.
+    pub async fn read_output_all_nodes(&self, path: &str) -> String {
+        let mut all = String::new();
+        for node in &self.nodes {
+            if let Ok(content) = node.read_remote_file(path).await {
+                if !content.trim().is_empty() {
+                    if !all.is_empty() {
+                        all.push('\n');
+                    }
+                    all.push_str(&content);
+                }
+            }
+        }
+        all
+    }
+
+    /// Build a minimal squashfs container image locally, then SCP to all nodes.
+    ///
+    /// The image contains bash, coreutils, and NSS libs — enough to run
+    /// shell scripts, resolve DNS, and exercise namespace isolation.
+    /// Returns the remote path to the `.sqsh` file.
+    pub async fn build_container_image(&self) -> Result<String> {
+        let remote_path = format!("{}/test-container.sqsh", self.remote_dir);
+
+        let local_tmp = tempfile::TempDir::new()?;
+        let rootfs = local_tmp.path().join("rootfs");
+        let local_img = local_tmp.path().join("test-container.sqsh");
+
+        let build_script = format!(
+            r#"set -e
+R='{rootfs}'
+mkdir -p "$R/bin" "$R/usr/bin" "$R/lib" "$R/lib64" \
+  "$R/etc" "$R/dev" "$R/proc" "$R/sys" "$R/tmp" \
+  "$R/run" "$R/home" "$R/mnt"
+for b in bash cat echo sleep hostname id df env stat ls wc head tail tr touch mkdir getent; do
+  src=$(which "$b" 2>/dev/null) || continue
+  [ -f "$src" ] && cp "$src" "$R/usr/bin/"
+done
+ln -sf /usr/bin/bash "$R/bin/bash"
+ln -sf /usr/bin/bash "$R/bin/sh"
+for f in "$R/usr/bin/"*; do
+  ldd "$f" 2>/dev/null | grep '=>' | awk '{{print $3}}' | while read -r lib; do
+    if [ -f "$lib" ]; then
+      dir=$(dirname "$lib")
+      mkdir -p "$R$dir"
+      cp -n "$lib" "$R$lib" 2>/dev/null || true
+    fi
+  done
+done
+for nsslib in libnss_dns.so.2 libnss_files.so.2 libresolv.so.2; do
+  src="/lib/x86_64-linux-gnu/$nsslib"
+  [ -f "$src" ] && mkdir -p "$R/lib/x86_64-linux-gnu" && cp -n "$src" "$R/lib/x86_64-linux-gnu/" 2>/dev/null || true
+done
+[ -f /lib64/ld-linux-x86-64.so.2 ] && cp -n /lib64/ld-linux-x86-64.so.2 "$R/lib64/" 2>/dev/null || true
+for f in /etc/passwd /etc/group /etc/nsswitch.conf; do
+  [ -f "$f" ] && cp "$f" "$R/etc/"
+done
+mksquashfs "$R" '{img}' -noappend -quiet >/dev/null 2>&1
+"#,
+            rootfs = rootfs.display(),
+            img = local_img.display(),
+        );
+
+        let output = tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg(&build_script)
+            .output()
+            .await?;
+        if !output.status.success() {
+            bail!(
+                "local mksquashfs failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        info!(
+            "built container image locally ({} bytes)",
+            std::fs::metadata(&local_img)?.len()
+        );
+
+        for (i, node) in self.nodes.iter().enumerate() {
+            node.scp_to(&local_img, &remote_path).await?;
+            info!("shipped container image to {}", self.node_names[i]);
+        }
+
+        Ok(remote_path)
+    }
+
+    /// Check container prerequisites. Panics with actionable hints if anything
+    /// is missing.
+    ///
+    /// Checks: mksquashfs on runner, unsquashfs on nodes, and that rootless
+    /// user namespaces work (AppArmor restriction on Ubuntu 24.04+).
+    pub async fn container_preflight(&self) {
+        assert!(
+            std::process::Command::new("mksquashfs")
+                .arg("--help")
+                .output()
+                .is_ok(),
+            "mksquashfs not found on test runner. Install:\n  sudo apt install squashfs-tools"
+        );
+
+        for (i, node) in self.nodes.iter().enumerate() {
+            let probe = node
+                .exec_allow_fail("command -v unsquashfs >/dev/null && echo OK || echo MISSING")
+                .await
+                .unwrap_or_default();
+            assert!(
+                probe.contains("OK"),
+                "unsquashfs not found on {}. Install:\n  sudo apt install squashfs-tools",
+                self.node_names[i]
+            );
+
+            let restrict = node
+                .exec_allow_fail(
+                    "sysctl -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || echo 0",
+                )
+                .await
+                .unwrap_or_default();
+            // If restriction is active, check that an AppArmor profile is loaded for spurd
+            if restrict.trim() == "1" {
+                let has_profile = node
+                    .exec_allow_fail(
+                        "sudo aa-status 2>/dev/null | grep -q 'spur-' && echo OK || echo MISSING",
+                    )
+                    .await
+                    .unwrap_or_default();
+                if !has_profile.contains("OK") {
+                    let spurd_path = format!("{}/bin/spurd", self.remote_dir);
+                    panic!(
+                        "Container tests need user namespace access on {node}, but \
+                         kernel.apparmor_restrict_unprivileged_userns=1 is active \
+                         and no AppArmor profile is loaded for spurd.\n\n\
+                         Fix with ONE of:\n\n\
+                         Option A — Disable the restriction (recommended for test nodes):\n  \
+                           ssh {user}@{host} 'sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0'\n  \
+                           # Persist across reboots:\n  \
+                           ssh {user}@{host} 'echo kernel.apparmor_restrict_unprivileged_userns=0 \
+                           | sudo tee /etc/sysctl.d/99-spur-userns.conf'\n\n\
+                         Option B — Load an AppArmor profile for spurd:\n  \
+                           ssh {user}@{host} \"echo 'abi <abi/4.0>,\n  \
+                           profile spur-test {spurd_path} flags=(unconfined) {{\n    \
+                           userns,\n  \
+                           }}' | sudo apparmor_parser -r\"",
+                        node = self.node_names[i],
+                        spurd_path = spurd_path,
+                        user = self.ssh_user,
+                        host = node.host,
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn generate_spur_conf(node_names: &[String]) -> String {
+    let nodes_list = node_names.join(",");
+    let mut nodes_toml = String::new();
+    for name in node_names {
+        nodes_toml.push_str(&format!(
+            r#"
+[[nodes]]
+names = "{name}"
+cpus = 64
+memory_mb = 262144
+"#
+        ));
+    }
+
+    format!(
+        r#"cluster_name = "bare-metal-ci"
+
+[scheduler]
+interval_secs = 1
+plugin = "backfill"
+
+[auth]
+plugin = "none"
+
+[[partitions]]
+name = "default"
+state = "UP"
+default = true
+nodes = "{nodes_list}"
+max_time = "24:00:00"
+default_time = "10:00"
+
+[network]
+wg_enabled = false
+agent_port = {agent_port}
+{nodes_toml}
+"#,
+        nodes_list = nodes_list,
+        agent_port = agent_port(),
+        nodes_toml = nodes_toml
+    )
+}
+
+fn shell_escape(s: &str) -> String {
+    if s.is_empty() {
+        return "''".into();
+    }
+    if s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || "/._-:".contains(c))
+    {
+        return s.to_string();
+    }
+    format!("'{}'", s.replace('\'', "'\"'\"'"))
+}
+
+pub fn parse_job_id(sbatch_output: &str) -> Option<u32> {
+    sbatch_output
+        .split_whitespace()
+        .last()
+        .and_then(|s| s.parse().ok())
+}
+
+/// Path to deploy/bare-metal scripts (respects `SPUR_TEST_BM_DEPLOY_DIR`).
+pub fn bare_metal_deploy_dir() -> std::path::PathBuf {
+    if let Ok(dir) = std::env::var("SPUR_TEST_BM_DEPLOY_DIR") {
+        return std::path::PathBuf::from(dir);
+    }
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|p| p.join("deploy/bare-metal"))
+        .unwrap_or_else(|| std::path::PathBuf::from("deploy/bare-metal"))
+}

--- a/crates/spur-tests/src/bare_metal/gpu/mod.rs
+++ b/crates/spur-tests/src/bare_metal/gpu/mod.rs
@@ -1,0 +1,26 @@
+pub mod multi_node;
+pub mod single_node;
+
+use tokio::sync::OnceCell;
+
+use crate::bare_metal::config::TestConfig;
+use crate::bare_metal::fixture::BareMetalFixture;
+
+static FIXTURE: OnceCell<BareMetalFixture> = OnceCell::const_new();
+
+pub async fn fixture() -> &'static BareMetalFixture {
+    FIXTURE
+        .get_or_init(|| async {
+            let config = TestConfig::from_env().expect("SPUR_TEST_BM_* config");
+            if config.nodes.len() < 2 {
+                panic!(
+                    "bare_metal::gpu requires at least 2 nodes in SPUR_TEST_BM_NODES (got {})",
+                    config.nodes.len()
+                );
+            }
+            BareMetalFixture::deploy(config)
+                .await
+                .expect("failed to deploy bare-metal cluster for gpu tests")
+        })
+        .await
+}

--- a/crates/spur-tests/src/bare_metal/gpu/multi_node.rs
+++ b/crates/spur-tests/src/bare_metal/gpu/multi_node.rs
@@ -1,0 +1,112 @@
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use serial_test::serial;
+
+    use crate::bare_metal::fixture::parse_job_id;
+    use crate::bare_metal::gpu::fixture;
+    use crate::bare_metal::wait_job;
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn hip_gpu_test_two_node() {
+        let f = fixture().await;
+        f.gpu_preflight(2).await;
+        f.ship_gpu_assets().await;
+
+        let gpu_bin = format!("{}/gpu_test", f.remote_dir);
+        let script = f
+            .write_script("gpu-2n.sh", &format!("#!/bin/bash\n'{gpu_bin}'\n"))
+            .await
+            .expect("script");
+        let out_path = format!("{}/hip-2n.out", f.remote_dir);
+
+        let sb = f
+            .sbatch(&["-J", "test-hip-2n", "-N", "2", "-o", &out_path, &script])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+        wait_job(f, job_id, Duration::from_secs(120))
+            .await
+            .expect("wait");
+
+        let content = f.read_output_on_any_node(&out_path).await.expect("out");
+        let diag = f.debug_job(job_id).await;
+        assert!(
+            content.contains("ALL PASS"),
+            "2-node HIP gpu_test must report ALL PASS.\n{diag}\noutput:\n{content}"
+        );
+        assert!(
+            content.contains("GPU count:"),
+            "HIP gpu_test must report GPU count.\noutput:\n{content}"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn pytorch_distributed() {
+        let f = fixture().await;
+        f.gpu_preflight(2).await;
+        f.ship_gpu_assets().await;
+
+        let job_sh = format!("{}/distributed_job.sh", f.remote_dir);
+        let out_path = format!("{}/pt-dist.out", f.remote_dir);
+        let sb = f
+            .sbatch(&["-J", "test-pt", "-N", "2", "-o", &out_path, &job_sh])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+        wait_job(f, job_id, Duration::from_secs(600))
+            .await
+            .expect("wait");
+
+        let content = f.read_output_on_any_node(&out_path).await.expect("out");
+        let diag = f.debug_job(job_id).await;
+        assert!(
+            content.contains("DONE"),
+            "PyTorch distributed must report DONE.\n{diag}\noutput:\n{content}"
+        );
+        assert!(
+            content.contains("TFLOPS") || content.contains("GPUs:"),
+            "PyTorch output must contain TFLOPS or GPUs count.\noutput:\n{content}"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn inference_two_node() {
+        let f = fixture().await;
+        f.gpu_preflight(2).await;
+        f.ship_gpu_assets().await;
+
+        let job_sh = format!("{}/inference_job.sh", f.remote_dir);
+        let out_path = format!("{}/infer.out", f.remote_dir);
+        let sb = f
+            .sbatch(&["-J", "test-infer", "-N", "2", "-o", &out_path, &job_sh])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+        wait_job(f, job_id, Duration::from_secs(600))
+            .await
+            .expect("wait");
+
+        let all = f.read_output_all_nodes(&out_path).await;
+        let diag = f.debug_job(job_id).await;
+        assert!(
+            all.contains("INFERENCE_OK"),
+            "Inference must report INFERENCE_OK.\n{diag}\noutput:\n{all}"
+        );
+        assert!(
+            all.contains("Throughput:"),
+            "Inference must report throughput.\noutput:\n{all}"
+        );
+        assert!(
+            !all.to_lowercase().contains("nan") && !all.to_lowercase().contains("non-finite"),
+            "Inference output contains NaN/non-finite values.\noutput:\n{all}"
+        );
+    }
+}

--- a/crates/spur-tests/src/bare_metal/gpu/single_node.rs
+++ b/crates/spur-tests/src/bare_metal/gpu/single_node.rs
@@ -1,0 +1,50 @@
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use serial_test::serial;
+
+    use crate::bare_metal::fixture::parse_job_id;
+    use crate::bare_metal::gpu::fixture;
+    use crate::bare_metal::wait_job;
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn hip_gpu_test() {
+        let f = fixture().await;
+        f.gpu_preflight(1).await;
+        f.ship_gpu_assets().await;
+
+        let gpu_bin = format!("{}/gpu_test", f.remote_dir);
+        let script = f
+            .write_script("gpu-1n.sh", &format!("#!/bin/bash\n'{gpu_bin}'\n"))
+            .await
+            .expect("script");
+        let out_path = format!("{}/hip-1n.out", f.remote_dir);
+
+        let sb = f
+            .sbatch(&["-J", "test-hip-1n", "-N", "1", "-o", &out_path, &script])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+        wait_job(f, job_id, Duration::from_secs(120))
+            .await
+            .expect("wait");
+
+        let content = f.read_output_on_any_node(&out_path).await.expect("out");
+        let diag = f.debug_job(job_id).await;
+        assert!(
+            content.contains("ALL PASS"),
+            "HIP gpu_test must report ALL PASS.\n{diag}\noutput:\n{content}"
+        );
+        assert!(
+            content.contains("GPU count:"),
+            "HIP gpu_test must report GPU count.\noutput:\n{content}"
+        );
+        assert!(
+            content.contains("MI300X") || content.contains("MI300") || content.contains("GPU"),
+            "HIP gpu_test must identify GPU model.\noutput:\n{content}"
+        );
+    }
+}

--- a/crates/spur-tests/src/bare_metal/mod.rs
+++ b/crates/spur-tests/src/bare_metal/mod.rs
@@ -1,0 +1,97 @@
+pub mod config;
+pub mod fixture;
+pub mod ssh;
+
+pub mod gpu;
+pub mod multi_node;
+pub mod single_node;
+
+use std::time::Duration;
+
+use anyhow::{bail, Result};
+
+use fixture::BareMetalFixture;
+
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Parse job state from `squeue -t all` output (2-letter Slurm codes).
+pub fn job_state(squeue_output: &str, job_id: u32) -> Option<String> {
+    let id = job_id.to_string();
+    for line in squeue_output.lines().skip(1) {
+        let fields: Vec<&str> = line.split_whitespace().collect();
+        if fields.first() != Some(&id.as_str()) {
+            continue;
+        }
+        for field in fields.iter().skip(1) {
+            if matches!(
+                *field,
+                "PD" | "R" | "CD" | "CG" | "F" | "CA" | "TO" | "NF" | "PR" | "S"
+            ) {
+                return Some(field.to_string());
+            }
+        }
+    }
+    None
+}
+
+pub async fn wait_job(fixture: &BareMetalFixture, job_id: u32, timeout: Duration) -> Result<()> {
+    let start = std::time::Instant::now();
+    loop {
+        let sq = fixture.squeue_all().await.unwrap_or_default();
+        let state = job_state(&sq, job_id);
+        match state.as_deref() {
+            Some("CD" | "F" | "CA" | "TO") => return Ok(()),
+            None => return Ok(()),
+            _ => {}
+        }
+        if start.elapsed() > timeout {
+            bail!("timeout waiting for job {job_id} (last state {:?})", state);
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+}
+
+pub async fn wait_final_state(
+    fixture: &BareMetalFixture,
+    job_id: u32,
+    timeout: Duration,
+) -> Result<String> {
+    let start = std::time::Instant::now();
+    let mut last = String::new();
+    loop {
+        let sq = fixture.squeue_all().await.unwrap_or_default();
+        let state = job_state(&sq, job_id);
+        match state.as_deref() {
+            Some(s @ ("CD" | "F" | "CA" | "TO")) => return Ok(s.to_string()),
+            Some(s) => last = s.to_string(),
+            None => {
+                if !last.is_empty() {
+                    return Ok(last);
+                }
+                return Ok("GONE".into());
+            }
+        }
+        if start.elapsed() > timeout {
+            return Ok("TIMEDOUT".into());
+        }
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+}
+
+pub async fn assert_eventually<F, Fut>(timeout: Duration, interval: Duration, msg: &str, mut f: F)
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    let start = std::time::Instant::now();
+    loop {
+        if f().await {
+            return;
+        }
+        assert!(
+            start.elapsed() < timeout,
+            "timed out after {timeout:?}: {msg}"
+        );
+        tokio::time::sleep(interval).await;
+    }
+}

--- a/crates/spur-tests/src/bare_metal/multi_node/container.rs
+++ b/crates/spur-tests/src/bare_metal/multi_node/container.rs
@@ -1,0 +1,165 @@
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use serial_test::serial;
+    use tokio::sync::OnceCell;
+
+    use crate::bare_metal::fixture::parse_job_id;
+    use crate::bare_metal::multi_node::fixture;
+    use crate::bare_metal::{wait_final_state, wait_job};
+
+    static CONTAINER_IMG: OnceCell<String> = OnceCell::const_new();
+
+    async fn container_image() -> &'static str {
+        CONTAINER_IMG
+            .get_or_init(|| async {
+                let f = fixture().await;
+                f.container_preflight().await;
+                f.build_container_image()
+                    .await
+                    .expect("failed to build container image")
+            })
+            .await
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn two_node_container_job() {
+        let f = fixture().await;
+        let img = container_image().await;
+        let out_path = format!("{}/ct-2n.out", f.remote_dir);
+        let script = f
+            .write_script(
+                "ct-2n.sh",
+                "#!/bin/bash\n\
+                 echo \"CONTAINER_NODE=$(hostname)\"\n\
+                 echo \"SPUR_NODE_RANK=${SPUR_NODE_RANK}\"\n\
+                 echo \"SPUR_NUM_NODES=${SPUR_NUM_NODES}\"\n\
+                 echo CONTAINER_2N_OK\n",
+            )
+            .await
+            .expect("script");
+
+        let sb = f
+            .sbatch(&[
+                "-J",
+                "ct-2node",
+                "-N",
+                "2",
+                "-o",
+                &out_path,
+                &format!("--container-image={img}"),
+                &script,
+            ])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+        wait_job(f, job_id, Duration::from_secs(90))
+            .await
+            .expect("wait");
+
+        let all = f.read_output_all_nodes(&out_path).await;
+        let diag = f.debug_job(job_id).await;
+        assert!(
+            all.contains("CONTAINER_2N_OK"),
+            "2-node container job must report CONTAINER_2N_OK\n{diag}\noutput:\n{all}"
+        );
+        assert!(
+            all.contains("SPUR_NUM_NODES=2"),
+            "must see SPUR_NUM_NODES=2\noutput:\n{all}"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn two_node_container_env_vars() {
+        let f = fixture().await;
+        let img = container_image().await;
+        let out_path = format!("{}/ct-2n-env.out", f.remote_dir);
+        let script = f
+            .write_script(
+                "ct-2n-env.sh",
+                "#!/bin/bash\n\
+                 echo \"RANK=${RANK}\"\n\
+                 echo \"WORLD_SIZE=${WORLD_SIZE}\"\n\
+                 echo \"MASTER_ADDR=${MASTER_ADDR}\"\n\
+                 echo \"SPUR_JOB_ID=${SPUR_JOB_ID}\"\n\
+                 echo CT_ENV_OK\n",
+            )
+            .await
+            .expect("script");
+
+        let sb = f
+            .sbatch(&[
+                "-J",
+                "ct-2n-env",
+                "-N",
+                "2",
+                "-o",
+                &out_path,
+                &format!("--container-image={img}"),
+                &script,
+            ])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+        wait_job(f, job_id, Duration::from_secs(90))
+            .await
+            .expect("wait");
+
+        let all = f.read_output_all_nodes(&out_path).await;
+        assert!(all.contains("CT_ENV_OK"), "missing CT_ENV_OK:\n{all}");
+        assert!(all.contains("WORLD_SIZE=2"), "missing WORLD_SIZE=2:\n{all}");
+        assert!(all.contains("RANK=0"), "missing RANK=0:\n{all}");
+        assert!(all.contains("RANK=1"), "missing RANK=1:\n{all}");
+        assert!(
+            all.lines()
+                .any(|l| l.starts_with("MASTER_ADDR=") && l.len() > "MASTER_ADDR=".len()),
+            "MASTER_ADDR should be non-empty:\n{all}"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn two_node_container_dns_both_nodes() {
+        let f = fixture().await;
+        let img = container_image().await;
+        let out_path = format!("{}/ct-2n-dns.out", f.remote_dir);
+        let script = f
+            .write_script(
+                "ct-2n-dns.sh",
+                "#!/bin/bash\n\
+                 getent hosts google.com >/dev/null 2>&1 || exit 1\n\
+                 echo \"DNS_OK_$(hostname)\"\n",
+            )
+            .await
+            .expect("script");
+
+        let sb = f
+            .sbatch(&[
+                "-J",
+                "ct-2n-dns",
+                "-N",
+                "2",
+                "-o",
+                &out_path,
+                &format!("--container-image={img}"),
+                &script,
+            ])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+        let state = wait_final_state(f, job_id, Duration::from_secs(60))
+            .await
+            .expect("wait");
+        let diag = f.debug_job(job_id).await;
+        assert!(
+            state == "CD" || state == "GONE",
+            "2-node container DNS failed, state={state}\n{diag}"
+        );
+    }
+}

--- a/crates/spur-tests/src/bare_metal/multi_node/dispatch.rs
+++ b/crates/spur-tests/src/bare_metal/multi_node/dispatch.rs
@@ -1,0 +1,110 @@
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use serial_test::serial;
+
+    use crate::bare_metal::fixture::parse_job_id;
+    use crate::bare_metal::multi_node::fixture;
+    use crate::bare_metal::wait_job;
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn two_node_job_completes() {
+        let f = fixture().await;
+        assert!(f.node_names.len() >= 2);
+
+        let out_path = format!("{}/two-node.out", f.remote_dir);
+        let script = f
+            .write_script(
+                "two-node.sh",
+                "#!/bin/bash\n\
+                 echo \"node=$(hostname)\"\n\
+                 echo \"SPUR_JOB_ID=${SPUR_JOB_ID}\"\n\
+                 echo \"SPUR_NODE_RANK=${SPUR_NODE_RANK}\"\n\
+                 echo \"SPUR_NUM_NODES=${SPUR_NUM_NODES}\"\n\
+                 echo \"SPUR_PEER_NODES=${SPUR_PEER_NODES}\"\n\
+                 echo TWO_NODE_OK\n",
+            )
+            .await
+            .expect("script");
+
+        let sb = f
+            .sbatch(&["-J", "test-2node", "-N", "2", "-o", &out_path, &script])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+        wait_job(f, job_id, Duration::from_secs(90))
+            .await
+            .expect("wait");
+
+        let all = f.read_output_all_nodes(&out_path).await;
+        assert!(all.contains("TWO_NODE_OK"), "missing TWO_NODE_OK:\n{all}");
+        assert!(
+            all.contains("SPUR_NUM_NODES=2"),
+            "missing SPUR_NUM_NODES=2:\n{all}"
+        );
+        assert!(
+            all.contains("SPUR_NODE_RANK="),
+            "missing SPUR_NODE_RANK:\n{all}"
+        );
+        assert!(
+            all.lines()
+                .any(|l| l.starts_with("SPUR_PEER_NODES=") && l.len() > "SPUR_PEER_NODES=".len()),
+            "SPUR_PEER_NODES should be set and non-empty:\n{all}"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn distributed_env_vars() {
+        let f = fixture().await;
+        let out_path = format!("{}/dist-env.out", f.remote_dir);
+        let script = f
+            .write_script(
+                "dist-env.sh",
+                "#!/bin/bash\n\
+                 echo \"RANK=${RANK}\"\n\
+                 echo \"WORLD_SIZE=${WORLD_SIZE}\"\n\
+                 echo \"MASTER_ADDR=${MASTER_ADDR}\"\n\
+                 echo \"MASTER_PORT=${MASTER_PORT}\"\n\
+                 echo DIST_ENV_OK\n",
+            )
+            .await
+            .expect("script");
+
+        let sb = f
+            .sbatch(&["-J", "test-dist-env", "-N", "2", "-o", &out_path, &script])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+        wait_job(f, job_id, Duration::from_secs(90))
+            .await
+            .expect("wait");
+
+        let mut all = f
+            .read_output_on_any_node(&out_path)
+            .await
+            .expect("local out");
+        for node in f.nodes.iter().skip(1) {
+            if let Ok(more) = node.read_remote_file(&out_path).await {
+                all.push('\n');
+                all.push_str(&more);
+            }
+        }
+
+        assert!(all.contains("WORLD_SIZE=2"));
+        assert!(all.contains("RANK=0"));
+        assert!(all.contains("RANK=1"));
+        assert!(all.contains("MASTER_PORT=29500"));
+        assert!(
+            all.lines()
+                .filter(|l| l.starts_with("MASTER_ADDR=") && *l != "MASTER_ADDR=")
+                .count()
+                >= 2,
+            "MASTER_ADDR should be set on both ranks:\n{all}"
+        );
+    }
+}

--- a/crates/spur-tests/src/bare_metal/multi_node/mod.rs
+++ b/crates/spur-tests/src/bare_metal/multi_node/mod.rs
@@ -1,0 +1,27 @@
+pub mod container;
+pub mod dispatch;
+pub mod scheduling;
+
+use tokio::sync::OnceCell;
+
+use crate::bare_metal::config::TestConfig;
+use crate::bare_metal::fixture::BareMetalFixture;
+
+static FIXTURE: OnceCell<BareMetalFixture> = OnceCell::const_new();
+
+pub async fn fixture() -> &'static BareMetalFixture {
+    FIXTURE
+        .get_or_init(|| async {
+            let config = TestConfig::from_env().expect("SPUR_TEST_BM_* config");
+            if config.nodes.len() < 2 {
+                panic!(
+                    "bare_metal::multi_node requires at least 2 nodes in SPUR_TEST_BM_NODES (got {})",
+                    config.nodes.len()
+                );
+            }
+            BareMetalFixture::deploy(config)
+                .await
+                .expect("failed to deploy bare-metal cluster for multi_node tests")
+        })
+        .await
+}

--- a/crates/spur-tests/src/bare_metal/multi_node/scheduling.rs
+++ b/crates/spur-tests/src/bare_metal/multi_node/scheduling.rs
@@ -1,0 +1,202 @@
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use serial_test::serial;
+
+    use crate::bare_metal::fixture::parse_job_id;
+    use crate::bare_metal::multi_node::fixture;
+    use crate::bare_metal::{job_state, wait_job};
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn nodelist_runs_on_requested_node() {
+        let f = fixture().await;
+        let target = &f.node_names[0];
+        let out_path = format!("{}/nodelist-{}.out", f.remote_dir, target);
+        let script = f
+            .write_script(
+                "nodename.sh",
+                "#!/bin/bash\necho \"RAN_ON=${SPUR_TARGET_NODE:-$(hostname)}\"\n",
+            )
+            .await
+            .expect("script");
+
+        let sb = f
+            .sbatch(&[
+                "-J",
+                "test-nodelist",
+                "-N",
+                "1",
+                "-w",
+                target,
+                "-o",
+                &out_path,
+                &script,
+            ])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+        wait_job(f, job_id, Duration::from_secs(60))
+            .await
+            .expect("wait");
+
+        let content = f.read_output_on_any_node(&out_path).await.expect("out");
+        assert!(
+            content.contains(&format!("RAN_ON={target}")),
+            "expected run on {target}, got:\n{content}"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn nodelist_runs_on_second_node() {
+        let f = fixture().await;
+        let target = &f.node_names[1];
+        let out_path = format!("{}/nodelist-{}.out", f.remote_dir, target);
+        let script = f
+            .write_script(
+                "nodename2.sh",
+                "#!/bin/bash\necho \"RAN_ON=${SPUR_TARGET_NODE:-$(hostname)}\"\n",
+            )
+            .await
+            .expect("script");
+
+        let sb = f
+            .sbatch(&[
+                "-J",
+                "test-nodelist2",
+                "-N",
+                "1",
+                "-w",
+                target,
+                "-o",
+                &out_path,
+                &script,
+            ])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+        wait_job(f, job_id, Duration::from_secs(60))
+            .await
+            .expect("wait");
+
+        let content = f.read_output_on_any_node(&out_path).await.expect("out");
+        assert!(
+            content.contains(&format!("RAN_ON={target}")),
+            "expected run on {target}, got:\n{content}"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn exclude_skips_node() {
+        let f = fixture().await;
+        assert!(
+            f.node_names.len() >= 2,
+            "exclude test requires at least 2 nodes, got {}",
+            f.node_names.len()
+        );
+        let excluded = &f.node_names[0];
+        let out_path = format!("{}/exclude.out", f.remote_dir);
+        let script = f
+            .write_script(
+                "nodename.sh",
+                "#!/bin/bash\necho \"RAN_ON=${SPUR_TARGET_NODE:-$(hostname)}\"\n",
+            )
+            .await
+            .expect("script");
+
+        let sb = f
+            .sbatch(&[
+                "-J",
+                "test-exclude",
+                "-N",
+                "1",
+                "-x",
+                excluded,
+                "-o",
+                &out_path,
+                &script,
+            ])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+        wait_job(f, job_id, Duration::from_secs(60))
+            .await
+            .expect("wait");
+
+        let content = f.read_output_on_any_node(&out_path).await.expect("out");
+        assert!(
+            !content.contains(&format!("RAN_ON={excluded}")),
+            "job must not run on excluded node {excluded}, got:\n{content}"
+        );
+        let allowed: Vec<_> = f.node_names.iter().skip(1).collect();
+        assert!(
+            allowed
+                .iter()
+                .any(|n| content.contains(&format!("RAN_ON={n}"))),
+            "expected run on one of {:?} (excluded {excluded}), got:\n{content}",
+            allowed
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn concurrent_jobs_on_two_nodes() {
+        let f = fixture().await;
+        assert!(
+            f.node_names.len() >= 2,
+            "concurrent test requires at least 2 nodes, got {}",
+            f.node_names.len()
+        );
+
+        let out1 = format!("{}/con1.out", f.remote_dir);
+        let out2 = format!("{}/con2.out", f.remote_dir);
+        let script = f
+            .write_script(
+                "concurrent.sh",
+                "#!/bin/bash\necho CONCURRENT_START\nsleep 5\necho CONCURRENT_DONE\n",
+            )
+            .await
+            .expect("script");
+
+        let sb1 = f
+            .sbatch(&["-J", "con1", "-N", "1", "-o", &out1, &script])
+            .await
+            .expect("sbatch1");
+        let sb2 = f
+            .sbatch(&["-J", "con2", "-N", "1", "-o", &out2, &script])
+            .await
+            .expect("sbatch2");
+        let j1 = parse_job_id(&sb1).expect("j1");
+        let j2 = parse_job_id(&sb2).expect("j2");
+
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        let sq = f.squeue_all().await.expect("squeue");
+        assert_eq!(job_state(&sq, j1).as_deref(), Some("R"));
+        assert_eq!(job_state(&sq, j2).as_deref(), Some("R"));
+
+        wait_job(f, j1, Duration::from_secs(60))
+            .await
+            .expect("wait j1");
+        wait_job(f, j2, Duration::from_secs(60))
+            .await
+            .expect("wait j2");
+
+        let c1 = f.read_output_on_any_node(&out1).await.expect("c1");
+        let c2 = f.read_output_on_any_node(&out2).await.expect("c2");
+        assert!(
+            c1.contains("CONCURRENT_DONE"),
+            "job1 missing CONCURRENT_DONE:\n{c1}"
+        );
+        assert!(
+            c2.contains("CONCURRENT_DONE"),
+            "job2 missing CONCURRENT_DONE:\n{c2}"
+        );
+    }
+}

--- a/crates/spur-tests/src/bare_metal/single_node/container.rs
+++ b/crates/spur-tests/src/bare_metal/single_node/container.rs
@@ -1,0 +1,346 @@
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use serial_test::serial;
+    use tokio::sync::OnceCell;
+
+    use crate::bare_metal::fixture::parse_job_id;
+    use crate::bare_metal::single_node::fixture;
+    use crate::bare_metal::wait_final_state;
+
+    static CONTAINER_IMG: OnceCell<String> = OnceCell::const_new();
+
+    async fn container_image() -> &'static str {
+        CONTAINER_IMG
+            .get_or_init(|| async {
+                let f = fixture().await;
+                f.container_preflight().await;
+                f.build_container_image()
+                    .await
+                    .expect("failed to build container image")
+            })
+            .await
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn container_launch_and_exit() {
+        let f = fixture().await;
+        let img = container_image().await;
+        let script = f
+            .write_script(
+                "c1.sh",
+                "#!/bin/bash\nhostname >/dev/null || exit 1\nid >/dev/null || exit 1\n",
+            )
+            .await
+            .expect("script");
+
+        let sb = f
+            .sbatch(&[
+                "-J",
+                "c1-launch",
+                "-N",
+                "1",
+                &format!("--container-image={img}"),
+                &script,
+            ])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+        let state = wait_final_state(f, job_id, Duration::from_secs(60))
+            .await
+            .expect("wait");
+        let diag = f.debug_job(job_id).await;
+        assert!(
+            state == "CD" || state == "GONE",
+            "container job must complete, got {state}\n{diag}"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn container_exit_code_propagation() {
+        let f = fixture().await;
+        let img = container_image().await;
+        let script = f
+            .write_script("c2.sh", "#!/bin/bash\nexit 42\n")
+            .await
+            .expect("script");
+
+        let sb = f
+            .sbatch(&[
+                "-J",
+                "c2-exitcode",
+                "-N",
+                "1",
+                &format!("--container-image={img}"),
+                &script,
+            ])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+        let state = wait_final_state(f, job_id, Duration::from_secs(60))
+            .await
+            .expect("wait");
+        assert_eq!(state, "F", "exit 42 should mark job failed");
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn container_cancel() {
+        let f = fixture().await;
+        let img = container_image().await;
+        let script = f
+            .write_script("c3.sh", "#!/bin/bash\nsleep 3600\n")
+            .await
+            .expect("script");
+
+        let sb = f
+            .sbatch(&[
+                "-J",
+                "c3-cancel",
+                "-N",
+                "1",
+                &format!("--container-image={img}"),
+                &script,
+            ])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+
+        // Wait for it to start running
+        for _ in 0..15 {
+            let sq = f.squeue_all().await.unwrap_or_default();
+            if crate::bare_metal::job_state(&sq, job_id).as_deref() == Some("R") {
+                break;
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+
+        f.scancel(&job_id.to_string()).await.expect("scancel");
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        let state = wait_final_state(f, job_id, Duration::from_secs(30))
+            .await
+            .expect("wait");
+        assert!(
+            state == "CA" || state == "F" || state == "GONE",
+            "cancelled container job should be CA/F, got {state}"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn container_dns_resolution() {
+        let f = fixture().await;
+        let img = container_image().await;
+        let out_path = format!("{}/c4.out", f.remote_dir);
+        let script = f
+            .write_script(
+                "c4.sh",
+                "#!/bin/bash\n\
+                 # Fail if resolv.conf has loopback stub (should be stripped)\n\
+                 grep -q '127.0.0.53' /etc/resolv.conf && exit 1\n\
+                 # Fail if DNS doesn't work\n\
+                 getent hosts google.com >/dev/null 2>&1 || exit 2\n\
+                 echo DNS_OK\n",
+            )
+            .await
+            .expect("script");
+
+        let sb = f
+            .sbatch(&[
+                "-J",
+                "c4-dns",
+                "-N",
+                "1",
+                "-o",
+                &out_path,
+                &format!("--container-image={img}"),
+                &script,
+            ])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+        let state = wait_final_state(f, job_id, Duration::from_secs(60))
+            .await
+            .expect("wait");
+        let diag = f.debug_job(job_id).await;
+        assert!(
+            state == "CD" || state == "GONE",
+            "DNS test failed (exit 1=loopback in resolv.conf, 2=getent failed), state={state}\n{diag}"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn container_dev_shm() {
+        let f = fixture().await;
+        let img = container_image().await;
+        let script = f
+            .write_script(
+                "c5.sh",
+                "#!/bin/bash\n\
+                 echo shm_test > /dev/shm/spur_ctest || exit 1\n\
+                 rm -f /dev/shm/spur_ctest\n\
+                 df /dev/shm >/dev/null 2>&1 || exit 2\n",
+            )
+            .await
+            .expect("script");
+
+        let sb = f
+            .sbatch(&[
+                "-J",
+                "c5-shm",
+                "-N",
+                "1",
+                &format!("--container-image={img}"),
+                &script,
+            ])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+        let state = wait_final_state(f, job_id, Duration::from_secs(60))
+            .await
+            .expect("wait");
+        let diag = f.debug_job(job_id).await;
+        assert!(
+            state == "CD" || state == "GONE",
+            "/dev/shm test failed (1=write failed, 2=not mounted), state={state}\n{diag}"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn container_pid_namespace() {
+        let f = fixture().await;
+        let img = container_image().await;
+        let script = f
+            .write_script(
+                "c6.sh",
+                "#!/bin/bash\n\
+                 [ \"$$\" = \"1\" ] || exit 1\n\
+                 [ -r /proc/self/status ] || exit 2\n",
+            )
+            .await
+            .expect("script");
+
+        let sb = f
+            .sbatch(&[
+                "-J",
+                "c6-pidns",
+                "-N",
+                "1",
+                &format!("--container-image={img}"),
+                &script,
+            ])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+        let state = wait_final_state(f, job_id, Duration::from_secs(60))
+            .await
+            .expect("wait");
+        let diag = f.debug_job(job_id).await;
+        assert!(
+            state == "CD" || state == "GONE",
+            "PID namespace test failed (1=not PID 1, 2=/proc missing), state={state}\n{diag}"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn container_env_vars() {
+        let f = fixture().await;
+        let img = container_image().await;
+        let script = f
+            .write_script(
+                "c7.sh",
+                "#!/bin/bash\n\
+                 [ -n \"$SPUR_JOB_ID\" ] || exit 1\n\
+                 [ -n \"$OMP_NUM_THREADS\" ] || exit 2\n",
+            )
+            .await
+            .expect("script");
+
+        let sb = f
+            .sbatch(&[
+                "-J",
+                "c7-env",
+                "-N",
+                "1",
+                &format!("--container-image={img}"),
+                &script,
+            ])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+        let state = wait_final_state(f, job_id, Duration::from_secs(60))
+            .await
+            .expect("wait");
+        let diag = f.debug_job(job_id).await;
+        assert!(
+            state == "CD" || state == "GONE",
+            "env var test failed (1=no SPUR_JOB_ID, 2=no OMP_NUM_THREADS), state={state}\n{diag}"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn container_bind_mount_readonly() {
+        let f = fixture().await;
+        let img = container_image().await;
+
+        let bind_dir = format!("{}/bind-test", f.remote_dir);
+        for node in &f.nodes {
+            node.exec(&format!(
+                "mkdir -p '{bind_dir}' && echo bind_mount_ci_test > '{bind_dir}/data.txt'"
+            ))
+            .await
+            .expect("setup bind dir");
+        }
+
+        let script = f
+            .write_script(
+                "c8.sh",
+                "#!/bin/bash\n\
+                 [ \"$(cat /mnt/data/data.txt 2>/dev/null)\" = \"bind_mount_ci_test\" ] || exit 1\n\
+                 # Write must fail on :ro mount\n\
+                 touch /mnt/data/write_test 2>/dev/null && exit 2\n\
+                 exit 0\n",
+            )
+            .await
+            .expect("script");
+
+        let mount_spec = format!("{bind_dir}:/mnt/data:ro");
+        let sb = f
+            .sbatch(&[
+                "-J",
+                "c8-bind",
+                "-N",
+                "1",
+                &format!("--container-image={img}"),
+                &format!("--container-mounts={mount_spec}"),
+                &script,
+            ])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+        let state = wait_final_state(f, job_id, Duration::from_secs(60))
+            .await
+            .expect("wait");
+        let diag = f.debug_job(job_id).await;
+        assert!(
+            state == "CD" || state == "GONE",
+            "bind mount test failed (1=content wrong, 2=ro not enforced), state={state}\n{diag}"
+        );
+    }
+}

--- a/crates/spur-tests/src/bare_metal/single_node/jobs.rs
+++ b/crates/spur-tests/src/bare_metal/single_node/jobs.rs
@@ -1,0 +1,235 @@
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use serial_test::serial;
+
+    use crate::bare_metal::fixture::parse_job_id;
+    use crate::bare_metal::single_node::fixture;
+    use crate::bare_metal::{wait_final_state, wait_job};
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn sinfo_returns_output() {
+        let f = fixture().await;
+        let out = f.sinfo().await.expect("sinfo");
+        assert!(!out.trim().is_empty(), "sinfo produced no output");
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn all_nodes_registered_and_idle() {
+        let f = fixture().await;
+        let out = f.sinfo().await.expect("sinfo");
+        for name in &f.node_names {
+            assert!(out.contains(name), "node {name} not in sinfo:\n{out}");
+        }
+        assert!(
+            f.cluster_is_ready(&out),
+            "expected {} idle nodes, sinfo:\n{out}",
+            f.node_names.len()
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn single_node_job_completes_with_output() {
+        let f = fixture().await;
+        let script = f
+            .write_script(
+                "test-basic.sh",
+                "#!/bin/bash\necho \"hostname=$(hostname)\"\necho \"SPUR_JOB_ID=${SPUR_JOB_ID}\"\necho SUCCESS\n",
+            )
+            .await
+            .expect("write script");
+
+        let out = f
+            .sbatch(&["-J", "test-basic", "-N", "1", &script])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&out).expect("job id from sbatch");
+
+        wait_job(f, job_id, Duration::from_secs(60))
+            .await
+            .expect("wait job");
+
+        let state = crate::bare_metal::wait_final_state(f, job_id, Duration::from_secs(30))
+            .await
+            .expect("final state");
+        assert!(
+            state == "CD" || state == "GONE",
+            "expected completed job, got {state}"
+        );
+
+        let content = f.read_job_output(job_id).await.expect("read out");
+        assert!(content.contains("SUCCESS"), "output:\n{content}");
+        assert!(
+            content.contains(&format!("SPUR_JOB_ID={job_id}")),
+            "output:\n{content}"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn failed_job_state_f() {
+        let f = fixture().await;
+        let out_path = format!("{}/spur-fail.out", f.remote_dir);
+        let script = f
+            .write_script(
+                "test-exitfail.sh",
+                "#!/bin/bash\necho before-failure\nexit 42\n",
+            )
+            .await
+            .expect("script");
+
+        let node = &f.node_names[0];
+        let sb = f
+            .sbatch(&[
+                "-J",
+                "test-exitfail",
+                "-N",
+                "1",
+                "-w",
+                node,
+                "-o",
+                &out_path,
+                &script,
+            ])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+
+        let state = wait_final_state(f, job_id, Duration::from_secs(60))
+            .await
+            .expect("wait");
+        assert_eq!(state, "F", "expected failed state");
+
+        let content = f.read_output_on_any_node(&out_path).await.expect("out");
+        assert!(content.contains("before-failure"));
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn custom_output_and_error_paths() {
+        let f = fixture().await;
+        let out_path = format!("{}/custom-out.txt", f.remote_dir);
+        let err_path = format!("{}/custom-err.txt", f.remote_dir);
+        let script = f
+            .write_script(
+                "test-io.sh",
+                "#!/bin/bash\necho stdout-line\necho stderr-line >&2\necho CUSTOM_IO_OK\n",
+            )
+            .await
+            .expect("script");
+
+        let node = &f.node_names[0];
+        let sb = f
+            .sbatch(&[
+                "-J",
+                "test-custom-io",
+                "-N",
+                "1",
+                "-w",
+                node,
+                "-o",
+                &out_path,
+                "-e",
+                &err_path,
+                &script,
+            ])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+        wait_job(f, job_id, Duration::from_secs(60))
+            .await
+            .expect("wait");
+
+        let stdout = f.read_output_on_any_node(&out_path).await.expect("stdout");
+        assert!(stdout.contains("CUSTOM_IO_OK"));
+        let stderr = f.read_output_on_any_node(&err_path).await.expect("stderr");
+        assert!(stderr.contains("stderr-line"));
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn percent_j_output_substitution() {
+        let f = fixture().await;
+        let script = f
+            .write_script("test-basic-j.sh", "#!/bin/bash\necho J_OK\n")
+            .await
+            .expect("script");
+        let pattern = format!("{}/spur-subst-%j.out", f.remote_dir);
+        let node = &f.node_names[0];
+
+        let sb = f
+            .sbatch(&[
+                "-J",
+                "test-subst",
+                "-N",
+                "1",
+                "-w",
+                node,
+                "-o",
+                &pattern,
+                &script,
+            ])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+        wait_job(f, job_id, Duration::from_secs(60))
+            .await
+            .expect("wait");
+
+        let path = format!("{}/spur-subst-{job_id}.out", f.remote_dir);
+        let content = f.read_output_on_any_node(&path).await.expect("out");
+        assert!(content.contains("J_OK"));
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn env_passthrough_export() {
+        let f = fixture().await;
+        let out_path = format!("{}/spur-env.out", f.remote_dir);
+        let script = f
+            .write_script(
+                "test-env.sh",
+                "#!/bin/bash\necho \"MYVAR=${MYVAR}\"\necho \"MULTIVAR=${MULTIVAR}\"\necho ENV_OK\n",
+            )
+            .await
+            .expect("script");
+        let node = &f.node_names[0];
+
+        let cmd = format!(
+            "SPUR_CONTROLLER_ADDR='{}' PATH='{}':$PATH MYVAR=hello123 MULTIVAR=world456 \
+             '{}/sbatch' -J test-env -N 1 -w {node} -o '{out_path}' --export=MYVAR,MULTIVAR '{script}'",
+            f.controller_addr, f.bin_dir, f.bin_dir, node = node, out_path = out_path, script = script
+        );
+        let sb = f.controller().exec(&cmd).await.expect("sbatch with env");
+        let job_id = parse_job_id(&sb).expect("job id from sbatch");
+
+        wait_job(f, job_id, Duration::from_secs(60))
+            .await
+            .expect("wait");
+        let content = f.read_output_on_any_node(&out_path).await.expect("out");
+        let output = if content.trim().is_empty() {
+            f.read_job_output(job_id).await.expect("job output")
+        } else {
+            content
+        };
+        assert!(
+            output.contains("MYVAR=hello123"),
+            "missing MYVAR=hello123:\n{output}"
+        );
+        assert!(
+            output.contains("MULTIVAR=world456"),
+            "missing MULTIVAR=world456:\n{output}"
+        );
+    }
+}

--- a/crates/spur-tests/src/bare_metal/single_node/lifecycle.rs
+++ b/crates/spur-tests/src/bare_metal/single_node/lifecycle.rs
@@ -1,0 +1,171 @@
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use serial_test::serial;
+
+    use crate::bare_metal::fixture::parse_job_id;
+    use crate::bare_metal::single_node::fixture;
+    use crate::bare_metal::{job_state, wait_final_state, wait_job};
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn job_cancel() {
+        let f = fixture().await;
+        let script = f
+            .write_script("test-long.sh", "#!/bin/bash\nsleep 300\n")
+            .await
+            .expect("script");
+
+        let sb = f
+            .sbatch(&["-J", "test-cancel", "-N", "1", &script])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        f.scancel(&job_id.to_string()).await.expect("scancel");
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let sq = f.squeue_all().await.expect("squeue");
+        let state = job_state(&sq, job_id);
+        assert!(
+            matches!(state.as_deref(), Some("CA") | Some("F") | None),
+            "expected cancelled, got {:?}",
+            state
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn job_hold_and_release() {
+        let f = fixture().await;
+        let out_path = format!("{}/spur-hold.out", f.remote_dir);
+        let script = f
+            .write_script("test-hold.sh", "#!/bin/bash\necho HOLD_OK\n")
+            .await
+            .expect("script");
+
+        let sb = f
+            .sbatch(&["-J", "test-hold", "-N", "1", "-H", "-o", &out_path, &script])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        let sq = f.squeue_all().await.expect("squeue");
+        assert_eq!(job_state(&sq, job_id).as_deref(), Some("PD"));
+
+        f.scontrol_release(&job_id.to_string())
+            .await
+            .expect("release");
+        wait_job(f, job_id, Duration::from_secs(60))
+            .await
+            .expect("wait after release");
+
+        let content = f.read_output_on_any_node(&out_path).await.expect("out");
+        assert!(content.contains("HOLD_OK"));
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn job_dependency_afterok() {
+        let f = fixture().await;
+        let out_a = format!("{}/dep-a.out", f.remote_dir);
+        let out_b = format!("{}/dep-b.out", f.remote_dir);
+        let script_a = f
+            .write_script(
+                "dep-a.sh",
+                "#!/bin/bash\necho DEP_A_START\nsleep 6\necho DEP_A_DONE\n",
+            )
+            .await
+            .expect("script a");
+        let script_b = f
+            .write_script("dep-b.sh", "#!/bin/bash\necho DEP_B_RAN\n")
+            .await
+            .expect("script b");
+
+        let sb_a = f
+            .sbatch(&["-J", "test-dep-a", "-N", "1", "-o", &out_a, &script_a])
+            .await
+            .expect("sbatch a");
+        let job_a = parse_job_id(&sb_a).expect("job a");
+
+        let sb_b = f
+            .sbatch(&[
+                "-J",
+                "test-dep-b",
+                "-N",
+                "1",
+                "-o",
+                &out_b,
+                &format!("--dependency=afterok:{job_a}"),
+                &script_b,
+            ])
+            .await
+            .expect("sbatch b");
+        let job_b = parse_job_id(&sb_b).expect("job b");
+
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        let sq = f.squeue_all().await.expect("squeue");
+        assert_eq!(job_state(&sq, job_a).as_deref(), Some("R"));
+        assert_eq!(job_state(&sq, job_b).as_deref(), Some("PD"));
+
+        wait_job(f, job_a, Duration::from_secs(60))
+            .await
+            .expect("wait a");
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        wait_job(f, job_b, Duration::from_secs(60))
+            .await
+            .expect("wait b");
+
+        let content = f.read_output_on_any_node(&out_b).await.expect("out b");
+        assert!(content.contains("DEP_B_RAN"));
+    }
+
+    #[tokio::test]
+    #[ignore]
+    #[serial]
+    async fn time_limit_enforced() {
+        let f = fixture().await;
+        let out_path = format!("{}/walltime.out", f.remote_dir);
+        let script = f
+            .write_script(
+                "walltime.sh",
+                "#!/bin/bash\necho WALLTIME_STARTED\nsleep 300\necho WALLTIME_SHOULD_NOT_REACH\n",
+            )
+            .await
+            .expect("script");
+
+        let sb = f
+            .sbatch(&[
+                "-J",
+                "test-walltime",
+                "-N",
+                "1",
+                "-o",
+                &out_path,
+                "-t",
+                "0:00:10",
+                &script,
+            ])
+            .await
+            .expect("sbatch");
+        let job_id = parse_job_id(&sb).expect("job id");
+
+        let state = wait_final_state(f, job_id, Duration::from_secs(45))
+            .await
+            .expect("wait terminal");
+        assert!(
+            matches!(state.as_str(), "CA" | "F" | "TO" | "GONE"),
+            "job should be killed, got {state}"
+        );
+
+        let content = f.read_output_on_any_node(&out_path).await.expect("out");
+        assert!(content.contains("WALLTIME_STARTED"));
+        assert!(!content.contains("WALLTIME_SHOULD_NOT_REACH"));
+    }
+}

--- a/crates/spur-tests/src/bare_metal/single_node/mod.rs
+++ b/crates/spur-tests/src/bare_metal/single_node/mod.rs
@@ -1,0 +1,21 @@
+pub mod container;
+pub mod jobs;
+pub mod lifecycle;
+
+use tokio::sync::OnceCell;
+
+use crate::bare_metal::config::TestConfig;
+use crate::bare_metal::fixture::BareMetalFixture;
+
+static FIXTURE: OnceCell<BareMetalFixture> = OnceCell::const_new();
+
+pub async fn fixture() -> &'static BareMetalFixture {
+    FIXTURE
+        .get_or_init(|| async {
+            let config = TestConfig::from_env().expect("SPUR_TEST_BM_* config");
+            BareMetalFixture::deploy(config)
+                .await
+                .expect("failed to deploy bare-metal cluster for single_node tests")
+        })
+        .await
+}

--- a/crates/spur-tests/src/bare_metal/ssh.rs
+++ b/crates/spur-tests/src/bare_metal/ssh.rs
@@ -1,0 +1,189 @@
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use openssh::{KnownHosts, Session, SessionBuilder, Stdio};
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+
+/// SSH session to a test node.
+pub struct SshNode {
+    pub host: String,
+    pub user: String,
+    ssh_key: Option<std::path::PathBuf>,
+    session: Session,
+}
+
+impl SshNode {
+    pub async fn connect(host: &str, user: &str, ssh_key: Option<&Path>) -> Result<Self> {
+        let mut builder = SessionBuilder::default();
+        builder.user(user.to_string());
+        builder.known_hosts_check(KnownHosts::Accept);
+        if let Some(key) = ssh_key {
+            builder.keyfile(key);
+        }
+
+        let destination = format!("{user}@{host}");
+        let session = builder
+            .connect(&destination)
+            .await
+            .with_context(|| format!("SSH connect to {destination}"))?;
+
+        Ok(Self {
+            host: host.to_string(),
+            user: user.to_string(),
+            ssh_key: ssh_key.map(|p| p.to_path_buf()),
+            session,
+        })
+    }
+
+    pub fn destination(&self) -> String {
+        format!("{}@{}", self.user, self.host)
+    }
+
+    /// Run a remote shell command and return stdout (stderr merged on failure).
+    pub async fn exec(&self, cmd: &str) -> Result<String> {
+        let output = self
+            .session
+            .command("sh")
+            .arg("-c")
+            .arg(cmd)
+            .output()
+            .await
+            .with_context(|| format!("exec on {}: {cmd}", self.host))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            bail!(
+                "command failed on {} (exit {:?}): {}\nstdout: {}",
+                self.host,
+                output.status.code(),
+                stderr,
+                stdout
+            );
+        }
+
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    }
+
+    /// Run a remote command, ignoring non-zero exit (returns stdout+stderr text).
+    pub async fn exec_allow_fail(&self, cmd: &str) -> Result<String> {
+        let output = self
+            .session
+            .command("sh")
+            .arg("-c")
+            .arg(cmd)
+            .output()
+            .await
+            .with_context(|| format!("exec on {}: {cmd}", self.host))?;
+
+        let mut combined = String::from_utf8_lossy(&output.stdout).into_owned();
+        if !output.stderr.is_empty() {
+            combined.push_str(&String::from_utf8_lossy(&output.stderr));
+        }
+        Ok(combined)
+    }
+
+    pub async fn kill_processes(&self, pattern: &str) -> Result<()> {
+        let _ = self
+            .exec_allow_fail(&format!("pkill -f '{pattern}' 2>/dev/null || true"))
+            .await;
+        Ok(())
+    }
+
+    pub async fn mkdir_p(&self, path: &str) -> Result<()> {
+        self.exec(&format!("mkdir -p '{path}'")).await?;
+        Ok(())
+    }
+
+    /// Create a unique directory with `mktemp -d` (e.g. `/tmp/spur-ci.XXXXXX`).
+    pub async fn mktemp_dir(&self, template: &str) -> Result<String> {
+        // Non-interactive SSH often has a minimal PATH; use absolute path to mktemp.
+        let path = self
+            .exec(&format!("/usr/bin/mktemp -d '{template}'"))
+            .await
+            .with_context(|| format!("mktemp on {}", self.host))?;
+        let path = path.trim().to_string();
+        if path.is_empty() {
+            bail!("mktemp returned empty path on {}", self.host);
+        }
+        Ok(path)
+    }
+
+    pub async fn rm_rf(&self, path: &str) -> Result<()> {
+        let _ = self
+            .exec_allow_fail(&format!("rm -rf '{path}' 2>/dev/null || true"))
+            .await;
+        Ok(())
+    }
+
+    pub async fn write_remote_file(&self, path: &str, contents: &[u8]) -> Result<()> {
+        let mut child = self
+            .session
+            .command("sh")
+            .arg("-c")
+            .arg(format!("cat > '{path}'"))
+            .stdin(Stdio::piped())
+            .spawn()
+            .await
+            .with_context(|| format!("write remote file {path} on {}", self.host))?;
+
+        if let Some(mut stdin) = child.stdin().take() {
+            stdin.write_all(contents).await?;
+            stdin.shutdown().await?;
+        }
+
+        let status = child.wait().await?;
+        if !status.success() {
+            bail!("failed to write {path} on {}", self.host);
+        }
+        Ok(())
+    }
+
+    pub async fn read_remote_file(&self, path: &str) -> Result<String> {
+        self.exec(&format!("test -f '{path}' && cat '{path}' || echo ''"))
+            .await
+    }
+
+    pub async fn scp_to(&self, local: &Path, remote: &str) -> Result<()> {
+        let mut cmd = Command::new("scp");
+        cmd.arg("-o")
+            .arg("StrictHostKeyChecking=accept-new")
+            .arg("-o")
+            .arg("BatchMode=yes");
+        if let Some(key) = &self.ssh_key {
+            cmd.arg("-i").arg(key);
+        }
+        cmd.arg(local)
+            .arg(format!("{}:{}", self.destination(), remote));
+        let output = cmd
+            .output()
+            .await
+            .with_context(|| format!("scp {} -> {}:{}", local.display(), self.host, remote))?;
+        if !output.status.success() {
+            bail!("scp failed: {}", String::from_utf8_lossy(&output.stderr));
+        }
+        Ok(())
+    }
+
+    pub async fn scp_from(&self, remote: &str, local: &Path) -> Result<()> {
+        let mut cmd = Command::new("scp");
+        cmd.arg("-o")
+            .arg("StrictHostKeyChecking=accept-new")
+            .arg("-o")
+            .arg("BatchMode=yes");
+        if let Some(key) = &self.ssh_key {
+            cmd.arg("-i").arg(key);
+        }
+        cmd.arg(format!("{}:{}", self.destination(), remote))
+            .arg(local);
+        let output = cmd
+            .output()
+            .await
+            .with_context(|| format!("scp {}:{} -> {}", self.host, remote, local.display()))?;
+        if !output.status.success() {
+            bail!("scp failed: {}", String::from_utf8_lossy(&output.stderr));
+        }
+        Ok(())
+    }
+}

--- a/crates/spur-tests/src/lib.rs
+++ b/crates/spur-tests/src/lib.rs
@@ -33,6 +33,9 @@ pub mod harness;
 // K8s integration tests (require a live cluster, run with `-- --ignored`)
 pub mod k8s;
 
+// Bare-metal E2E tests (require SSH + nodes, run with `-- --ignored`)
+pub mod bare_metal;
+
 // Unit / component tests (no running daemons needed)
 pub mod t01_run;
 pub mod t05_queue;


### PR DESCRIPTION
SSH-based test harness that deploys Spur on remote nodes, runs tests, and tears down. Replaces deploy/bare-metal/cluster_test.sh with structured Rust tests covering scheduler, containers, and GPU tiers.

Tiers:
- single_node: 19 tests (jobs, lifecycle, containers C1-C8)
- multi_node: 9 tests (dispatch, scheduling, containers)
- gpu::single_node: 1-node HIP with preflight + strict assertions
- gpu::multi_node: 2-node HIP, PyTorch distributed, inference

Key design decisions:
- Deterministic remote dirs (/tmp/spur-bm-{pid}-{ts}), matching K8s namespace pattern for predictable CI log collection and cleanup
- GPU preflight hard-fails if no GPU hardware detected
- Container preflight checks AppArmor userns restriction (Ubuntu 24.04) and gives actionable fix commands
- Ephemeral PyTorch venv created per run (pip cache for speed)
- Container image built locally via mksquashfs, SCP'd to nodes
- debug_job() collects scontrol, sinfo, squeue, stdout, and daemon logs on assertion failure
