### PR TITLE
chore(license): add SPDX license headers to all source files

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,15 +1,27 @@
 #!/usr/bin/env bash
 #
-# Runs cargo fmt --check before each commit. Bypass with: git commit --no-verify
+# Pre-commit checks:
+#   1. cargo fmt --check
+#   2. SPDX license headers on staged source files
+#
+# Bypass with: git commit --no-verify
 
-if ! command -v cargo >/dev/null 2>&1; then
-  exit 0
+if command -v cargo >/dev/null 2>&1; then
+  if ! cargo fmt --all --check 2>/dev/null; then
+    echo "pre-commit: cargo fmt found unformatted code."
+    echo ""
+    echo "  Run: cargo fmt --all"
+    echo "  Bypass with: git commit --no-verify"
+    exit 1
+  fi
 fi
 
-if ! cargo fmt --all --check 2>/dev/null; then
-  echo "pre-commit: cargo fmt found unformatted code."
-  echo ""
-  echo "  Run: cargo fmt --all"
-  echo "  Bypass with: git commit --no-verify"
-  exit 1
+# Check SPDX license headers on staged source files
+mapfile -t staged < <(
+    git diff --cached --name-only --diff-filter=d -- '*.rs' '*.proto' '*.py' '*.sh' 'Dockerfile' '*/Dockerfile' '*/Dockerfile.*'
+)
+
+if [ ${#staged[@]} -gt 0 ]; then
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  "$REPO_ROOT/scripts/check-license-headers.sh" "${staged[@]}" || exit 1
 fi

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -59,3 +59,12 @@ jobs:
             exit 1
           fi
           echo "PASS: all commit messages are valid."
+
+  license-headers:
+    name: SPDX License Headers
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check SPDX license headers
+        run: ./scripts/check-license-headers.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Minimal Spur runtime image — downloads pre-built release binaries.
 #
 # Build:

--- a/crates/spur-cli/src/exec.rs
+++ b/crates/spur-cli/src/exec.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! `spur exec` — execute a command inside a running container job.
 
 use anyhow::{Context, Result};

--- a/crates/spur-cli/src/format_engine.rs
+++ b/crates/spur-cli/src/format_engine.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Slurm-compatible format string engine.
 ///
 /// Parses format strings like `"%.18i %.9P %.8j %.8u %.2t %10M %6D %R"`

--- a/crates/spur-cli/src/image.rs
+++ b/crates/spur-cli/src/image.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! `spur image` subcommands for container image management.
 
 use std::process::Stdio;

--- a/crates/spur-cli/src/main.rs
+++ b/crates/spur-cli/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 mod exec;
 mod format_engine;
 mod image;

--- a/crates/spur-cli/src/net.rs
+++ b/crates/spur-cli/src/net.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! `spur net` subcommands for WireGuard mesh management.
 
 use std::net::Ipv4Addr;

--- a/crates/spur-cli/src/sacct.rs
+++ b/crates/spur-cli/src/sacct.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Context, Result};
 use clap::Parser;
 use spur_proto::proto::slurm_accounting_client::SlurmAccountingClient;

--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand};
 

--- a/crates/spur-cli/src/salloc.rs
+++ b/crates/spur-cli/src/salloc.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Context, Result};
 use clap::Parser;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;

--- a/crates/spur-cli/src/sattach.rs
+++ b/crates/spur-cli/src/sattach.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Context, Result};
 use clap::Parser;
 use spur_proto::proto::slurm_agent_client::SlurmAgentClient;

--- a/crates/spur-cli/src/sbatch.rs
+++ b/crates/spur-cli/src/sbatch.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{bail, Context, Result};
 use clap::Parser;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;

--- a/crates/spur-cli/src/scancel.rs
+++ b/crates/spur-cli/src/scancel.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{bail, Context, Result};
 use clap::Parser;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand};
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;

--- a/crates/spur-cli/src/scrontab.rs
+++ b/crates/spur-cli/src/scrontab.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::Result;
 use clap::Parser;
 use std::path::PathBuf;

--- a/crates/spur-cli/src/sdiag.rs
+++ b/crates/spur-cli/src/sdiag.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Context, Result};
 use clap::Parser;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;

--- a/crates/spur-cli/src/sinfo.rs
+++ b/crates/spur-cli/src/sinfo.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::BTreeMap;
 
 use anyhow::{Context, Result};

--- a/crates/spur-cli/src/smd.rs
+++ b/crates/spur-cli/src/smd.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Context, Result};
 use clap::Parser;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;

--- a/crates/spur-cli/src/sprio.rs
+++ b/crates/spur-cli/src/sprio.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Context, Result};
 use clap::Parser;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;

--- a/crates/spur-cli/src/squeue.rs
+++ b/crates/spur-cli/src/squeue.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Context, Result};
 use clap::Parser;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;

--- a/crates/spur-cli/src/sreport.rs
+++ b/crates/spur-cli/src/sreport.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use spur_proto::proto::slurm_accounting_client::SlurmAccountingClient;

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Context, Result};
 use clap::Parser;
 use spur_proto::proto::slurm_agent_client::SlurmAgentClient;

--- a/crates/spur-cli/src/sshare.rs
+++ b/crates/spur-cli/src/sshare.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Context, Result};
 use clap::Parser;
 use spur_proto::proto::slurm_accounting_client::SlurmAccountingClient;

--- a/crates/spur-cli/src/sstat.rs
+++ b/crates/spur-cli/src/sstat.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{bail, Context, Result};
 use clap::Parser;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;

--- a/crates/spur-cli/src/strigger.rs
+++ b/crates/spur-cli/src/strigger.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::Result;
 use clap::Parser;
 use std::path::PathBuf;

--- a/crates/spur-core/src/accounting.rs
+++ b/crates/spur-core/src/accounting.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Accounting data models: accounts, users, QOS, associations, TRES.
 
 use serde::{Deserialize, Serialize};

--- a/crates/spur-core/src/array.rs
+++ b/crates/spur-core/src/array.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Job array specification parsing and task expansion.
 //!
 //! Supports Slurm-compatible array specs:

--- a/crates/spur-core/src/auth.rs
+++ b/crates/spur-core/src/auth.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Authentication and authorization.
 //!
 //! Supports JWT token verification for gRPC and REST APIs.

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;

--- a/crates/spur-core/src/dependency.rs
+++ b/crates/spur-core/src/dependency.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Job dependency parsing and checking.
 //!
 //! Supports: afterok:N, afterany:N, afternotok:N, aftercorr:N, singleton

--- a/crates/spur-core/src/hostlist.rs
+++ b/crates/spur-core/src/hostlist.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use thiserror::Error;
 
 /// Errors from hostlist parsing.

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/crates/spur-core/src/lib.rs
+++ b/crates/spur-core/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod accounting;
 pub mod array;
 pub mod auth;

--- a/crates/spur-core/src/node.rs
+++ b/crates/spur-core/src/node.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 

--- a/crates/spur-core/src/partition.rs
+++ b/crates/spur-core/src/partition.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 /// Partition (queue) configuration.

--- a/crates/spur-core/src/qos.rs
+++ b/crates/spur-core/src/qos.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! QOS enforcement logic.
 //!
 //! Checks per-QOS limits before allowing a job to be scheduled.

--- a/crates/spur-core/src/reservation.rs
+++ b/crates/spur-core/src/reservation.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 

--- a/crates/spur-core/src/resource.rs
+++ b/crates/spur-core/src/resource.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/crates/spur-core/src/step.rs
+++ b/crates/spur-core/src/step.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Job steps — sub-executions within a running job.
 //!
 //! When `srun` is called inside a batch script, it creates a job step.

--- a/crates/spur-core/src/topology.rs
+++ b/crates/spur-core/src/topology.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use serde::{Deserialize, Serialize};
 
 use crate::job::{JobId, JobSpec, JobState};

--- a/crates/spur-ffi/src/lib.rs
+++ b/crates/spur-ffi/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! C FFI compatibility shim — libslurm-compat.so
 //!
 //! Exports extern "C" functions matching a subset of Slurm's libslurm ABI,

--- a/crates/spur-ffi/src/types.rs
+++ b/crates/spur-ffi/src/types.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! #[repr(C)] types matching Slurm's ABI layout.
 
 use std::os::raw::{c_char, c_uint};

--- a/crates/spur-k8s/src/agent.rs
+++ b/crates/spur-k8s/src/agent.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::BTreeMap;
 use std::time::Duration;
 

--- a/crates/spur-k8s/src/crd.rs
+++ b/crates/spur-k8s/src/crd.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/crates/spur-k8s/src/health.rs
+++ b/crates/spur-k8s/src/health.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! HTTP health, readiness, and metrics server for the K8s operator.
 
 use std::net::SocketAddr;

--- a/crates/spur-k8s/src/heartbeat.rs
+++ b/crates/spur-k8s/src/heartbeat.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 
 use tokio::sync::RwLock;

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::pin::pin;
 use std::sync::Arc;

--- a/crates/spur-k8s/src/lib.rs
+++ b/crates/spur-k8s/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod agent;
 pub mod crd;
 pub mod health;

--- a/crates/spur-k8s/src/main.rs
+++ b/crates/spur-k8s/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 mod agent;
 mod crd;
 mod health;

--- a/crates/spur-k8s/src/node_watcher.rs
+++ b/crates/spur-k8s/src/node_watcher.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::pin::pin;

--- a/crates/spur-net/src/address.rs
+++ b/crates/spur-net/src/address.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! IP address pool allocation from a CIDR block.
 //!
 //! The controller maintains a pool of IPs and hands them out to agents

--- a/crates/spur-net/src/detect.rs
+++ b/crates/spur-net/src/detect.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Detect the node's network address for registration with the controller.
 //!
 //! Priority: WireGuard interface IP > hostname resolution > fallback.

--- a/crates/spur-net/src/lib.rs
+++ b/crates/spur-net/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod address;
 pub mod detect;
 pub mod oci;

--- a/crates/spur-net/src/oci.rs
+++ b/crates/spur-net/src/oci.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Native OCI/Docker image puller.
 //!
 //! Downloads container images directly from registries using the

--- a/crates/spur-net/src/wireguard.rs
+++ b/crates/spur-net/src/wireguard.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! WireGuard key generation and config file management.
 //!
 //! Shells out to `wg` and `wg-quick` which are standard on any Linux

--- a/crates/spur-proto/build.rs
+++ b/crates/spur-proto/build.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .protoc_arg("--experimental_allow_proto3_optional")

--- a/crates/spur-proto/src/lib.rs
+++ b/crates/spur-proto/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod proto {
     tonic::include_proto!("slurm");
 }

--- a/crates/spur-sched/src/backfill.rs
+++ b/crates/spur-sched/src/backfill.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 
 use chrono::{Duration, Utc};

--- a/crates/spur-sched/src/cons_tres.rs
+++ b/crates/spur-sched/src/cons_tres.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Consumable TRES resource selection.
 //!
 //! Tracks resources at core/socket/GPU granularity within a node.

--- a/crates/spur-sched/src/lib.rs
+++ b/crates/spur-sched/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod backfill;
 pub mod cons_tres;
 pub mod priority;

--- a/crates/spur-sched/src/priority.rs
+++ b/crates/spur-sched/src/priority.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Calculate effective job priority.
 ///
 /// effective_priority = base_priority * fair_share_factor * age_factor * partition_tier

--- a/crates/spur-sched/src/timeline.rs
+++ b/crates/spur-sched/src/timeline.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use chrono::{DateTime, Duration, Utc};
 use spur_core::resource::ResourceSet;
 

--- a/crates/spur-sched/src/traits.rs
+++ b/crates/spur-sched/src/traits.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use spur_core::job::{Job, JobId};
 use spur_core::node::Node;
 use spur_core::partition::Partition;

--- a/crates/spur-spank/src/lib.rs
+++ b/crates/spur-spank/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! SPANK plugin host.
 //!
 //! Loads existing Slurm SPANK plugins (.so files) via dlopen and provides

--- a/crates/spur-tests/src/bare_metal/config.rs
+++ b/crates/spur-tests/src/bare_metal/config.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::PathBuf;
 
 use anyhow::{bail, Result};

--- a/crates/spur-tests/src/bare_metal/fixture.rs
+++ b/crates/spur-tests/src/bare_metal/fixture.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::Path;
 use std::time::Duration;
 

--- a/crates/spur-tests/src/bare_metal/gpu/mod.rs
+++ b/crates/spur-tests/src/bare_metal/gpu/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod multi_node;
 pub mod single_node;
 

--- a/crates/spur-tests/src/bare_metal/gpu/multi_node.rs
+++ b/crates/spur-tests/src/bare_metal/gpu/multi_node.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;

--- a/crates/spur-tests/src/bare_metal/gpu/single_node.rs
+++ b/crates/spur-tests/src/bare_metal/gpu/single_node.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;

--- a/crates/spur-tests/src/bare_metal/mod.rs
+++ b/crates/spur-tests/src/bare_metal/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod config;
 pub mod fixture;
 pub mod ssh;

--- a/crates/spur-tests/src/bare_metal/multi_node/container.rs
+++ b/crates/spur-tests/src/bare_metal/multi_node/container.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;

--- a/crates/spur-tests/src/bare_metal/multi_node/dispatch.rs
+++ b/crates/spur-tests/src/bare_metal/multi_node/dispatch.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;

--- a/crates/spur-tests/src/bare_metal/multi_node/mod.rs
+++ b/crates/spur-tests/src/bare_metal/multi_node/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod container;
 pub mod dispatch;
 pub mod scheduling;

--- a/crates/spur-tests/src/bare_metal/multi_node/scheduling.rs
+++ b/crates/spur-tests/src/bare_metal/multi_node/scheduling.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;

--- a/crates/spur-tests/src/bare_metal/single_node/container.rs
+++ b/crates/spur-tests/src/bare_metal/single_node/container.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;

--- a/crates/spur-tests/src/bare_metal/single_node/jobs.rs
+++ b/crates/spur-tests/src/bare_metal/single_node/jobs.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;

--- a/crates/spur-tests/src/bare_metal/single_node/lifecycle.rs
+++ b/crates/spur-tests/src/bare_metal/single_node/lifecycle.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;

--- a/crates/spur-tests/src/bare_metal/single_node/mod.rs
+++ b/crates/spur-tests/src/bare_metal/single_node/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod container;
 pub mod jobs;
 pub mod lifecycle;

--- a/crates/spur-tests/src/bare_metal/ssh.rs
+++ b/crates/spur-tests/src/bare_metal/ssh.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::Path;
 
 use anyhow::{bail, Context, Result};

--- a/crates/spur-tests/src/harness.rs
+++ b/crates/spur-tests/src/harness.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Test harness utilities.
 //!
 //! Provides helpers for standing up test clusters, submitting jobs,

--- a/crates/spur-tests/src/k8s/fixture.rs
+++ b/crates/spur-tests/src/k8s/fixture.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::PathBuf;
 use std::time::Duration;
 

--- a/crates/spur-tests/src/k8s/mod.rs
+++ b/crates/spur-tests/src/k8s/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod fixture;
 pub mod multi_node;
 pub mod single_node;

--- a/crates/spur-tests/src/k8s/multi_node/lifecycle.rs
+++ b/crates/spur-tests/src/k8s/multi_node/lifecycle.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;

--- a/crates/spur-tests/src/k8s/multi_node/mod.rs
+++ b/crates/spur-tests/src/k8s/multi_node/mod.rs
@@ -1,1 +1,4 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod lifecycle;

--- a/crates/spur-tests/src/k8s/single_node/cross_namespace.rs
+++ b/crates/spur-tests/src/k8s/single_node/cross_namespace.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use k8s_openapi::api::core::v1::Pod;

--- a/crates/spur-tests/src/k8s/single_node/mod.rs
+++ b/crates/spur-tests/src/k8s/single_node/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod cross_namespace;
 pub mod spurjob;
 

--- a/crates/spur-tests/src/k8s/single_node/spurjob.rs
+++ b/crates/spur-tests/src/k8s/single_node/spurjob.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;

--- a/crates/spur-tests/src/lib.rs
+++ b/crates/spur-tests/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Spur Test Suite
 //!
 //! Test numbering mirrors Slurm's testsuite for 1-1 mapping:

--- a/crates/spur-tests/src/t01_run.rs
+++ b/crates/spur-tests/src/t01_run.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! T01: Job step and task distribution tests.
 //!
 //! Corresponds to Slurm's test1.x series (srun).

--- a/crates/spur-tests/src/t05_queue.rs
+++ b/crates/spur-tests/src/t05_queue.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! T05: Job queue viewing (squeue / spur queue).
 //!
 //! Corresponds to Slurm's test5.x series.

--- a/crates/spur-tests/src/t06_cancel.rs
+++ b/crates/spur-tests/src/t06_cancel.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! T06: Job cancellation and control.
 //!
 //! Corresponds to Slurm's test6.x series.

--- a/crates/spur-tests/src/t07_sched.rs
+++ b/crates/spur-tests/src/t07_sched.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! T07: Scheduler tests.
 //!
 //! Corresponds to Slurm's test7.x series (scheduling/plugins).

--- a/crates/spur-tests/src/t17_submit.rs
+++ b/crates/spur-tests/src/t17_submit.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! T17: Job submission (sbatch / spur submit).
 //!
 //! Corresponds to Slurm's test17.x series.

--- a/crates/spur-tests/src/t21_acctmgr.rs
+++ b/crates/spur-tests/src/t21_acctmgr.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! T21: Accounting management tests.
 //!
 //! Corresponds to Slurm's test21.x series (sacctmgr).

--- a/crates/spur-tests/src/t24_priority.rs
+++ b/crates/spur-tests/src/t24_priority.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! T24: Priority and fair-share.
 //!
 //! Corresponds to Slurm's test24.x series.

--- a/crates/spur-tests/src/t28_arrays.rs
+++ b/crates/spur-tests/src/t28_arrays.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! T28: Job arrays.
 //!
 //! Corresponds to Slurm's test28.x series.

--- a/crates/spur-tests/src/t28b_array_expand.rs
+++ b/crates/spur-tests/src/t28b_array_expand.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! T28b: Job array expansion tests.
 //!
 //! Tests array spec parsing — complement to t28_arrays which tests

--- a/crates/spur-tests/src/t39_gpu.rs
+++ b/crates/spur-tests/src/t39_gpu.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! T39: GPU/GRES scheduling tests.
 //!
 //! Corresponds to Slurm's test39.x series.

--- a/crates/spur-tests/src/t50_core.rs
+++ b/crates/spur-tests/src/t50_core.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! T50: Core type tests.
 //!
 //! Tests for Job, Node, ResourceSet, Partition types.

--- a/crates/spur-tests/src/t51_hostlist.rs
+++ b/crates/spur-tests/src/t51_hostlist.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! T51: Hostlist expansion and compression.
 //!
 //! Corresponds to Slurm's slurm_unit/common/hostlist tests.

--- a/crates/spur-tests/src/t52_config.rs
+++ b/crates/spur-tests/src/t52_config.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! T52: Configuration parsing.
 //!
 //! Tests for TOML config loading, time parsing, partition building.

--- a/crates/spur-tests/src/t55_format.rs
+++ b/crates/spur-tests/src/t55_format.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! T55: CLI format string engine.
 //!
 //! Tests the Slurm-compatible %X format string parser and renderer.

--- a/crates/spur-tests/src/t56_deps.rs
+++ b/crates/spur-tests/src/t56_deps.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! T56: Job dependency tests.
 //!
 //! Tests dependency parsing, satisfaction checking, and edge cases.

--- a/crates/spur-tests/src/t57_auth.rs
+++ b/crates/spur-tests/src/t57_auth.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! T57: Authentication and authorization tests.
 
 #[cfg(test)]

--- a/crates/spur-tests/src/t58_spank.rs
+++ b/crates/spur-tests/src/t58_spank.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! T58: SPANK plugin host tests.
 //!
 //! Tests the SPANK plugin loading, hook invocation, and plugstack parsing.

--- a/crates/spur-update/src/cache.rs
+++ b/crates/spur-update/src/cache.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 use std::path::Path;

--- a/crates/spur-update/src/check.rs
+++ b/crates/spur-update/src/check.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use semver::Version;

--- a/crates/spur-update/src/download.rs
+++ b/crates/spur-update/src/download.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{bail, Context, Result};
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};

--- a/crates/spur-update/src/install.rs
+++ b/crates/spur-update/src/install.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::{bail, Context, Result};
 use flate2::read::GzDecoder;
 use std::fs;

--- a/crates/spur-update/src/lib.rs
+++ b/crates/spur-update/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Auto-update and version checking for Spur binaries.
 //!
 //! Provides:

--- a/crates/spurctld/src/accounting.rs
+++ b/crates/spurctld/src/accounting.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use chrono::{DateTime, Utc};
 use tonic::transport::Channel;
 use tracing::warn;

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::atomic::{AtomicU32, Ordering};

--- a/crates/spurctld/src/fairshare_cache.rs
+++ b/crates/spurctld/src/fairshare_cache.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 mod accounting;
 mod cluster;
 mod fairshare_cache;

--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Raft-based consensus for spurctld.
 //!
 //! Raft is always-on: even single-node deployments run a 1-member Raft

--- a/crates/spurctld/src/raft_server.rs
+++ b/crates/spurctld/src/raft_server.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! gRPC server for Raft internal RPCs.
 //!
 //! Runs on a dedicated port (default 6821) separate from the client API,

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashSet;
 use std::sync::Arc;
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::sync::Arc;

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! gRPC server implementing the SlurmAgent service.
 //! Receives job launch/cancel requests from spurctld.
 

--- a/crates/spurd/src/container.rs
+++ b/crates/spurd/src/container.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Native container support for Spur.
 //!
 //! Implements Enroot-like rootless containers using Linux user namespaces

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::os::fd::{FromRawFd, OwnedFd, RawFd};

--- a/crates/spurd/src/gpu.rs
+++ b/crates/spurd/src/gpu.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use spur_core::resource::{GpuLinkType, GpuResource};
 use std::path::Path;
 use tracing::debug;

--- a/crates/spurd/src/landlock.rs
+++ b/crates/spurd/src/landlock.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Landlock filesystem access control for bare-metal job isolation.
 //!
 //! Restricts filesystem access to the job's working directory, GPU device

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 mod agent_server;
 pub mod container;
 mod executor;

--- a/crates/spurd/src/pmi.rs
+++ b/crates/spurd/src/pmi.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Minimal PMI-1 wire protocol server for MPI rank bootstrap.
 
 use std::collections::HashMap;

--- a/crates/spurd/src/reporter.rs
+++ b/crates/spurd/src/reporter.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::Context;

--- a/crates/spurd/src/seccomp.rs
+++ b/crates/spurd/src/seccomp.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 //! Seccomp-BPF syscall filter for job isolation.
 //!
 //! Implements a default-deny syscall whitelist inspired by the AXIS sandbox

--- a/crates/spurdbd/src/db.rs
+++ b/crates/spurdbd/src/db.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use chrono::{DateTime, Utc};
 use sqlx::postgres::PgPoolOptions;
 use sqlx::{PgPool, Row};

--- a/crates/spurdbd/src/fairshare.rs
+++ b/crates/spurdbd/src/fairshare.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use chrono::{DateTime, Duration, Utc};
 
 use crate::db::UsageRecord;

--- a/crates/spurdbd/src/main.rs
+++ b/crates/spurdbd/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 mod db;
 mod fairshare;
 mod server;

--- a/crates/spurdbd/src/server.rs
+++ b/crates/spurdbd/src/server.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::net::SocketAddr;
 
 use chrono::{DateTime, Utc};

--- a/crates/spurrestd/src/main.rs
+++ b/crates/spurrestd/src/main.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 mod routes;
 
 use std::sync::Arc;

--- a/crates/spurrestd/src/routes.rs
+++ b/crates/spurrestd/src/routes.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::sync::Arc;
 
 use axum::{

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Multi-stage build: one image with all Spur binaries
 # Builder uses manylinux_2_28 (glibc 2.28) for broad compatibility
 FROM quay.io/pypa/manylinux_2_28_x86_64 AS builder

--- a/deploy/Dockerfile.manylinux
+++ b/deploy/Dockerfile.manylinux
@@ -1,3 +1,6 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Build portable Spur binaries using manylinux_2_28 (glibc 2.28 / AlmaLinux 8)
 #
 # Compatible with: Ubuntu 20.04+, Debian 10+, RHEL 8+, Fedora 28+

--- a/deploy/bare-metal/cluster_test.sh
+++ b/deploy/bare-metal/cluster_test.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Spur MI300X Cluster Integration Test
 #
 # Runs a sequence of tests against a live Spur cluster:

--- a/deploy/bare-metal/deploy.sh
+++ b/deploy/bare-metal/deploy.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Deploy Spur to MI300X cluster
 #
 # Topology:

--- a/deploy/bare-metal/distributed_job.sh
+++ b/deploy/bare-metal/distributed_job.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Distributed PyTorch GPU test for Spur
 # Submit: ~/spur/bin/sbatch -J dist-test -N 2 ~/spur/distributed_job.sh
 source ~/spur/venv/bin/activate

--- a/deploy/bare-metal/distributed_test.py
+++ b/deploy/bare-metal/distributed_test.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Distributed PyTorch GPU test for Spur cluster.
 

--- a/deploy/bare-metal/inference_job.sh
+++ b/deploy/bare-metal/inference_job.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Spur job wrapper: activate venv and run the TP inference test.
 # Deployed to ~/spur/ on each cluster node.
 source ~/spur/venv/bin/activate

--- a/deploy/bare-metal/inference_test.py
+++ b/deploy/bare-metal/inference_test.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 """
 Tensor-parallel transformer inference test for MI300X clusters.
 

--- a/deploy/bare-metal/setup-runner.sh
+++ b/deploy/bare-metal/setup-runner.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Install a GitHub Actions self-hosted runner on mi300.
 #
 # Run this once on mi300 (ssh mi300, then bash setup-runner.sh <REPO> <TOKEN>).

--- a/deploy/build-portable.sh
+++ b/deploy/build-portable.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Build portable Spur binaries using manylinux_2_28 Docker image (glibc 2.28)
 #
 # Outputs binaries to dist/bin/ in the repo root.

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Install Spur — AI-native job scheduler
 #
 # Usage:

--- a/proto/raft_internal.proto
+++ b/proto/raft_internal.proto
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 syntax = "proto3";
 
 package raft_internal;

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 syntax = "proto3";
 
 package slurm;

--- a/scripts/check-license-headers.sh
+++ b/scripts/check-license-headers.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Checks that source files contain the SPDX license header.
+# Used by both the pre-commit hook and CI workflow.
+#
+# Usage:
+#   scripts/check-license-headers.sh          # check all tracked source files
+#   scripts/check-license-headers.sh file...  # check specific files only
+
+set -euo pipefail
+
+SPDX_TAG="SPDX-License-Identifier: Apache-2.0"
+
+check_file() {
+    local file="$1"
+    # Read enough lines to find the header (shebangs push it down a line or two)
+    if ! head -5 "$file" | grep -qF "$SPDX_TAG"; then
+        echo "  $file"
+        return 1
+    fi
+    return 0
+}
+
+# If arguments were passed, check only those files; otherwise check all tracked files.
+if [ $# -gt 0 ]; then
+    files=("$@")
+else
+    mapfile -t files < <(git ls-files -- '*.rs' '*.proto' '*.py' '*.sh' 'Dockerfile' '*/Dockerfile' '*/Dockerfile.*')
+fi
+
+failed=0
+missing=()
+
+for f in "${files[@]}"; do
+    [ -f "$f" ] || continue
+    if ! check_file "$f"; then
+        missing+=("$f")
+        failed=1
+    fi
+done
+
+if [ "$failed" -ne 0 ]; then
+    echo ""
+    echo "ERROR: ${#missing[@]} file(s) missing SPDX license header."
+    echo "Each source file (.rs, .proto, .py, .sh, Dockerfile) must contain:"
+    echo "  SPDX-License-Identifier: Apache-2.0"
+    echo ""
+    echo "For .rs and .proto files, add these lines at the top:"
+    echo "  // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved."
+    echo "  // SPDX-License-Identifier: Apache-2.0"
+    echo ""
+    echo "For .py and .sh files (after the shebang, if any):"
+    echo "  # Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved."
+    echo "  # SPDX-License-Identifier: Apache-2.0"
+    exit 1
+fi
+
+echo "All source files have SPDX license headers."


### PR DESCRIPTION
Add "Copyright (c) 2026 Advanced Micro Devices, Inc." and SPDX-License-Identifier: Apache-2.0 to every .rs, .proto, .py, .sh, and Dockerfile. Include a reusable check script, extend the pre-commit hook, and add a license-headers job to the PR lint workflow.
