### PR TITLE
feat(spur-metrics): add job metrics collection in spurctld

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3359,6 +3359,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "spur-metrics"
+version = "0.3.0"
+dependencies = [
+ "chrono",
+ "spur-core",
+]
+
+[[package]]
 name = "spur-net"
 version = "0.3.0"
 dependencies = [
@@ -3469,6 +3477,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spur-core",
+ "spur-metrics",
  "spur-proto",
  "spur-sched",
  "spur-update",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/spur-core",
     "crates/spur-net",
     "crates/spur-sched",
+    "crates/spur-metrics",
 
     "crates/spurctld",
     "crates/spurd",

--- a/crates/spur-metrics/Cargo.toml
+++ b/crates/spur-metrics/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "spur-metrics"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+spur-core = { path = "../spur-core" }
+
+[lints]
+workspace = true
+
+[dev-dependencies]
+chrono = { workspace = true }

--- a/crates/spur-metrics/src/job.rs
+++ b/crates/spur-metrics/src/job.rs
@@ -1,0 +1,168 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use spur_core::job::{Job, JobState, PendingReason};
+
+/// Number of [`JobState`] variants (index for `by_state`).
+pub const JOB_STATE_COUNT: usize = JobState::COUNT;
+
+/// Aggregated job metrics derived from the controller job map.
+///
+/// Built by scanning in-memory `Job` records (lazy, on read). Durable state lives
+/// in the Raft-backed job map on `ClusterManager`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct JobMetricsSnapshot {
+    /// Total jobs in the controller map (includes terminal jobs).
+    pub total: u64,
+    /// Count per [`JobState`]; index via [`job_state_index`].
+    pub by_state: [u64; JOB_STATE_COUNT],
+    /// Pending jobs with `pending_reason == Held`.
+    pub held_pending: u64,
+    /// Sum of allocated CPUs for jobs in Running or Completing.
+    pub running_cpus: u64,
+    /// Sum of allocated memory (bytes) for Running or Completing.
+    pub running_memory_bytes: u64,
+    /// Sum of allocated GPU count for Running or Completing.
+    pub running_gpus: u64,
+}
+
+/// Map [`JobState`] to a stable index in [`JobMetricsSnapshot::by_state`]
+/// (proto wire discriminant via [`JobState::from_proto_i32`]).
+pub fn job_state_index(state: JobState) -> usize {
+    let wire = state.to_proto_i32();
+    debug_assert_eq!(JobState::from_proto_i32(wire), Some(state));
+    wire as usize
+}
+
+fn counts_toward_running_alloc(state: JobState) -> bool {
+    matches!(state, JobState::Running | JobState::Completing)
+}
+
+impl JobMetricsSnapshot {
+    /// Rebuild metrics by scanning all jobs.
+    pub fn collect<'a>(jobs: impl IntoIterator<Item = &'a Job>) -> Self {
+        let mut snap = Self::default();
+        for job in jobs {
+            snap.total += 1;
+            snap.by_state[job_state_index(job.state)] += 1;
+
+            if job.state == JobState::Pending && job.pending_reason == PendingReason::Held {
+                snap.held_pending += 1;
+            }
+
+            if counts_toward_running_alloc(job.state) {
+                if let Some(ref alloc) = job.allocated_resources {
+                    snap.running_cpus += u64::from(alloc.cpus);
+                    snap.running_memory_bytes += alloc.memory_mb.saturating_mul(1024 * 1024);
+                    snap.running_gpus += u64::from(alloc.total_gpus());
+                }
+            }
+        }
+        snap
+    }
+
+    /// Count for a single state.
+    pub fn count_state(&self, state: JobState) -> u64 {
+        self.by_state[job_state_index(state)]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use spur_core::job::{Job, JobSpec, JobState, PendingReason};
+    use spur_core::resource::{GpuLinkType, GpuResource, ResourceSet};
+
+    use super::*;
+
+    fn job_with_state(id: u32, state: JobState, held: bool) -> Job {
+        let mut job = Job::new(id, JobSpec::default());
+        job.state = state;
+        if held {
+            job.pending_reason = PendingReason::Held;
+        }
+        job
+    }
+
+    fn running_with_alloc(id: u32, cpus: u32, memory_mb: u64, gpu_count: u32) -> Job {
+        let mut job = Job::new(id, JobSpec::default());
+        job.state = JobState::Running;
+        job.start_time = Some(Utc::now());
+        let mut gpus = Vec::new();
+        for i in 0..gpu_count {
+            gpus.push(GpuResource {
+                device_id: i,
+                gpu_type: "mi300x".into(),
+                memory_mb: 0,
+                peer_gpus: vec![],
+                link_type: GpuLinkType::XGMI,
+            });
+        }
+        job.allocated_resources = Some(ResourceSet {
+            cpus,
+            memory_mb,
+            gpus,
+            generic: Default::default(),
+        });
+        job
+    }
+
+    #[test]
+    fn empty_jobs() {
+        let snap = JobMetricsSnapshot::collect([]);
+        assert_eq!(snap, JobMetricsSnapshot::default());
+    }
+
+    #[test]
+    fn counts_by_state_and_held() {
+        let jobs = [
+            job_with_state(1, JobState::Pending, true),
+            job_with_state(2, JobState::Pending, false),
+            job_with_state(3, JobState::Running, false),
+            job_with_state(4, JobState::Completed, false),
+        ];
+        let snap = JobMetricsSnapshot::collect(jobs.iter());
+        assert_eq!(snap.total, 4);
+        assert_eq!(snap.count_state(JobState::Pending), 2);
+        assert_eq!(snap.held_pending, 1);
+        assert_eq!(snap.count_state(JobState::Running), 1);
+        assert_eq!(snap.count_state(JobState::Completed), 1);
+    }
+
+    #[test]
+    fn running_alloc_sums_running_and_completing() {
+        let jobs = [
+            running_with_alloc(1, 4, 8192, 2),
+            {
+                let mut j = running_with_alloc(2, 2, 4096, 1);
+                j.state = JobState::Completing;
+                j
+            },
+            job_with_state(3, JobState::Pending, false),
+            job_with_state(4, JobState::Pending, false),
+        ];
+        let snap = JobMetricsSnapshot::collect(jobs.iter());
+        assert_eq!(snap.running_cpus, 4 + 2);
+        assert_eq!(snap.running_memory_bytes, (8192 + 4096) * 1024 * 1024);
+        assert_eq!(snap.running_gpus, 2 + 1);
+        assert_eq!(snap.count_state(JobState::Pending), 2);
+    }
+
+    #[test]
+    fn job_state_index_uses_proto_wire() {
+        for &state in &JobState::ALL {
+            let wire = state.to_proto_i32();
+            assert_eq!(JobState::from_proto_i32(wire), Some(state));
+            assert_eq!(job_state_index(state), wire as usize);
+        }
+    }
+
+    #[test]
+    fn pending_job_with_alloc_not_counted() {
+        let mut job = running_with_alloc(1, 4, 1024, 1);
+        job.state = JobState::Pending;
+        let snap = JobMetricsSnapshot::collect([&job]);
+        assert_eq!(snap.running_cpus, 0);
+        assert_eq!(snap.running_gpus, 0);
+    }
+}

--- a/crates/spur-metrics/src/lib.rs
+++ b/crates/spur-metrics/src/lib.rs
@@ -1,0 +1,6 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Cluster metrics aggregation for spurctld.
+
+pub mod job;

--- a/crates/spurctld/Cargo.toml
+++ b/crates/spurctld/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 spur-proto = { path = "../spur-proto" }
 spur-core = { path = "../spur-core" }
 spur-sched = { path = "../spur-sched" }
+spur-metrics = { path = "../spur-metrics" }
 spur-update = { path = "../spur-update" }
 
 tokio = { workspace = true }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -20,6 +20,7 @@ use spur_core::reservation::Reservation;
 use spur_core::resource::ResourceSet;
 use spur_core::step::{JobStep, StepState, STEP_BATCH};
 use spur_core::wal::WalOperation;
+use spur_metrics::job::JobMetricsSnapshot;
 
 use crate::accounting::AccountingNotifier;
 use crate::fairshare_cache::FairshareCache;
@@ -166,6 +167,34 @@ impl ClusterManager {
     /// Get a job by ID.
     pub fn get_job(&self, job_id: JobId) -> Option<Job> {
         self.jobs.read().get(&job_id).cloned()
+    }
+
+    /// Aggregated job metrics from the current in-memory job map (lazy scan).
+    ///
+    /// The `jobs` map is authoritative (WAL-backed); this scans it on each call.
+    /// Export (phase 14.1e) should call this when serving `/metrics/jobs`.
+    pub fn job_metrics(&self) -> JobMetricsSnapshot {
+        let jobs = self.jobs.read();
+        JobMetricsSnapshot::collect(jobs.values())
+    }
+
+    /// Log job metrics at `debug` level.
+    ///
+    /// **Temporary (remove when metrics export lands):** non-test caller of
+    /// [`job_metrics`](Self::job_metrics) for clippy and coarse operator visibility.
+    pub fn log_job_metrics_debug(&self) {
+        let m = self.job_metrics();
+        debug!(
+            total = m.total,
+            pending = m.count_state(JobState::Pending),
+            running = m.count_state(JobState::Running),
+            completing = m.count_state(JobState::Completing),
+            held_pending = m.held_pending,
+            running_cpus = m.running_cpus,
+            running_memory_bytes = m.running_memory_bytes,
+            running_gpus = m.running_gpus,
+            "cluster job metrics snapshot (OpenMetrics export not yet wired)"
+        );
     }
 
     /// Get jobs matching filters.
@@ -1369,6 +1398,7 @@ impl ClusterManager {
                                 *avail = avail.saturating_sub(*count);
                             }
                         }
+                        self.next_job_id.store(next_id, Ordering::Relaxed);
                         return;
                     }
                 }
@@ -1750,6 +1780,7 @@ mod tests {
     use super::*;
     use spur_core::job::JobSpec;
     use spur_core::resource::ResourceSet;
+    use spur_metrics::job::JobMetricsSnapshot;
     use tempfile::TempDir;
 
     fn test_config() -> SlurmConfig {
@@ -2108,6 +2139,46 @@ mod tests {
 
         let node = cm.get_node("worker1").unwrap();
         assert_eq!(node.alloc_resources.cpus, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn job_metrics_track_lifecycle() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        assert_eq!(cm.job_metrics(), JobMetricsSnapshot::default());
+
+        register_node(&cm, "worker1", 8, 16000);
+        let job_id = submit_and_wait(&cm, basic_spec("metrics-job"));
+
+        let m = cm.job_metrics();
+        assert_eq!(m.total, 1);
+        assert_eq!(m.count_state(JobState::Pending), 1);
+
+        let resources = ResourceSet {
+            cpus: 4,
+            memory_mb: 8192,
+            ..Default::default()
+        };
+        cm.start_job(job_id, vec!["worker1".into()], resources)
+            .unwrap();
+        settle(&cm, job_id, JobState::Running);
+
+        let m = cm.job_metrics();
+        assert_eq!(m.count_state(JobState::Running), 1);
+        assert_eq!(m.running_cpus, 4);
+        assert_eq!(m.running_memory_bytes, 8192 * 1024 * 1024);
+
+        cm.complete_job(job_id, 0, JobState::Completed).unwrap();
+        settle(&cm, job_id, JobState::Completed);
+
+        let m = cm.job_metrics();
+        assert_eq!(m.count_state(JobState::Completed), 1);
+        assert_eq!(m.running_cpus, 0);
+
+        // Snapshot matches a full scan of the job map.
+        let expected = JobMetricsSnapshot::collect(cm.get_jobs(&[], None, None, None, &[]).iter());
+        assert_eq!(cm.job_metrics(), expected);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -165,7 +165,8 @@ async fn main() -> anyhow::Result<()> {
         scheduler_loop::run(sched_cluster, sched_raft).await;
     });
 
-    // Start node health checker (90s timeout, only on leader)
+    // Start node health checker (90s timeout, only on leader).
+    // Also logs job metrics at debug until OpenMetrics export replaces this path.
     let health_cluster = cluster.clone();
     let health_raft = raft_handle.clone();
     tokio::spawn(async move {
@@ -176,6 +177,7 @@ async fn main() -> anyhow::Result<()> {
                 continue;
             }
             health_cluster.check_node_health(90);
+            health_cluster.log_job_metrics_debug();
         }
     });
 


### PR DESCRIPTION
### Summary
Add job-level metrics collection for spurctld. Introduces the spur-metrics crate and wires ClusterManager::job_metrics() to aggregate from the authoritative in-memory job map. Metrics are computed lazily on read (no separate cache, no WAL refresh hooks). OpenMetrics HTTP export (:6822) is follow-up work (14.1e).

### What changed
- crates/spur-metrics: JobMetricsSnapshot and JobMetricsSnapshot::collect() — counts by JobState, held pending jobs, and running/completing allocation sums (CPUs, memory, GPUs). Job-state buckets use proto wire indices via JobState::from_proto_i32.
- crates/spurctld: ClusterManager::job_metrics() scans jobs under a read lock on each call. Temporary log_job_metrics_debug() in the leader health loop (removed when export lands).
- Snapshot restore: log job/node counts after dropping write guards (avoids deadlock under info!).

### Test plan
- cargo test -p spur-metrics
- cargo test -p spurctld job_metrics
- cargo test -p spurctld snapshot_and_restore
- cargo fmt --check
- cargo clippy --workspace --exclude spur-ffi --all-targets --locked -- -D unused