### PR TITLE
ci(pr-lint): add workflow to enforce conventional commits on PRs

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,61 @@
+name: PR Lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  conventional-commits:
+    runs-on: ubuntu-latest
+    env:
+      PATTERN: "^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\\([a-zA-Z0-9_-]+\\))?!?: .+$"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          echo "Checking PR title: '$PR_TITLE'"
+          if ! echo "$PR_TITLE" | grep -Eq "$PATTERN"; then
+            echo "FAIL: PR title does not match conventional commits format."
+            echo "Expected: type(scope): description  (e.g. 'feat(spur-cli): add magic option')"
+            echo "Valid types: feat fix docs style refactor perf test build ci chore revert"
+            exit 1
+          fi
+          echo "PASS: PR title is valid."
+
+      - name: Validate PR commits
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          COMMITS=$(git log --no-merges --format='%s' "origin/${BASE_REF}"..HEAD)
+
+          if [ -z "$COMMITS" ]; then
+            echo "No commits found between origin/${BASE_REF} and HEAD."
+            exit 0
+          fi
+
+          FAILED=0
+          while IFS= read -r msg; do
+            echo "Checking commit: '$msg'"
+            if ! echo "$msg" | grep -Eq "$PATTERN"; then
+              echo "  FAIL: invalid format."
+              FAILED=1
+            fi
+          done <<< "$COMMITS"
+
+          if [ "$FAILED" -ne 0 ]; then
+            echo "FAIL: one or more commit messages do not match conventional commits format."
+            echo "Rebase and reword commits to match: type(scope): description"
+            echo "Valid types: feat fix docs style refactor perf test build ci chore revert"
+            exit 1
+          fi
+          echo "PASS: all commit messages are valid."


### PR DESCRIPTION
Validates PR title and all commit subjects against the conventional commits pattern. Uses git log against the base branch instead of the GitHub API to avoid token/rate-limit dependencies. All user-controlled inputs (PR title, base ref) are passed via env vars to prevent script injection.
