### PR TITLE
chore(config): add workspace-wide Clippy lint configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,3 +89,29 @@ base64 = "0.22"
 
 # Internal
 spur-update = { path = "crates/spur-update" }
+
+[workspace.lints.clippy]
+unnecessary_unwrap = "warn"
+clone_on_copy = "warn"
+if_same_then_else = "warn"
+not_unsafe_ptr_arg_deref = "warn"
+redundant_field_names = "warn"
+redundant_pattern_matching = "warn"
+collapsible_str_replace = "warn"
+manual_ok_err = "warn"
+manual_range_patterns = "warn"
+derivable_impls = "warn"
+useless_vec = "warn"
+for_kv_map = "warn"
+nonminimal_bool = "warn"
+let_and_return = "warn"
+redundant_closure = "warn"
+single_match = "warn"
+needless_return = "warn"
+doc_lazy_continuation = "warn"
+# TODO: enable after fixing remaining violations
+# should_implement_trait = "warn"
+# too_many_arguments = "warn"
+# large_enum_variant = "warn"
+# result_large_err = "warn"
+# type_complexity = "warn"

--- a/crates/spur-cli/Cargo.toml
+++ b/crates/spur-cli/Cargo.toml
@@ -28,3 +28,6 @@ nix = { workspace = true, features = ["user"] }
 libc = "0.2"
 flate2 = { workspace = true }
 tar = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/spur-core/Cargo.toml
+++ b/crates/spur-core/Cargo.toml
@@ -18,3 +18,6 @@ prost-types = { workspace = true }
 jsonwebtoken = { workspace = true }
 whoami = "2"
 nix = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/spur-ffi/Cargo.toml
+++ b/crates/spur-ffi/Cargo.toml
@@ -13,3 +13,6 @@ spur-core = { path = "../spur-core" }
 tokio = { workspace = true }
 tonic = { workspace = true }
 prost-types = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/spur-k8s/Cargo.toml
+++ b/crates/spur-k8s/Cargo.toml
@@ -29,3 +29,6 @@ axum = { workspace = true }
 hostname = "0.4.2"
 tokio-stream = "0.1"
 backoff = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/spur-net/Cargo.toml
+++ b/crates/spur-net/Cargo.toml
@@ -16,3 +16,6 @@ flate2 = { workspace = true }
 tar = { workspace = true }
 bytes = { workspace = true }
 base64 = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/spur-proto/Cargo.toml
+++ b/crates/spur-proto/Cargo.toml
@@ -10,3 +10,6 @@ prost-types = { workspace = true }
 
 [build-dependencies]
 tonic-build = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/spur-sched/Cargo.toml
+++ b/crates/spur-sched/Cargo.toml
@@ -7,3 +7,6 @@ edition.workspace = true
 spur-core = { path = "../spur-core" }
 tracing = { workspace = true }
 chrono = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/spur-spank/Cargo.toml
+++ b/crates/spur-spank/Cargo.toml
@@ -9,3 +9,6 @@ tracing = { workspace = true }
 anyhow = { workspace = true }
 libloading = "0.9.0"
 thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/crates/spur-tests/Cargo.toml
+++ b/crates/spur-tests/Cargo.toml
@@ -33,3 +33,6 @@ openssh = { version = "0.11", default-features = false, features = ["process-mux
 
 [dev-dependencies]
 serial_test = "3.4.0"
+
+[lints]
+workspace = true

--- a/crates/spur-update/Cargo.toml
+++ b/crates/spur-update/Cargo.toml
@@ -18,3 +18,6 @@ flate2 = { workspace = true }
 tar = { workspace = true }
 semver = "1"
 sha2 = "0.10"
+
+[lints]
+workspace = true

--- a/crates/spurctld/Cargo.toml
+++ b/crates/spurctld/Cargo.toml
@@ -30,3 +30,6 @@ openraft = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
+
+[lints]
+workspace = true

--- a/crates/spurd/Cargo.toml
+++ b/crates/spurd/Cargo.toml
@@ -31,3 +31,6 @@ tokio-stream = "0.1"
 
 [dev-dependencies]
 tempfile = "3"
+
+[lints]
+workspace = true

--- a/crates/spurdbd/Cargo.toml
+++ b/crates/spurdbd/Cargo.toml
@@ -21,3 +21,6 @@ anyhow = { workspace = true }
 sqlx = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/spurrestd/Cargo.toml
+++ b/crates/spurrestd/Cargo.toml
@@ -22,3 +22,6 @@ tracing-subscriber = { workspace = true }
 clap = { workspace = true }
 anyhow = { workspace = true }
 prost-types = { workspace = true }
+
+[lints]
+workspace = true


### PR DESCRIPTION
## Summary

- Add `[workspace.lints.clippy]` to root `Cargo.toml` with 18 lints at warn level covering correctness (e.g. `unnecessary_unwrap`, `clone_on_copy`, `not_unsafe_ptr_arg_deref`) and simplification (e.g. `redundant_field_names`, `collapsible_str_replace`, `useless_vec`).
- Add `[lints] workspace = true` to all 14 member crate `Cargo.toml` files so every crate inherits the same lint policy.
- Comment out 5 additional lints (`should_implement_trait`, `too_many_arguments`, `large_enum_variant`, `result_large_err`, `type_complexity`) that require larger refactors before enabling.

## Motivation

Previously each crate used Clippy defaults with no shared policy, so lint violations could regress silently. A workspace-level config gives a single place to manage lint strictness. All lints start at warn so local development isn't blocked; a follow-up PR will clean up the remaining ~20 warnings and then enable `-D warnings` in CI.

## Test plan

- [x] `cargo clippy --all-targets --all-features` — zero errors, only the known ~20 warn-level violations remaining
- [x] `cargo build --all-targets` — compiles cleanly
- [x] `cargo test` — all tests pass