### PR TITLE
ci(e2e): queue concurrent runs instead of cancelling them

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,7 +24,7 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     concurrency:
       group: bare-metal-cluster
-      cancel-in-progress: true
+      cancel-in-progress: false
     env:
       BM_NODES: ${{ secrets.BM_NODES }}
       BM_SSH_USER: ${{ secrets.BM_SSH_USER }}
@@ -330,7 +330,7 @@ jobs:
     needs: push-image
     concurrency:
       group: k8s-integration
-      cancel-in-progress: true
+      cancel-in-progress: false
     env:
       KUBECONFIG: /home/amd/.kube/config
       SPUR_TEST_NS: spur-ci-${{ github.event.workflow_run.id }}


### PR DESCRIPTION
Both e2e concurrency groups (`bare-metal-cluster` and `k8s-integration`) had `cancel-in-progress: true`, which killed in-flight jobs whenever a new workflow run entered the queue. This caused PR runs to be cancelled when a main-branch push arrived (or vice versa).

Switched to `cancel-in-progress: false` so runs queue behind the active one instead of cancelling it. Jobs take ~20 min, so the queue wait is acceptable.

## Changes

- `bare-metal-cluster` concurrency group: `cancel-in-progress: true` → `false`
- `k8s-integration` concurrency group: `cancel-in-progress: true` → `false`