### PR TITLE
ci(build): add --locked to cargo commands to reject stale Cargo.lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
             ${{ runner.os }}-cargo-clippy-
 
       - name: Clippy
-        run: cargo clippy --workspace --exclude spur-ffi --all-targets -- -W clippy::all -D unused
+        run: cargo clippy --workspace --exclude spur-ffi --all-targets --locked -- -W clippy::all -D unused
 
   build:
     needs: [fmt, clippy]
@@ -72,7 +72,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Build
-        run: cargo build --all-targets
+        run: cargo build --all-targets --locked
 
   test:
     needs: [build]
@@ -97,7 +97,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Test
-        run: cargo test
+        run: cargo test --locked
 
       - name: Prepare K8s test binary
         run: |

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -16,7 +16,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 WORKDIR /build
 COPY . .
 
-RUN cargo build --release \
+RUN cargo build --release --locked \
     --bin spur \
     --bin spurctld \
     --bin spurd \


### PR DESCRIPTION
Prevents PRs from merging with a Cargo.lock that's out of sync with Cargo.toml. Without this, cargo silently updates the lockfile in CI and the build passes, but the repo is left inconsistent after merge.
