### PR TITLE
chore(deny): remove unused license allowances

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -22,11 +22,6 @@ allow = [
     "CDLA-Permissive-2.0",
 ]
 
-[[licenses.clarify]]
-name = "ring"
-expression = "MIT AND ISC AND OpenSSL"
-license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
-
 [bans]
 multiple-versions = "warn"
 wildcards = "deny"

--- a/deny.toml
+++ b/deny.toml
@@ -9,7 +9,6 @@ confidence-threshold = 0.8
 
 allow = [
     "MIT",
-    "MIT-0",
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
@@ -17,13 +16,9 @@ allow = [
     "0BSD",
     "ISC",
     "Unicode-3.0",
-    "Unicode-DFS-2016",
     "Zlib",
     "BSL-1.0",
-    "CC0-1.0",
     "Unlicense",
-    "MPL-2.0",
-    "OpenSSL",
     "CDLA-Permissive-2.0",
 ]
 


### PR DESCRIPTION
## Summary
- Remove 5 license entries from `deny.toml` that are not present in the dependency tree: `MIT-0`, `Unicode-DFS-2016`, `CC0-1.0`, `MPL-2.0`, `OpenSSL`
- Eliminates all "license-not-encountered" warnings from `cargo deny check licenses`

## Test plan
- [x] `cargo deny check licenses` passes with zero warnings
- [x] `cargo deny check` passes (remaining warnings are pre-existing duplicate-version warnings from transitive deps)