### PR TITLE
chore(ci): pin Rust toolchain to 1.95.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
+      - name: Install Rust toolchain
+        run: rustup show
       - name: Check formatting
         run: cargo fmt --all --check
 
@@ -31,9 +30,8 @@ jobs:
       - name: Install protobuf compiler
         run: sudo apt-get install -y protobuf-compiler
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
+      - name: Install Rust toolchain
+        run: rustup show
 
       - name: Cache cargo registry and build
         uses: actions/cache@v4
@@ -58,7 +56,8 @@ jobs:
       - name: Install protobuf compiler
         run: sudo apt-get install -y protobuf-compiler
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: rustup show
 
       - name: Cache cargo registry and build
         uses: actions/cache@v4
@@ -97,7 +96,8 @@ jobs:
       - name: Install protobuf compiler
         run: sudo apt-get install -y protobuf-compiler
 
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        run: rustup show
 
       - name: Cache cargo registry and build
         uses: actions/cache@v4

--- a/crates/spur-core/src/topology.rs
+++ b/crates/spur-core/src/topology.rs
@@ -241,7 +241,7 @@ impl TopologyTree {
 
         let groups = self.group_by_switch(candidates);
         let mut sorted_groups: Vec<(String, Vec<&'a str>)> = groups.into_iter().collect();
-        sorted_groups.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+        sorted_groups.sort_by_key(|g| std::cmp::Reverse(g.1.len()));
 
         // If the largest group has enough, use it
         if sorted_groups[0].1.len() >= count {

--- a/crates/spur-tests/src/t05_queue.rs
+++ b/crates/spur-tests/src/t05_queue.rs
@@ -117,7 +117,7 @@ mod tests {
         j3.priority = 1000;
 
         let mut jobs = [j1, j2, j3];
-        jobs.sort_by(|a, b| b.priority.cmp(&a.priority));
+        jobs.sort_by_key(|j| std::cmp::Reverse(j.priority));
 
         assert_eq!(jobs[0].spec.name, "high");
         assert_eq!(jobs[1].spec.name, "mid");

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -974,7 +974,7 @@ impl ClusterManager {
             );
         }
 
-        pending.sort_by(|a, b| b.priority.cmp(&a.priority));
+        pending.sort_by_key(|j| std::cmp::Reverse(j.priority));
         pending
     }
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -13,8 +13,10 @@ RUN yum install -y unzip && yum clean all && \
     unzip -o /tmp/protoc.zip -d /usr/local && \
     rm /tmp/protoc.zip
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+COPY rust-toolchain.toml .
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
 ENV PATH="/root/.cargo/bin:${PATH}"
+RUN rustup show
 
 RUN cargo install cargo-chef --locked --version 0.1.77
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

- Pin the Rust toolchain to 1.95.0 via `rust-toolchain.toml` as a single source of truth for local dev, CI, and Docker builds
- Fix 3 `clippy::unnecessary_sort_by` warnings that 1.95.0 promotes into `clippy::all`
- CI jobs use `rustup show` (reads `rust-toolchain.toml` automatically) instead of `dtolnay/rust-toolchain@stable`; Dockerfile COPYs the file so rustup installs the pinned version

## Motivation

Rust 1.95.0 added new clippy lints to `clippy::all` that would break CI unpredictably when GitHub runners update. Pinning the toolchain makes upgrades deliberate and reviewable — one file to change, one PR to review.

## Test plan

- [x] `cargo fmt --all --check` passes with 1.95.0
- [x] `cargo clippy --workspace --exclude spur-ffi --all-targets --locked -- -W clippy::all -D unused` passes with 1.95.0
- [x] `cargo build --all-targets --locked` passes with 1.95.0
- [x] `cargo test --locked` passes with 1.95.0 (960+ tests, 0 failures)