### PR TITLE
refactor(spur-core): implement FromStr trait for enum parsers, rename SlurmConfig methods

### DIFF
--- a/crates/spur-cli/src/main.rs
+++ b/crates/spur-cli/src/main.rs
@@ -45,7 +45,7 @@ fn load_controller_addr_from_config() {
         return;
     }
 
-    if let Ok(config) = spur_core::config::SlurmConfig::load(&config_path) {
+    if let Ok(config) = spur_core::config::SlurmConfig::load_from_file(&config_path) {
         // Extract host and port from the config
         let host = config
             .controller

--- a/crates/spur-core/src/accounting.rs
+++ b/crates/spur-core/src/accounting.rs
@@ -3,8 +3,11 @@
 
 //! Accounting data models: accounts, users, QOS, associations, TRES.
 
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::convert::Infallible;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
 
 /// Trackable RESource types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -158,14 +161,16 @@ pub enum QosPreemptMode {
     Suspend,
 }
 
-impl QosPreemptMode {
-    pub fn from_str(s: &str) -> Self {
-        match s.to_lowercase().as_str() {
+impl FromStr for QosPreemptMode {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Infallible> {
+        Ok(match s.to_lowercase().as_str() {
             "cancel" => Self::Cancel,
             "requeue" => Self::Requeue,
             "suspend" => Self::Suspend,
             _ => Self::Off,
-        }
+        })
     }
 }
 
@@ -241,9 +246,18 @@ mod tests {
 
     #[test]
     fn test_qos_preempt_mode() {
-        assert_eq!(QosPreemptMode::from_str("cancel"), QosPreemptMode::Cancel);
-        assert_eq!(QosPreemptMode::from_str("off"), QosPreemptMode::Off);
-        assert_eq!(QosPreemptMode::from_str("unknown"), QosPreemptMode::Off);
+        assert_eq!(
+            "cancel".parse::<QosPreemptMode>().unwrap(),
+            QosPreemptMode::Cancel
+        );
+        assert_eq!(
+            "off".parse::<QosPreemptMode>().unwrap(),
+            QosPreemptMode::Off
+        );
+        assert_eq!(
+            "unknown".parse::<QosPreemptMode>().unwrap(),
+            QosPreemptMode::Off
+        );
     }
 
     #[test]

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -521,7 +521,7 @@ pub struct ClusterPeer {
 
 impl SlurmConfig {
     /// Load from a TOML file.
-    pub fn load(path: &Path) -> Result<Self, ConfigError> {
+    pub fn load_from_file(path: &Path) -> Result<Self, ConfigError> {
         let content = std::fs::read_to_string(path)?;
         let config: Self = toml::from_str(&content)?;
         config.validate()?;
@@ -529,7 +529,7 @@ impl SlurmConfig {
     }
 
     /// Load from a TOML string.
-    pub fn from_str(s: &str) -> Result<Self, ConfigError> {
+    pub fn load_from_str(s: &str) -> Result<Self, ConfigError> {
         let config: Self = toml::from_str(s)?;
         config.validate()?;
         Ok(config)
@@ -770,7 +770,7 @@ cpus = 256
 memory_mb = 1024000
 "#;
 
-        let config = SlurmConfig::from_str(toml).unwrap();
+        let config = SlurmConfig::load_from_str(toml).unwrap();
         assert_eq!(config.cluster_name, "test-cluster");
         assert_eq!(config.partitions.len(), 2);
         assert_eq!(config.nodes.len(), 2);

--- a/crates/spur-core/src/step.rs
+++ b/crates/spur-core/src/step.rs
@@ -6,6 +6,9 @@
 //! When `srun` is called inside a batch script, it creates a job step.
 //! Steps track their own resource allocation, task distribution, and status.
 
+use std::convert::Infallible;
+use std::str::FromStr;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -80,14 +83,16 @@ pub enum TaskDistribution {
     Arbitrary,
 }
 
-impl TaskDistribution {
-    pub fn from_str(s: &str) -> Self {
-        match s.to_lowercase().as_str() {
+impl FromStr for TaskDistribution {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Infallible> {
+        Ok(match s.to_lowercase().as_str() {
             "cyclic" => Self::Cyclic,
             "plane" => Self::Plane,
             "arbitrary" => Self::Arbitrary,
             _ => Self::Block,
-        }
+        })
     }
 }
 
@@ -163,10 +168,12 @@ pub enum CpuBind {
     Mask(String),
 }
 
-impl CpuBind {
-    pub fn from_str(s: &str) -> Self {
+impl FromStr for CpuBind {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Infallible> {
         let lower = s.to_lowercase();
-        if lower.starts_with("map_cpu:") {
+        Ok(if lower.starts_with("map_cpu:") {
             Self::Map(s[8..].to_string())
         } else if lower.starts_with("mask_cpu:") {
             Self::Mask(s[9..].to_string())
@@ -179,7 +186,7 @@ impl CpuBind {
                 "rank" => Self::Rank,
                 _ => Self::None,
             }
-        }
+        })
     }
 }
 
@@ -196,10 +203,12 @@ pub enum GpuBind {
     Mask(String),
 }
 
-impl GpuBind {
-    pub fn from_str(s: &str) -> Self {
+impl FromStr for GpuBind {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Infallible> {
         let lower = s.to_lowercase();
-        if lower.starts_with("map_gpu:") {
+        Ok(if lower.starts_with("map_gpu:") {
             Self::Map(s[8..].to_string())
         } else if lower.starts_with("mask_gpu:") {
             Self::Mask(s[9..].to_string())
@@ -208,7 +217,7 @@ impl GpuBind {
                 "closest" => Self::Closest,
                 _ => Self::None,
             }
-        }
+        })
     }
 }
 
@@ -250,30 +259,39 @@ mod tests {
 
     #[test]
     fn test_cpu_bind_parse() {
-        assert_eq!(CpuBind::from_str("cores"), CpuBind::Cores);
-        assert_eq!(CpuBind::from_str("threads"), CpuBind::Threads);
-        assert_eq!(CpuBind::from_str("none"), CpuBind::None);
+        assert_eq!("cores".parse::<CpuBind>().unwrap(), CpuBind::Cores);
+        assert_eq!("threads".parse::<CpuBind>().unwrap(), CpuBind::Threads);
+        assert_eq!("none".parse::<CpuBind>().unwrap(), CpuBind::None);
         assert!(matches!(
-            CpuBind::from_str("map_cpu:0,1,2,3"),
+            "map_cpu:0,1,2,3".parse::<CpuBind>().unwrap(),
             CpuBind::Map(_)
         ));
     }
 
     #[test]
     fn test_gpu_bind_parse() {
-        assert_eq!(GpuBind::from_str("closest"), GpuBind::Closest);
-        assert_eq!(GpuBind::from_str("none"), GpuBind::None);
-        assert!(matches!(GpuBind::from_str("map_gpu:0,1"), GpuBind::Map(_)));
+        assert_eq!("closest".parse::<GpuBind>().unwrap(), GpuBind::Closest);
+        assert_eq!("none".parse::<GpuBind>().unwrap(), GpuBind::None);
+        assert!(matches!(
+            "map_gpu:0,1".parse::<GpuBind>().unwrap(),
+            GpuBind::Map(_)
+        ));
     }
 
     #[test]
     fn test_task_distribution_from_str() {
         assert_eq!(
-            TaskDistribution::from_str("cyclic"),
+            "cyclic".parse::<TaskDistribution>().unwrap(),
             TaskDistribution::Cyclic
         );
-        assert_eq!(TaskDistribution::from_str("block"), TaskDistribution::Block);
-        assert_eq!(TaskDistribution::from_str("plane"), TaskDistribution::Plane);
+        assert_eq!(
+            "block".parse::<TaskDistribution>().unwrap(),
+            TaskDistribution::Block
+        );
+        assert_eq!(
+            "plane".parse::<TaskDistribution>().unwrap(),
+            TaskDistribution::Plane
+        );
     }
 
     #[test]

--- a/crates/spur-tests/src/harness.rs
+++ b/crates/spur-tests/src/harness.rs
@@ -149,7 +149,7 @@ pub fn test_script(directives: &[&str], body: &str) -> String {
 
 /// Minimal TOML config for testing.
 pub fn test_config() -> SlurmConfig {
-    SlurmConfig::from_str(
+    SlurmConfig::load_from_str(
         r#"
 cluster_name = "test-cluster"
 

--- a/crates/spur-tests/src/t01_run.rs
+++ b/crates/spur-tests/src/t01_run.rs
@@ -48,17 +48,17 @@ mod tests {
 
     #[test]
     fn t01_5_cpu_bind_types() {
-        assert_eq!(CpuBind::from_str("cores"), CpuBind::Cores);
-        assert_eq!(CpuBind::from_str("threads"), CpuBind::Threads);
-        assert_eq!(CpuBind::from_str("sockets"), CpuBind::Sockets);
-        assert_eq!(CpuBind::from_str("ldoms"), CpuBind::Ldoms);
-        assert_eq!(CpuBind::from_str("rank"), CpuBind::Rank);
-        assert_eq!(CpuBind::from_str("none"), CpuBind::None);
+        assert_eq!("cores".parse::<CpuBind>().unwrap(), CpuBind::Cores);
+        assert_eq!("threads".parse::<CpuBind>().unwrap(), CpuBind::Threads);
+        assert_eq!("sockets".parse::<CpuBind>().unwrap(), CpuBind::Sockets);
+        assert_eq!("ldoms".parse::<CpuBind>().unwrap(), CpuBind::Ldoms);
+        assert_eq!("rank".parse::<CpuBind>().unwrap(), CpuBind::Rank);
+        assert_eq!("none".parse::<CpuBind>().unwrap(), CpuBind::None);
     }
 
     #[test]
     fn t01_6_cpu_bind_map() {
-        match CpuBind::from_str("map_cpu:0,4,8,12") {
+        match "map_cpu:0,4,8,12".parse::<CpuBind>().unwrap() {
             CpuBind::Map(s) => assert_eq!(s, "0,4,8,12"),
             other => panic!("expected Map, got {:?}", other),
         }
@@ -68,13 +68,13 @@ mod tests {
 
     #[test]
     fn t01_7_gpu_bind_types() {
-        assert_eq!(GpuBind::from_str("closest"), GpuBind::Closest);
-        assert_eq!(GpuBind::from_str("none"), GpuBind::None);
+        assert_eq!("closest".parse::<GpuBind>().unwrap(), GpuBind::Closest);
+        assert_eq!("none".parse::<GpuBind>().unwrap(), GpuBind::None);
     }
 
     #[test]
     fn t01_8_gpu_bind_map() {
-        match GpuBind::from_str("map_gpu:0,1,2,3") {
+        match "map_gpu:0,1,2,3".parse::<GpuBind>().unwrap() {
             GpuBind::Map(s) => assert_eq!(s, "0,1,2,3"),
             other => panic!("expected Map, got {:?}", other),
         }

--- a/crates/spur-tests/src/t21_acctmgr.rs
+++ b/crates/spur-tests/src/t21_acctmgr.rs
@@ -98,10 +98,22 @@ mod tests {
 
     #[test]
     fn t21_9_qos_preempt_modes() {
-        assert_eq!(QosPreemptMode::from_str("cancel"), QosPreemptMode::Cancel);
-        assert_eq!(QosPreemptMode::from_str("requeue"), QosPreemptMode::Requeue);
-        assert_eq!(QosPreemptMode::from_str("suspend"), QosPreemptMode::Suspend);
-        assert_eq!(QosPreemptMode::from_str("off"), QosPreemptMode::Off);
+        assert_eq!(
+            "cancel".parse::<QosPreemptMode>().unwrap(),
+            QosPreemptMode::Cancel
+        );
+        assert_eq!(
+            "requeue".parse::<QosPreemptMode>().unwrap(),
+            QosPreemptMode::Requeue
+        );
+        assert_eq!(
+            "suspend".parse::<QosPreemptMode>().unwrap(),
+            QosPreemptMode::Suspend
+        );
+        assert_eq!(
+            "off".parse::<QosPreemptMode>().unwrap(),
+            QosPreemptMode::Off
+        );
     }
 
     // ── T21.10: QOS limit enforcement ────────────────────────────

--- a/crates/spur-tests/src/t50_core.rs
+++ b/crates/spur-tests/src/t50_core.rs
@@ -941,7 +941,7 @@ state_dir = "/tmp/spur-test"
 name = "peer-a"
 address = "http://peer-a:6817"
 "#;
-        let cfg = SlurmConfig::from_str(toml).unwrap();
+        let cfg = SlurmConfig::load_from_str(toml).unwrap();
         assert_eq!(cfg.federation.clusters.len(), 1);
         assert_eq!(cfg.federation.clusters[0].name, "peer-a");
     }
@@ -1056,7 +1056,7 @@ address = "http://peer-a:6817"
             listen_addr = "[::]:6821"
             hosts = ["ctrl.example.com"]
         "#;
-        let config = spur_core::config::SlurmConfig::from_str(toml).unwrap();
+        let config = spur_core::config::SlurmConfig::load_from_str(toml).unwrap();
         assert_eq!(config.controller.listen_addr, "[::]:6821");
         assert_eq!(config.controller.hosts[0], "ctrl.example.com");
 

--- a/crates/spur-tests/src/t52_config.rs
+++ b/crates/spur-tests/src/t52_config.rs
@@ -66,19 +66,19 @@ mod tests {
 
     #[test]
     fn t52_10_minimal_config() {
-        let config = SlurmConfig::from_str(r#"cluster_name = "test""#).unwrap();
+        let config = SlurmConfig::load_from_str(r#"cluster_name = "test""#).unwrap();
         assert_eq!(config.cluster_name, "test");
     }
 
     #[test]
     fn t52_11_missing_cluster_name() {
-        let result = SlurmConfig::from_str(r#"[controller]"#);
+        let result = SlurmConfig::load_from_str(r#"[controller]"#);
         assert!(result.is_err());
     }
 
     #[test]
     fn t52_12_full_config() {
-        let config = SlurmConfig::from_str(
+        let config = SlurmConfig::load_from_str(
             r#"
 cluster_name = "prod-cluster"
 
@@ -138,7 +138,7 @@ memory_mb = 1024000
 
     #[test]
     fn t52_13_build_partitions() {
-        let config = SlurmConfig::from_str(
+        let config = SlurmConfig::load_from_str(
             r#"
 cluster_name = "test"
 
@@ -174,7 +174,7 @@ max_time = "1:00"
 
     #[test]
     fn t52_14_scheduler_defaults() {
-        let config = SlurmConfig::from_str(
+        let config = SlurmConfig::load_from_str(
             r#"
 cluster_name = "test"
 [scheduler]
@@ -193,7 +193,7 @@ plugin = "backfill"
     #[test]
     fn t52_15_listen_addr_preserved_from_config() {
         // Regression: spurctld ignored config listen_addr and always bound to :6817 (#37).
-        let config = SlurmConfig::from_str(
+        let config = SlurmConfig::load_from_str(
             r#"
 cluster_name = "prod"
 [controller]
@@ -208,7 +208,7 @@ state_dir = "/var/spool/spur"
     #[test]
     fn t52_16_listen_addr_default_parseable() {
         // When listen_addr is not in config the default must be a valid socket address.
-        let config = SlurmConfig::from_str(
+        let config = SlurmConfig::load_from_str(
             r#"
 cluster_name = "test"
 [controller]

--- a/crates/spur-update/src/check.rs
+++ b/crates/spur-update/src/check.rs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::convert::Infallible;
+use std::str::FromStr;
+
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use semver::Version;
@@ -14,12 +17,14 @@ pub enum Channel {
     Nightly,
 }
 
-impl Channel {
-    pub fn from_str(s: &str) -> Self {
-        match s {
+impl FromStr for Channel {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Infallible> {
+        Ok(match s {
             "nightly" => Self::Nightly,
             _ => Self::Stable,
-        }
+        })
     }
 }
 
@@ -145,9 +150,9 @@ mod tests {
 
     #[test]
     fn channel_from_str() {
-        assert_eq!(Channel::from_str("stable"), Channel::Stable);
-        assert_eq!(Channel::from_str("nightly"), Channel::Nightly);
-        assert_eq!(Channel::from_str("anything"), Channel::Stable);
+        assert_eq!("stable".parse::<Channel>().unwrap(), Channel::Stable);
+        assert_eq!("nightly".parse::<Channel>().unwrap(), Channel::Nightly);
+        assert_eq!("anything".parse::<Channel>().unwrap(), Channel::Stable);
     }
 
     #[test]

--- a/crates/spur-update/src/lib.rs
+++ b/crates/spur-update/src/lib.rs
@@ -43,7 +43,7 @@ pub fn spawn_startup_check(
         return;
     }
 
-    let channel = Channel::from_str(channel);
+    let channel = channel.parse::<Channel>().unwrap();
     let cache_dir = PathBuf::from(cache_dir);
 
     tokio::spawn(async move {

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -56,7 +56,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Load config if it exists, otherwise use defaults
     let mut config = if args.config.exists() {
-        spur_core::config::SlurmConfig::load(&args.config)?
+        spur_core::config::SlurmConfig::load_from_file(&args.config)?
     } else {
         info!("no config file found, using defaults");
         spur_core::config::SlurmConfig {


### PR DESCRIPTION
## Summary

- Convert 5 infallible enum types (`Channel`, `TaskDistribution`, `CpuBind`, `GpuBind`, `QosPreemptMode`) from inherent `from_str` methods to proper `impl FromStr` trait implementations with `Err = Infallible`, silencing clippy's `should_implement_trait` warning and enabling `.parse::<T>()` usage
- Rename `SlurmConfig::load` → `load_from_file` and `SlurmConfig::from_str` → `load_from_str` for clarity — the TOML parsing + domain validation semantics don't fit the `FromStr` trait contract, so a rename avoids the clippy collision without misusing the trait
- Update all ~42 call sites across 10 files (mostly test assertions)

## Motivation

Clippy flagged 6 instances of `should_implement_trait` where inherent `from_str` methods shadowed the standard `FromStr` trait. For the 5 enum types, implementing the trait is the right fix — it makes them available to `.parse()`, generic `T: FromStr` bounds, and prevents orphan-rule lockout for downstream consumers. For `SlurmConfig`, the method performs TOML deserialization + validation which doesn't match `FromStr` semantics, so renaming is the cleaner solution.

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes (all existing tests updated, zero logic changes)
- [x] `cargo fmt --check --all` clean
- [x] No remaining references to old method names (verified via grep)