### PR TITLE
chore(hooks): add local git hooks for commit format and formatting

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Validates that the commit message subject follows conventional commits:
+#   type(scope): description
+#
+# Enforced in CI via .github/workflows/pr-lint.yml; this hook gives
+# immediate local feedback. Bypass with: git commit --no-verify
+
+PATTERN="^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-zA-Z0-9_-]+\))?!?: .+$"
+
+subject=$(head -1 "$1")
+
+if ! echo "$subject" | grep -Eq "$PATTERN"; then
+  echo "commit-msg: subject does not match conventional commits format."
+  echo ""
+  echo "  Got:      $subject"
+  echo "  Expected: type(scope): description"
+  echo "  Example:  feat(spur-cli): add magic option"
+  echo ""
+  echo "Valid types: feat fix docs style refactor perf test build ci chore revert"
+  echo "Bypass with: git commit --no-verify"
+  exit 1
+fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Runs cargo fmt --check before each commit. Bypass with: git commit --no-verify
+
+if ! command -v cargo >/dev/null 2>&1; then
+  exit 0
+fi
+
+if ! cargo fmt --all --check 2>/dev/null; then
+  echo "pre-commit: cargo fmt found unformatted code."
+  echo ""
+  echo "  Run: cargo fmt --all"
+  echo "  Bypass with: git commit --no-verify"
+  exit 1
+fi


### PR DESCRIPTION
Adds .githooks/ with commit-msg (conventional commits validation) and pre-commit (cargo fmt --check). 

Opt-in via:
```git config core.hooksPath .githooks```
