### PR TITLE
ci(e2e): migrate CI container images to private GHCR

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -1,0 +1,23 @@
+name: Cleanup CI Images
+
+on:
+  schedule:
+    # Saturday 3:00 AM UTC
+    - cron: "0 3 * * 6"
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete old CI images
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: spur
+          package-type: container
+          min-versions-to-keep: 20
+          ignore-versions: "^(latest|v\\d+)"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,6 +16,7 @@ permissions:
   statuses: write
   actions: read
   contents: read
+  packages: write
 
 jobs:
   bare-metal:
@@ -298,12 +299,20 @@ jobs:
             });
 
   push-image:
-    name: Push Image to Registry
+    name: Push Image to GHCR
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'success'
-    env:
-      IMAGE_TAG: ${{ secrets.REGISTRY }}/spur:${{ github.event.workflow_run.head_sha }}
     steps:
+      - name: Compute GHCR image reference
+        id: image
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const sha = '${{ github.event.workflow_run.head_sha }}';
+            const repo = '${{ github.repository }}'.toLowerCase();
+            return `ghcr.io/${repo}:${sha}`;
+
       - name: Download image artifact
         uses: actions/download-artifact@v4
         with:
@@ -312,13 +321,16 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Log in to registry
+      - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.REGISTRY_USERNAME }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Load, retag, and push
+        env:
+          IMAGE_TAG: ${{ steps.image.outputs.result }}
         run: |
           docker load -i /tmp/spur-image.tar
           docker tag spur:ci "$IMAGE_TAG"
@@ -334,9 +346,23 @@ jobs:
     env:
       KUBECONFIG: /home/amd/.kube/config
       SPUR_TEST_NS: spur-ci-${{ github.event.workflow_run.id }}
-      SPUR_CI_IMAGE: ${{ secrets.REGISTRY }}/spur:${{ github.event.workflow_run.head_sha }}
       RUST_LOG: info
     steps:
+      - name: Compute GHCR image reference
+        id: image
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const sha = '${{ github.event.workflow_run.head_sha }}';
+            const repo = '${{ github.repository }}'.toLowerCase();
+            return `ghcr.io/${repo}:${sha}`;
+
+      - name: Set SPUR_CI_IMAGE
+        run: |
+          echo "SPUR_CI_IMAGE=${{ steps.image.outputs.result }}" >> "$GITHUB_ENV"
+          echo "SPUR_CI_IMAGE=${{ steps.image.outputs.result }}"
+
       - name: Set pending status
         uses: actions/github-script@v7
         with:
@@ -409,15 +435,12 @@ jobs:
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Create registry pull secret
-        env:
-          REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
-          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
         run: |
           set -euo pipefail
           kubectl create secret docker-registry regcred \
-            --docker-server="https://index.docker.io/v1/" \
-            --docker-username="$REGISTRY_USERNAME" \
-            --docker-password="$REGISTRY_PASSWORD" \
+            --docker-server=ghcr.io \
+            --docker-username="${{ github.actor }}" \
+            --docker-password="${{ secrets.GITHUB_TOKEN }}" \
             -n "$SPUR_TEST_NS" \
             --dry-run=client -o yaml | kubectl apply -f -
 


### PR DESCRIPTION
## Summary

Migrates E2E CI container images from the external private registry to private GHCR (`ghcr.io/rocm/spur:<commit-sha>`). Removes dependency on `REGISTRY`, `REGISTRY_USERNAME`, and `REGISTRY_PASSWORD` secrets.

- **push-image:** Computes lowercase GHCR ref via `github-script`, pushes with `GITHUB_TOKEN`
- **k8s:** Recomputes the same ref on the self-hosted runner, sets `SPUR_CI_IMAGE` via `GITHUB_ENV`, updates `regcred` for `ghcr.io`
- **cleanup-images.yml:** Weekly prune (keep 20 versions, protect `latest` / `v*` tags)

## Post-merge

1. Run one full CI → E2E cycle and confirm GHCR push + cluster image pull
2. Confirm package `spur` has **Manage Actions access** → `ROCm/spur` (Admin) for cleanup workflow
3. Delete obsolete secrets: `REGISTRY`, `REGISTRY_USERNAME`, `REGISTRY_PASSWORD`