### PR TITLE
fix(spur-core): box JobSpec in WalOperation::JobSubmit to fix large_enum_variant

### DIFF
--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -17,7 +17,7 @@ pub enum WalOperation {
     // Job operations
     JobSubmit {
         job_id: JobId,
-        spec: JobSpec,
+        spec: Box<JobSpec>,
     },
     JobStateChange {
         job_id: JobId,

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -86,7 +86,7 @@ impl ClusterManager {
             };
             self.propose(WalOperation::JobSubmit {
                 job_id: task_id,
-                spec: task_spec,
+                spec: Box::new(task_spec),
             })?;
         }
 
@@ -1290,7 +1290,7 @@ impl ClusterManager {
 
         match op {
             WalOperation::JobSubmit { job_id, spec } => {
-                let mut job = Job::new(*job_id, spec.clone());
+                let mut job = Job::new(*job_id, (**spec).clone());
                 if let Some(het_group) = spec.het_group {
                     job.het_group = Some(het_group);
                     if het_group > 0 {
@@ -1877,7 +1877,7 @@ mod tests {
         let spec = basic_spec("test-job");
         cm.apply_operation(&WalOperation::JobSubmit {
             job_id: 1,
-            spec: spec.clone(),
+            spec: Box::new(spec.clone()),
         });
 
         let job = cm.get_job(1).unwrap();
@@ -1894,7 +1894,7 @@ mod tests {
 
         cm.apply_operation(&WalOperation::JobSubmit {
             job_id: 1,
-            spec: basic_spec("j"),
+            spec: Box::new(basic_spec("j")),
         });
         cm.apply_operation(&WalOperation::JobStateChange {
             job_id: 1,
@@ -1914,7 +1914,7 @@ mod tests {
         register_node(&cm, "node1", 8, 16000);
         cm.apply_operation(&WalOperation::JobSubmit {
             job_id: 1,
-            spec: basic_spec("j"),
+            spec: Box::new(basic_spec("j")),
         });
 
         let resources = ResourceSet {
@@ -1945,7 +1945,7 @@ mod tests {
         register_node(&cm, "node1", 8, 16000);
         cm.apply_operation(&WalOperation::JobSubmit {
             job_id: 1,
-            spec: basic_spec("j"),
+            spec: Box::new(basic_spec("j")),
         });
         cm.apply_operation(&WalOperation::JobStateChange {
             job_id: 1,
@@ -2034,7 +2034,7 @@ mod tests {
 
         cm.apply_operation(&WalOperation::JobSubmit {
             job_id: 1,
-            spec: basic_spec("j"),
+            spec: Box::new(basic_spec("j")),
         });
         cm.apply_operation(&WalOperation::JobPriorityChange {
             job_id: 1,


### PR DESCRIPTION
## Summary

- Box `JobSpec` in the `WalOperation::JobSubmit` variant to resolve the `large_enum_variant` Clippy warning. This shrinks `WalOperation` from ~1 KB (dominated by `JobSpec`'s 60+ fields) to ~200 bytes (governed by `NodeRegister`), eliminating ~984 bytes of dead padding on every non-`JobSubmit` WAL operation.
- Serde serializes `Box<T>` identically to `T`, so existing Raft log entries on disk remain compatible with no migration needed.

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes (336/336, 1 pre-existing flaky test unrelated to this change)
- [x] `cargo fmt --check --all` clean
- [x] Verified all 7 `WalOperation::JobSubmit` sites updated (1 production, 1 match arm, 5 tests)
- [x] Audited serialization compatibility — `Box<T>` is serde-transparent
- [x] Audited snapshot restore, FFI, gRPC, K8s, REST — none touch `WalOperation::JobSubmit`