### PR TITLE
feat(spur): add Completing (CG) job state with per-node completion

### DIFF
--- a/crates/spur-cli/src/squeue.rs
+++ b/crates/spur-cli/src/squeue.rs
@@ -75,13 +75,10 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
 
     let fields = format_engine::parse_format(&fmt, &format_engine::squeue_header);
 
-    // Parse state filter — default to Pending+Running when no filter specified (Slurm default)
+    // Parse state filter — default to Pending+Running+Completing when no filter specified (Slurm default)
     let states = match args.states.as_deref() {
         Some(s) => parse_states_arg(s)?,
-        None => vec![
-            spur_proto::proto::JobState::JobPending,
-            spur_proto::proto::JobState::JobRunning,
-        ],
+        None => default_squeue_states(),
     };
 
     // Parse job ID filter
@@ -172,6 +169,15 @@ fn state_name(state: i32) -> String {
         .unwrap_or_else(|| "UNKNOWN".into())
 }
 
+/// Default `squeue` states when `-t` is omitted: PD, R, CG (Slurm parity).
+fn default_squeue_states() -> Vec<spur_proto::proto::JobState> {
+    vec![
+        spur_proto::proto::JobState::JobPending,
+        spur_proto::proto::JobState::JobRunning,
+        spur_proto::proto::JobState::JobCompleting,
+    ]
+}
+
 /// Parse `-t` / `--states` (comma-separated). Whole-string `all` means no state filter.
 /// Unknown tokens are rejected (Slurm exits with an error rather than showing all jobs).
 fn parse_states_arg(s: &str) -> Result<Vec<spur_proto::proto::JobState>> {
@@ -248,6 +254,15 @@ fn format_timestamp(ts: Option<&prost_types::Timestamp>) -> String {
 mod tests {
     use super::*;
     use spur_proto::proto::JobState as P;
+
+    #[test]
+    fn default_squeue_states_includes_completing() {
+        let states = default_squeue_states();
+        assert_eq!(states.len(), 3);
+        assert!(states.contains(&P::JobPending));
+        assert!(states.contains(&P::JobRunning));
+        assert!(states.contains(&P::JobCompleting));
+    }
 
     #[test]
     fn parse_states_arg_accepts_codes_and_names() {

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -369,6 +369,9 @@ pub struct SchedulerConfig {
     /// Default job time limit (minutes), if not set per-partition.
     #[serde(default = "default_time_limit")]
     pub default_time_limit_minutes: u32,
+    /// Max seconds to wait in COMPLETING before force-finishing the job.
+    #[serde(default = "default_complete_wait")]
+    pub complete_wait_secs: u32,
 }
 
 fn default_scheduler_plugin() -> String {
@@ -383,6 +386,9 @@ fn default_halflife() -> u32 {
 fn default_time_limit() -> u32 {
     60
 }
+fn default_complete_wait() -> u32 {
+    300
+}
 
 impl Default for SchedulerConfig {
     fn default() -> Self {
@@ -392,6 +398,7 @@ impl Default for SchedulerConfig {
             max_jobs_per_cycle: 10000,
             fairshare_halflife_days: 14,
             default_time_limit_minutes: 60,
+            complete_wait_secs: 300,
         }
     }
 }

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -71,6 +71,40 @@ impl JobState {
         matches!(self, Self::Running | Self::Completing | Self::Suspended)
     }
 
+    /// Per-node completion state implied by one exit code.
+    pub fn completion_state_for_exit_code(exit_code: i32) -> Self {
+        if exit_code == 0 {
+            Self::Completed
+        } else {
+            Self::Failed
+        }
+    }
+
+    /// Validate `ReportJobStatusRequest` terminal state against exit_code.
+    pub fn validate_completion_report_state(
+        reported: Self,
+        exit_code: i32,
+    ) -> Result<(), CompletionReportStateError> {
+        match reported {
+            Self::Completed | Self::Failed => {
+                let expected = Self::completion_state_for_exit_code(exit_code);
+                if reported == expected {
+                    Ok(())
+                } else {
+                    Err(CompletionReportStateError::InvalidStateForExitCode {
+                        reported,
+                        exit_code,
+                        expected,
+                    })
+                }
+            }
+            _ if reported.is_terminal() => {
+                Err(CompletionReportStateError::InvalidCompletionState { reported })
+            }
+            _ => Ok(()),
+        }
+    }
+
     /// Every core variant, in proto discriminant order for iteration only.
     pub const ALL: [JobState; 10] = [
         Self::Pending,
@@ -404,6 +438,10 @@ pub struct Job {
     /// Component index within a heterogeneous job group (0 = first).
     #[serde(default)]
     pub het_group: Option<u32>,
+
+    /// Per-node exit codes reported while the job is in Completing.
+    #[serde(default)]
+    pub node_completions: HashMap<String, i32>,
 }
 
 impl Job {
@@ -438,7 +476,25 @@ impl Job {
             requeue_count: 0,
             het_job_id: None,
             het_group: None,
+            node_completions: HashMap::new(),
         }
+    }
+
+    /// Derive final job state and exit code from per-node completion reports.
+    pub fn derived_completion(node_completions: &HashMap<String, i32>) -> (JobState, i32) {
+        let exit_code = node_completions
+            .values()
+            .copied()
+            .filter(|c| *c != 0)
+            .max()
+            .unwrap_or(0);
+        let state = JobState::completion_state_for_exit_code(exit_code);
+        (state, exit_code)
+    }
+
+    pub fn all_nodes_completed(&self) -> bool {
+        !self.allocated_nodes.is_empty()
+            && self.node_completions.len() == self.allocated_nodes.len()
     }
 
     /// Compute the run time.
@@ -485,6 +541,47 @@ pub enum JobTransitionError {
     Invalid { from: JobState, to: JobState },
 }
 
+/// Errors from validating completion reports from agents/operators.
+#[derive(Debug, Error)]
+pub enum CompletionReportStateError {
+    #[error("invalid completion state {reported}; only COMPLETED or FAILED are accepted for completion reports")]
+    InvalidCompletionState { reported: JobState },
+
+    #[error(
+        "completion state {reported} does not match exit_code {exit_code}; expected {expected}"
+    )]
+    InvalidStateForExitCode {
+        reported: JobState,
+        exit_code: i32,
+        expected: JobState,
+    },
+}
+
+/// Errors from recording a per-node job completion report.
+#[derive(Debug, Error)]
+pub enum NodeCompleteError {
+    #[error("job {job_id} not found")]
+    JobNotFound { job_id: JobId },
+
+    #[error("node {node} is not allocated to job {job_id}")]
+    NodeNotAllocated { job_id: JobId, node: String },
+
+    #[error("raft propose failed: {source}")]
+    RaftPropose {
+        #[source]
+        source: anyhow::Error,
+    },
+}
+
+impl NodeCompleteError {
+    pub fn retryable(&self) -> bool {
+        match self {
+            Self::JobNotFound { .. } | Self::NodeNotAllocated { .. } => false,
+            Self::RaftPropose { .. } => true,
+        }
+    }
+}
+
 impl Job {
     /// Attempt a state transition, enforcing the state machine.
     pub fn transition(&mut self, to: JobState) -> Result<(), JobTransitionError> {
@@ -501,6 +598,7 @@ impl Job {
             (JobState::Running, JobState::Suspended) => true,
             (JobState::Completing, JobState::Completed) => true,
             (JobState::Completing, JobState::Failed) => true,
+            (JobState::Completing, JobState::Cancelled) => true,
             (JobState::Suspended, JobState::Running) => true,
             (JobState::Suspended, JobState::Cancelled) => true,
             // Requeue transitions: terminal → Pending (for --requeue jobs)
@@ -556,6 +654,91 @@ mod tests {
 
         job.transition(JobState::Completed).unwrap();
         assert_eq!(job.state, JobState::Completed);
+        assert!(job.end_time.is_some());
+    }
+
+    #[test]
+    fn derived_completion_uses_worst_exit_code() {
+        let mut completions = HashMap::new();
+        completions.insert("n1".into(), 0);
+        completions.insert("n2".into(), 42);
+        let (state, code) = Job::derived_completion(&completions);
+        assert_eq!(state, JobState::Failed);
+        assert_eq!(code, 42);
+
+        completions.insert("n2".into(), 0);
+        let (state, code) = Job::derived_completion(&completions);
+        assert_eq!(state, JobState::Completed);
+        assert_eq!(code, 0);
+    }
+
+    #[test]
+    fn completion_state_for_exit_code_maps_expected_states() {
+        assert_eq!(
+            JobState::completion_state_for_exit_code(0),
+            JobState::Completed
+        );
+        assert_eq!(
+            JobState::completion_state_for_exit_code(42),
+            JobState::Failed
+        );
+        assert_eq!(
+            JobState::completion_state_for_exit_code(-1),
+            JobState::Failed
+        );
+    }
+
+    #[test]
+    fn validate_completion_report_state_accepts_aligned_pairs() {
+        assert!(JobState::validate_completion_report_state(JobState::Completed, 0).is_ok());
+        assert!(JobState::validate_completion_report_state(JobState::Failed, 7).is_ok());
+    }
+
+    #[test]
+    fn validate_completion_report_state_rejects_mismatch() {
+        let err = JobState::validate_completion_report_state(JobState::Completed, 9).unwrap_err();
+        assert!(matches!(
+            err,
+            CompletionReportStateError::InvalidStateForExitCode {
+                reported: JobState::Completed,
+                exit_code: 9,
+                expected: JobState::Failed
+            }
+        ));
+    }
+
+    #[test]
+    fn validate_completion_report_state_rejects_other_terminal_states() {
+        let err = JobState::validate_completion_report_state(JobState::Cancelled, 0).unwrap_err();
+        assert!(matches!(
+            err,
+            CompletionReportStateError::InvalidCompletionState {
+                reported: JobState::Cancelled
+            }
+        ));
+    }
+
+    #[test]
+    fn node_complete_error_retryable() {
+        assert!(!NodeCompleteError::JobNotFound { job_id: 1 }.retryable());
+        assert!(!NodeCompleteError::NodeNotAllocated {
+            job_id: 1,
+            node: "n1".into(),
+        }
+        .retryable());
+        assert!(NodeCompleteError::RaftPropose {
+            source: anyhow::anyhow!("test"),
+        }
+        .retryable());
+    }
+
+    #[test]
+    fn completing_to_cancelled() {
+        let mut job = make_job();
+        job.transition(JobState::Running).unwrap();
+        job.transition(JobState::Completing).unwrap();
+        job.transition(JobState::Cancelled).unwrap();
+        assert_eq!(job.state, JobState::Cancelled);
         assert!(job.end_time.is_some());
     }
 

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -80,7 +80,9 @@ impl JobState {
         }
     }
 
-    /// Validate `ReportJobStatusRequest` terminal state against exit_code.
+    /// Validate `ReportJobStatusRequest.state` for per-node completion reports.
+    ///
+    /// Only `Completed` and `Failed` are valid; state must match `exit_code`.
     pub fn validate_completion_report_state(
         reported: Self,
         exit_code: i32,
@@ -98,10 +100,7 @@ impl JobState {
                     })
                 }
             }
-            _ if reported.is_terminal() => {
-                Err(CompletionReportStateError::InvalidCompletionState { reported })
-            }
-            _ => Ok(()),
+            _ => Err(CompletionReportStateError::InvalidCompletionState { reported }),
         }
     }
 
@@ -714,6 +713,28 @@ mod tests {
             err,
             CompletionReportStateError::InvalidCompletionState {
                 reported: JobState::Cancelled
+            }
+        ));
+    }
+
+    #[test]
+    fn validate_completion_report_state_rejects_completing() {
+        let err = JobState::validate_completion_report_state(JobState::Completing, 0).unwrap_err();
+        assert!(matches!(
+            err,
+            CompletionReportStateError::InvalidCompletionState {
+                reported: JobState::Completing
+            }
+        ));
+    }
+
+    #[test]
+    fn validate_completion_report_state_rejects_running() {
+        let err = JobState::validate_completion_report_state(JobState::Running, 0).unwrap_err();
+        assert!(matches!(
+            err,
+            CompletionReportStateError::InvalidCompletionState {
+                reported: JobState::Running
             }
         ));
     }

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -34,6 +34,11 @@ pub enum WalOperation {
         exit_code: i32,
         state: JobState,
     },
+    JobNodeComplete {
+        job_id: JobId,
+        node_name: String,
+        exit_code: i32,
+    },
     JobPriorityChange {
         job_id: JobId,
         old_priority: u32,

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -440,19 +440,6 @@ async fn watch_pods(ctx: Arc<JobControllerCtx>) -> anyhow::Result<()> {
             };
 
             if should_report {
-                let final_state = {
-                    let tracker = ctx.pod_tracker.lock().await;
-                    if let Some(t) = tracker.get(&job_id) {
-                        if t.failed {
-                            4 // JOB_FAILED
-                        } else {
-                            state
-                        }
-                    } else {
-                        state
-                    }
-                };
-
                 let final_exit_code = {
                     let tracker = ctx.pod_tracker.lock().await;
                     tracker
@@ -462,8 +449,8 @@ async fn watch_pods(ctx: Arc<JobControllerCtx>) -> anyhow::Result<()> {
                 };
 
                 let final_message = {
-                    let mut tracker = ctx.pod_tracker.lock().await;
-                    let msg = tracker
+                    let tracker = ctx.pod_tracker.lock().await;
+                    tracker
                         .get(&job_id)
                         .map(|t| {
                             if t.failed && !t.message.is_empty() {
@@ -472,34 +459,78 @@ async fn watch_pods(ctx: Arc<JobControllerCtx>) -> anyhow::Result<()> {
                                 format!("Pod {} {}", pod_name, phase)
                             }
                         })
-                        .unwrap_or_else(|| format!("Pod {} {}", pod_name, phase));
-                    // Clean up tracker for terminal jobs
-                    if final_state == 3 || final_state == 4 {
-                        tracker.remove(&job_id);
-                    }
-                    msg
+                        .unwrap_or_else(|| format!("Pod {} {}", pod_name, phase))
                 };
+
+                let spec_node_set = pod
+                    .spec
+                    .as_ref()
+                    .and_then(|s| s.node_name.as_ref())
+                    .is_some_and(|n| !n.is_empty());
+
+                let Some(reporting_node) = resolve_reporting_node(&pod) else {
+                    error!(
+                        job_id,
+                        pod = %pod_name,
+                        phase,
+                        "cannot resolve reporting_node (spec.nodeName and spur.ai/target-node both missing)"
+                    );
+                    continue;
+                };
+
+                if !spec_node_set {
+                    warn!(
+                        job_id,
+                        pod = %pod_name,
+                        phase,
+                        node = %reporting_node,
+                        "spec.nodeName empty; using spur.ai/target-node label for reporting_node"
+                    );
+                }
 
                 info!(job_id, pod = %pod_name, phase, "reporting Pod completion to spurctld");
 
                 let mut ctrl = ctx.ctrl_client.lock().await;
+                let report_state =
+                    spur_core::job::JobState::completion_state_for_exit_code(final_exit_code);
                 let req = ReportJobStatusRequest {
                     job_id,
-                    state: final_state,
+                    state: report_state.to_proto_i32(),
                     exit_code: final_exit_code,
                     message: final_message,
                     drain_node: false,
                     drain_reason: String::new(),
-                    reporting_node: String::new(),
+                    reporting_node,
                 };
                 if let Err(e) = ctrl.report_job_status(req).await {
                     error!(job_id, error = %e, "failed to report job status");
+                } else if report_state.is_terminal() {
+                    ctx.pod_tracker.lock().await.remove(&job_id);
                 }
             }
         }
     }
 
     Ok(())
+}
+
+const TARGET_NODE_LABEL: &str = "spur.ai/target-node";
+
+/// Resolve the Spur node name for a terminal Pod completion report.
+fn resolve_reporting_node(pod: &Pod) -> Option<String> {
+    pod.spec
+        .as_ref()
+        .and_then(|s| s.node_name.as_ref())
+        .filter(|n| !n.is_empty())
+        .cloned()
+        .or_else(|| {
+            pod.metadata
+                .labels
+                .as_ref()
+                .and_then(|l| l.get(TARGET_NODE_LABEL))
+                .filter(|n| !n.is_empty())
+                .cloned()
+        })
 }
 
 /// Extract failure details from a Failed pod's container statuses.
@@ -813,6 +844,55 @@ mod tests {
         assert!(!is_terminal("Suspended"));
         assert!(!is_terminal("Unknown"));
         assert!(!is_terminal(""));
+    }
+
+    // --- resolve_reporting_node ---
+
+    fn pod_with_node_and_label(spec_node: Option<&str>, label_node: Option<&str>) -> Pod {
+        use k8s_openapi::api::core::v1::PodSpec;
+        let mut labels = BTreeMap::new();
+        if let Some(n) = label_node {
+            labels.insert(TARGET_NODE_LABEL.to_string(), n.to_string());
+        }
+        Pod {
+            metadata: kube::api::ObjectMeta {
+                labels: if labels.is_empty() {
+                    None
+                } else {
+                    Some(labels)
+                },
+                ..Default::default()
+            },
+            spec: spec_node.map(|node_name| PodSpec {
+                node_name: Some(node_name.to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn resolve_reporting_node_prefers_spec_node_name() {
+        let pod = pod_with_node_and_label(Some("worker1"), Some("worker2"));
+        assert_eq!(resolve_reporting_node(&pod), Some("worker1".into()));
+    }
+
+    #[test]
+    fn resolve_reporting_node_falls_back_to_target_node_label() {
+        let pod = pod_with_node_and_label(None, Some("worker2"));
+        assert_eq!(resolve_reporting_node(&pod), Some("worker2".into()));
+    }
+
+    #[test]
+    fn resolve_reporting_node_returns_none_when_both_missing() {
+        let pod = pod_with_node_and_label(None, None);
+        assert_eq!(resolve_reporting_node(&pod), None);
+    }
+
+    #[test]
+    fn resolve_reporting_node_ignores_empty_strings() {
+        let pod = pod_with_node_and_label(Some(""), Some("worker2"));
+        assert_eq!(resolve_reporting_node(&pod), Some("worker2".into()));
     }
 
     // --- extract_failure_details ---

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -12,7 +12,7 @@ use tracing::{debug, info, warn};
 
 use spur_core::accounting::{Qos, TresRecord, TresType};
 use spur_core::config::SlurmConfig;
-use spur_core::job::{Job, JobId, JobSpec, JobState, PendingReason};
+use spur_core::job::{Job, JobId, JobSpec, JobState, NodeCompleteError, PendingReason};
 use spur_core::node::{Node, NodeEvent, NodeSource, NodeState};
 use spur_core::partition::Partition;
 use spur_core::qos::{check_qos_limits, QosCheckResult};
@@ -24,7 +24,18 @@ use spur_metrics::job::JobMetricsSnapshot;
 
 use crate::accounting::AccountingNotifier;
 use crate::fairshare_cache::FairshareCache;
-use crate::raft::{SpurRaft, StateMachineApply};
+use crate::raft::{ClientResponse, JobFinalized, SpurRaft, StateMachineApply};
+
+/// Result of recording a per-node completion report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NodeCompleteResult {
+    /// Node recorded; waiting for remaining nodes.
+    Completing,
+    /// All allocated nodes have reported; job is now terminal.
+    AllDone { state: JobState, exit_code: i32 },
+    /// Job was already in a terminal state (duplicate or race with cancel/timeout).
+    AlreadyTerminal,
+}
 
 /// Central cluster state manager.
 ///
@@ -231,11 +242,14 @@ impl ClusterManager {
         // Use JobComplete (not JobStateChange) so that resource deallocation
         // fires for any allocated nodes. For pending jobs, allocated_nodes is empty
         // so the deallocation loop is a no-op.
-        self.propose(WalOperation::JobComplete {
+        let resp = self.propose(WalOperation::JobComplete {
             job_id,
             exit_code: -1,
             state: JobState::Cancelled,
         })?;
+        if let Some(f) = resp.job_finalized {
+            self.run_job_finalized_side_effects(f);
+        }
 
         info!(job_id, "job cancelled");
         Ok(())
@@ -326,7 +340,49 @@ impl ClusterManager {
         Ok(())
     }
 
-    /// Complete a job.
+    /// Record completion from one allocated node (multi-node COMPLETING flow).
+    pub fn node_complete(
+        &self,
+        job_id: JobId,
+        node_name: &str,
+        exit_code: i32,
+    ) -> Result<NodeCompleteResult, NodeCompleteError> {
+        {
+            let jobs = self.jobs.read();
+            let job = jobs
+                .get(&job_id)
+                .ok_or(NodeCompleteError::JobNotFound { job_id })?;
+            if job.state.is_terminal() {
+                return Ok(NodeCompleteResult::AlreadyTerminal);
+            }
+            if !job.allocated_nodes.iter().any(|n| n == node_name) {
+                return Err(NodeCompleteError::NodeNotAllocated {
+                    job_id,
+                    node: node_name.to_string(),
+                });
+            }
+        }
+
+        let resp = self
+            .propose(WalOperation::JobNodeComplete {
+                job_id,
+                node_name: node_name.to_string(),
+                exit_code,
+            })
+            .map_err(|source| NodeCompleteError::RaftPropose { source })?;
+
+        if let Some(f) = resp.job_finalized {
+            self.run_job_finalized_side_effects(f);
+            return Ok(NodeCompleteResult::AllDone {
+                state: f.state,
+                exit_code: f.exit_code,
+            });
+        }
+
+        Ok(NodeCompleteResult::Completing)
+    }
+
+    /// Complete a job (controller-initiated or force-finish from COMPLETING timeout).
     pub fn complete_job(
         &self,
         job_id: JobId,
@@ -346,13 +402,61 @@ impl ClusterManager {
 
         // propose() handles: state transition, exit_code, end_time,
         // resource deallocation, step completion, license return
-        self.propose(WalOperation::JobComplete {
+        let resp = self.propose(WalOperation::JobComplete {
             job_id,
             exit_code,
             state,
         })?;
+        if let Some(f) = resp.job_finalized {
+            self.run_job_finalized_side_effects(f);
+        }
 
-        // Notifications (side effects, not replicated)
+        debug!(job_id, exit_code, "job completed");
+        Ok(())
+    }
+
+    fn run_job_finalized_side_effects(&self, finalized: JobFinalized) {
+        self.run_epilog_slurmctld(finalized.job_id);
+        self.notify_job_finished(finalized.job_id, finalized.state, finalized.exit_code);
+    }
+
+    fn run_epilog_slurmctld(&self, job_id: JobId) {
+        let Some(epilog_ctld) = self.config.hooks.epilog_slurmctld.clone() else {
+            return;
+        };
+        let job = self.get_job(job_id);
+        let ctx = spur_core::hooks::HookContext {
+            job_id,
+            work_dir: job
+                .as_ref()
+                .map(|j| j.spec.work_dir.clone())
+                .unwrap_or_else(|| "/tmp".into()),
+            uid: job.as_ref().map(|j| j.spec.uid).unwrap_or(0),
+            gid: job.as_ref().map(|j| j.spec.gid).unwrap_or(0),
+            partition: job
+                .as_ref()
+                .and_then(|j| j.spec.partition.clone())
+                .unwrap_or_default(),
+            nodelist: job
+                .as_ref()
+                .map(|j| j.allocated_nodes.join(","))
+                .unwrap_or_default(),
+            script_context: "epilog_slurmctld".into(),
+            gpu_devices: Vec::new(),
+            cpus: job.as_ref().map(|j| j.spec.cpus_per_task).unwrap_or(1),
+            memory_mb: job
+                .as_ref()
+                .and_then(|j| j.spec.memory_per_node_mb)
+                .unwrap_or(0),
+        };
+        tokio::spawn(async move {
+            if let Err(e) = spur_core::hooks::run_hook(&epilog_ctld, &ctx).await {
+                warn!(job_id, error = %e, "EpilogSlurmctld failed");
+            }
+        });
+    }
+
+    fn notify_job_finished(&self, job_id: JobId, state: JobState, exit_code: i32) {
         let spec_for_notify = self.jobs.read().get(&job_id).map(|j| j.spec.clone());
         if let Some(spec) = spec_for_notify {
             let is_success = state == JobState::Completed;
@@ -377,11 +481,10 @@ impl ClusterManager {
             JobState::Timeout | JobState::Preempted | JobState::NodeFail
         );
         if should_requeue {
-            self.maybe_requeue(job_id)?;
+            if let Err(e) = self.maybe_requeue(job_id) {
+                warn!(job_id, error = %e, "failed to requeue job");
+            }
         }
-
-        debug!(job_id, exit_code, "job completed");
-        Ok(())
     }
 
     /// Requeue a job if spec.requeue is set and attempt limit not exceeded.
@@ -1278,7 +1381,40 @@ impl ClusterManager {
     /// (`StateMachineApply`) handles in-memory state on all nodes.
     // openraft's RaftError exceeds clippy's 128-byte threshold in the intermediate Result
     #[allow(clippy::result_large_err)]
-    fn propose(&self, op: WalOperation) -> anyhow::Result<()> {
+    fn complete_job_steps_and_licenses(
+        &self,
+        job_id: &JobId,
+        exit_code: i32,
+        timestamp: DateTime<Utc>,
+    ) {
+        let mut steps = self.steps.write();
+        for step in steps.values_mut() {
+            if step.job_id == *job_id && !step.state.is_terminal() {
+                step.state = if exit_code == 0 {
+                    StepState::Completed
+                } else {
+                    StepState::Failed
+                };
+                step.exit_code = Some(exit_code);
+                step.end_time = Some(timestamp);
+            }
+        }
+        drop(steps);
+
+        let lic_req = if let Some(job) = self.jobs.read().get(job_id) {
+            extract_license_requirements(&job.spec)
+        } else {
+            HashMap::new()
+        };
+        if !lic_req.is_empty() {
+            let mut pool = self.license_pool.write();
+            for (lic, count) in &lic_req {
+                *pool.entry(lic.clone()).or_insert(0) += count;
+            }
+        }
+    }
+
+    fn propose(&self, op: WalOperation) -> anyhow::Result<ClientResponse> {
         let raft = self
             .raft
             .read()
@@ -1287,13 +1423,14 @@ impl ClusterManager {
         tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async { raft.client_write(op).await })
         })
-        .map(|_| ())
+        .map(|res| res.data)
         .map_err(|e| anyhow::anyhow!("raft propose failed: {}", e))
     }
 
     /// Apply a WalOperation to in-memory state.
     /// Called by Raft's `apply_to_state_machine` on commit.
-    fn apply_operation(&self, op: &WalOperation) {
+    fn apply_operation(&self, op: &WalOperation) -> ClientResponse {
+        let mut response = ClientResponse::default();
         let mut jobs = self.jobs.write();
         let mut nodes = self.nodes.write();
         let mut next_id = self.next_job_id.load(Ordering::Relaxed);
@@ -1379,8 +1516,80 @@ impl ClusterManager {
                             }
                         }
                         self.next_job_id.store(next_id, Ordering::Relaxed);
-                        return;
+                        return ClientResponse::default();
                     }
+                }
+            }
+            WalOperation::JobNodeComplete {
+                job_id,
+                node_name,
+                exit_code,
+            } => {
+                let finalized = {
+                    let Some(job) = jobs.get_mut(job_id) else {
+                        return ClientResponse::default();
+                    };
+                    if job.state.is_terminal() {
+                        return ClientResponse::default();
+                    }
+
+                    let already_reported = job.node_completions.contains_key(node_name);
+                    job.node_completions.insert(node_name.clone(), *exit_code);
+
+                    if let Some(ref total) = job.allocated_resources {
+                        if !already_reported {
+                            deallocate_job_node(
+                                &mut nodes,
+                                total,
+                                job.allocated_nodes.len(),
+                                node_name,
+                            );
+                        }
+                    }
+
+                    if job.state == JobState::Running {
+                        if let Err(e) = job.transition(JobState::Completing) {
+                            warn!(job_id = *job_id, error = %e, "invalid transition to Completing");
+                        }
+                        job.end_time = Some(timestamp);
+                    }
+
+                    if job.all_nodes_completed() {
+                        let (final_state, final_exit) =
+                            Job::derived_completion(&job.node_completions);
+                        match job.transition(final_state) {
+                            Ok(()) => {
+                                job.exit_code = Some(final_exit);
+                                job.end_time = Some(timestamp);
+                                job.node_completions.clear();
+                                Some((final_state, final_exit))
+                            }
+                            Err(e) => {
+                                warn!(
+                                    job_id = *job_id,
+                                    error = %e,
+                                    "invalid final completion transition"
+                                );
+                                None
+                            }
+                        }
+                    } else {
+                        None
+                    }
+                };
+
+                if let Some((final_state, final_exit)) = finalized {
+                    drop(jobs);
+                    drop(nodes);
+                    self.complete_job_steps_and_licenses(job_id, final_exit, timestamp);
+                    self.next_job_id.store(next_id, Ordering::Relaxed);
+                    return ClientResponse {
+                        job_finalized: Some(JobFinalized {
+                            job_id: *job_id,
+                            state: final_state,
+                            exit_code: final_exit,
+                        }),
+                    };
                 }
             }
             WalOperation::JobComplete {
@@ -1390,70 +1599,46 @@ impl ClusterManager {
             } => {
                 let freed_nodes;
                 let allocated_resources;
+                let already_deallocated;
                 if let Some(job) = jobs.get_mut(job_id) {
-                    if let Err(e) = job.transition(*state) {
-                        warn!(job_id = *job_id, error = %e, "invalid state transition in WAL apply");
+                    match job.transition(*state) {
+                        Ok(()) if state.is_terminal() => {
+                            response.job_finalized = Some(JobFinalized {
+                                job_id: *job_id,
+                                state: *state,
+                                exit_code: *exit_code,
+                            });
+                        }
+                        Ok(()) => {}
+                        Err(e) => {
+                            warn!(
+                                job_id = *job_id,
+                                error = %e,
+                                "invalid state transition in WAL apply"
+                            );
+                        }
                     }
                     job.exit_code = Some(*exit_code);
                     job.end_time = Some(timestamp);
                     freed_nodes = job.allocated_nodes.clone();
                     allocated_resources = job.allocated_resources.clone();
+                    already_deallocated = job.node_completions.keys().cloned().collect::<Vec<_>>();
+                    job.node_completions.clear();
                 } else {
-                    return;
+                    return ClientResponse::default();
                 }
-                // Deallocate node resources
+                // Deallocate node resources not already freed during COMPLETING
                 if let Some(ref total) = allocated_resources {
-                    let node_count = freed_nodes.len().max(1) as u32;
-                    let per_node = ResourceSet {
-                        cpus: total.cpus / node_count,
-                        memory_mb: total.memory_mb / node_count as u64,
-                        gpus: total.gpus.clone(),
-                        generic: total
-                            .generic
-                            .iter()
-                            .map(|(k, v)| (k.clone(), v / node_count as u64))
-                            .collect(),
-                    };
                     for name in &freed_nodes {
-                        if let Some(node) = nodes.get_mut(name) {
-                            node.alloc_resources = node.alloc_resources.subtract(&per_node);
-                            node.update_state_from_alloc();
-                            if node.state == NodeState::Draining
-                                && node.alloc_resources.cpus == 0
-                                && node.alloc_resources.gpus.is_empty()
-                            {
-                                node.state = NodeState::Drain;
-                            }
+                        if already_deallocated.iter().any(|n| n == name) {
+                            continue;
                         }
+                        deallocate_job_node(&mut nodes, total, freed_nodes.len(), name);
                     }
                 }
-                // Complete all steps
                 drop(jobs);
                 drop(nodes);
-                let mut steps = self.steps.write();
-                for step in steps.values_mut() {
-                    if step.job_id == *job_id && !step.state.is_terminal() {
-                        step.state = if *exit_code == 0 {
-                            StepState::Completed
-                        } else {
-                            StepState::Failed
-                        };
-                        step.exit_code = Some(*exit_code);
-                        step.end_time = Some(timestamp);
-                    }
-                }
-                // Return licenses
-                let lic_req = if let Some(job) = self.jobs.read().get(job_id) {
-                    extract_license_requirements(&job.spec)
-                } else {
-                    HashMap::new()
-                };
-                if !lic_req.is_empty() {
-                    let mut pool = self.license_pool.write();
-                    for (lic, count) in &lic_req {
-                        *pool.entry(lic.clone()).or_insert(0) += count;
-                    }
-                }
+                self.complete_job_steps_and_licenses(job_id, *exit_code, timestamp);
             }
             WalOperation::JobPriorityChange {
                 job_id,
@@ -1519,7 +1704,7 @@ impl ClusterManager {
                 let mut nodes = self.nodes.write();
                 nodes.insert(name.clone(), node);
                 self.next_job_id.store(next_id, Ordering::Relaxed);
-                return;
+                return ClientResponse::default();
             }
             WalOperation::NodeUpdate {
                 name,
@@ -1557,6 +1742,7 @@ impl ClusterManager {
             }
         }
         self.next_job_id.store(next_id, Ordering::Relaxed);
+        response
     }
 }
 
@@ -1573,8 +1759,8 @@ struct ClusterSnapshot {
 }
 
 impl StateMachineApply for ClusterManager {
-    fn apply_operation(&self, op: &WalOperation) {
-        self.apply_operation(op);
+    fn apply_operation(&self, op: &WalOperation) -> ClientResponse {
+        self.apply_operation(op)
     }
 
     fn snapshot_state(&self) -> Result<Vec<u8>, anyhow::Error> {
@@ -1628,6 +1814,39 @@ impl StateMachineApply for ClusterManager {
 
 /// Extract license requirements from a job's GRES list.
 /// License GRES entries are formatted as "license:<name>:<count>" or "license:<name>".
+fn per_node_resources(total: &ResourceSet, node_count: usize) -> ResourceSet {
+    let node_count = node_count.max(1) as u32;
+    ResourceSet {
+        cpus: total.cpus / node_count,
+        memory_mb: total.memory_mb / node_count as u64,
+        gpus: total.gpus.clone(),
+        generic: total
+            .generic
+            .iter()
+            .map(|(k, v)| (k.clone(), v / node_count as u64))
+            .collect(),
+    }
+}
+
+fn deallocate_job_node(
+    nodes: &mut HashMap<String, Node>,
+    total: &ResourceSet,
+    node_count: usize,
+    node_name: &str,
+) {
+    let per_node = per_node_resources(total, node_count);
+    if let Some(node) = nodes.get_mut(node_name) {
+        node.alloc_resources = node.alloc_resources.subtract(&per_node);
+        node.update_state_from_alloc();
+        if node.state == NodeState::Draining
+            && node.alloc_resources.cpus == 0
+            && node.alloc_resources.gpus.is_empty()
+        {
+            node.state = NodeState::Drain;
+        }
+    }
+}
+
 fn extract_license_requirements(spec: &JobSpec) -> HashMap<String, u64> {
     let mut licenses = HashMap::new();
     for gres in &spec.gres {
@@ -2121,6 +2340,291 @@ mod tests {
 
         let node = cm.get_node("worker1").unwrap();
         assert_eq!(node.alloc_resources.cpus, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn apply_job_node_complete_single_node() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        register_node(&cm, "worker1", 8, 16000);
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("single-completing")),
+        });
+        cm.apply_operation(&WalOperation::JobStateChange {
+            job_id: 1,
+            old_state: JobState::Pending,
+            new_state: JobState::Running,
+        });
+        cm.apply_operation(&WalOperation::JobStart {
+            job_id: 1,
+            nodes: vec!["worker1".into()],
+            resources: ResourceSet {
+                cpus: 2,
+                memory_mb: 4000,
+                ..Default::default()
+            },
+        });
+
+        cm.apply_operation(&WalOperation::JobNodeComplete {
+            job_id: 1,
+            node_name: "worker1".into(),
+            exit_code: 0,
+        });
+
+        let job = cm.get_job(1).unwrap();
+        assert_eq!(job.state, JobState::Completed);
+        assert_eq!(job.exit_code, Some(0));
+        assert!(job.node_completions.is_empty());
+        assert_eq!(cm.get_node("worker1").unwrap().alloc_resources.cpus, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn apply_job_node_complete_multi_node() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        for name in ["n1", "n2", "n3"] {
+            register_node(&cm, name, 8, 16000);
+        }
+
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("multi-completing")),
+        });
+        cm.apply_operation(&WalOperation::JobStateChange {
+            job_id: 1,
+            old_state: JobState::Pending,
+            new_state: JobState::Running,
+        });
+        cm.apply_operation(&WalOperation::JobStart {
+            job_id: 1,
+            nodes: vec!["n1".into(), "n2".into(), "n3".into()],
+            resources: ResourceSet {
+                cpus: 6,
+                memory_mb: 12000,
+                ..Default::default()
+            },
+        });
+
+        cm.apply_operation(&WalOperation::JobNodeComplete {
+            job_id: 1,
+            node_name: "n1".into(),
+            exit_code: 0,
+        });
+        let job = cm.get_job(1).unwrap();
+        assert_eq!(job.state, JobState::Completing);
+        assert_eq!(job.node_completions.len(), 1);
+        assert_eq!(cm.get_node("n1").unwrap().alloc_resources.cpus, 0);
+        assert!(cm.get_node("n2").unwrap().alloc_resources.cpus > 0);
+
+        cm.apply_operation(&WalOperation::JobNodeComplete {
+            job_id: 1,
+            node_name: "n2".into(),
+            exit_code: 0,
+        });
+        assert_eq!(cm.get_job(1).unwrap().state, JobState::Completing);
+
+        cm.apply_operation(&WalOperation::JobNodeComplete {
+            job_id: 1,
+            node_name: "n3".into(),
+            exit_code: 42,
+        });
+
+        let job = cm.get_job(1).unwrap();
+        assert_eq!(job.state, JobState::Failed);
+        assert_eq!(job.exit_code, Some(42));
+        for name in ["n1", "n2", "n3"] {
+            assert_eq!(cm.get_node(name).unwrap().alloc_resources.cpus, 0);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn apply_job_node_complete_returns_finalized_once() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        for name in ["n1", "n2"] {
+            register_node(&cm, name, 8, 16000);
+        }
+
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("finalize-response")),
+        });
+        cm.apply_operation(&WalOperation::JobStateChange {
+            job_id: 1,
+            old_state: JobState::Pending,
+            new_state: JobState::Running,
+        });
+        cm.apply_operation(&WalOperation::JobStart {
+            job_id: 1,
+            nodes: vec!["n1".into(), "n2".into()],
+            resources: ResourceSet {
+                cpus: 4,
+                memory_mb: 8000,
+                ..Default::default()
+            },
+        });
+
+        let r1 = cm.apply_operation(&WalOperation::JobNodeComplete {
+            job_id: 1,
+            node_name: "n1".into(),
+            exit_code: 0,
+        });
+        assert!(r1.job_finalized.is_none());
+        assert_eq!(cm.get_job(1).unwrap().state, JobState::Completing);
+
+        let r2 = cm.apply_operation(&WalOperation::JobNodeComplete {
+            job_id: 1,
+            node_name: "n2".into(),
+            exit_code: 0,
+        });
+        let f = r2.job_finalized.expect("last node should finalize");
+        assert_eq!(f.job_id, 1);
+        assert_eq!(f.state, JobState::Completed);
+        assert_eq!(f.exit_code, 0);
+        assert_eq!(cm.get_job(1).unwrap().state, JobState::Completed);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn apply_job_complete_returns_finalized() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        register_node(&cm, "worker1", 8, 16000);
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("job-complete-response")),
+        });
+        cm.apply_operation(&WalOperation::JobStateChange {
+            job_id: 1,
+            old_state: JobState::Pending,
+            new_state: JobState::Running,
+        });
+        cm.apply_operation(&WalOperation::JobStart {
+            job_id: 1,
+            nodes: vec!["worker1".into()],
+            resources: ResourceSet {
+                cpus: 2,
+                memory_mb: 4000,
+                ..Default::default()
+            },
+        });
+
+        let resp = cm.apply_operation(&WalOperation::JobComplete {
+            job_id: 1,
+            exit_code: 0,
+            state: JobState::Completed,
+        });
+        let f = resp.job_finalized.expect("JobComplete should finalize");
+        assert_eq!(f.job_id, 1);
+        assert_eq!(f.state, JobState::Completed);
+        assert_eq!(f.exit_code, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn node_complete_penultimate_returns_completing() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        for name in ["n1", "n2", "n3"] {
+            register_node(&cm, name, 8, 16000);
+        }
+
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("penultimate")),
+        });
+        cm.apply_operation(&WalOperation::JobStateChange {
+            job_id: 1,
+            old_state: JobState::Pending,
+            new_state: JobState::Running,
+        });
+        cm.apply_operation(&WalOperation::JobStart {
+            job_id: 1,
+            nodes: vec!["n1".into(), "n2".into(), "n3".into()],
+            resources: ResourceSet {
+                cpus: 6,
+                memory_mb: 12000,
+                ..Default::default()
+            },
+        });
+        cm.apply_operation(&WalOperation::JobNodeComplete {
+            job_id: 1,
+            node_name: "n1".into(),
+            exit_code: 0,
+        });
+
+        let result = cm.node_complete(1, "n2", 0).unwrap();
+        assert_eq!(result, NodeCompleteResult::Completing);
+        assert_eq!(cm.get_job(1).unwrap().state, JobState::Completing);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancel_job_while_completing() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        for name in ["n1", "n2", "n3"] {
+            register_node(&cm, name, 8, 16000);
+        }
+
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("cancel-while-cg")),
+        });
+        cm.apply_operation(&WalOperation::JobStateChange {
+            job_id: 1,
+            old_state: JobState::Pending,
+            new_state: JobState::Running,
+        });
+        cm.apply_operation(&WalOperation::JobStart {
+            job_id: 1,
+            nodes: vec!["n1".into(), "n2".into(), "n3".into()],
+            resources: ResourceSet {
+                cpus: 6,
+                memory_mb: 12000,
+                ..Default::default()
+            },
+        });
+
+        cm.apply_operation(&WalOperation::JobNodeComplete {
+            job_id: 1,
+            node_name: "n1".into(),
+            exit_code: 0,
+        });
+
+        let job = cm.get_job(1).unwrap();
+        assert_eq!(job.state, JobState::Completing);
+        assert_eq!(job.node_completions.len(), 1);
+        assert_eq!(cm.get_node("n1").unwrap().alloc_resources.cpus, 0);
+        assert!(cm.get_node("n2").unwrap().alloc_resources.cpus > 0);
+
+        cm.cancel_job(1, "testuser").unwrap();
+        settle(&cm, 1, JobState::Cancelled);
+
+        let job = cm.get_job(1).unwrap();
+        assert_eq!(job.state, JobState::Cancelled);
+        assert_eq!(job.exit_code, Some(-1));
+        assert!(job.node_completions.is_empty());
+        for name in ["n1", "n2", "n3"] {
+            assert_eq!(
+                cm.get_node(name).unwrap().alloc_resources.cpus,
+                0,
+                "node {name} should be deallocated after cancel"
+            );
+        }
+
+        cm.apply_operation(&WalOperation::JobNodeComplete {
+            job_id: 1,
+            node_name: "n2".into(),
+            exit_code: 0,
+        });
+
+        let job = cm.get_job(1).unwrap();
+        assert_eq!(job.state, JobState::Cancelled);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1379,8 +1379,6 @@ impl ClusterManager {
 
     /// Persist a mutation via Raft consensus. The apply callback
     /// (`StateMachineApply`) handles in-memory state on all nodes.
-    // openraft's RaftError exceeds clippy's 128-byte threshold in the intermediate Result
-    #[allow(clippy::result_large_err)]
     fn complete_job_steps_and_licenses(
         &self,
         job_id: &JobId,
@@ -1414,6 +1412,7 @@ impl ClusterManager {
         }
     }
 
+    #[allow(clippy::result_large_err)]
     fn propose(&self, op: WalOperation) -> anyhow::Result<ClientResponse> {
         let raft = self
             .raft

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -379,6 +379,11 @@ impl ClusterManager {
             });
         }
 
+        let jobs = self.jobs.read();
+        if jobs.get(&job_id).is_some_and(|job| job.state.is_terminal()) {
+            return Ok(NodeCompleteResult::AlreadyTerminal);
+        }
+
         Ok(NodeCompleteResult::Completing)
     }
 
@@ -2678,6 +2683,47 @@ mod tests {
 
         let job = cm.get_job(1).unwrap();
         assert_eq!(job.state, JobState::Cancelled);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn node_complete_returns_already_terminal_after_cancel() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        for name in ["n1", "n2", "n3"] {
+            register_node(&cm, name, 8, 16000);
+        }
+
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("nc-after-cancel")),
+        });
+        cm.apply_operation(&WalOperation::JobStateChange {
+            job_id: 1,
+            old_state: JobState::Pending,
+            new_state: JobState::Running,
+        });
+        cm.apply_operation(&WalOperation::JobStart {
+            job_id: 1,
+            nodes: vec!["n1".into(), "n2".into(), "n3".into()],
+            resources: ResourceSet {
+                cpus: 6,
+                memory_mb: 12000,
+                ..Default::default()
+            },
+        });
+        cm.apply_operation(&WalOperation::JobNodeComplete {
+            job_id: 1,
+            node_name: "n1".into(),
+            exit_code: 0,
+        });
+
+        cm.cancel_job(1, "testuser").unwrap();
+        settle(&cm, 1, JobState::Cancelled);
+
+        let result = cm.node_complete(1, "n2", 0).unwrap();
+        assert_eq!(result, NodeCompleteResult::AlreadyTerminal);
+        assert_eq!(cm.get_job(1).unwrap().state, JobState::Cancelled);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1600,22 +1600,23 @@ impl ClusterManager {
                 let allocated_resources;
                 let already_deallocated;
                 if let Some(job) = jobs.get_mut(job_id) {
-                    match job.transition(*state) {
-                        Ok(()) if state.is_terminal() => {
-                            response.job_finalized = Some(JobFinalized {
-                                job_id: *job_id,
-                                state: *state,
-                                exit_code: *exit_code,
-                            });
-                        }
-                        Ok(()) => {}
-                        Err(e) => {
-                            warn!(
-                                job_id = *job_id,
-                                error = %e,
-                                "invalid state transition in WAL apply"
-                            );
-                        }
+                    if job.state.is_terminal() {
+                        return ClientResponse::default();
+                    }
+                    if let Err(e) = job.transition(*state) {
+                        warn!(
+                            job_id = *job_id,
+                            error = %e,
+                            "invalid state transition in WAL apply"
+                        );
+                        return ClientResponse::default();
+                    }
+                    if state.is_terminal() {
+                        response.job_finalized = Some(JobFinalized {
+                            job_id: *job_id,
+                            state: *state,
+                            exit_code: *exit_code,
+                        });
                     }
                     job.exit_code = Some(*exit_code);
                     job.end_time = Some(timestamp);
@@ -2521,6 +2522,59 @@ mod tests {
         assert_eq!(f.job_id, 1);
         assert_eq!(f.state, JobState::Completed);
         assert_eq!(f.exit_code, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn apply_job_complete_noop_when_already_terminal() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        register_node(&cm, "worker1", 8, 16000);
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("double-complete")),
+        });
+        cm.apply_operation(&WalOperation::JobStateChange {
+            job_id: 1,
+            old_state: JobState::Pending,
+            new_state: JobState::Running,
+        });
+        cm.apply_operation(&WalOperation::JobStart {
+            job_id: 1,
+            nodes: vec!["worker1".into()],
+            resources: ResourceSet {
+                cpus: 2,
+                memory_mb: 4000,
+                ..Default::default()
+            },
+        });
+
+        let first = cm.apply_operation(&WalOperation::JobComplete {
+            job_id: 1,
+            exit_code: 0,
+            state: JobState::Completed,
+        });
+        first
+            .job_finalized
+            .expect("first JobComplete should finalize");
+        let node = cm.get_node("worker1").unwrap();
+        assert_eq!(node.alloc_resources.cpus, 0);
+        assert_eq!(node.alloc_resources.memory_mb, 0);
+
+        let second = cm.apply_operation(&WalOperation::JobComplete {
+            job_id: 1,
+            exit_code: -1,
+            state: JobState::Cancelled,
+        });
+        assert!(second.job_finalized.is_none());
+
+        let job = cm.get_job(1).unwrap();
+        assert_eq!(job.state, JobState::Completed);
+        assert_eq!(job.exit_code, Some(0));
+
+        let node = cm.get_node("worker1").unwrap();
+        assert_eq!(node.alloc_resources.cpus, 0);
+        assert_eq!(node.alloc_resources.memory_mb, 0);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -35,14 +35,24 @@ openraft::declare_raft_types!(
 
 pub type SpurRaft = Raft<SpurTypeConfig>;
 
+/// Set when a committed WAL entry transitions a job to a terminal state.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct JobFinalized {
+    pub job_id: u32,
+    pub state: spur_core::job::JobState,
+    pub exit_code: i32,
+}
+
 /// Response returned after a Raft write is committed.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct ClientResponse;
+pub struct ClientResponse {
+    pub job_finalized: Option<JobFinalized>,
+}
 
 /// Trait for applying committed Raft entries to the cluster state.
 /// Implemented by ClusterManager to avoid a circular dependency with SpurStore.
 pub trait StateMachineApply: Send + Sync {
-    fn apply_operation(&self, op: &WalOperation);
+    fn apply_operation(&self, op: &WalOperation) -> ClientResponse;
     fn snapshot_state(&self) -> Result<Vec<u8>, anyhow::Error>;
     fn restore_from_snapshot(&self, data: &[u8]);
 }
@@ -339,14 +349,16 @@ impl openraft::RaftStorage<SpurTypeConfig> for Arc<SpurStore> {
                 EntryPayload::Normal(op) => {
                     debug!(index = entry.log_id.index, "raft: applying WalOperation");
                     inner.applied_count += 1;
-                    self.applier.apply_operation(op);
+                    results.push(self.applier.apply_operation(op));
                 }
                 EntryPayload::Membership(mem) => {
                     inner.last_membership = StoredMembership::new(Some(entry.log_id), mem.clone());
+                    results.push(ClientResponse::default());
                 }
-                EntryPayload::Blank => {}
+                EntryPayload::Blank => {
+                    results.push(ClientResponse::default());
+                }
             }
-            results.push(ClientResponse);
         }
         Ok(results)
     }
@@ -667,7 +679,9 @@ mod tests {
 
     struct NoopApplier;
     impl StateMachineApply for NoopApplier {
-        fn apply_operation(&self, _op: &WalOperation) {}
+        fn apply_operation(&self, _op: &WalOperation) -> ClientResponse {
+            ClientResponse::default()
+        }
         fn snapshot_state(&self) -> Result<Vec<u8>, anyhow::Error> {
             Ok(Vec::new())
         }

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -26,6 +26,11 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
     tokio::spawn(async move {
         enforce_time_limits(enforcer_cluster, enforcer_raft).await;
     });
+    let completing_cluster = cluster.clone();
+    let completing_raft = raft.clone();
+    tokio::spawn(async move {
+        enforce_completing_timeout(completing_cluster, completing_raft).await;
+    });
     let power_cluster = cluster.clone();
     let power_raft = raft.clone();
     tokio::spawn(async move {
@@ -734,9 +739,22 @@ async fn enforce_time_limits(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>
             }
         }
 
-        let running = cluster.get_jobs(&[spur_core::job::JobState::Running], None, None, None, &[]);
+        let running = cluster.get_jobs(
+            &[
+                spur_core::job::JobState::Running,
+                spur_core::job::JobState::Completing,
+            ],
+            None,
+            None,
+            None,
+            &[],
+        );
 
         for job in &running {
+            if job.state == spur_core::job::JobState::Completing {
+                continue;
+            }
+
             let (Some(time_limit), Some(start_time)) = (job.spec.time_limit, job.start_time) else {
                 continue;
             };
@@ -792,6 +810,80 @@ async fn enforce_time_limits(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>
         let running_ids: HashSet<_> = running.iter().map(|j| j.job_id).collect();
         warned_jobs.retain(|id| running_ids.contains(id));
         warn_times.retain(|id, _| running_ids.contains(id));
+    }
+}
+
+/// Force-finish jobs stuck in COMPLETING past `complete_wait_secs`.
+async fn enforce_completing_timeout(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
+    let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(10));
+
+    loop {
+        interval.tick().await;
+
+        if !raft.is_leader() {
+            continue;
+        }
+
+        let now = Utc::now();
+        let wait = chrono::Duration::seconds(cluster.config.scheduler.complete_wait_secs as i64);
+
+        let completing = cluster.get_jobs(
+            &[spur_core::job::JobState::Completing],
+            None,
+            None,
+            None,
+            &[],
+        );
+
+        for job in completing {
+            let Some(completing_since) = job.end_time else {
+                continue;
+            };
+            if now - completing_since < wait {
+                continue;
+            }
+
+            let missing: Vec<_> = job
+                .allocated_nodes
+                .iter()
+                .filter(|n| !job.node_completions.contains_key(*n))
+                .cloned()
+                .collect();
+
+            let (mut state, mut exit_code) =
+                spur_core::job::Job::derived_completion(&job.node_completions);
+            if job.node_completions.is_empty() {
+                state = spur_core::job::JobState::Failed;
+                exit_code = -1;
+            } else if !missing.is_empty() {
+                warn!(
+                    job_id = job.job_id,
+                    missing = ?missing,
+                    reported = job.node_completions.len(),
+                    expected = job.allocated_nodes.len(),
+                    "completing timeout — not all nodes reported"
+                );
+                state = spur_core::job::JobState::Failed;
+                if exit_code == 0 {
+                    exit_code = 1;
+                }
+            }
+
+            info!(
+                job_id = job.job_id,
+                state = ?state,
+                exit_code,
+                "completing timeout expired — force-finishing job"
+            );
+
+            if let Err(e) = cluster.complete_job(job.job_id, exit_code, state) {
+                warn!(
+                    job_id = job.job_id,
+                    error = %e,
+                    "failed to force-finish job after completing timeout"
+                );
+            }
+        }
     }
 }
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -8,9 +8,10 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use tokio::sync::Mutex;
 use tonic::metadata::MetadataValue;
-use tonic::{Request, Response, Status};
+use tonic::{Code, Request, Response, Status};
 use tracing::warn;
 
+use spur_core::job::NodeCompleteError;
 use spur_core::reservation::Reservation;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::slurm_controller_server::{SlurmController, SlurmControllerServer};
@@ -520,60 +521,24 @@ impl SlurmController for ControllerService {
         let state = spur_core::job::JobState::from_proto_i32(req.state)
             .ok_or_else(|| Status::invalid_argument("invalid job state"))?;
 
-        if state.is_terminal() {
-            let exit_code = req.exit_code;
-            match self.cluster.complete_job(req.job_id, exit_code, state) {
-                Ok(()) => {
-                    // Run EpilogSlurmctld if configured (failure is logged, not fatal)
-                    if let Some(ref epilog_ctld) = self.cluster.config.hooks.epilog_slurmctld {
-                        let job = self.cluster.get_job(req.job_id);
-                        let ctx = spur_core::hooks::HookContext {
-                            job_id: req.job_id,
-                            work_dir: job
-                                .as_ref()
-                                .map(|j| j.spec.work_dir.clone())
-                                .unwrap_or_else(|| "/tmp".into()),
-                            uid: job.as_ref().map(|j| j.spec.uid).unwrap_or(0),
-                            gid: job.as_ref().map(|j| j.spec.gid).unwrap_or(0),
-                            partition: job
-                                .as_ref()
-                                .and_then(|j| j.spec.partition.clone())
-                                .unwrap_or_default(),
-                            nodelist: job
-                                .as_ref()
-                                .map(|j| j.allocated_nodes.join(","))
-                                .unwrap_or_default(),
-                            script_context: "epilog_slurmctld".into(),
-                            gpu_devices: Vec::new(),
-                            cpus: job.as_ref().map(|j| j.spec.cpus_per_task).unwrap_or(1),
-                            memory_mb: job
-                                .as_ref()
-                                .and_then(|j| j.spec.memory_per_node_mb)
-                                .unwrap_or(0),
-                        };
-                        if let Err(e) = spur_core::hooks::run_hook(epilog_ctld, &ctx).await {
-                            warn!(
-                                job_id = req.job_id,
-                                error = %e,
-                                "EpilogSlurmctld failed"
-                            );
-                        }
-                    }
-                }
-                Err(e) => {
-                    // Multi-node jobs: non-first nodes may report after the job
-                    // is already terminal. Log and continue so drain requests
-                    // below are still processed.
-                    warn!(
-                        job_id = req.job_id,
-                        error = %e,
-                        "complete_job failed (likely duplicate report from multi-node job)"
-                    );
-                }
+        // `state` only gates whether this report enters the per-node completion
+        // path. The final job outcome is still derived from aggregated node
+        // exit codes in `Job::derived_completion`.
+        let completion_result = if state.is_terminal() {
+            validate_completion_report_state_for_rpc(state, req.exit_code)?;
+            if req.reporting_node.is_empty() {
+                return Err(Status::invalid_argument(
+                    "reporting_node is required for job completion reports",
+                ));
             }
-        }
+            Some(
+                self.cluster
+                    .node_complete(req.job_id, &req.reporting_node, req.exit_code),
+            )
+        } else {
+            None
+        };
 
-        // Process drain request regardless of whether complete_job succeeded
         if req.drain_node && !req.reporting_node.is_empty() {
             warn!(
                 node = %req.reporting_node,
@@ -594,7 +559,30 @@ impl SlurmController for ControllerService {
             }
         }
 
-        Ok(Response::new(()))
+        use crate::cluster::NodeCompleteResult;
+
+        match completion_result {
+            Some(Ok(NodeCompleteResult::AllDone { .. })) => Ok(Response::new(())),
+            Some(Ok(NodeCompleteResult::Completing)) => Ok(Response::new(())),
+            Some(Ok(NodeCompleteResult::AlreadyTerminal)) => {
+                warn!(
+                    job_id = req.job_id,
+                    node = %req.reporting_node,
+                    "duplicate completion report for terminal job"
+                );
+                Ok(Response::new(()))
+            }
+            Some(Err(e)) => {
+                warn!(
+                    job_id = req.job_id,
+                    node = %req.reporting_node,
+                    error = %e,
+                    "node_complete failed"
+                );
+                Err(node_complete_to_status(e))
+            }
+            None => Ok(Response::new(())),
+        }
     }
 
     async fn heartbeat(
@@ -1410,10 +1398,30 @@ fn annotate_nodes_with_reservations(
     }
 }
 
+fn node_complete_to_status(err: NodeCompleteError) -> Status {
+    let message = err.to_string();
+    let code = match err {
+        NodeCompleteError::JobNotFound { .. } => Code::NotFound,
+        NodeCompleteError::NodeNotAllocated { .. } => Code::InvalidArgument,
+        NodeCompleteError::RaftPropose { .. } => Code::Unavailable,
+    };
+    Status::new(code, message)
+}
+
+fn validate_completion_report_state_for_rpc(
+    state: spur_core::job::JobState,
+    exit_code: i32,
+) -> Result<(), Status> {
+    spur_core::job::JobState::validate_completion_report_state(state, exit_code)
+        .map_err(|e| Status::invalid_argument(e.to_string()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use chrono::Duration;
+    use spur_core::job::{JobState, NodeCompleteError};
+    use tonic::Code;
 
     fn make_node_info(name: &str) -> NodeInfo {
         NodeInfo {
@@ -1495,5 +1503,67 @@ mod tests {
         ];
         annotate_nodes_with_reservations(&mut nodes, &reservations, Utc::now());
         assert_eq!(nodes[0].active_reservation, "first");
+    }
+
+    #[test]
+    fn node_complete_error_status_mapping_covers_all_variants() {
+        let cases: Vec<(NodeCompleteError, Code, bool)> = vec![
+            (
+                NodeCompleteError::JobNotFound { job_id: 1 },
+                Code::NotFound,
+                false,
+            ),
+            (
+                NodeCompleteError::NodeNotAllocated {
+                    job_id: 1,
+                    node: "n1".into(),
+                },
+                Code::InvalidArgument,
+                false,
+            ),
+            (
+                NodeCompleteError::RaftPropose {
+                    source: anyhow::anyhow!("test"),
+                },
+                Code::Unavailable,
+                true,
+            ),
+        ];
+
+        for (err, want_code, want_retry) in cases {
+            assert_eq!(err.retryable(), want_retry, "{err:?}");
+            let retry = err.retryable();
+            let status = node_complete_to_status(err);
+            assert_eq!(status.code(), want_code);
+            let agent_retryable = matches!(
+                status.code(),
+                Code::Unavailable | Code::Internal | Code::DeadlineExceeded | Code::Unknown
+            );
+            assert_eq!(retry, agent_retryable, "{status:?}");
+        }
+    }
+
+    #[test]
+    fn completion_report_state_accepts_completed_zero() {
+        assert!(validate_completion_report_state_for_rpc(JobState::Completed, 0).is_ok());
+    }
+
+    #[test]
+    fn completion_report_state_accepts_failed_nonzero() {
+        assert!(validate_completion_report_state_for_rpc(JobState::Failed, 42).is_ok());
+    }
+
+    #[test]
+    fn completion_report_state_rejects_completed_nonzero() {
+        let err = validate_completion_report_state_for_rpc(JobState::Completed, 1).unwrap_err();
+        assert_eq!(err.code(), Code::InvalidArgument);
+        assert!(err.message().contains("does not match exit_code"));
+    }
+
+    #[test]
+    fn completion_report_state_rejects_cancelled() {
+        let err = validate_completion_report_state_for_rpc(JobState::Cancelled, 0).unwrap_err();
+        assert_eq!(err.code(), Code::InvalidArgument);
+        assert!(err.message().contains("invalid completion state"));
     }
 }

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1408,6 +1408,7 @@ fn node_complete_to_status(err: NodeCompleteError) -> Status {
     Status::new(code, message)
 }
 
+#[allow(clippy::result_large_err)]
 fn validate_completion_report_state_for_rpc(
     state: spur_core::job::JobState,
     exit_code: i32,

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -521,16 +521,11 @@ impl SlurmController for ControllerService {
         let state = spur_core::job::JobState::from_proto_i32(req.state)
             .ok_or_else(|| Status::invalid_argument("invalid job state"))?;
 
-        // `state` only gates whether this report enters the per-node completion
-        // path. The final job outcome is still derived from aggregated node
-        // exit codes in `Job::derived_completion`.
-        let completion_result = if state.is_terminal() {
+        // Non-empty `reporting_node` means a per-node completion report. The final
+        // job outcome is still derived from aggregated exit codes in
+        // `Job::derived_completion`.
+        let completion_result = if !req.reporting_node.is_empty() {
             validate_completion_report_state_for_rpc(state, req.exit_code)?;
-            if req.reporting_node.is_empty() {
-                return Err(Status::invalid_argument(
-                    "reporting_node is required for job completion reports",
-                ));
-            }
             Some(
                 self.cluster
                     .node_complete(req.job_id, &req.reporting_node, req.exit_code),
@@ -1564,6 +1559,20 @@ mod tests {
     #[test]
     fn completion_report_state_rejects_cancelled() {
         let err = validate_completion_report_state_for_rpc(JobState::Cancelled, 0).unwrap_err();
+        assert_eq!(err.code(), Code::InvalidArgument);
+        assert!(err.message().contains("invalid completion state"));
+    }
+
+    #[test]
+    fn completion_report_state_rejects_completing() {
+        let err = validate_completion_report_state_for_rpc(JobState::Completing, 0).unwrap_err();
+        assert_eq!(err.code(), Code::InvalidArgument);
+        assert!(err.message().contains("invalid completion state"));
+    }
+
+    #[test]
+    fn completion_report_state_rejects_running() {
+        let err = validate_completion_report_state_for_rpc(JobState::Running, 0).unwrap_err();
         assert_eq!(err.code(), Code::InvalidArgument);
         assert!(err.message().contains("invalid completion state"));
     }

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -240,13 +240,18 @@ impl AgentService {
                     let drain = if drain_jobs.contains(&c.job_id) {
                         Some(DrainRequest {
                             reason: "epilog script failed".into(),
-                            node_name: local_hostname.clone(),
                         })
                     } else {
                         None
                     };
-                    report_completion(&controller_addr, c.job_id, c.exit_code, drain.as_ref())
-                        .await;
+                    report_completion(
+                        &controller_addr,
+                        c.job_id,
+                        c.exit_code,
+                        &local_hostname,
+                        drain.as_ref(),
+                    )
+                    .await;
                 }
             }
         });
@@ -255,22 +260,44 @@ impl AgentService {
 
 struct DrainRequest {
     reason: String,
-    node_name: String,
+}
+
+fn completion_report_retryable(status: &tonic::Status) -> bool {
+    use tonic::Code;
+    matches!(
+        status.code(),
+        Code::Unavailable | Code::Internal | Code::DeadlineExceeded | Code::Unknown
+    )
+}
+
+#[cfg(test)]
+mod completion_report_tests {
+    use super::completion_report_retryable;
+    use tonic::Status;
+
+    #[test]
+    fn permanent_errors_are_not_retryable() {
+        assert!(!completion_report_retryable(&Status::invalid_argument("x")));
+        assert!(!completion_report_retryable(&Status::not_found("x")));
+    }
+
+    #[test]
+    fn transient_errors_are_retryable() {
+        assert!(completion_report_retryable(&Status::unavailable("x")));
+        assert!(completion_report_retryable(&Status::internal("x")));
+    }
 }
 
 async fn report_completion(
     controller_addr: &str,
     job_id: u32,
     exit_code: i32,
+    reporting_node: &str,
     drain: Option<&DrainRequest>,
 ) {
     use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 
-    let state = if exit_code == 0 {
-        JobState::JobCompleted as i32
-    } else {
-        JobState::JobFailed as i32
-    };
+    let state = spur_core::job::JobState::completion_state_for_exit_code(exit_code).to_proto_i32();
 
     let url = if controller_addr.starts_with("http") {
         controller_addr.to_string()
@@ -290,10 +317,7 @@ async fn report_completion(
                     message: format!("exit_code={}", exit_code),
                     drain_node: drain.is_some(),
                     drain_reason: drain.as_ref().map(|d| d.reason.clone()).unwrap_or_default(),
-                    reporting_node: drain
-                        .as_ref()
-                        .map(|d| d.node_name.clone())
-                        .unwrap_or_default(),
+                    reporting_node: reporting_node.to_string(),
                 };
                 match client.report_job_status(req).await {
                     Ok(_) => {
@@ -301,6 +325,16 @@ async fn report_completion(
                         return;
                     }
                     Err(e) => {
+                        if !completion_report_retryable(&e) {
+                            error!(
+                                job_id,
+                                attempt,
+                                code = ?e.code(),
+                                error = %e,
+                                "ReportJobStatus failed with non-retryable error"
+                            );
+                            return;
+                        }
                         warn!(
                             job_id,
                             attempt,
@@ -752,10 +786,9 @@ impl SlurmAgent for AgentService {
                     let drain_reason = format!("prolog failed: {}", err_msg);
                     tokio::spawn(async move {
                         let drain = DrainRequest {
-                            reason: drain_reason,
-                            node_name,
+                            reason: drain_reason.clone(),
                         };
-                        report_completion(&controller, job_id, -1, Some(&drain)).await;
+                        report_completion(&controller, job_id, -1, &node_name, Some(&drain)).await;
                     });
                 }
 

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -590,6 +590,13 @@ message GetFairshareFactorsResponse {
 
 message ReportJobStatusRequest {
   uint32 job_id = 1;
+  // Completion gate for per-node reports. Must be JOB_COMPLETED when
+  // exit_code==0, or JOB_FAILED when exit_code!=0.
+  //
+  // spurctld aggregates all per-node exit codes via derived_completion and
+  // computes the final job state from those codes. This field does not set the
+  // final job state by itself. Other terminal states (CANCELLED, TIMEOUT,
+  // NODE_FAIL) are invalid on this RPC.
   JobState state = 2;
   int32 exit_code = 3;
   string message = 4;  // Pod status message or error


### PR DESCRIPTION
## Summary

Implements Slurm-compatible **COMPLETING** (`CG`) job state: jobs transition from `Running` on the first per-node completion report, deallocate nodes as each node reports, and finalize to `Completed`/`Failed` when all allocated nodes have reported (worst non-zero exit wins). Adds `scancel` during CG (`Completing → Cancelled`), centralized `job_finalized` side effects (epilog + accounting `notify_job_end`), and a completing timeout (`scheduler.complete_wait_secs`, default 300s) for stragglers.

Also aligns completion reporting across agents: `ReportJobStatus.state` must be `Completed`/`Failed` and match `exit_code`; K8s resolves `reporting_node` from `spec.nodeName` with `spur.ai/target-node` label fallback; default `squeue` includes CG when `-t` is omitted.

## Changes

### spur-core
- Add `JobState::Completing` with transitions `Running → Completing` and `Completing → Completed | Failed | Cancelled`.
- Track per-node exit codes in `node_completions`; `derived_completion()` picks the worst non-zero exit across nodes.
- Add `WalOperation::JobNodeComplete` for incremental completion reports (vs one-shot `JobComplete`).
- Add `completion_state_for_exit_code()` and `validate_completion_report_state()` so RPC reports only use `Completed`/`Failed` aligned with `exit_code`.
- Add `scheduler.complete_wait_secs` (default 300) for stuck-CG timeout.

### spurctld
- Implement `node_complete()`: first report moves job to `Completing` and sets `end_time`; each report deallocates that node; last report applies `derived_completion()` and emits `job_finalized`.
- Route `report_job_status` terminal reports through `node_complete` with gRPC error mapping (`NodeCompleteError`).
- Wire `cancel_job` through `JobComplete(Cancelled)` and `run_job_finalized_side_effects` (epilog + `notify_job_end`) when finalize succeeds.
- Add `enforce_completing_timeout` in the scheduler loop to force-finish jobs past `complete_wait_secs` if nodes never report.
- Extend `ClientResponse` with `job_finalized` so notify/epilog run once on the leader after Raft commit.

### spurd
- Set `reporting_node` on `ReportJobStatus` from the agent hostname.
- Derive reported state from exit code via `completion_state_for_exit_code`.
- Retry transient controller RPC failures before giving up on completion reports.

### spur-k8s
- Add `resolve_reporting_node()`: prefer `pod.spec.nodeName`, fall back to `spur.ai/target-node` label, skip pod if neither resolves.
- Align reported completion state with exit code in `watch_pods`.

### spur-cli
- Default `squeue` state filter includes `Completing` when `-t` is omitted (PD + R + CG).

### proto
- Document `ReportJobStatusRequest.state`: gates whether completion is accepted; `exit_code` drives the final terminal state via `derived_completion`.

## Test plan

- [x] `cargo test -p spur-core completing completion validate_completion derived_completion`
- [x] `cargo test -p spurctld apply_job_node_complete cancel_job_while_completing node_complete_penultimate completion_report`
- [x] `cargo test -p spur-k8s resolve_reporting_node`
- [x] `cargo test -p spur-cli default_squeue_states`
- [x] `cargo fmt --check --all`
- [x] `cargo clippy --workspace --exclude spur-ffi --all-targets`
- [x] Multi-node bare-metal: job reaches CG in `squeue`, all nodes report → terminal
- [x] `scancel` during CG → `CANCELLED`, finalize logged in spurctld
- [x] K8s dev cluster: SpurJob runs to `Completed` on `spur:completing-e2e`; `resolve_reporting_node` label fallback verified by unit tests (live empty-`nodeName` test blocked by the API after pod bind)