### PR TITLE
ci(e2e): use queue:max for true FIFO queuing in concurrency groups

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,7 +24,7 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     concurrency:
       group: bare-metal-cluster
-      cancel-in-progress: false
+      queue: max
     env:
       BM_NODES: ${{ secrets.BM_NODES }}
       BM_SSH_USER: ${{ secrets.BM_SSH_USER }}
@@ -330,7 +330,7 @@ jobs:
     needs: push-image
     concurrency:
       group: k8s-integration
-      cancel-in-progress: false
+      queue: max
     env:
       KUBECONFIG: /home/amd/.kube/config
       SPUR_TEST_NS: spur-ci-${{ github.event.workflow_run.id }}


### PR DESCRIPTION
## Problem

E2E jobs were being cancelled even with `cancel-in-progress: false` (merged in #206). This is a GitHub Actions platform limitation: a concurrency group holds at most 1 running + 1 pending slot. When a 3rd run arrives, the pending one is evicted unconditionally — `cancel-in-progress` only protects the *running* job.

## Fix

Switch to the new `queue: max` option ([GA 2026-05-07](https://github.blog/changelog/2026-05-07-github-actions-concurrency-groups-now-allow-larger-queues/)) which allows up to 100 pending jobs per concurrency group in FIFO order. No pending run is evicted unless the queue overflows (100+) or times out (24h).

```yaml
concurrency:
  group: bare-metal-cluster
  queue: max
```

## Changes

- `bare-metal-cluster` group: `cancel-in-progress: false` → `queue: max`
- `k8s-integration` group: `cancel-in-progress: false` → `queue: max`