### PR TITLE
feat(spur-core): proto-backed JobState/NodeState with ALL/COUNT and consumer dedup

### DIFF
--- a/crates/spur-cli/src/sacct.rs
+++ b/crates/spur-cli/src/sacct.rs
@@ -192,20 +192,9 @@ fn resolve_sacct_field(job: &spur_proto::proto::JobInfo, spec: char) -> String {
 }
 
 fn state_name(state: i32) -> String {
-    match state {
-        0 => "PENDING",
-        1 => "RUNNING",
-        2 => "COMPLETING",
-        3 => "COMPLETED",
-        4 => "FAILED",
-        5 => "CANCELLED",
-        6 => "TIMEOUT",
-        7 => "NODE_FAIL",
-        8 => "PREEMPTED",
-        9 => "SUSPENDED",
-        _ => "UNKNOWN",
-    }
-    .into()
+    spur_core::job::JobState::from_proto_i32(state)
+        .map(|s| s.display().to_string())
+        .unwrap_or_else(|| "UNKNOWN".into())
 }
 
 fn parse_acct_state(s: &str) -> Option<i32> {

--- a/crates/spur-cli/src/sattach.rs
+++ b/crates/spur-cli/src/sattach.rs
@@ -271,19 +271,9 @@ impl Drop for RawModeGuard {
 }
 
 fn state_name(state: i32) -> &'static str {
-    match state {
-        0 => "PENDING",
-        1 => "RUNNING",
-        2 => "COMPLETING",
-        3 => "COMPLETED",
-        4 => "FAILED",
-        5 => "CANCELLED",
-        6 => "TIMEOUT",
-        7 => "NODE_FAIL",
-        8 => "PREEMPTED",
-        9 => "SUSPENDED",
-        _ => "UNKNOWN",
-    }
+    spur_core::job::JobState::from_proto_i32(state)
+        .map(|s| s.display())
+        .unwrap_or("UNKNOWN")
 }
 
 #[cfg(test)]

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -453,32 +453,15 @@ async fn ping(controller: &str) -> Result<()> {
 }
 
 fn state_name(state: i32) -> &'static str {
-    match state {
-        0 => "PENDING",
-        1 => "RUNNING",
-        2 => "COMPLETING",
-        3 => "COMPLETED",
-        4 => "FAILED",
-        5 => "CANCELLED",
-        6 => "TIMEOUT",
-        7 => "NODE_FAIL",
-        8 => "PREEMPTED",
-        9 => "SUSPENDED",
-        _ => "UNKNOWN",
-    }
+    spur_core::job::JobState::from_proto_i32(state)
+        .map(|s| s.display())
+        .unwrap_or("UNKNOWN")
 }
 
 fn node_state_name(state: i32) -> &'static str {
-    match state {
-        0 => "IDLE",
-        1 => "ALLOCATED",
-        2 => "MIXED",
-        3 => "DOWN",
-        4 => "DRAINED",
-        5 => "DRAINING",
-        6 => "ERROR",
-        _ => "UNKNOWN",
-    }
+    spur_core::node::NodeState::from_proto_i32(state)
+        .map(|s| s.display_upper())
+        .unwrap_or("UNKNOWN")
 }
 
 fn format_ts(ts: Option<&prost_types::Timestamp>) -> String {

--- a/crates/spur-cli/src/sinfo.rs
+++ b/crates/spur-cli/src/sinfo.rs
@@ -278,19 +278,9 @@ fn effective_state_str(node: &NodeInfo) -> String {
     {
         return "resv".into();
     }
-    match node.state {
-        0 => "idle",
-        1 => "alloc",
-        2 => "mix",
-        3 => "down",
-        4 => "drain",
-        5 => "drng",
-        6 => "err",
-        7 => "unk",
-        8 => "susp",
-        _ => "unk",
-    }
-    .into()
+    spur_core::node::NodeState::from_proto_i32(node.state)
+        .map(|s| s.short().to_string())
+        .unwrap_or_else(|| "unk".into())
 }
 
 #[cfg(test)]
@@ -481,46 +471,9 @@ mod tests {
     }
 
     #[test]
-    fn test_effective_state_idle_reserved() {
-        let node = make_reserved_node("n1", NodeState::NodeIdle, "p", "maint");
-        assert_eq!(effective_state_str(&node), "resv");
-    }
-
-    #[test]
-    fn test_effective_state_alloc_reserved() {
-        let node = make_reserved_node("n1", NodeState::NodeAllocated, "p", "maint");
-        assert_eq!(effective_state_str(&node), "alloc");
-    }
-
-    #[test]
     fn test_effective_state_mixed_reserved() {
         let node = make_reserved_node("n1", NodeState::NodeMixed, "p", "maint");
         assert_eq!(effective_state_str(&node), "mix");
-    }
-
-    #[test]
-    fn test_effective_state_all_base_states() {
-        let cases = [
-            (NodeState::NodeIdle, "idle"),
-            (NodeState::NodeAllocated, "alloc"),
-            (NodeState::NodeMixed, "mix"),
-            (NodeState::NodeDown, "down"),
-            (NodeState::NodeDrain, "drain"),
-            (NodeState::NodeDraining, "drng"),
-            (NodeState::NodeError, "err"),
-            (NodeState::NodeUnknown, "unk"),
-            (NodeState::NodeSuspended, "susp"),
-        ];
-        for (state, expected) in cases {
-            let node = make_node("n1", state, "p");
-            assert_eq!(
-                effective_state_str(&node),
-                expected,
-                "state {:?} should display as {}",
-                state,
-                expected
-            );
-        }
     }
 
     // --- grouping tests ---

--- a/crates/spur-cli/src/smd.rs
+++ b/crates/spur-cli/src/smd.rs
@@ -111,54 +111,7 @@ fn node_state_str(node: &NodeInfo) -> &'static str {
     if !node.active_reservation.is_empty() && node.state == NodeState::NodeIdle as i32 {
         return "resv";
     }
-    match node.state {
-        0 => "idle",
-        1 => "alloc",
-        2 => "mix",
-        3 => "DOWN",
-        4 => "drain",
-        5 => "drng",
-        6 => "ERROR",
-        7 => "unk",
-        8 => "susp",
-        _ => "???",
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn make_node(name: &str, state: NodeState, reservation: &str) -> NodeInfo {
-        NodeInfo {
-            name: name.into(),
-            state: state as i32,
-            active_reservation: reservation.into(),
-            ..Default::default()
-        }
-    }
-
-    #[test]
-    fn test_smd_state_reserved() {
-        let node = make_node("n1", NodeState::NodeIdle, "maint");
-        assert_eq!(node_state_str(&node), "resv");
-    }
-
-    #[test]
-    fn test_smd_state_alloc_reserved() {
-        let node = make_node("n1", NodeState::NodeAllocated, "maint");
-        assert_eq!(node_state_str(&node), "alloc");
-    }
-
-    #[test]
-    fn test_smd_state_idle_no_reservation() {
-        let node = make_node("n1", NodeState::NodeIdle, "");
-        assert_eq!(node_state_str(&node), "idle");
-    }
-
-    #[test]
-    fn test_smd_state_down() {
-        let node = make_node("n1", NodeState::NodeDown, "");
-        assert_eq!(node_state_str(&node), "DOWN");
-    }
+    spur_core::node::NodeState::from_proto_i32(node.state)
+        .map(|s| s.short())
+        .unwrap_or("???")
 }

--- a/crates/spur-cli/src/squeue.rs
+++ b/crates/spur-cli/src/squeue.rs
@@ -76,20 +76,13 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let fields = format_engine::parse_format(&fmt, &format_engine::squeue_header);
 
     // Parse state filter — default to Pending+Running when no filter specified (Slurm default)
-    let states = args
-        .states
-        .as_ref()
-        .map(|s| {
-            s.split(',')
-                .filter_map(|st| parse_state_filter(st.trim()))
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_else(|| {
-            vec![
-                spur_proto::proto::JobState::JobPending,
-                spur_proto::proto::JobState::JobRunning,
-            ]
-        });
+    let states = match args.states.as_deref() {
+        Some(s) => parse_states_arg(s)?,
+        None => vec![
+            spur_proto::proto::JobState::JobPending,
+            spur_proto::proto::JobState::JobRunning,
+        ],
+    };
 
     // Parse job ID filter
     let job_ids = args
@@ -168,53 +161,44 @@ fn resolve_job_field(job: &spur_proto::proto::JobInfo, spec: char) -> String {
 }
 
 fn state_code(state: i32) -> String {
-    match state {
-        0 => "PD",
-        1 => "R",
-        2 => "CG",
-        3 => "CD",
-        4 => "F",
-        5 => "CA",
-        6 => "TO",
-        7 => "NF",
-        8 => "PR",
-        9 => "S",
-        _ => "?",
-    }
-    .into()
+    spur_core::job::JobState::from_proto_i32(state)
+        .map(|s| s.code().to_string())
+        .unwrap_or_else(|| "?".into())
 }
 
 fn state_name(state: i32) -> String {
-    match state {
-        0 => "PENDING",
-        1 => "RUNNING",
-        2 => "COMPLETING",
-        3 => "COMPLETED",
-        4 => "FAILED",
-        5 => "CANCELLED",
-        6 => "TIMEOUT",
-        7 => "NODE_FAIL",
-        8 => "PREEMPTED",
-        9 => "SUSPENDED",
-        _ => "UNKNOWN",
-    }
-    .into()
+    spur_core::job::JobState::from_proto_i32(state)
+        .map(|s| s.display().to_string())
+        .unwrap_or_else(|| "UNKNOWN".into())
 }
 
-fn parse_state_filter(s: &str) -> Option<spur_proto::proto::JobState> {
-    match s.to_uppercase().as_str() {
-        "PD" | "PENDING" => Some(spur_proto::proto::JobState::JobPending),
-        "R" | "RUNNING" => Some(spur_proto::proto::JobState::JobRunning),
-        "CG" | "COMPLETING" => Some(spur_proto::proto::JobState::JobCompleting),
-        "CD" | "COMPLETED" => Some(spur_proto::proto::JobState::JobCompleted),
-        "F" | "FAILED" => Some(spur_proto::proto::JobState::JobFailed),
-        "CA" | "CANCELLED" => Some(spur_proto::proto::JobState::JobCancelled),
-        "TO" | "TIMEOUT" => Some(spur_proto::proto::JobState::JobTimeout),
-        "NF" | "NODE_FAIL" => Some(spur_proto::proto::JobState::JobNodeFail),
-        "PR" | "PREEMPTED" => Some(spur_proto::proto::JobState::JobPreempted),
-        "S" | "SUSPENDED" => Some(spur_proto::proto::JobState::JobSuspended),
-        _ => None,
+/// Parse `-t` / `--states` (comma-separated). Whole-string `all` means no state filter.
+/// Unknown tokens are rejected (Slurm exits with an error rather than showing all jobs).
+fn parse_states_arg(s: &str) -> Result<Vec<spur_proto::proto::JobState>> {
+    use spur_core::job::JobState;
+
+    let trimmed = s.trim();
+    if trimmed.eq_ignore_ascii_case("all") {
+        return Ok(Vec::new());
     }
+
+    let tokens: Vec<&str> = trimmed
+        .split(',')
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .collect();
+
+    if tokens.is_empty() {
+        anyhow::bail!("Invalid job state specified: (empty)");
+    }
+
+    let mut states = Vec::with_capacity(tokens.len());
+    for token in tokens {
+        let core = JobState::from_code_or_name(token)
+            .ok_or_else(|| anyhow::anyhow!("Invalid job state specified: {token}"))?;
+        states.push(core.to_proto());
+    }
+    Ok(states)
 }
 
 fn format_runtime(job: &spur_proto::proto::JobInfo) -> String {
@@ -257,5 +241,40 @@ fn format_timestamp(ts: Option<&prost_types::Timestamp>) -> String {
             dt.format("%Y-%m-%dT%H:%M:%S").to_string()
         }
         _ => "N/A".into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spur_proto::proto::JobState as P;
+
+    #[test]
+    fn parse_states_arg_accepts_codes_and_names() {
+        let states = parse_states_arg("R,PD").unwrap();
+        assert_eq!(states.len(), 2);
+        assert_eq!(states[0], P::JobRunning);
+        assert_eq!(states[1], P::JobPending);
+    }
+
+    #[test]
+    fn parse_states_arg_all_means_no_filter() {
+        assert!(parse_states_arg("all").unwrap().is_empty());
+        assert!(parse_states_arg("ALL").unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_states_arg_rejects_unknown() {
+        let err = parse_states_arg("BOGUS").unwrap_err();
+        assert!(err.to_string().contains("BOGUS"));
+
+        let err = parse_states_arg("R,BOGUS").unwrap_err();
+        assert!(err.to_string().contains("BOGUS"));
+    }
+
+    #[test]
+    fn parse_states_arg_rejects_empty_list() {
+        assert!(parse_states_arg("").is_err());
+        assert!(parse_states_arg("  ,  ").is_err());
     }
 }

--- a/crates/spur-cli/src/sstat.rs
+++ b/crates/spur-cli/src/sstat.rs
@@ -241,19 +241,9 @@ fn resolve_field(job: &spur_proto::proto::JobInfo, field: &StatField) -> String 
 }
 
 fn state_name(state: i32) -> &'static str {
-    match state {
-        0 => "PENDING",
-        1 => "RUNNING",
-        2 => "COMPLETING",
-        3 => "COMPLETED",
-        4 => "FAILED",
-        5 => "CANCELLED",
-        6 => "TIMEOUT",
-        7 => "NODE_FAIL",
-        8 => "PREEMPTED",
-        9 => "SUSPENDED",
-        _ => "UNKNOWN",
-    }
+    spur_core::job::JobState::from_proto_i32(state)
+        .map(|s| s.display())
+        .unwrap_or("UNKNOWN")
 }
 
 fn format_duration(total_seconds: i64) -> String {

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -70,6 +70,75 @@ impl JobState {
     pub fn is_active(&self) -> bool {
         matches!(self, Self::Running | Self::Completing | Self::Suspended)
     }
+
+    /// Every core variant, in proto discriminant order for iteration only.
+    pub const ALL: [JobState; 10] = [
+        Self::Pending,
+        Self::Running,
+        Self::Completing,
+        Self::Completed,
+        Self::Failed,
+        Self::Cancelled,
+        Self::Timeout,
+        Self::NodeFail,
+        Self::Preempted,
+        Self::Suspended,
+    ];
+
+    pub const COUNT: usize = Self::ALL.len();
+
+    /// Convert a prost `JobState` enum to core.
+    pub fn from_proto(p: spur_proto::proto::JobState) -> Self {
+        match p {
+            spur_proto::proto::JobState::JobPending => Self::Pending,
+            spur_proto::proto::JobState::JobRunning => Self::Running,
+            spur_proto::proto::JobState::JobCompleting => Self::Completing,
+            spur_proto::proto::JobState::JobCompleted => Self::Completed,
+            spur_proto::proto::JobState::JobFailed => Self::Failed,
+            spur_proto::proto::JobState::JobCancelled => Self::Cancelled,
+            spur_proto::proto::JobState::JobTimeout => Self::Timeout,
+            spur_proto::proto::JobState::JobNodeFail => Self::NodeFail,
+            spur_proto::proto::JobState::JobPreempted => Self::Preempted,
+            spur_proto::proto::JobState::JobSuspended => Self::Suspended,
+        }
+    }
+
+    /// Convert core state to prost `JobState`.
+    pub fn to_proto(self) -> spur_proto::proto::JobState {
+        match self {
+            Self::Pending => spur_proto::proto::JobState::JobPending,
+            Self::Running => spur_proto::proto::JobState::JobRunning,
+            Self::Completing => spur_proto::proto::JobState::JobCompleting,
+            Self::Completed => spur_proto::proto::JobState::JobCompleted,
+            Self::Failed => spur_proto::proto::JobState::JobFailed,
+            Self::Cancelled => spur_proto::proto::JobState::JobCancelled,
+            Self::Timeout => spur_proto::proto::JobState::JobTimeout,
+            Self::NodeFail => spur_proto::proto::JobState::JobNodeFail,
+            Self::Preempted => spur_proto::proto::JobState::JobPreempted,
+            Self::Suspended => spur_proto::proto::JobState::JobSuspended,
+        }
+    }
+
+    /// Convert a proto wire discriminant to core.
+    pub fn from_proto_i32(v: i32) -> Option<Self> {
+        spur_proto::proto::JobState::try_from(v)
+            .ok()
+            .map(Self::from_proto)
+    }
+
+    /// Core state as proto wire discriminant.
+    pub fn to_proto_i32(self) -> i32 {
+        self.to_proto() as i32
+    }
+
+    /// Parse from a Slurm state code ("PD", "R") or full name ("PENDING", "RUNNING").
+    pub fn from_code_or_name(s: &str) -> Option<Self> {
+        let upper = s.to_uppercase();
+        Self::ALL
+            .iter()
+            .find(|st| st.code() == upper || st.display() == upper)
+            .copied()
+    }
 }
 
 impl std::fmt::Display for JobState {
@@ -508,9 +577,68 @@ mod tests {
     }
 
     #[test]
-    fn test_state_codes() {
-        assert_eq!(JobState::Pending.code(), "PD");
-        assert_eq!(JobState::Running.code(), "R");
-        assert_eq!(JobState::Completed.code(), "CD");
+    fn all_is_complete_and_ordered() {
+        use std::collections::HashSet;
+        let mut seen = HashSet::new();
+        assert_eq!(JobState::ALL.len(), JobState::COUNT);
+        for state in &JobState::ALL {
+            assert!(seen.insert(state), "duplicate variant in ALL: {state}");
+        }
+    }
+
+    #[test]
+    fn job_state_proto_discriminants_match_core() {
+        use spur_proto::proto::JobState as P;
+
+        const TABLE: &[(P, JobState)] = &[
+            (P::JobPending, JobState::Pending),
+            (P::JobRunning, JobState::Running),
+            (P::JobCompleting, JobState::Completing),
+            (P::JobCompleted, JobState::Completed),
+            (P::JobFailed, JobState::Failed),
+            (P::JobCancelled, JobState::Cancelled),
+            (P::JobTimeout, JobState::Timeout),
+            (P::JobNodeFail, JobState::NodeFail),
+            (P::JobPreempted, JobState::Preempted),
+            (P::JobSuspended, JobState::Suspended),
+        ];
+
+        assert_eq!(TABLE.len(), JobState::COUNT);
+        for &(proto, core) in TABLE {
+            let wire = proto as i32;
+            assert_eq!(P::try_from(wire).ok(), Some(proto));
+            assert_eq!(JobState::from_proto_i32(wire), Some(core));
+            assert_eq!(
+                JobState::ALL.iter().position(|&s| s == core),
+                Some(wire as usize),
+                "ALL position for {core:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn job_state_proto_try_from_unknown_wire_values() {
+        use spur_proto::proto::JobState as P;
+
+        for bad in [-1, JobState::COUNT as i32, 99, i32::MAX] {
+            assert_eq!(JobState::from_proto_i32(bad), None);
+            assert!(P::try_from(bad).is_err());
+        }
+    }
+
+    #[test]
+    fn job_state_core_proto_roundtrip() {
+        for &core in &JobState::ALL {
+            assert_eq!(JobState::from_proto_i32(core.to_proto_i32()), Some(core));
+            assert_eq!(JobState::from_proto(core.to_proto()), core);
+        }
+    }
+
+    #[test]
+    fn job_state_from_code_or_name_roundtrip() {
+        for &state in &JobState::ALL {
+            assert_eq!(JobState::from_code_or_name(state.code()), Some(state));
+            assert_eq!(JobState::from_code_or_name(state.display()), Some(state));
+        }
     }
 }

--- a/crates/spur-core/src/node.rs
+++ b/crates/spur-core/src/node.rs
@@ -94,6 +94,21 @@ impl NodeState {
         }
     }
 
+    /// Uppercase display for scontrol output (Slurm convention).
+    pub fn display_upper(&self) -> &'static str {
+        match self {
+            Self::Idle => "IDLE",
+            Self::Allocated => "ALLOCATED",
+            Self::Mixed => "MIXED",
+            Self::Down => "DOWN",
+            Self::Drain => "DRAINED",
+            Self::Draining => "DRAINING",
+            Self::Error => "ERROR",
+            Self::Unknown => "UNKNOWN",
+            Self::Suspended => "SUSPENDED",
+        }
+    }
+
     /// Short suffix used in sinfo (e.g., "idle", "alloc", "mix").
     pub fn short(&self) -> &'static str {
         match self {
@@ -111,6 +126,64 @@ impl NodeState {
 
     pub fn is_available(&self) -> bool {
         matches!(self, Self::Idle | Self::Mixed)
+    }
+
+    /// Every core variant, in proto discriminant order for iteration only.
+    /// Wire conversion uses [`from_proto`](Self::from_proto) / [`to_proto`](Self::to_proto), not array index.
+    pub const ALL: [NodeState; 9] = [
+        Self::Idle,
+        Self::Allocated,
+        Self::Mixed,
+        Self::Down,
+        Self::Drain,
+        Self::Draining,
+        Self::Error,
+        Self::Unknown,
+        Self::Suspended,
+    ];
+
+    pub const COUNT: usize = Self::ALL.len();
+
+    /// Convert a prost `NodeState` enum to core.
+    pub fn from_proto(p: spur_proto::proto::NodeState) -> Self {
+        match p {
+            spur_proto::proto::NodeState::NodeIdle => Self::Idle,
+            spur_proto::proto::NodeState::NodeAllocated => Self::Allocated,
+            spur_proto::proto::NodeState::NodeMixed => Self::Mixed,
+            spur_proto::proto::NodeState::NodeDown => Self::Down,
+            spur_proto::proto::NodeState::NodeDrain => Self::Drain,
+            spur_proto::proto::NodeState::NodeDraining => Self::Draining,
+            spur_proto::proto::NodeState::NodeError => Self::Error,
+            spur_proto::proto::NodeState::NodeUnknown => Self::Unknown,
+            spur_proto::proto::NodeState::NodeSuspended => Self::Suspended,
+        }
+    }
+
+    /// Convert core state to prost `NodeState`.
+    pub fn to_proto(self) -> spur_proto::proto::NodeState {
+        match self {
+            Self::Idle => spur_proto::proto::NodeState::NodeIdle,
+            Self::Allocated => spur_proto::proto::NodeState::NodeAllocated,
+            Self::Mixed => spur_proto::proto::NodeState::NodeMixed,
+            Self::Down => spur_proto::proto::NodeState::NodeDown,
+            Self::Drain => spur_proto::proto::NodeState::NodeDrain,
+            Self::Draining => spur_proto::proto::NodeState::NodeDraining,
+            Self::Error => spur_proto::proto::NodeState::NodeError,
+            Self::Unknown => spur_proto::proto::NodeState::NodeUnknown,
+            Self::Suspended => spur_proto::proto::NodeState::NodeSuspended,
+        }
+    }
+
+    /// Convert a proto wire discriminant to core.
+    pub fn from_proto_i32(v: i32) -> Option<Self> {
+        spur_proto::proto::NodeState::try_from(v)
+            .ok()
+            .map(Self::from_proto)
+    }
+
+    /// Core state as proto wire discriminant.
+    pub fn to_proto_i32(self) -> i32 {
+        self.to_proto() as i32
     }
 }
 
@@ -244,18 +317,6 @@ impl Node {
 mod tests {
     use super::*;
 
-    const ALL_STATES: &[NodeState] = &[
-        NodeState::Idle,
-        NodeState::Allocated,
-        NodeState::Mixed,
-        NodeState::Down,
-        NodeState::Drain,
-        NodeState::Draining,
-        NodeState::Error,
-        NodeState::Unknown,
-        NodeState::Suspended,
-    ];
-
     #[test]
     fn register_from_unknown_yields_idle() {
         assert_eq!(
@@ -266,7 +327,7 @@ mod tests {
 
     #[test]
     fn register_from_non_unknown_is_noop() {
-        for &s in ALL_STATES.iter().filter(|s| **s != NodeState::Unknown) {
+        for &s in NodeState::ALL.iter().filter(|s| **s != NodeState::Unknown) {
             assert_eq!(
                 s.transition(&NodeEvent::Register, false),
                 None,
@@ -358,8 +419,8 @@ mod tests {
 
     #[test]
     fn admin_can_force_any_state() {
-        for &from in ALL_STATES {
-            for &to in ALL_STATES {
+        for &from in &NodeState::ALL {
+            for &to in &NodeState::ALL {
                 assert_eq!(
                     from.transition(&NodeEvent::AdminSetState(to), false),
                     Some(to),
@@ -371,7 +432,7 @@ mod tests {
 
     #[test]
     fn power_suspend_from_any_state() {
-        for &s in ALL_STATES {
+        for &s in &NodeState::ALL {
             assert_eq!(
                 s.transition(&NodeEvent::PowerSuspend, false),
                 Some(NodeState::Suspended),
@@ -386,7 +447,10 @@ mod tests {
             NodeState::Suspended.transition(&NodeEvent::PowerResume, false),
             Some(NodeState::Idle),
         );
-        for &s in ALL_STATES.iter().filter(|s| **s != NodeState::Suspended) {
+        for &s in NodeState::ALL
+            .iter()
+            .filter(|s| **s != NodeState::Suspended)
+        {
             assert_eq!(
                 s.transition(&NodeEvent::PowerResume, false),
                 None,
@@ -415,6 +479,63 @@ mod tests {
         }
         for &s in &non_holds {
             assert!(!s.is_admin_hold(), "{s:?} should not be admin hold");
+        }
+    }
+
+    #[test]
+    fn all_is_complete_and_ordered() {
+        use std::collections::HashSet;
+        let mut seen = HashSet::new();
+        assert_eq!(NodeState::ALL.len(), NodeState::COUNT);
+        for state in &NodeState::ALL {
+            assert!(seen.insert(state), "duplicate variant in ALL: {state}");
+        }
+    }
+
+    #[test]
+    fn node_state_proto_discriminants_match_core() {
+        use spur_proto::proto::NodeState as P;
+
+        const TABLE: &[(P, NodeState)] = &[
+            (P::NodeIdle, NodeState::Idle),
+            (P::NodeAllocated, NodeState::Allocated),
+            (P::NodeMixed, NodeState::Mixed),
+            (P::NodeDown, NodeState::Down),
+            (P::NodeDrain, NodeState::Drain),
+            (P::NodeDraining, NodeState::Draining),
+            (P::NodeError, NodeState::Error),
+            (P::NodeUnknown, NodeState::Unknown),
+            (P::NodeSuspended, NodeState::Suspended),
+        ];
+
+        assert_eq!(TABLE.len(), NodeState::COUNT);
+        for &(proto, core) in TABLE {
+            let wire = proto as i32;
+            assert_eq!(P::try_from(wire).ok(), Some(proto));
+            assert_eq!(NodeState::from_proto_i32(wire), Some(core));
+            assert_eq!(
+                NodeState::ALL.iter().position(|&s| s == core),
+                Some(wire as usize),
+                "ALL position for {core:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn node_state_proto_try_from_unknown_wire_values() {
+        use spur_proto::proto::NodeState as P;
+
+        for bad in [-1, NodeState::COUNT as i32, 99, i32::MAX] {
+            assert_eq!(NodeState::from_proto_i32(bad), None);
+            assert!(P::try_from(bad).is_err());
+        }
+    }
+
+    #[test]
+    fn node_state_core_proto_roundtrip() {
+        for &core in &NodeState::ALL {
+            assert_eq!(NodeState::from_proto_i32(core.to_proto_i32()), Some(core));
+            assert_eq!(NodeState::from_proto(core.to_proto()), core);
         }
     }
 }

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -655,20 +655,9 @@ fn is_terminal(state: &str) -> bool {
 }
 
 fn proto_job_state_to_string(state: i32) -> String {
-    match state {
-        0 => "Pending",
-        1 => "Running",
-        2 => "Completing",
-        3 => "Completed",
-        4 => "Failed",
-        5 => "Cancelled",
-        6 => "Timeout",
-        7 => "NodeFail",
-        8 => "Preempted",
-        9 => "Suspended",
-        _ => "Unknown",
-    }
-    .to_string()
+    spur_core::job::JobState::from_proto_i32(state)
+        .map(|s| format!("{s:?}"))
+        .unwrap_or_else(|| "Unknown".into())
 }
 
 /// Convert a core JobSpec into proto JobSpec for gRPC submission.
@@ -758,27 +747,13 @@ mod tests {
     // --- proto_job_state_to_string ---
 
     #[test]
-    fn test_proto_job_state_to_string() {
-        assert_eq!(proto_job_state_to_string(0), "Pending");
-        assert_eq!(proto_job_state_to_string(1), "Running");
-        assert_eq!(proto_job_state_to_string(3), "Completed");
-        assert_eq!(proto_job_state_to_string(4), "Failed");
-        assert_eq!(proto_job_state_to_string(99), "Unknown");
-    }
-
-    #[test]
-    fn test_proto_job_state_all_values() {
-        assert_eq!(proto_job_state_to_string(2), "Completing");
-        assert_eq!(proto_job_state_to_string(5), "Cancelled");
-        assert_eq!(proto_job_state_to_string(6), "Timeout");
-        assert_eq!(proto_job_state_to_string(7), "NodeFail");
-        assert_eq!(proto_job_state_to_string(8), "Preempted");
-        assert_eq!(proto_job_state_to_string(9), "Suspended");
-    }
-
-    #[test]
-    fn test_proto_job_state_negative() {
+    fn test_proto_job_state_to_string_all_values() {
+        for &state in &spur_core::job::JobState::ALL {
+            let wire = state.to_proto_i32();
+            assert_eq!(proto_job_state_to_string(wire), format!("{state:?}"));
+        }
         assert_eq!(proto_job_state_to_string(-1), "Unknown");
+        assert_eq!(proto_job_state_to_string(99), "Unknown");
     }
 
     // --- is_terminal ---

--- a/crates/spur-tests/src/t50_core.rs
+++ b/crates/spur-tests/src/t50_core.rs
@@ -118,29 +118,6 @@ mod tests {
         assert_transition_err(&mut job, JobState::Failed);
     }
 
-    // ── T50.13: Job state display ─────────────────────────────────
-
-    #[test]
-    fn t50_13_state_codes() {
-        assert_eq!(JobState::Pending.code(), "PD");
-        assert_eq!(JobState::Running.code(), "R");
-        assert_eq!(JobState::Completing.code(), "CG");
-        assert_eq!(JobState::Completed.code(), "CD");
-        assert_eq!(JobState::Failed.code(), "F");
-        assert_eq!(JobState::Cancelled.code(), "CA");
-        assert_eq!(JobState::Timeout.code(), "TO");
-        assert_eq!(JobState::NodeFail.code(), "NF");
-        assert_eq!(JobState::Preempted.code(), "PR");
-        assert_eq!(JobState::Suspended.code(), "S");
-    }
-
-    #[test]
-    fn t50_14_state_display_names() {
-        assert_eq!(JobState::Pending.display(), "PENDING");
-        assert_eq!(JobState::Running.display(), "RUNNING");
-        assert_eq!(JobState::Completed.display(), "COMPLETED");
-    }
-
     // ── T50.15: Job path resolution ───────────────────────────────
 
     #[test]
@@ -233,15 +210,6 @@ mod tests {
         node.update_state_from_alloc();
         // Should stay Drain, not flip to Idle
         assert_eq!(node.state, NodeState::Drain);
-    }
-
-    #[test]
-    fn t50_23_node_schedulable() {
-        assert!(NodeState::Idle.is_available());
-        assert!(NodeState::Mixed.is_available());
-        assert!(!NodeState::Down.is_available());
-        assert!(!NodeState::Drain.is_available());
-        assert!(!NodeState::Allocated.is_available());
     }
 
     // ── T50.24: ResourceSet ───────────────────────────────────────
@@ -509,15 +477,14 @@ mod tests {
 
     #[test]
     fn t50_43_node_available_states() {
-        // Comprehensive check: only Idle and Mixed are available
-        assert!(NodeState::Idle.is_available());
-        assert!(NodeState::Mixed.is_available());
-        assert!(!NodeState::Down.is_available());
-        assert!(!NodeState::Drain.is_available());
-        assert!(!NodeState::Draining.is_available());
-        assert!(!NodeState::Allocated.is_available());
-        assert!(!NodeState::Error.is_available());
-        assert!(!NodeState::Unknown.is_available());
+        for state in &NodeState::ALL {
+            let available = state.is_available();
+            assert_eq!(
+                available,
+                matches!(state, NodeState::Idle | NodeState::Mixed),
+                "{state:?} availability"
+            );
+        }
     }
 
     // ── T50.44: Mail type field ─────────────────────────────────
@@ -694,14 +661,6 @@ mod tests {
         node.state = NodeState::Suspended;
         node.update_state_from_alloc();
         assert_eq!(node.state, NodeState::Suspended);
-    }
-
-    // ── T50.62: Suspended display and short ───────────────────────
-
-    #[test]
-    fn t50_62_suspended_display() {
-        assert_eq!(NodeState::Suspended.display(), "suspended");
-        assert_eq!(NodeState::Suspended.short(), "susp");
     }
 
     // ── T50.63–70: Begin time, deadline, spread_job, open_mode fields ──

--- a/crates/spur-tests/src/t55_format.rs
+++ b/crates/spur-tests/src/t55_format.rs
@@ -52,56 +52,57 @@ mod tests {
     #[test]
     fn t55_7_job_state_display_matches_slurm() {
         use spur_core::job::JobState;
-        // These must match Slurm's output exactly
-        let expected = vec![
-            (JobState::Pending, "PD", "PENDING"),
-            (JobState::Running, "R", "RUNNING"),
-            (JobState::Completing, "CG", "COMPLETING"),
-            (JobState::Completed, "CD", "COMPLETED"),
-            (JobState::Failed, "F", "FAILED"),
-            (JobState::Cancelled, "CA", "CANCELLED"),
-            (JobState::Timeout, "TO", "TIMEOUT"),
-            (JobState::NodeFail, "NF", "NODE_FAIL"),
-            (JobState::Preempted, "PR", "PREEMPTED"),
-            (JobState::Suspended, "S", "SUSPENDED"),
+        let expected: [(&str, &str); JobState::COUNT] = [
+            ("PD", "PENDING"),
+            ("R", "RUNNING"),
+            ("CG", "COMPLETING"),
+            ("CD", "COMPLETED"),
+            ("F", "FAILED"),
+            ("CA", "CANCELLED"),
+            ("TO", "TIMEOUT"),
+            ("NF", "NODE_FAIL"),
+            ("PR", "PREEMPTED"),
+            ("S", "SUSPENDED"),
         ];
-        for (state, code, name) in expected {
-            assert_eq!(state.code(), code, "code mismatch for {:?}", state);
-            assert_eq!(state.display(), name, "display mismatch for {:?}", state);
+        assert_eq!(JobState::ALL.len(), expected.len());
+        for (i, state) in JobState::ALL.iter().enumerate() {
+            let (code, name) = expected[i];
+            assert_eq!(state.code(), code, "code mismatch for {state:?}");
+            assert_eq!(state.display(), name, "display mismatch for {state:?}");
         }
     }
 
     #[test]
     fn t55_8_node_state_display_matches_slurm() {
         use spur_core::node::NodeState;
-        let expected = vec![
-            (NodeState::Idle, "idle"),
-            (NodeState::Allocated, "allocated"),
-            (NodeState::Mixed, "mixed"),
-            (NodeState::Down, "down"),
-            (NodeState::Drain, "drained"),
-            (NodeState::Draining, "draining"),
-            (NodeState::Error, "error"),
-            (NodeState::Unknown, "unknown"),
+        let expected: [&str; NodeState::COUNT] = [
+            "idle",
+            "allocated",
+            "mixed",
+            "down",
+            "drained",
+            "draining",
+            "error",
+            "unknown",
+            "suspended",
         ];
-        for (state, name) in expected {
-            assert_eq!(state.display(), name);
+        for (i, state) in NodeState::ALL.iter().enumerate() {
+            assert_eq!(
+                state.display(),
+                expected[i],
+                "display mismatch for {state:?}"
+            );
         }
     }
 
     #[test]
     fn t55_9_node_state_short_matches_slurm() {
         use spur_core::node::NodeState;
-        let expected = vec![
-            (NodeState::Idle, "idle"),
-            (NodeState::Allocated, "alloc"),
-            (NodeState::Mixed, "mix"),
-            (NodeState::Down, "down"),
-            (NodeState::Drain, "drain"),
-            (NodeState::Draining, "drng"),
+        let expected: [&str; NodeState::COUNT] = [
+            "idle", "alloc", "mix", "down", "drain", "drng", "err", "unk", "susp",
         ];
-        for (state, short) in expected {
-            assert_eq!(state.short(), short);
+        for (i, state) in NodeState::ALL.iter().enumerate() {
+            assert_eq!(state.short(), expected[i], "short mismatch for {state:?}");
         }
     }
 

--- a/crates/spurctld/src/accounting.rs
+++ b/crates/spurctld/src/accounting.rs
@@ -10,7 +10,7 @@ use spur_core::resource::ResourceSet;
 use spur_proto::proto::slurm_accounting_client::SlurmAccountingClient;
 use spur_proto::proto::{RecordJobEndRequest, RecordJobStartRequest};
 
-use crate::server::{datetime_to_proto, job_state_to_proto, resource_to_proto};
+use crate::server::{datetime_to_proto, resource_to_proto};
 
 pub struct AccountingNotifier {
     client: SlurmAccountingClient<Channel>,
@@ -61,7 +61,7 @@ impl AccountingNotifier {
     ) {
         let req = RecordJobEndRequest {
             job_id,
-            final_state: job_state_to_proto(state) as i32,
+            final_state: state.to_proto_i32(),
             exit_code,
             end_time: Some(datetime_to_proto(end_time)),
         };

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -169,7 +169,7 @@ impl SlurmController for ControllerService {
         let states: Vec<spur_core::job::JobState> = req
             .states
             .iter()
-            .filter_map(|s| proto_to_job_state(*s))
+            .filter_map(|s| spur_core::job::JobState::from_proto_i32(*s))
             .collect();
 
         let user = if req.user.is_empty() {
@@ -375,7 +375,7 @@ impl SlurmController for ControllerService {
 
         let req = request.into_inner();
         if let Some(state) = req.state {
-            let node_state = proto_to_node_state(state)
+            let node_state = spur_core::node::NodeState::from_proto_i32(state)
                 .ok_or_else(|| Status::invalid_argument("invalid node state"))?;
             self.cluster
                 .update_node_state(&req.name, node_state, req.reason)
@@ -517,7 +517,7 @@ impl SlurmController for ControllerService {
         }
 
         let req = request.into_inner();
-        let state = proto_to_job_state(req.state)
+        let state = spur_core::job::JobState::from_proto_i32(req.state)
             .ok_or_else(|| Status::invalid_argument("invalid job state"))?;
 
         if state.is_terminal() {
@@ -1164,37 +1164,6 @@ fn proto_to_job_spec(spec: JobSpec) -> Result<spur_core::job::JobSpec, Status> {
     })
 }
 
-fn proto_to_job_state(s: i32) -> Option<spur_core::job::JobState> {
-    match s {
-        0 => Some(spur_core::job::JobState::Pending),
-        1 => Some(spur_core::job::JobState::Running),
-        2 => Some(spur_core::job::JobState::Completing),
-        3 => Some(spur_core::job::JobState::Completed),
-        4 => Some(spur_core::job::JobState::Failed),
-        5 => Some(spur_core::job::JobState::Cancelled),
-        6 => Some(spur_core::job::JobState::Timeout),
-        7 => Some(spur_core::job::JobState::NodeFail),
-        8 => Some(spur_core::job::JobState::Preempted),
-        9 => Some(spur_core::job::JobState::Suspended),
-        _ => None,
-    }
-}
-
-fn proto_to_node_state(s: i32) -> Option<spur_core::node::NodeState> {
-    match s {
-        0 => Some(spur_core::node::NodeState::Idle),
-        1 => Some(spur_core::node::NodeState::Allocated),
-        2 => Some(spur_core::node::NodeState::Mixed),
-        3 => Some(spur_core::node::NodeState::Down),
-        4 => Some(spur_core::node::NodeState::Drain),
-        5 => Some(spur_core::node::NodeState::Draining),
-        6 => Some(spur_core::node::NodeState::Error),
-        7 => Some(spur_core::node::NodeState::Unknown),
-        8 => Some(spur_core::node::NodeState::Suspended),
-        _ => None,
-    }
-}
-
 fn proto_to_resource_set(r: spur_proto::proto::ResourceSet) -> spur_core::resource::ResourceSet {
     spur_core::resource::ResourceSet {
         cpus: r.cpus,
@@ -1228,7 +1197,7 @@ fn job_to_proto(job: &spur_core::job::Job) -> JobInfo {
         uid: job.spec.uid,
         partition: job.spec.partition.clone().unwrap_or_default(),
         account: job.spec.account.clone().unwrap_or_default(),
-        state: job_state_to_proto(job.state) as i32,
+        state: job.state.to_proto_i32(),
         state_reason: job.pending_reason.display().to_string(),
         submit_time: Some(datetime_to_proto(job.submit_time)),
         start_time: job.start_time.map(datetime_to_proto),
@@ -1275,7 +1244,7 @@ fn job_to_proto(job: &spur_core::job::Job) -> JobInfo {
 fn node_to_proto(node: &spur_core::node::Node) -> NodeInfo {
     NodeInfo {
         name: node.name.clone(),
-        state: node_state_to_proto(node.state) as i32,
+        state: node.state.to_proto_i32(),
         state_reason: node.state_reason.clone().unwrap_or_default(),
         partition: node.partitions.first().cloned().unwrap_or_default(),
         total_resources: Some(resource_to_proto(&node.total_resources)),
@@ -1348,35 +1317,6 @@ pub(crate) fn resource_to_proto(
             })
             .collect(),
         generic: r.generic.clone(),
-    }
-}
-
-pub(crate) fn job_state_to_proto(s: spur_core::job::JobState) -> spur_proto::proto::JobState {
-    match s {
-        spur_core::job::JobState::Pending => spur_proto::proto::JobState::JobPending,
-        spur_core::job::JobState::Running => spur_proto::proto::JobState::JobRunning,
-        spur_core::job::JobState::Completing => spur_proto::proto::JobState::JobCompleting,
-        spur_core::job::JobState::Completed => spur_proto::proto::JobState::JobCompleted,
-        spur_core::job::JobState::Failed => spur_proto::proto::JobState::JobFailed,
-        spur_core::job::JobState::Cancelled => spur_proto::proto::JobState::JobCancelled,
-        spur_core::job::JobState::Timeout => spur_proto::proto::JobState::JobTimeout,
-        spur_core::job::JobState::NodeFail => spur_proto::proto::JobState::JobNodeFail,
-        spur_core::job::JobState::Preempted => spur_proto::proto::JobState::JobPreempted,
-        spur_core::job::JobState::Suspended => spur_proto::proto::JobState::JobSuspended,
-    }
-}
-
-fn node_state_to_proto(s: spur_core::node::NodeState) -> spur_proto::proto::NodeState {
-    match s {
-        spur_core::node::NodeState::Idle => spur_proto::proto::NodeState::NodeIdle,
-        spur_core::node::NodeState::Allocated => spur_proto::proto::NodeState::NodeAllocated,
-        spur_core::node::NodeState::Mixed => spur_proto::proto::NodeState::NodeMixed,
-        spur_core::node::NodeState::Down => spur_proto::proto::NodeState::NodeDown,
-        spur_core::node::NodeState::Drain => spur_proto::proto::NodeState::NodeDrain,
-        spur_core::node::NodeState::Draining => spur_proto::proto::NodeState::NodeDraining,
-        spur_core::node::NodeState::Error => spur_proto::proto::NodeState::NodeError,
-        spur_core::node::NodeState::Unknown => spur_proto::proto::NodeState::NodeUnknown,
-        spur_core::node::NodeState::Suspended => spur_proto::proto::NodeState::NodeSuspended,
     }
 }
 

--- a/crates/spurrestd/src/routes.rs
+++ b/crates/spurrestd/src/routes.rs
@@ -78,8 +78,19 @@ impl<T: Serialize> ApiResponse<T> {
 }
 
 fn error_response(msg: &str) -> (StatusCode, Json<ApiResponse<serde_json::Value>>) {
+    api_error_response(StatusCode::INTERNAL_SERVER_ERROR, msg)
+}
+
+fn bad_request_response(msg: &str) -> (StatusCode, Json<ApiResponse<serde_json::Value>>) {
+    api_error_response(StatusCode::BAD_REQUEST, msg)
+}
+
+fn api_error_response(
+    status: StatusCode,
+    msg: &str,
+) -> (StatusCode, Json<ApiResponse<serde_json::Value>>) {
     (
-        StatusCode::INTERNAL_SERVER_ERROR,
+        status,
         Json(ApiResponse {
             meta: meta(),
             errors: vec![ApiError {
@@ -161,13 +172,10 @@ async fn get_jobs(
         .await
         .map_err(|e| error_response(&format!("connection failed: {}", e)))?;
 
-    let states: Vec<i32> = query
-        .state
-        .iter()
-        .flat_map(|s| s.split(','))
-        .filter_map(|s| parse_job_state(s.trim()))
-        .map(|s| s as i32)
-        .collect();
+    let states: Vec<i32> = match query.state.as_deref() {
+        Some(s) => parse_states_query(s).map_err(|e| bad_request_response(&e))?,
+        None => Vec::new(),
+    };
 
     let resp = client
         .get_jobs(spur_proto::proto::GetJobsRequest {
@@ -440,47 +448,62 @@ fn partition_info_to_json(p: &spur_proto::proto::PartitionInfo) -> serde_json::V
 }
 
 fn state_name(state: i32) -> &'static str {
-    match state {
-        0 => "PENDING",
-        1 => "RUNNING",
-        2 => "COMPLETING",
-        3 => "COMPLETED",
-        4 => "FAILED",
-        5 => "CANCELLED",
-        6 => "TIMEOUT",
-        7 => "NODE_FAIL",
-        8 => "PREEMPTED",
-        9 => "SUSPENDED",
-        _ => "UNKNOWN",
-    }
+    spur_core::job::JobState::from_proto_i32(state)
+        .map(|s| s.display())
+        .unwrap_or("UNKNOWN")
 }
 
 fn node_state_name(state: i32) -> &'static str {
-    match state {
-        0 => "idle",
-        1 => "allocated",
-        2 => "mixed",
-        3 => "down",
-        4 => "drained",
-        5 => "draining",
-        6 => "error",
-        _ => "unknown",
-    }
+    spur_core::node::NodeState::from_proto_i32(state)
+        .map(|s| s.display())
+        .unwrap_or("unknown")
 }
 
-fn parse_job_state(s: &str) -> Option<spur_proto::proto::JobState> {
-    use spur_proto::proto::JobState;
-    match s.to_uppercase().as_str() {
-        "PD" | "PENDING" => Some(JobState::JobPending),
-        "R" | "RUNNING" => Some(JobState::JobRunning),
-        "CG" | "COMPLETING" => Some(JobState::JobCompleting),
-        "CD" | "COMPLETED" => Some(JobState::JobCompleted),
-        "F" | "FAILED" => Some(JobState::JobFailed),
-        "CA" | "CANCELLED" => Some(JobState::JobCancelled),
-        "TO" | "TIMEOUT" => Some(JobState::JobTimeout),
-        "NF" | "NODE_FAIL" => Some(JobState::JobNodeFail),
-        "PR" | "PREEMPTED" => Some(JobState::JobPreempted),
-        "S" | "SUSPENDED" => Some(JobState::JobSuspended),
-        _ => None,
+fn parse_states_query(s: &str) -> Result<Vec<i32>, String> {
+    use spur_core::job::JobState;
+
+    let trimmed = s.trim();
+    if trimmed.eq_ignore_ascii_case("all") {
+        return Ok(Vec::new());
+    }
+
+    let tokens: Vec<&str> = trimmed
+        .split(',')
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .collect();
+
+    if tokens.is_empty() {
+        return Err("Invalid job state specified: (empty)".into());
+    }
+
+    let mut states = Vec::with_capacity(tokens.len());
+    for token in tokens {
+        let core = JobState::from_code_or_name(token)
+            .ok_or_else(|| format!("Invalid job state specified: {token}"))?;
+        states.push(core.to_proto_i32());
+    }
+    Ok(states)
+}
+
+#[cfg(test)]
+mod state_filter_tests {
+    use super::*;
+
+    #[test]
+    fn parse_states_query_accepts_valid_tokens() {
+        let states = parse_states_query("RUNNING,PD").unwrap();
+        assert_eq!(states.len(), 2);
+    }
+
+    #[test]
+    fn parse_states_query_rejects_unknown() {
+        assert!(parse_states_query("BOGUS").is_err());
+        assert!(parse_states_query("R,BOGUS").is_err());
+    }
+
+    #[test]
+    fn parse_states_query_all_means_no_filter() {
+        assert!(parse_states_query("all").unwrap().is_empty());
     }
 }


### PR DESCRIPTION
## Summary

This PR centralizes job and node state handling in spur-core with `ALL`, `COUNT`, and proto-backed conversion (`from_proto`, `to_proto`, `from_proto_i32`, `from_code_or_name`), then removes duplicate i32 match tables across spurctld, spur-cli, spurrestd, and spur-k8s. Invalid `squeue -t` and REST `state=` tokens are rejected before `GetJobs` (Slurm-aligned) instead of silently widening to all jobs. Redundant state/proto unit tests are removed where coverage already exists in spur-core and `t55_*`.

## Changes

- **spur-core**: `JobState` / `NodeState` `ALL`, `COUNT`, proto conversion helpers, discriminants/roundtrip/unknown-wire tests
- **spurctld**: drop local state conversion shims; use core `from_proto_i32` / `to_proto_i32`
- **spur-cli**: use core `code()` / `display()` / `display_upper()` / `short()` / `from_proto_i32`; validate `squeue -t`
- **spurrestd**: same mapping; HTTP 400 on invalid `state=` query
- **spur-k8s**: `proto_job_state_to_string` via `JobState::from_proto_i32`
- **spur-tests**: dedupe overlapping state display tests (`t50_*` trims, `t55` tables kept)

## Follow-ups (out of scope)

- `scancel -t` / `sacct --state` still use silent `filter_map` on state tokens
- Metrics PR (`pr-212`) should rebase after merge and use `JobState::COUNT` / `ALL` instead of `JOB_STATE_COUNT` / `job_state_index()`