### PR TITLE
fix(spur-metrics): inherit publish=false for cargo-deny wildcard check

### DIFF
--- a/crates/spur-metrics/Cargo.toml
+++ b/crates/spur-metrics/Cargo.toml
@@ -3,6 +3,7 @@ name = "spur-metrics"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+publish.workspace = true
 repository.workspace = true
 
 [dependencies]


### PR DESCRIPTION
## Summary

`spur-metrics` was missing `publish.workspace = true`, so cargo-deny treated it as a publishable crate and failed on the unversioned path dependency on `spur-core`. Inheriting the workspace `publish = false` setting matches every other internal crate and fixes the CI `deny` job.

## Test plan

- [x] `cargo deny check`