### PR TITLE
chore(clippy): suppress result_large_err on 3 functions in spurctld

### DIFF
--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1267,6 +1267,8 @@ impl ClusterManager {
 
     /// Persist a mutation via Raft consensus. The apply callback
     /// (`StateMachineApply`) handles in-memory state on all nodes.
+    // openraft's RaftError exceeds clippy's 128-byte threshold in the intermediate Result
+    #[allow(clippy::result_large_err)]
     fn propose(&self, op: WalOperation) -> anyhow::Result<()> {
         let raft = self
             .raft

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -82,6 +82,8 @@ impl LeaderProxy {
 }
 
 impl ControllerService {
+    // tonic::Status is 176 bytes (over clippy's 128-byte threshold); fixed upstream in tonic 0.13+
+    #[allow(clippy::result_large_err)]
     fn check_leader<T>(&self, request: &Request<T>) -> Result<(), Status> {
         if self.raft.is_leader() {
             return Ok(());
@@ -959,6 +961,8 @@ pub async fn serve(
 
 // ---- Proto conversion helpers ----
 
+// tonic::Status is 176 bytes (over clippy's 128-byte threshold); fixed upstream in tonic 0.13+
+#[allow(clippy::result_large_err)]
 fn proto_to_job_spec(spec: JobSpec) -> Result<spur_core::job::JobSpec, Status> {
     let mut gres = spec.gres;
     for lic in &spec.licenses {


### PR DESCRIPTION
## Summary

Add per-function `#[allow(clippy::result_large_err)]` on 3 functions in `spurctld` where the error type exceeds clippy's default 128-byte threshold due to upstream dependencies (`tonic::Status` at 176 bytes, openraft's `RaftError`). These annotations can be removed when we upgrade to tonic 0.13+ which boxes `Status` internals (hyperium/tonic#2282).

## Affected functions

- `server.rs`: `check_leader`, `proto_to_job_spec` — `tonic::Status` (176 bytes)
- `cluster.rs`: `propose` — openraft `RaftError` intermediate