### PR TITLE
refactor: resolve too_many_arguments Clippy warnings across workspace

### DIFF
--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -131,30 +131,24 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             Ok(())
         }
         ScontrolCommand::Hold { job_id } => {
-            update_job(
+            send_job_update(
                 &args.controller,
-                job_id,
-                None,
-                None,
-                Some(true),
-                None,
-                None,
-                None,
-                None,
+                spur_proto::proto::UpdateJobRequest {
+                    job_id,
+                    hold: Some(true),
+                    ..Default::default()
+                },
             )
             .await
         }
         ScontrolCommand::Release { job_id } => {
-            update_job(
+            send_job_update(
                 &args.controller,
-                job_id,
-                None,
-                None,
-                Some(false),
-                None,
-                None,
-                None,
-                None,
+                spur_proto::proto::UpdateJobRequest {
+                    job_id,
+                    hold: Some(false),
+                    ..Default::default()
+                },
             )
             .await
         }
@@ -204,18 +198,30 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             add_accounts,
             remove_accounts,
         } => {
-            update_reservation(
-                &args.controller,
-                &name,
-                duration,
-                &add_nodes,
-                &remove_nodes,
-                &add_users,
-                &remove_users,
-                &add_accounts,
-                &remove_accounts,
-            )
-            .await
+            let split_csv = |s: &str| -> Vec<String> {
+                s.split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect()
+            };
+            let mut client = SlurmControllerClient::connect(args.controller.to_string())
+                .await
+                .context("failed to connect to spurctld")?;
+            client
+                .update_reservation(spur_proto::proto::UpdateReservationRequest {
+                    name: name.clone(),
+                    duration_minutes: duration,
+                    add_nodes: split_csv(&add_nodes),
+                    remove_nodes: split_csv(&remove_nodes),
+                    add_users: split_csv(&add_users),
+                    remove_users: split_csv(&remove_users),
+                    add_accounts: split_csv(&add_accounts),
+                    remove_accounts: split_csv(&remove_accounts),
+                })
+                .await
+                .context("failed to update reservation")?;
+            println!("Reservation {} updated", name);
+            Ok(())
         }
         ScontrolCommand::DeleteReservation { name } => {
             delete_reservation(&args.controller, &name).await
@@ -486,41 +492,14 @@ fn format_ts(ts: Option<&prost_types::Timestamp>) -> String {
     }
 }
 
-async fn update_job(
-    controller: &str,
-    job_id: u32,
-    priority: Option<u32>,
-    time_limit: Option<String>,
-    hold: Option<bool>,
-    partition: Option<String>,
-    account: Option<String>,
-    comment: Option<String>,
-    qos: Option<String>,
-) -> Result<()> {
+async fn send_job_update(controller: &str, req: spur_proto::proto::UpdateJobRequest) -> Result<()> {
+    let hold = req.hold;
+    let job_id = req.job_id;
     let mut client = SlurmControllerClient::connect(controller.to_string())
         .await
         .context("failed to connect to spurctld")?;
 
-    let tl = time_limit.as_ref().and_then(|t| {
-        spur_core::config::parse_time_minutes(t).map(|m| prost_types::Duration {
-            seconds: m as i64 * 60,
-            nanos: 0,
-        })
-    });
-
-    client
-        .update_job(spur_proto::proto::UpdateJobRequest {
-            job_id,
-            partition,
-            account,
-            priority,
-            time_limit: tl,
-            hold,
-            comment,
-            qos,
-        })
-        .await
-        .context("update failed")?;
+    client.update_job(req).await.context("update failed")?;
 
     if hold == Some(true) {
         println!("job {} held", job_id);
@@ -572,8 +551,26 @@ async fn parse_and_update(controller: &str, params: &[String]) -> Result<()> {
 
     let jid =
         job_id.ok_or_else(|| anyhow::anyhow!("scontrol update: JobId= or NodeName= required"))?;
-    update_job(
-        controller, jid, priority, time_limit, None, partition, account, comment, qos,
+
+    let tl = time_limit.as_ref().and_then(|t| {
+        spur_core::config::parse_time_minutes(t).map(|m| prost_types::Duration {
+            seconds: m as i64 * 60,
+            nanos: 0,
+        })
+    });
+
+    send_job_update(
+        controller,
+        spur_proto::proto::UpdateJobRequest {
+            job_id: jid,
+            priority,
+            time_limit: tl,
+            partition,
+            account,
+            comment,
+            qos,
+            ..Default::default()
+        },
     )
     .await
 }
@@ -658,47 +655,6 @@ async fn create_reservation(
         .context("failed to create reservation")?;
 
     println!("Reservation {} created", name);
-    Ok(())
-}
-
-/// Update a reservation via the controller.
-async fn update_reservation(
-    controller: &str,
-    name: &str,
-    duration: u32,
-    add_nodes: &str,
-    remove_nodes: &str,
-    add_users: &str,
-    remove_users: &str,
-    add_accounts: &str,
-    remove_accounts: &str,
-) -> Result<()> {
-    let mut client = SlurmControllerClient::connect(controller.to_string())
-        .await
-        .context("failed to connect to spurctld")?;
-
-    let split_csv = |s: &str| -> Vec<String> {
-        s.split(',')
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty())
-            .collect()
-    };
-
-    client
-        .update_reservation(spur_proto::proto::UpdateReservationRequest {
-            name: name.to_string(),
-            duration_minutes: duration,
-            add_nodes: split_csv(add_nodes),
-            remove_nodes: split_csv(remove_nodes),
-            add_users: split_csv(add_users),
-            remove_users: split_csv(remove_users),
-            add_accounts: split_csv(add_accounts),
-            remove_accounts: split_csv(remove_accounts),
-        })
-        .await
-        .context("failed to update reservation")?;
-
-    println!("Reservation {} updated", name);
     Ok(())
 }
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -440,6 +440,7 @@ impl ClusterManager {
     }
 
     /// Register a node agent.
+    #[allow(clippy::too_many_arguments)]
     pub fn register_node(
         &self,
         name: String,
@@ -636,6 +637,7 @@ impl ClusterManager {
     }
 
     /// Update job properties.
+    #[allow(clippy::too_many_arguments)]
     pub fn update_job(
         &self,
         job_id: JobId,
@@ -988,6 +990,7 @@ impl ClusterManager {
     }
 
     /// Update an existing reservation.
+    #[allow(clippy::too_many_arguments)]
     pub fn update_reservation(
         &self,
         name: &str,

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -587,12 +587,6 @@ impl SlurmAgent for AgentService {
             spec.stderr_path.clone()
         };
 
-        // Launch the job
-        let open_mode = if spec.open_mode.is_empty() {
-            None
-        } else {
-            Some(spec.open_mode.as_str())
-        };
         // Build container launch config if this is a containerized job
         let container_launch = if !spec.container_image.is_empty() {
             Some(executor::ContainerLaunchConfig {
@@ -603,39 +597,42 @@ impl SlurmAgent for AgentService {
             None
         };
 
-        match executor::launch_job(
+        let launch_cfg = executor::JobLaunchConfig {
             job_id,
-            &launch_script,
-            &work_dir,
-            &env,
-            &stdout_path,
-            &stderr_path,
-            spec.cpus_per_task.max(1),
-            spec.memory_per_node_mb,
-            &gpu_devices,
-            &cpu_ids,
-            (*self.spank).as_ref(),
-            open_mode,
-            spec.uid,
-            spec.gid,
-            container_launch,
-        )
-        .await
-        {
+            script: launch_script,
+            work_dir: work_dir.clone(),
+            environment: env,
+            stdout_path,
+            stderr_path,
+            cpus: spec.cpus_per_task.max(1),
+            memory_mb: spec.memory_per_node_mb,
+            gpu_devices,
+            cpu_ids,
+            open_mode: if spec.open_mode.is_empty() {
+                None
+            } else {
+                Some(spec.open_mode.clone())
+            },
+            uid: spec.uid,
+            gid: spec.gid,
+            container: container_launch,
+        };
+
+        match executor::launch_job(&launch_cfg, (*self.spank).as_ref()).await {
             Ok(running_job) => {
                 let mut jobs = self.running.lock().await;
+                info!(job_id, gpus = ?launch_cfg.gpu_devices, "job launched successfully");
                 jobs.insert(
                     job_id,
                     TrackedJob {
                         job: running_job,
                         rootfs_mode: rootfs_mode.clone(),
                         allocation: alloc_result,
-                        stdout_path,
-                        stderr_path,
+                        stdout_path: launch_cfg.stdout_path,
+                        stderr_path: launch_cfg.stderr_path,
                         has_pid_namespace: nix::unistd::geteuid().is_root(),
                     },
                 );
-                info!(job_id, gpus = ?gpu_devices, "job launched successfully");
                 Ok(Response::new(LaunchJobResponse {
                     success: true,
                     error: String::new(),

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -27,6 +27,27 @@ pub struct ContainerLaunchConfig {
     pub rootfs: PathBuf,
 }
 
+/// Everything an agent needs to launch a job process on this node.
+///
+/// Groups the resolved execution parameters that come from multiple sources
+/// (JobSpec, scheduler allocation, agent config) into a single value.
+pub struct JobLaunchConfig {
+    pub job_id: JobId,
+    pub script: String,
+    pub work_dir: String,
+    pub environment: HashMap<String, String>,
+    pub stdout_path: String,
+    pub stderr_path: String,
+    pub cpus: u32,
+    pub memory_mb: u64,
+    pub gpu_devices: Vec<u32>,
+    pub cpu_ids: Vec<u32>,
+    pub open_mode: Option<String>,
+    pub uid: u32,
+    pub gid: u32,
+    pub container: Option<ContainerLaunchConfig>,
+}
+
 /// A running job process — either a tokio-managed child or a raw-forked container.
 pub enum RunningJob {
     /// Non-container jobs managed by tokio::process::Child.
@@ -130,22 +151,25 @@ impl RunningJob {
 /// Otherwise, it uses the standard `tokio::Command` path with optional
 /// `build_namespace_wrapper()` for non-container namespace isolation.
 pub async fn launch_job(
-    job_id: JobId,
-    script: &str,
-    work_dir: &str,
-    environment: &HashMap<String, String>,
-    stdout_path: &str,
-    stderr_path: &str,
-    cpus: u32,
-    memory_mb: u64,
-    gpu_devices: &[u32],
-    cpu_ids: &[u32],
+    cfg: &JobLaunchConfig,
     spank: Option<&SpankHost>,
-    open_mode: Option<&str>,
-    uid: u32,
-    gid: u32,
-    container: Option<ContainerLaunchConfig>,
 ) -> anyhow::Result<RunningJob> {
+    let JobLaunchConfig {
+        job_id,
+        ref script,
+        ref work_dir,
+        ref environment,
+        ref stdout_path,
+        ref stderr_path,
+        cpus,
+        memory_mb,
+        ref gpu_devices,
+        ref cpu_ids,
+        ref open_mode,
+        uid,
+        gid,
+        ref container,
+    } = *cfg;
     info!(job_id, work_dir, "launching job");
 
     // Run prolog if configured
@@ -221,6 +245,7 @@ pub async fn launch_job(
     }
 
     let use_append = open_mode
+        .as_deref()
         .map(|m| m.eq_ignore_ascii_case("append"))
         .unwrap_or(false);
 
@@ -308,16 +333,12 @@ pub async fn launch_job(
     // Container jobs: use explicit fork() + container_init() instead of bash wrapper.
     if let Some(ctn) = container {
         return launch_container_job(
-            job_id,
-            &ctn,
+            cfg,
+            ctn,
             &env,
+            use_append,
             &stdout_resolved,
             &stderr_resolved,
-            use_append,
-            cpus,
-            memory_mb,
-            cpu_ids,
-            work_dir,
         )
         .await;
     }
@@ -630,20 +651,16 @@ fn resolve_output_path(pattern: &str, job_id: JobId, work_dir: &str) -> String {
 ///
 /// The parent tracks the child PID via a sync pipe and wraps waitpid in a
 /// blocking tokio task so it doesn't stall the async runtime.
-#[allow(clippy::too_many_arguments)]
 async fn launch_container_job(
-    job_id: JobId,
+    cfg: &JobLaunchConfig,
     ctn: &ContainerLaunchConfig,
     env: &HashMap<String, String>,
+    use_append: bool,
     stdout_path: &str,
     stderr_path: &str,
-    use_append: bool,
-    cpus: u32,
-    memory_mb: u64,
-    cpu_ids: &[u32],
-    _work_dir: &str,
 ) -> anyhow::Result<RunningJob> {
-    let cgroup_path = setup_cgroup(job_id, cpus, memory_mb, cpu_ids)?;
+    let job_id = cfg.job_id;
+    let cgroup_path = setup_cgroup(job_id, cfg.cpus, cfg.memory_mb, &cfg.cpu_ids)?;
 
     // Open stdout/stderr files before fork (child will dup2 these)
     let stdout_fd: std::fs::File = if use_append {

--- a/crates/spurdbd/src/db.rs
+++ b/crates/spurdbd/src/db.rs
@@ -127,6 +127,7 @@ CREATE INDEX IF NOT EXISTS idx_assoc_account ON associations(account);
 "#;
 
 /// Record a job start in the database.
+#[allow(clippy::too_many_arguments)]
 pub async fn record_job_start(
     pool: &PgPool,
     job_id: i32,
@@ -564,6 +565,7 @@ pub struct UserRecord {
 }
 
 /// Create or update a QOS.
+#[allow(clippy::too_many_arguments)]
 pub async fn upsert_qos(
     pool: &PgPool,
     name: &str,


### PR DESCRIPTION
## Summary

- Introduce `JobLaunchConfig` struct in `spurd` to replace 15 positional parameters in `executor::launch_job`. Also refactor `launch_container_job` to accept the struct, removing its existing `#[allow(clippy::too_many_arguments)]`.
- Eliminate `scontrol::update_job` and `scontrol::update_reservation` wrapper functions. Hold/Release callers now construct `UpdateJobRequest` with named fields and `..Default::default()` instead of 7-`None` positional chains. Reservation update logic inlined at its single call site.
- Add `#[allow(clippy::too_many_arguments)]` to 5 single-caller functions whose signatures mirror their proto request types: `register_node`, `update_job`, `update_reservation`, `record_job_start`, `upsert_qos`.

## Motivation

Clipy flagged 8 functions for `too_many_arguments`. Rather than uniformly creating 6 new parameter structs (which would duplicate existing proto types), each function was addressed based on its caller count and whether an existing type already covers the parameter set. The 15-arg `launch_job` got a dedicated struct; the `scontrol` wrappers were eliminated since the proto types already provide named fields; the remaining 5 proto-mirroring functions got targeted suppressions.

## Test plan

- [x] `cargo clippy --all-targets --all-features` — zero `too_many_arguments` warnings
- [x] `cargo build --all-targets` — compiles cleanly
- [x] `cargo test` — 336 unit tests pass
- [x] Bare-metal E2E single-node — 20/20 pass (including all container tests)
- [x] Bare-metal E2E multi-node — 9/9 pass (including multi-node container dispatch)