### PR TITLE
fix(spur-core): set priority 0 for jobs submitted with hold flag

### DIFF
--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -339,12 +339,12 @@ pub struct Job {
 
 impl Job {
     pub fn new(job_id: JobId, spec: JobSpec) -> Self {
-        let priority = spec.priority.unwrap_or(1000);
-        let state = if spec.hold {
-            JobState::Pending
+        let priority = if spec.hold {
+            0
         } else {
-            JobState::Pending
+            spec.priority.unwrap_or(1000)
         };
+        let state = JobState::Pending;
         let pending_reason = if spec.hold {
             PendingReason::Held
         } else {

--- a/crates/spur-tests/src/t06_cancel.rs
+++ b/crates/spur-tests/src/t06_cancel.rs
@@ -58,6 +58,7 @@ mod tests {
         );
         assert_eq!(job.state, JobState::Pending);
         assert_eq!(job.pending_reason, PendingReason::Held);
+        assert_eq!(job.priority, 0);
     }
 
     // ── T06.5: Held jobs not in schedulable pending ──────────────

--- a/crates/spur-tests/src/t07_sched.rs
+++ b/crates/spur-tests/src/t07_sched.rs
@@ -1027,6 +1027,7 @@ mod tests {
             },
         );
         assert_eq!(job.pending_reason, spur_core::job::PendingReason::Held);
+        assert_eq!(job.priority, 0);
     }
 
     #[test]

--- a/crates/spur-tests/src/t17_submit.rs
+++ b/crates/spur-tests/src/t17_submit.rs
@@ -115,6 +115,7 @@ mod tests {
         );
         assert_eq!(job.state, spur_core::job::JobState::Pending);
         assert_eq!(job.pending_reason, spur_core::job::PendingReason::Held);
+        assert_eq!(job.priority, 0);
     }
 
     // ── T17.9: Array spec ────────────────────────────────────────

--- a/crates/spur-tests/src/t50_core.rs
+++ b/crates/spur-tests/src/t50_core.rs
@@ -360,6 +360,7 @@ mod tests {
         );
         assert_eq!(job.state, JobState::Pending);
         assert_eq!(job.pending_reason, PendingReason::Held);
+        assert_eq!(job.priority, 0);
     }
 
     // ── T50.33–37: Requeue state transitions ───────────────────


### PR DESCRIPTION
## Summary

- `sbatch -H` (submit with hold) now sets job priority to 0, matching Slurm semantics where held jobs have "priority of zero" per the sbatch man page
- Previously `Job::new()` only set `PendingReason::Held` but left priority at the default 1000, while `scontrol hold` correctly set both priority 0 and `PendingReason::Held`
- The scheduling gate (`pending_jobs()` filter on `PendingReason::Held`) already prevented held jobs from running, so this was a display/consistency bug — `squeue -o %p` showed different priorities for the same held state depending on how the job was held
- Also resolves clippy `if_same_then_else` warning — both branches of a dead `if spec.hold` on `JobState` returned `Pending`

## Known follow-up

`release_job()` hardcodes `new_priority: 1000` rather than restoring the original user-specified priority. Real Slurm recalculates via its multifactor priority plugin on release. This is pre-existing and not introduced by this change.

## Test plan

- [x] 4 existing hold tests updated to assert `priority == 0` — all pass
- [x] `cargo test` full suite passes
- [x] CI green