### PR TITLE
fix(spur-cli): log gRPC errors in srun post-streaming polling loop

### DIFF
--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -418,7 +418,9 @@ async fn try_stream_output(
                     Err(_) => {}
                 }
             }
-            Err(_) => {}
+            Err(e) => {
+                eprintln!("srun: warning: failed to get job status: {}", e.message());
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- The post-streaming polling loop in `try_stream_output` silently discarded gRPC
  errors, while the other two srun polling loops (wait-for-running and
  poll_for_completion) both log them. This caused srun to hang indefinitely with
  no user-visible output when the controller became unreachable after streaming
  ended.
- Adds the same `Err(e) => eprintln!(...)` arm that the other two loops already
  have, making all three consistent.

## Test plan
- [x] `cargo clippy --all-targets` shows no `single_match` warning on srun.rs
- [x] Manual: ran `srun sleep 30` on bare-metal testbed, killed controller mid-job,
      confirmed srun prints `"srun: warning: failed to get job status: tcp connect error"`
      every second instead of hanging silently