### PR TITLE
refactor(spur-cli): use JobState enum instead of raw integers in srun

### DIFF
--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -266,6 +266,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let mut poll_interval = tokio::time::interval(tokio::time::Duration::from_secs(1));
     #[allow(unused_assignments)]
     let mut nodelist = String::new();
+    let mut warned_unknown_state = false;
 
     loop {
         poll_interval.tick().await;
@@ -290,7 +291,16 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
                     ) => {
                         handle_terminal_state(state, job_id, job.exit_code, &work_dir).await;
                     }
-                    _ => {}
+                    Ok(_) => {}
+                    Err(_) if !warned_unknown_state => {
+                        warned_unknown_state = true;
+                        eprintln!(
+                            "srun: warning: job {} has unrecognized state {} \
+                             (controller may be newer than client)",
+                            job_id, job.state
+                        );
+                    }
+                    Err(_) => {}
                 }
             }
             Err(e) => {
@@ -378,24 +388,34 @@ async fn try_stream_output(
 
     // Wait for terminal state and get exit code
     let mut poll_interval = tokio::time::interval(tokio::time::Duration::from_secs(1));
+    let mut warned_unknown_state = false;
     loop {
         poll_interval.tick().await;
         match controller.get_job(GetJobRequest { job_id }).await {
             Ok(resp) => {
                 let job = resp.into_inner();
-                if let Ok(state) = JobState::try_from(job.state) {
-                    match state {
-                        JobState::JobCompleted => {
-                            std::process::exit(job.exit_code);
-                        }
+                match JobState::try_from(job.state) {
+                    Ok(JobState::JobCompleted) => {
+                        std::process::exit(job.exit_code);
+                    }
+                    Ok(
                         JobState::JobFailed
                         | JobState::JobCancelled
                         | JobState::JobTimeout
-                        | JobState::JobNodeFail => {
-                            std::process::exit(job.exit_code.max(1));
-                        }
-                        _ => {}
+                        | JobState::JobNodeFail,
+                    ) => {
+                        std::process::exit(job.exit_code.max(1));
                     }
+                    Ok(_) => {}
+                    Err(_) if !warned_unknown_state => {
+                        warned_unknown_state = true;
+                        eprintln!(
+                            "srun: warning: job {} has unrecognized state {} \
+                             (controller may be newer than client)",
+                            job_id, job.state
+                        );
+                    }
+                    Err(_) => {}
                 }
             }
             Err(_) => {}
@@ -410,20 +430,32 @@ async fn poll_for_completion(
     work_dir: &str,
 ) {
     let mut poll_interval = tokio::time::interval(tokio::time::Duration::from_secs(1));
+    let mut warned_unknown_state = false;
     loop {
         poll_interval.tick().await;
         match client.get_job(GetJobRequest { job_id }).await {
             Ok(resp) => {
                 let job = resp.into_inner();
-                if let Ok(
-                    state @ (JobState::JobCompleted
-                    | JobState::JobFailed
-                    | JobState::JobCancelled
-                    | JobState::JobTimeout
-                    | JobState::JobNodeFail),
-                ) = JobState::try_from(job.state)
-                {
-                    handle_terminal_state(state, job_id, job.exit_code, work_dir).await;
+                match JobState::try_from(job.state) {
+                    Ok(
+                        state @ (JobState::JobCompleted
+                        | JobState::JobFailed
+                        | JobState::JobCancelled
+                        | JobState::JobTimeout
+                        | JobState::JobNodeFail),
+                    ) => {
+                        handle_terminal_state(state, job_id, job.exit_code, work_dir).await;
+                    }
+                    Ok(_) => {}
+                    Err(_) if !warned_unknown_state => {
+                        warned_unknown_state = true;
+                        eprintln!(
+                            "srun: warning: job {} has unrecognized state {} \
+                             (controller may be newer than client)",
+                            job_id, job.state
+                        );
+                    }
+                    Err(_) => {}
                 }
             }
             Err(e) => {

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{
-    CancelJobRequest, CreateJobStepRequest, GetJobRequest, GetNodeRequest, JobSpec,
+    CancelJobRequest, CreateJobStepRequest, GetJobRequest, GetNodeRequest, JobSpec, JobState,
     StreamJobOutputRequest, SubmitJobRequest,
 };
 use std::collections::HashMap;
@@ -273,20 +273,24 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         match client.get_job(GetJobRequest { job_id }).await {
             Ok(resp) => {
                 let job = resp.into_inner();
-                match job.state {
-                    1 => {
-                        // RUNNING
+                match JobState::try_from(job.state) {
+                    Ok(JobState::JobRunning) => {
                         nodelist = job.nodelist.clone();
                         if !nodelist.is_empty() {
                             eprintln!("srun: job {} running on {}", job_id, nodelist);
                         }
                         break;
                     }
-                    3 | 4 | 5 | 6 | 7 => {
-                        // Already terminal
-                        handle_terminal_state(job.state, job_id, job.exit_code, &work_dir).await;
+                    Ok(
+                        state @ (JobState::JobCompleted
+                        | JobState::JobFailed
+                        | JobState::JobCancelled
+                        | JobState::JobTimeout
+                        | JobState::JobNodeFail),
+                    ) => {
+                        handle_terminal_state(state, job_id, job.exit_code, &work_dir).await;
                     }
-                    _ => {} // Still pending
+                    _ => {}
                 }
             }
             Err(e) => {
@@ -379,14 +383,19 @@ async fn try_stream_output(
         match controller.get_job(GetJobRequest { job_id }).await {
             Ok(resp) => {
                 let job = resp.into_inner();
-                if job.state >= 3 {
-                    // Terminal
-                    let code = if job.state == 3 {
-                        job.exit_code
-                    } else {
-                        job.exit_code.max(1)
-                    };
-                    std::process::exit(code);
+                if let Ok(state) = JobState::try_from(job.state) {
+                    match state {
+                        JobState::JobCompleted => {
+                            std::process::exit(job.exit_code);
+                        }
+                        JobState::JobFailed
+                        | JobState::JobCancelled
+                        | JobState::JobTimeout
+                        | JobState::JobNodeFail => {
+                            std::process::exit(job.exit_code.max(1));
+                        }
+                        _ => {}
+                    }
                 }
             }
             Err(_) => {}
@@ -406,8 +415,15 @@ async fn poll_for_completion(
         match client.get_job(GetJobRequest { job_id }).await {
             Ok(resp) => {
                 let job = resp.into_inner();
-                if job.state >= 3 {
-                    handle_terminal_state(job.state, job_id, job.exit_code, work_dir).await;
+                if let Ok(
+                    state @ (JobState::JobCompleted
+                    | JobState::JobFailed
+                    | JobState::JobCancelled
+                    | JobState::JobTimeout
+                    | JobState::JobNodeFail),
+                ) = JobState::try_from(job.state)
+                {
+                    handle_terminal_state(state, job_id, job.exit_code, work_dir).await;
                 }
             }
             Err(e) => {
@@ -417,33 +433,31 @@ async fn poll_for_completion(
     }
 }
 
-async fn handle_terminal_state(state: i32, job_id: u32, exit_code: i32, work_dir: &str) -> ! {
+async fn handle_terminal_state(state: JobState, job_id: u32, exit_code: i32, work_dir: &str) -> ! {
     match state {
-        3 => {
-            // COMPLETED
+        JobState::JobCompleted => {
             print_job_output(work_dir, job_id).await;
             std::process::exit(exit_code);
         }
-        4 => {
-            // FAILED
+        JobState::JobFailed => {
             print_job_output(work_dir, job_id).await;
             eprintln!("srun: job {} failed with exit code {}", job_id, exit_code);
             std::process::exit(exit_code.max(1));
         }
-        5 => {
+        JobState::JobCancelled => {
             eprintln!("srun: job {} cancelled", job_id);
             std::process::exit(1);
         }
-        6 => {
+        JobState::JobTimeout => {
             eprintln!("srun: job {} timed out", job_id);
             std::process::exit(1);
         }
-        7 => {
+        JobState::JobNodeFail => {
             eprintln!("srun: job {} failed (node failure)", job_id);
             std::process::exit(1);
         }
         _ => {
-            eprintln!("srun: job {} ended with state {}", job_id, state);
+            eprintln!("srun: job {} ended with state {:?}", job_id, state);
             std::process::exit(1);
         }
     }


### PR DESCRIPTION
## Summary

- Replace all raw `i32` comparisons against proto `JobState` discriminants in `srun.rs` with typed `JobState::try_from()` + named variant matching
- `handle_terminal_state` now takes `JobState` instead of `i32`, making terminal-state checks self-documenting and resilient to proto enum renumbering
- Fixes two latent bugs where `job.state >= 3` incorrectly treated `PREEMPTED` (8) and `SUSPENDED` (9) as terminal states — a suspended job can resume to RUNNING and a preempted job can requeue to PENDING
- Resolves clippy `manual_range_patterns` warning (`3 | 4 | 5 | 6 | 7`)

## Bugs fixed

The `>= 3` check appeared in two polling loops (`try_stream_output` exit-code handler and `poll_for_completion`). If a job entered SUSPENDED or PREEMPTED state, srun would incorrectly treat it as terminal and exit. With the new code, only the 5 actual terminal states (COMPLETED, FAILED, CANCELLED, TIMEOUT, NODE_FAIL) trigger exit.

## Test plan

- [x] `cargo clippy -p spur-cli --all-targets` — no `manual_range_patterns` warning
- [x] `cargo test` passes (no behavioral change for the 5 terminal states)
- [x] CI green