### PR TITLE
perf(deploy): use cargo-chef to cache dependency builds in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+target/
+.git/
+.github/
+*.tar
+*.tar.gz
+docs/

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,11 +1,11 @@
 # Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Multi-stage build: one image with all Spur binaries
-# Builder uses manylinux_2_28 (glibc 2.28) for broad compatibility
-FROM quay.io/pypa/manylinux_2_28_x86_64 AS builder
+# manylinux_2_28 (glibc 2.28) for broad compatibility.
+# cargo-chef caches dependency builds across source changes.
 
-# Install protoc (AlmaLinux 8 ships protoc 3.5 which is too old for prost)
+FROM quay.io/pypa/manylinux_2_28_x86_64 AS chef
+
 ARG PROTOC_VERSION=25.1
 RUN yum install -y unzip && yum clean all && \
     curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" \
@@ -16,9 +16,19 @@ RUN yum install -y unzip && yum clean all && \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-WORKDIR /build
-COPY . .
+RUN cargo install cargo-chef --locked --version 0.1.77
 
+WORKDIR /build
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /build/recipe.json recipe.json
+RUN cargo chef cook --release --locked --recipe-path recipe.json
+
+COPY . .
 RUN cargo build --release --locked \
     --bin spur \
     --bin spurctld \
@@ -27,7 +37,6 @@ RUN cargo build --release --locked \
     --bin spurrestd \
     --bin spur-k8s-operator
 
-# Runtime image
 FROM ubuntu:22.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -35,7 +44,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     util-linux \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy all binaries
 COPY --from=builder /build/target/release/spur /usr/local/bin/
 COPY --from=builder /build/target/release/spurctld /usr/local/bin/
 COPY --from=builder /build/target/release/spurd /usr/local/bin/
@@ -43,6 +51,5 @@ COPY --from=builder /build/target/release/spurdbd /usr/local/bin/
 COPY --from=builder /build/target/release/spurrestd /usr/local/bin/
 COPY --from=builder /build/target/release/spur-k8s-operator /usr/local/bin/
 
-# Default to running the operator
 ENTRYPOINT ["spur-k8s-operator"]
 CMD ["run"]

--- a/deploy/Dockerfile.manylinux
+++ b/deploy/Dockerfile.manylinux
@@ -1,20 +1,15 @@
 # Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Build portable Spur binaries using manylinux_2_28 (glibc 2.28 / AlmaLinux 8)
+# Portable Spur binaries via manylinux_2_28 (glibc 2.28).
+# Compatible with Ubuntu 20.04+, Debian 10+, RHEL 8+, Fedora 28+.
 #
-# Compatible with: Ubuntu 20.04+, Debian 10+, RHEL 8+, Fedora 28+
-#
-# Usage (extract binaries to ./dist/bin/):
+# Usage:
 #   DOCKER_BUILDKIT=1 docker build -f deploy/Dockerfile.manylinux \
 #     --target dist --output type=local,dest=./dist .
-#
-# Or use the helper script:
-#   ./deploy/build-portable.sh
 
-FROM quay.io/pypa/manylinux_2_28_x86_64 AS builder
+FROM quay.io/pypa/manylinux_2_28_x86_64 AS chef
 
-# Install protoc (AlmaLinux 8 ships protoc 3.5 which is too old for prost)
 ARG PROTOC_VERSION=25.1
 RUN yum install -y unzip && yum clean all && \
     curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" \
@@ -23,14 +18,23 @@ RUN yum install -y unzip && yum clean all && \
     rm /tmp/protoc.zip && \
     protoc --version
 
-# Install Rust stable toolchain
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-WORKDIR /build
-COPY . .
+RUN cargo install cargo-chef --locked --version 0.1.77
 
-RUN cargo build --release \
+WORKDIR /build
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /build/recipe.json recipe.json
+RUN cargo chef cook --release --locked --recipe-path recipe.json
+
+COPY . .
+RUN cargo build --release --locked \
     --bin spur \
     --bin spurctld \
     --bin spurd \
@@ -38,7 +42,6 @@ RUN cargo build --release \
     --bin spurrestd \
     --bin spur-k8s-operator
 
-# Verify glibc requirements stay within 2.28
 RUN echo "=== Required GLIBC versions ===" && \
     for bin in spur spurctld spurd spurdbd spurrestd spur-k8s-operator; do \
         MAX=$(objdump -T target/release/${bin} 2>/dev/null \
@@ -46,7 +49,6 @@ RUN echo "=== Required GLIBC versions ===" && \
         echo "  ${bin}: requires ${MAX:-none}"; \
     done
 
-# Output stage -- just the binaries (use with --output)
 FROM scratch AS dist
 COPY --from=builder /build/target/release/spur /bin/
 COPY --from=builder /build/target/release/spurctld /bin/


### PR DESCRIPTION
## Summary

- Docker builds were recompiling all ~300 crates from scratch on every source change because `COPY . .` invalidated the cargo build layer. This adds [cargo-chef](https://github.com/LukeMathWalker/cargo-chef) to split dependency compilation into a separate cached layer that only rebuilds when `Cargo.toml`/`Cargo.lock` change.
- Adds a `.dockerignore` to exclude `target/`, `.git/`, and other irrelevant paths from the build context.
- Applies to both `deploy/Dockerfile` and `deploy/Dockerfile.manylinux`.

## Expected Impact

- Code-only changes: Docker build drops from ~5 min to ~1 min (dependencies are cached).
- Dependency changes: similar to current timing (full rebuild).