### PR TITLE
ci(ci): fully parallelize CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,15 +42,15 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-clippy-
+            ${{ runner.os }}-cargo-${{ github.job }}-
+            ${{ runner.os }}-cargo-
 
       - name: Clippy
         run: cargo clippy --workspace --exclude spur-ffi --all-targets --locked -- -W clippy::all -D unused
 
   build:
-    needs: [fmt, clippy]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -67,37 +67,13 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
+            ${{ runner.os }}-cargo-${{ github.job }}-
             ${{ runner.os }}-cargo-
 
-      - name: Build
+      - name: Build all targets
         run: cargo build --all-targets --locked
-
-  test:
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install protobuf compiler
-        run: sudo apt-get install -y protobuf-compiler
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo registry and build
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
-      - name: Test
-        run: cargo test --locked
 
       - name: Prepare K8s test binary
         run: |
@@ -113,9 +89,33 @@ jobs:
           path: artifacts/spur-k8s-tests
           retention-days: 1
 
-  build-e2e-artifacts:
-    name: Build E2E Artifacts
-    needs: [test]
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install protobuf compiler
+        run: sudo apt-get install -y protobuf-compiler
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ github.job }}-
+            ${{ runner.os }}-cargo-
+
+      - name: Test
+        run: cargo test --locked
+
+  build-docker-image:
+    name: Build Docker Image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Make all CI jobs (`fmt`, `clippy`, `build`, `test`, `build-docker-image`) run fully in parallel with zero inter-dependencies.
- Separate the K8s test binary upload into the `build` job (was previously bundled in `test`).
- Rename `build-e2e-artifacts` → `build-docker-image` to reflect its actual purpose.
- Use job-specific cache keys (`${{ github.job }}` in key) to avoid save contention between parallel jobs, while keeping broad `restore-keys` so any job can warm from a sibling's cache.

## Job Layout

```
fmt                  (independent, ~30s)
clipy                (independent, ~5m)
build                (independent, ~5m, uploads K8s test binary)
test                 (independent, ~6m)
build-docker-image   (independent, ~6-8m, uploads image + release binaries)
```

## Impact

Critical path drops from ~16-21 min (fully serial: fmt → clippy → build → test → build-e2e-artifacts) to ~6-8 min (longest single job). Branch protection still requires all jobs to pass before merge, so no safety is lost.