### PR TITLE
fix(ci): use venv for Python E2E test deps

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -106,8 +106,11 @@ jobs:
           sparse-checkout-cone-mode: false
           path: trusted-repo
 
-      - name: Install Python test dependencies
-        run: pip install -r trusted-repo/tests/e2e/requirements.txt
+      - name: Set up Python venv and install test deps
+        run: |
+          python3 -m venv /tmp/spur-e2e-venv
+          /tmp/spur-e2e-venv/bin/pip install -r trusted-repo/tests/e2e/requirements.txt
+          echo "/tmp/spur-e2e-venv/bin" >> "$GITHUB_PATH"
 
       - name: Load SSH key into agent
         run: |
@@ -282,6 +285,10 @@ jobs:
       - name: Kill SSH agent
         if: always()
         run: ssh-agent -k || true
+
+      - name: Cleanup venv
+        if: always()
+        run: rm -rf /tmp/spur-e2e-venv
 
       - name: Report status
         if: always()


### PR DESCRIPTION
## Summary

The CI runner has PEP 668 externally-managed Python, so bare `pip install` fails with `externally-managed-environment`. Fix by creating a temp venv, installing deps there, and adding its `bin/` to `$GITHUB_PATH` for subsequent steps.

## Changes

- Replace `pip install -r requirements.txt` with venv creation + install
- Add venv cleanup step at the end of the job