### PR TITLE
test(e2e): add prolog/epilog hook e2e tests

### DIFF
--- a/tests/e2e/cluster.py
+++ b/tests/e2e/cluster.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import paramiko
 import pytest
+import tomli_w
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +26,25 @@ CLI_SYMLINKS = ["sbatch", "srun", "squeue", "scancel", "sinfo", "scontrol"]
 
 CONTROLLER_PORT = int(os.environ.get("SPUR_TEST_CONTROLLER_PORT", "6817"))
 AGENT_PORT = int(os.environ.get("SPUR_TEST_AGENT_PORT", "6818"))
+
+
+def make_remote_dir() -> str:
+    """Generate a unique remote working directory path."""
+    return f"/tmp/spur-e2e-{os.getpid()}-{time.time_ns()}"
+
+
+def deep_merge(base: dict, overrides: dict) -> dict:
+    """Deep-merge *overrides* into *base* (mutates and returns *base*).
+
+    - Dicts are merged recursively.
+    - Everything else (scalars, lists) is replaced outright.
+    """
+    for key, value in overrides.items():
+        if key in base and isinstance(base[key], dict) and isinstance(value, dict):
+            deep_merge(base[key], value)
+        else:
+            base[key] = value
+    return base
 
 
 class SshNode:
@@ -79,10 +99,12 @@ class SshNode:
         """Upload a local file to the remote node."""
         self.sftp.put(local_path, remote_path)
 
-    def write_file(self, remote_path: str, content: str):
-        """Write string content to a remote file."""
+    def write_file(self, remote_path: str, content: str, mode: int | None = None):
+        """Write string content to a remote file, optionally setting permissions."""
         with self.sftp.open(remote_path, "w") as f:
             f.write(content)
+        if mode is not None:
+            self.sftp.chmod(remote_path, mode)
 
     def read_file(self, remote_path: str) -> str:
         """Read a remote file. Returns empty string if file doesn't exist."""
@@ -156,14 +178,35 @@ class SpurCluster:
         self.state_dir = f"{remote_dir}/state"
         self.log_dir = f"{remote_dir}/log"
         self.controller_addr = f"http://{nodes[0].host}:{CONTROLLER_PORT}"
+        self.config_overrides: dict = {}
 
-    def deploy(self):
-        """Start cluster processes, write config, wait for ready."""
-        for node in self.nodes:
-            node.kill_processes("spurctld")
-            node.kill_processes("spurd")
+    # --- Lifecycle ---
+
+    def provision(self):
+        """Create remote dirs and resolve hostnames.
+
+        After this call the cluster infrastructure is ready (dirs exist,
+        hostnames known) but no daemons are running.  Call :meth:`start`
+        to bring up the cluster with a specific configuration.
+        """
         self._create_dirs()
         self._resolve_hostnames()
+        logger.info("Cluster provisioned: %s", self.node_names)
+
+    def start(self, config_overrides: dict | None = None, kill_stale: bool = True):
+        """Write config and start all daemons.
+
+        *config_overrides* is deep-merged into the default config.
+        Requires :meth:`provision` to have been called first.
+
+        When *kill_stale* is True (default), any lingering spurctld/spurd
+        processes on the nodes are killed before starting fresh.
+        """
+        if not self.node_names:
+            raise RuntimeError("provision() must be called before start()")
+        if kill_stale:
+            self.stop()
+        self.config_overrides = config_overrides or {}
         self._write_config()
         self._start_controller()
         time.sleep(2)
@@ -171,11 +214,21 @@ class SpurCluster:
         self._wait_all_idle(timeout=120)
         logger.info("Cluster ready: %s", self.node_names)
 
-    def teardown(self):
-        """Kill all spur processes and remove the working directory."""
+    def stop(self):
+        """Kill all daemons but keep the working directory intact."""
         for node in self.nodes:
             node.kill_processes("spurctld")
             node.kill_processes("spurd")
+
+    def deploy(self, config_overrides: dict | None = None):
+        """Provision + start in one call."""
+        self.provision()
+        self.start(config_overrides)
+
+    def teardown(self):
+        """Kill all daemons and remove the working directory."""
+        self.stop()
+        for node in self.nodes:
             node.exec_allow_fail(f"rm -rf '{self.remote_dir}'")
         logger.info("Cluster torn down")
 
@@ -206,11 +259,21 @@ class SpurCluster:
     def scontrol(self, *args: str) -> str:
         return self.cli(["scontrol"] + list(args))
 
-    def write_script(self, name: str, body: str) -> str:
-        """Write an executable script on the controller. Returns remote path."""
+    def write_file(self, name: str, body: str, *,
+                   all_nodes: bool = False, executable: bool = True) -> str:
+        """Write a file under remote_dir. Returns the absolute remote path.
+
+        By default the file is written to the controller node only and
+        made executable.  Set *all_nodes=True* to write on every node,
+        and *executable=False* for non-script files.
+        """
         path = f"{self.remote_dir}/{name}"
-        self.nodes[0].write_file(path, body)
-        self.nodes[0].exec(f"chmod +x '{path}'")
+        mode = 0o755 if executable else None
+        targets = self.nodes if all_nodes else self.nodes[:1]
+        parent = path.rsplit("/", 1)[0]
+        for node in targets:
+            node.exec(f"mkdir -p '{parent}'")
+            node.write_file(path, body, mode=mode)
         return path
 
     def read_output_on_any_node(self, path: str) -> str:
@@ -369,25 +432,36 @@ mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
                 name = node.host
             self.node_names.append(name)
 
-    def _write_config(self):
+    def _default_config(self) -> dict:
         nodes_list = ",".join(self.node_names)
-        nodes_toml = ""
-        for name in self.node_names:
-            nodes_toml += f'\n[[nodes]]\nnames = "{name}"\ncpus = 64\nmemory_mb = 262144\n'
+        return {
+            "cluster_name": "e2e-test",
+            "scheduler": {"interval_secs": 1, "plugin": "backfill"},
+            "auth": {"plugin": "none"},
+            "network": {"wg_enabled": False, "agent_port": AGENT_PORT},
+            "partitions": [
+                {
+                    "name": "default",
+                    "state": "UP",
+                    "default": True,
+                    "nodes": nodes_list,
+                    "max_time": "24:00:00",
+                    "default_time": "10:00",
+                }
+            ],
+            "nodes": [
+                {"names": name, "cpus": 64, "memory_mb": 262144}
+                for name in self.node_names
+            ],
+        }
 
-        config = (
-            f'cluster_name = "e2e-test"\n\n'
-            f"[scheduler]\n"
-            f'interval_secs = 1\nplugin = "backfill"\n\n'
-            f"[auth]\n"
-            f'plugin = "none"\n\n'
-            f"[[partitions]]\n"
-            f'name = "default"\nstate = "UP"\ndefault = true\n'
-            f'nodes = "{nodes_list}"\nmax_time = "24:00:00"\ndefault_time = "10:00"\n\n'
-            f"[network]\nwg_enabled = false\nagent_port = {AGENT_PORT}\n"
-            f"{nodes_toml}"
-        )
-        self.nodes[0].write_file(f"{self.etc_dir}/spur.conf", config)
+    def _write_config(self):
+        cfg = self._default_config()
+        deep_merge(cfg, self.config_overrides)
+        config = tomli_w.dumps(cfg)
+
+        for node in self.nodes:
+            node.write_file(f"{self.etc_dir}/spur.conf", config)
 
     def _start_controller(self):
         listen = f"[::]:{CONTROLLER_PORT}"
@@ -407,6 +481,7 @@ mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
             agent_listen = f"0.0.0.0:{AGENT_PORT}"
             cmd = (
                 f"nohup '{self.bin_dir}/spurd' "
+                f"-f '{self.etc_dir}/spur.conf' "
                 f"--controller '{self.controller_addr}' "
                 f"--listen '{agent_listen}' "
                 f"--hostname '{hostname}' --address '{address}' --log-level info -D "

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import pytest
 
-from cluster import SshNode, SpurCluster, ensure_bins
+from cluster import SshNode, SpurCluster, ensure_bins, make_remote_dir
 
 
 def _repo_root() -> Path:
@@ -107,30 +107,50 @@ def _ensure_bins(ssh_nodes, remote_bin_dir):
     ensure_bins(ssh_nodes, _get_binaries_dir(), remote_bin_dir)
 
 
-def _make_remote_dir() -> str:
-    """Generate a unique remote working directory path per test."""
-    return f"/tmp/spur-e2e-{os.getpid()}-{int(time.time() * 1000)}"
-
-
 def _deploy_cluster(ssh_nodes, remote_bin_dir):
     """Helper: create, deploy, and return a SpurCluster. Tears down on deploy failure."""
-    remote_dir = _make_remote_dir()
-    spur_cluster = SpurCluster(ssh_nodes, remote_dir, remote_bin_dir)
+    c = SpurCluster(ssh_nodes, make_remote_dir(), remote_bin_dir)
     try:
-        spur_cluster.deploy()
+        c.deploy()
     except Exception:
-        spur_cluster.teardown()
+        c.teardown()
         raise
-    return spur_cluster
+    return c
+
+
+def _provision_cluster(ssh_nodes, remote_bin_dir):
+    """Helper: create and provision (but do not start) a SpurCluster."""
+    c = SpurCluster(ssh_nodes, make_remote_dir(), remote_bin_dir)
+    try:
+        c.provision()
+    except Exception:
+        c.teardown()
+        raise
+    return c
 
 
 @pytest.fixture
 def cluster(ssh_nodes, remote_bin_dir):
     """
-    Per-test fixture: starts a fresh Spur cluster in a unique remote dir,
-    yields it, then kills processes and removes the dir.
+    Per-test fixture: a fully running Spur cluster with default config.
+    Torn down (processes killed, dirs removed) after the test.
     """
     spur_cluster = _deploy_cluster(ssh_nodes, remote_bin_dir)
+    yield spur_cluster
+    spur_cluster.teardown()
+
+
+@pytest.fixture
+def unstarted_cluster(ssh_nodes, remote_bin_dir):
+    """
+    Per-test fixture: a provisioned cluster (dirs created, hostnames
+    resolved) but **not started**.
+
+    The test should write any scripts or files it needs, then call
+    ``cluster.start(config_overrides)`` to bring up the daemons with
+    the desired configuration.
+    """
+    spur_cluster = _provision_cluster(ssh_nodes, remote_bin_dir)
     yield spur_cluster
     spur_cluster.teardown()
 

--- a/tests/e2e/requirements.txt
+++ b/tests/e2e/requirements.txt
@@ -1,2 +1,3 @@
 pytest==9.0.3
 paramiko==5.0.0
+tomli-w==1.2.0

--- a/tests/e2e/test_container.py
+++ b/tests/e2e/test_container.py
@@ -41,7 +41,7 @@ class TestContainerSingleNode:
     def test_container_launch_and_exit(self, container_cluster):
         cluster = container_cluster
         img = cluster.container_image
-        script = cluster.write_script(
+        script = cluster.write_file(
             "c1.sh",
             "#!/bin/bash\nhostname >/dev/null || exit 1\nid >/dev/null || exit 1\n",
         )
@@ -56,7 +56,7 @@ class TestContainerSingleNode:
     def test_container_exit_code_propagation(self, container_cluster):
         cluster = container_cluster
         img = cluster.container_image
-        script = cluster.write_script("c2.sh", "#!/bin/bash\nexit 42\n")
+        script = cluster.write_file("c2.sh", "#!/bin/bash\nexit 42\n")
 
         sb = cluster.sbatch(["-J", "c2-exit", "-N", "1", f"--container-image={img}", script])
         job_id = parse_job_id(sb)
@@ -68,7 +68,7 @@ class TestContainerSingleNode:
     def test_container_cancel(self, container_cluster):
         cluster = container_cluster
         img = cluster.container_image
-        script = cluster.write_script("c3.sh", "#!/bin/bash\nsleep 3600\n")
+        script = cluster.write_file("c3.sh", "#!/bin/bash\nsleep 3600\n")
 
         sb = cluster.sbatch(["-J", "c3-cancel", "-N", "1", f"--container-image={img}", script])
         job_id = parse_job_id(sb)
@@ -93,7 +93,7 @@ class TestContainerSingleNode:
         cluster = container_cluster
         img = cluster.container_image
         out_path = f"{cluster.remote_dir}/c4.out"
-        script = cluster.write_script(
+        script = cluster.write_file(
             "c4.sh",
             "#!/bin/bash\n"
             "grep -q '127.0.0.53' /etc/resolv.conf && exit 1\n"
@@ -117,7 +117,7 @@ class TestContainerSingleNode:
     def test_container_dev_shm(self, container_cluster):
         cluster = container_cluster
         img = cluster.container_image
-        script = cluster.write_script(
+        script = cluster.write_file(
             "c5.sh",
             "#!/bin/bash\n"
             "echo shm_test > /dev/shm/spur_ctest || exit 1\n"
@@ -137,7 +137,7 @@ class TestContainerSingleNode:
     def test_container_pid_namespace(self, container_cluster):
         cluster = container_cluster
         img = cluster.container_image
-        script = cluster.write_script(
+        script = cluster.write_file(
             "c6.sh",
             '#!/bin/bash\n[ "$$" = "1" ] || exit 1\n[ -r /proc/self/status ] || exit 2\n',
         )
@@ -154,7 +154,7 @@ class TestContainerSingleNode:
     def test_container_env_vars(self, container_cluster):
         cluster = container_cluster
         img = cluster.container_image
-        script = cluster.write_script(
+        script = cluster.write_file(
             "c7.sh",
             '#!/bin/bash\n[ -n "$SPUR_JOB_ID" ] || exit 1\n[ -n "$OMP_NUM_THREADS" ] || exit 2\n',
         )
@@ -177,7 +177,7 @@ class TestContainerSingleNode:
         for node in cluster.nodes:
             node.exec(f"mkdir -p '{bind_dir}' && echo bind_mount_ci_test > '{bind_dir}/data.txt'")
 
-        script = cluster.write_script(
+        script = cluster.write_file(
             "c8.sh",
             "#!/bin/bash\n"
             '[ "$(cat /mnt/data/data.txt 2>/dev/null)" = "bind_mount_ci_test" ] || exit 1\n'
@@ -207,7 +207,7 @@ class TestContainerMultiNode:
         cluster = multi_container_cluster
         img = cluster.container_image
         out_path = f"{cluster.remote_dir}/ct-2n.out"
-        script = cluster.write_script(
+        script = cluster.write_file(
             "ct-2n.sh",
             "#!/bin/bash\n"
             'echo "CONTAINER_NODE=$(hostname)"\n'
@@ -234,7 +234,7 @@ class TestContainerMultiNode:
         cluster = multi_container_cluster
         img = cluster.container_image
         out_path = f"{cluster.remote_dir}/ct-2n-env.out"
-        script = cluster.write_script(
+        script = cluster.write_file(
             "ct-2n-env.sh",
             "#!/bin/bash\n"
             'echo "RANK=${RANK}"\n'
@@ -265,7 +265,7 @@ class TestContainerMultiNode:
         cluster = multi_container_cluster
         img = cluster.container_image
         out_path = f"{cluster.remote_dir}/ct-2n-dns.out"
-        script = cluster.write_script(
+        script = cluster.write_file(
             "ct-2n-dns.sh",
             "#!/bin/bash\n"
             "getent hosts google.com >/dev/null 2>&1 || exit 1\n"

--- a/tests/e2e/test_gpu.py
+++ b/tests/e2e/test_gpu.py
@@ -64,7 +64,7 @@ class TestGpuSingleNode:
                 )
 
         gpu_bin = f"{cluster.remote_dir}/gpu_test"
-        script = cluster.write_script("gpu-1n.sh", f"#!/bin/bash\n'{gpu_bin}'\n")
+        script = cluster.write_file("gpu-1n.sh", f"#!/bin/bash\n'{gpu_bin}'\n")
         out_path = f"{cluster.remote_dir}/hip-1n.out"
 
         sb = cluster.sbatch(["-J", "hip-1n", "-N", "1", "-o", out_path, script])
@@ -97,7 +97,7 @@ class TestGpuMultiNode:
                 )
 
         gpu_bin = f"{cluster.remote_dir}/gpu_test"
-        script = cluster.write_script("gpu-2n.sh", f"#!/bin/bash\n'{gpu_bin}'\n")
+        script = cluster.write_file("gpu-2n.sh", f"#!/bin/bash\n'{gpu_bin}'\n")
         out_path = f"{cluster.remote_dir}/hip-2n.out"
 
         sb = cluster.sbatch(["-J", "hip-2n", "-N", "2", "-o", out_path, script])
@@ -125,7 +125,7 @@ class TestGpuMultiNode:
             cluster.ship_file_to_all(src, "distributed_test.py")
 
         # Generate a wrapper that activates the venv and runs the script
-        job_sh = cluster.write_script(
+        job_sh = cluster.write_file(
             "distributed_job.sh",
             f"#!/bin/bash\nsource '{venv_path}/bin/activate'\n"
             f"exec python3 '{rd}/distributed_test.py'\n",
@@ -160,7 +160,7 @@ class TestGpuMultiNode:
             cluster.ship_file_to_all(src, "inference_test.py")
 
         # Generate a wrapper that activates the venv and runs the script
-        job_sh = cluster.write_script(
+        job_sh = cluster.write_file(
             "inference_job.sh",
             f"#!/bin/bash\nsource '{venv_path}/bin/activate'\n"
             f"exec python3 '{rd}/inference_test.py'\n",

--- a/tests/e2e/test_multi_node.py
+++ b/tests/e2e/test_multi_node.py
@@ -16,7 +16,7 @@ class TestMultiNodeDispatch:
     def test_two_node_job_completes(self, multi_node_cluster):
         cluster = multi_node_cluster
         out_path = f"{cluster.remote_dir}/two-node.out"
-        script = cluster.write_script(
+        script = cluster.write_file(
             "two-node.sh",
             "#!/bin/bash\n"
             'echo "node=$(hostname)"\n'
@@ -43,7 +43,7 @@ class TestMultiNodeDispatch:
     def test_distributed_env_vars(self, multi_node_cluster):
         cluster = multi_node_cluster
         out_path = f"{cluster.remote_dir}/dist-env.out"
-        script = cluster.write_script(
+        script = cluster.write_file(
             "dist-env.sh",
             "#!/bin/bash\n"
             'echo "RANK=${RANK}"\n'
@@ -76,7 +76,7 @@ class TestMultiNodeScheduling:
         cluster = multi_node_cluster
         target = cluster.node_names[0]
         out_path = f"{cluster.remote_dir}/nodelist-{target}.out"
-        script = cluster.write_script(
+        script = cluster.write_file(
             "nodename.sh",
             '#!/bin/bash\necho "RAN_ON=${SPUR_TARGET_NODE:-$(hostname)}"\n',
         )
@@ -92,7 +92,7 @@ class TestMultiNodeScheduling:
         cluster = multi_node_cluster
         target = cluster.node_names[1]
         out_path = f"{cluster.remote_dir}/nodelist-{target}.out"
-        script = cluster.write_script(
+        script = cluster.write_file(
             "nodename2.sh",
             '#!/bin/bash\necho "RAN_ON=${SPUR_TARGET_NODE:-$(hostname)}"\n',
         )
@@ -108,7 +108,7 @@ class TestMultiNodeScheduling:
         cluster = multi_node_cluster
         excluded = cluster.node_names[0]
         out_path = f"{cluster.remote_dir}/exclude.out"
-        script = cluster.write_script(
+        script = cluster.write_file(
             "nodename-ex.sh",
             '#!/bin/bash\necho "RAN_ON=${SPUR_TARGET_NODE:-$(hostname)}"\n',
         )
@@ -130,7 +130,7 @@ class TestMultiNodeScheduling:
         cluster = multi_node_cluster
         out1 = f"{cluster.remote_dir}/con1.out"
         out2 = f"{cluster.remote_dir}/con2.out"
-        script = cluster.write_script(
+        script = cluster.write_file(
             "concurrent.sh",
             "#!/bin/bash\necho CONCURRENT_START\nsleep 5\necho CONCURRENT_DONE\n",
         )

--- a/tests/e2e/test_prolog_epilog.py
+++ b/tests/e2e/test_prolog_epilog.py
@@ -1,0 +1,435 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for the Spur prolog/epilog hook framework.
+
+Tests cover all hook types (prolog, epilog, prolog_slurmctld, epilog_slurmctld),
+environment variable propagation, failure semantics, and execution ordering.
+"""
+
+import time
+
+from cluster import parse_job_id, wait_job, job_state
+
+
+LOGGING_PROLOG = """\
+#!/bin/bash
+mkdir -p "{RD}/hook-out"
+{
+    echo "HOOK=prolog"
+    echo "TS=$(date +%s%N)"
+    echo "SPUR_JOB_ID=$SPUR_JOB_ID"
+    echo "SPUR_JOB_USER=$SPUR_JOB_USER"
+    echo "SPUR_JOB_UID=$SPUR_JOB_UID"
+    echo "SPUR_JOB_GID=$SPUR_JOB_GID"
+    echo "SPUR_JOB_WORK_DIR=$SPUR_JOB_WORK_DIR"
+    echo "SPUR_JOB_PARTITION=$SPUR_JOB_PARTITION"
+    echo "SPUR_JOB_NODELIST=$SPUR_JOB_NODELIST"
+    echo "SPUR_CPUS_ON_NODE=$SPUR_CPUS_ON_NODE"
+    echo "SPUR_JOB_MEMORY_MB=$SPUR_JOB_MEMORY_MB"
+    echo "SPUR_SCRIPT_CONTEXT=$SPUR_SCRIPT_CONTEXT"
+} > "{RD}/hook-out/prolog-$SPUR_JOB_ID.log"
+"""
+
+LOGGING_EPILOG = """\
+#!/bin/bash
+mkdir -p "{RD}/hook-out"
+{
+    echo "HOOK=epilog"
+    echo "TS=$(date +%s%N)"
+    echo "SPUR_JOB_ID=$SPUR_JOB_ID"
+    echo "SPUR_JOB_USER=$SPUR_JOB_USER"
+    echo "SPUR_JOB_UID=$SPUR_JOB_UID"
+    echo "SPUR_JOB_GID=$SPUR_JOB_GID"
+    echo "SPUR_JOB_WORK_DIR=$SPUR_JOB_WORK_DIR"
+    echo "SPUR_JOB_PARTITION=$SPUR_JOB_PARTITION"
+    echo "SPUR_JOB_NODELIST=$SPUR_JOB_NODELIST"
+    echo "SPUR_CPUS_ON_NODE=$SPUR_CPUS_ON_NODE"
+    echo "SPUR_JOB_MEMORY_MB=$SPUR_JOB_MEMORY_MB"
+    echo "SPUR_SCRIPT_CONTEXT=$SPUR_SCRIPT_CONTEXT"
+} > "{RD}/hook-out/epilog-$SPUR_JOB_ID.log"
+"""
+
+LOGGING_PROLOG_CTLD = """\
+#!/bin/bash
+mkdir -p "{RD}/hook-out"
+{
+    echo "HOOK=prolog_slurmctld"
+    echo "SPUR_JOB_ID=$SPUR_JOB_ID"
+    echo "SPUR_JOB_PARTITION=$SPUR_JOB_PARTITION"
+    echo "SPUR_JOB_NODELIST=$SPUR_JOB_NODELIST"
+    echo "SPUR_SCRIPT_CONTEXT=$SPUR_SCRIPT_CONTEXT"
+} > "{RD}/hook-out/prolog_ctld-$SPUR_JOB_ID.log"
+"""
+
+LOGGING_EPILOG_CTLD = """\
+#!/bin/bash
+mkdir -p "{RD}/hook-out"
+{
+    echo "HOOK=epilog_slurmctld"
+    echo "SPUR_JOB_ID=$SPUR_JOB_ID"
+    echo "SPUR_JOB_PARTITION=$SPUR_JOB_PARTITION"
+    echo "SPUR_SCRIPT_CONTEXT=$SPUR_SCRIPT_CONTEXT"
+} > "{RD}/hook-out/epilog_ctld-$SPUR_JOB_ID.log"
+"""
+
+FAILING_HOOK = """\
+#!/bin/bash
+exit 1
+"""
+
+
+def _parse_hook_log(content: str) -> dict[str, str]:
+    """Parse a hook log file (KEY=VALUE per line) into a dict."""
+    result = {}
+    for line in content.strip().splitlines():
+        if "=" in line:
+            key, _, value = line.partition("=")
+            result[key] = value
+    return result
+
+
+def _read_hook_log(cluster, job_id, hook_name, *, controller_only=False):
+    """Read and parse a hook log file, asserting it exists."""
+    path = f"{cluster.remote_dir}/hook-out/{hook_name}-{job_id}.log"
+    if controller_only:
+        raw = cluster.nodes[0].read_file(path)
+    else:
+        raw = cluster.read_output_on_any_node(path)
+    assert raw.strip(), f"hook log not found: {path}"
+    return _parse_hook_log(raw)
+
+
+def _setup_hooks(cluster, **hook_bodies: str) -> dict:
+    """Write hook scripts to all nodes and return config overrides.
+
+    Each keyword argument maps a hook name (e.g. ``prolog``,
+    ``epilog_slurmctld``) to a script body template.  ``{RD}`` in
+    the body is replaced with ``cluster.remote_dir``.
+
+    Returns a *config_overrides* dict ready to pass to
+    :meth:`SpurCluster.start`.
+    """
+    rd = cluster.remote_dir
+    hooks_config: dict[str, str] = {}
+    for hook_name, body in hook_bodies.items():
+        script_name = f"hooks/{hook_name}.sh"
+        cluster.write_file(script_name, body.replace("{RD}", rd), all_nodes=True)
+        hooks_config[hook_name] = f"{rd}/{script_name}"
+    return {"hooks": hooks_config}
+
+
+def _wait_node_state(cluster, target_state, timeout=15):
+    """Poll sinfo until any node shows *target_state* (case-insensitive)."""
+    target = target_state.lower()
+    deadline = time.time() + timeout
+    info = ""
+    while time.time() < deadline:
+        info = cluster.sinfo()
+        if target in info.lower():
+            return info
+        time.sleep(1)
+    assert False, (
+        f"no node reached '{target_state}' within {timeout}s:\n{info}"
+    )
+
+
+class TestHookExecution:
+    """Verify hooks execute in the right order with correct env vars."""
+
+    def test_prolog_executes_before_epilog(self, unstarted_cluster):
+        cluster = unstarted_cluster
+        cluster.start(_setup_hooks(cluster, prolog=LOGGING_PROLOG, epilog=LOGGING_EPILOG))
+
+        out_path = f"{cluster.remote_dir}/ordering.out"
+        script = cluster.write_file("test.sh", "#!/bin/bash\nsleep 2\necho DONE\n")
+        sb = cluster.sbatch(["-J", "ordering", "-N", "1", "-o", out_path, script])
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+
+        state = wait_job(cluster, job_id, timeout=60)
+        assert state in ("CD", "GONE"), f"expected completed, got {state}"
+
+        content = cluster.read_output_on_any_node(out_path)
+        assert "DONE" in content, f"job output missing:\n{content}"
+
+        prolog = _read_hook_log(cluster, job_id, "prolog")
+        epilog = _read_hook_log(cluster, job_id, "epilog")
+
+        assert int(prolog["TS"]) < int(epilog["TS"]), (
+            f"prolog must run before epilog: {prolog['TS']} vs {epilog['TS']}"
+        )
+
+    def test_prolog_receives_all_env_vars(self, unstarted_cluster):
+        cluster = unstarted_cluster
+        cluster.start(_setup_hooks(cluster, prolog=LOGGING_PROLOG))
+
+        script = cluster.write_file("test.sh", "#!/bin/bash\necho ENV_OK\n")
+        sb = cluster.sbatch(["-J", "env-prolog", "-N", "1", script])
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+
+        state = wait_job(cluster, job_id, timeout=60)
+        assert state in ("CD", "GONE"), f"expected completed, got {state}"
+
+        log = _read_hook_log(cluster, job_id, "prolog")
+        assert log["SPUR_JOB_ID"] == str(job_id)
+        assert log["SPUR_JOB_PARTITION"] == "default"
+        assert log["SPUR_SCRIPT_CONTEXT"] == "prolog_slurmd"
+        assert log.get("SPUR_JOB_USER"), "SPUR_JOB_USER must be set"
+        assert log.get("SPUR_JOB_UID"), "SPUR_JOB_UID must be set"
+        assert log.get("SPUR_JOB_GID"), "SPUR_JOB_GID must be set"
+        assert log.get("SPUR_JOB_WORK_DIR"), "SPUR_JOB_WORK_DIR must be set"
+        assert log.get("SPUR_JOB_NODELIST"), "SPUR_JOB_NODELIST must be set"
+        assert log.get("SPUR_CPUS_ON_NODE"), "SPUR_CPUS_ON_NODE must be set"
+        assert log.get("SPUR_JOB_MEMORY_MB"), "SPUR_JOB_MEMORY_MB must be set"
+
+    def test_epilog_receives_all_env_vars(self, unstarted_cluster):
+        cluster = unstarted_cluster
+        cluster.start(_setup_hooks(cluster, epilog=LOGGING_EPILOG))
+
+        script = cluster.write_file("test.sh", "#!/bin/bash\necho ENV_OK\n")
+        sb = cluster.sbatch(["-J", "env-epilog", "-N", "1", script])
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+
+        state = wait_job(cluster, job_id, timeout=60)
+        assert state in ("CD", "GONE"), f"expected completed, got {state}"
+
+        log = _read_hook_log(cluster, job_id, "epilog")
+        assert log["SPUR_JOB_ID"] == str(job_id)
+        assert log["SPUR_JOB_PARTITION"] == "default"
+        assert log["SPUR_SCRIPT_CONTEXT"] == "epilog_slurmd"
+        assert log.get("SPUR_JOB_USER"), "SPUR_JOB_USER must be set"
+        assert log.get("SPUR_JOB_UID"), "SPUR_JOB_UID must be set"
+        assert log.get("SPUR_JOB_GID"), "SPUR_JOB_GID must be set"
+        assert log.get("SPUR_JOB_WORK_DIR"), "SPUR_JOB_WORK_DIR must be set"
+        assert log.get("SPUR_JOB_NODELIST"), "SPUR_JOB_NODELIST must be set"
+        assert log.get("SPUR_CPUS_ON_NODE"), "SPUR_CPUS_ON_NODE must be set"
+        assert log.get("SPUR_JOB_MEMORY_MB"), "SPUR_JOB_MEMORY_MB must be set"
+
+    def test_prolog_nodelist_matches_allocated_node(self, unstarted_cluster):
+        cluster = unstarted_cluster
+        cluster.start(_setup_hooks(cluster, prolog=LOGGING_PROLOG))
+
+        target = cluster.node_names[0]
+        script = cluster.write_file("test.sh", "#!/bin/bash\necho OK\n")
+        sb = cluster.sbatch(["-J", "nodelist-check", "-N", "1", "-w", target, script])
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+
+        state = wait_job(cluster, job_id, timeout=60)
+        assert state in ("CD", "GONE"), f"expected completed, got {state}"
+
+        log = _read_hook_log(cluster, job_id, "prolog")
+        assert log["SPUR_JOB_NODELIST"] == target, (
+            f"expected nodelist {target!r}, got {log['SPUR_JOB_NODELIST']!r}"
+        )
+
+    def test_all_hooks_env_vars_consistent(self, unstarted_cluster):
+        """All four hook types receive the same job ID and correct script context."""
+        cluster = unstarted_cluster
+        cluster.start(_setup_hooks(
+            cluster,
+            prolog=LOGGING_PROLOG,
+            epilog=LOGGING_EPILOG,
+            prolog_slurmctld=LOGGING_PROLOG_CTLD,
+            epilog_slurmctld=LOGGING_EPILOG_CTLD,
+        ))
+        script = cluster.write_file("test.sh", "#!/bin/bash\necho CONSISTENT_OK\n")
+        sb = cluster.sbatch(["-J", "consistent", "-N", "1", script])
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+
+        state = wait_job(cluster, job_id, timeout=60)
+        assert state in ("CD", "GONE"), f"expected completed, got {state}"
+
+        prolog = _read_hook_log(cluster, job_id, "prolog")
+        epilog = _read_hook_log(cluster, job_id, "epilog")
+        prolog_ctld = _read_hook_log(cluster, job_id, "prolog_ctld", controller_only=True)
+        epilog_ctld = _read_hook_log(cluster, job_id, "epilog_ctld", controller_only=True)
+
+        jid_str = str(job_id)
+        assert prolog["SPUR_JOB_ID"] == jid_str
+        assert epilog["SPUR_JOB_ID"] == jid_str
+        assert prolog_ctld["SPUR_JOB_ID"] == jid_str
+        assert epilog_ctld["SPUR_JOB_ID"] == jid_str
+
+        assert prolog["SPUR_SCRIPT_CONTEXT"] == "prolog_slurmd"
+        assert epilog["SPUR_SCRIPT_CONTEXT"] == "epilog_slurmd"
+        assert prolog_ctld["SPUR_SCRIPT_CONTEXT"] == "prolog_slurmctld"
+        assert epilog_ctld["SPUR_SCRIPT_CONTEXT"] == "epilog_slurmctld"
+
+    def test_multiple_jobs_get_independent_hooks(self, unstarted_cluster):
+        """Each job should trigger its own prolog/epilog with the correct job ID."""
+        cluster = unstarted_cluster
+        cluster.start(_setup_hooks(cluster, prolog=LOGGING_PROLOG, epilog=LOGGING_EPILOG))
+        script = cluster.write_file("test.sh", "#!/bin/bash\necho MULTI_OK\n")
+
+        sb1 = cluster.sbatch(["-J", "multi-1", "-N", "1", script])
+        jid1 = parse_job_id(sb1)
+        assert jid1 is not None
+        wait_job(cluster, jid1, timeout=60)
+
+        sb2 = cluster.sbatch(["-J", "multi-2", "-N", "1", script])
+        jid2 = parse_job_id(sb2)
+        assert jid2 is not None
+        wait_job(cluster, jid2, timeout=60)
+
+        assert jid1 != jid2
+
+        for job_id in (jid1, jid2):
+            prolog = _read_hook_log(cluster, job_id, "prolog")
+            epilog = _read_hook_log(cluster, job_id, "epilog")
+            assert prolog["SPUR_JOB_ID"] == str(job_id), (
+                f"prolog logged wrong job_id for job {job_id}: {prolog['SPUR_JOB_ID']}"
+            )
+            assert epilog["SPUR_JOB_ID"] == str(job_id), (
+                f"epilog logged wrong job_id for job {job_id}: {epilog['SPUR_JOB_ID']}"
+            )
+
+    def test_hooks_run_for_failed_job_script(self, unstarted_cluster):
+        cluster = unstarted_cluster
+        cluster.start(_setup_hooks(cluster, prolog=LOGGING_PROLOG, epilog=LOGGING_EPILOG))
+        script = cluster.write_file("test.sh", "#!/bin/bash\nexit 42\n")
+        sb = cluster.sbatch(["-J", "fail-job-hooks", "-N", "1", script])
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+
+        state = wait_job(cluster, job_id, timeout=60)
+        assert state == "F", f"expected failed state, got {state}"
+
+        prolog = _read_hook_log(cluster, job_id, "prolog")
+        epilog = _read_hook_log(cluster, job_id, "epilog")
+        assert prolog["SPUR_JOB_ID"] == str(job_id)
+        assert epilog["SPUR_JOB_ID"] == str(job_id)
+
+
+class TestHookFailure:
+    """Verify failure semantics for all hook types."""
+
+    def test_prolog_failure_fails_job_and_drains_node(self, unstarted_cluster):
+        # TODO: Slurm requeues+holds the job on prolog failure. Spur currently
+        # races between JobFailed (agent report_completion) and requeue
+        # (scheduler all-dispatch-fail path), so we accept both F and PD.
+        # Tighten to PD-only once requeue+hold semantics are implemented.
+        cluster = unstarted_cluster
+        cluster.start(_setup_hooks(cluster, prolog=FAILING_HOOK))
+        out_path = f"{cluster.remote_dir}/fail-prolog.out"
+        script = cluster.write_file(
+            "test.sh", "#!/bin/bash\necho SHOULD_NOT_RUN\n"
+        )
+        sb = cluster.sbatch(["-J", "fail-prolog", "-N", "1", "-o", out_path, script])
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+
+        _wait_node_state(cluster, "drain")
+
+        # With multiple nodes the scheduler may re-dispatch before the failure
+        # report lands, draining nodes one by one.  Once all are drained the
+        # job is either F (failure reported) or PD (stuck, no eligible nodes).
+        deadline = time.time() + 30
+        state = None
+        while time.time() < deadline:
+            sq = cluster.squeue_all()
+            state = job_state(sq, job_id)
+            if state in ("F", "PD", None):
+                break
+            time.sleep(1)
+        assert state in ("F", "PD", None), (
+            f"job should fail or stay pending after prolog failure, got {state}"
+        )
+
+        content = cluster.read_output_on_any_node(out_path)
+        assert "SHOULD_NOT_RUN" not in content, (
+            "job should not have run after prolog failure"
+        )
+
+        if state == "PD":
+            cluster.scancel(str(job_id))
+
+    def test_epilog_failure_drains_node(self, unstarted_cluster):
+        cluster = unstarted_cluster
+        cluster.start(_setup_hooks(cluster, epilog=FAILING_HOOK))
+        out_path = f"{cluster.remote_dir}/fail-epilog.out"
+        script = cluster.write_file("test.sh", "#!/bin/bash\necho EPILOG_JOB_OK\n")
+        sb = cluster.sbatch(["-J", "fail-epilog", "-N", "1", "-o", out_path, script])
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+
+        state = wait_job(cluster, job_id, timeout=60)
+        assert state in ("CD", "GONE"), (
+            f"job should complete before epilog runs, got {state}"
+        )
+
+        content = cluster.read_output_on_any_node(out_path)
+        assert "EPILOG_JOB_OK" in content, (
+            "job should have run before epilog failure"
+        )
+
+        _wait_node_state(cluster, "drain")
+
+    def test_prolog_slurmctld_failure_requeues_batch_job(self, unstarted_cluster):
+        """PrologSlurmctld failure requeues batch jobs — they never reach the agents."""
+        cluster = unstarted_cluster
+        cluster.start(_setup_hooks(
+            cluster, prolog_slurmctld=FAILING_HOOK, prolog=LOGGING_PROLOG,
+        ))
+        out_path = f"{cluster.remote_dir}/ctld-fail.out"
+        script = cluster.write_file("test.sh", "#!/bin/bash\necho SHOULD_NOT_RUN\n")
+        sb = cluster.sbatch(["-J", "ctld-fail", "-N", "1", "-o", out_path, script])
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+
+        deadline = time.time() + 30
+        state = None
+        while time.time() < deadline:
+            sq = cluster.squeue_all()
+            state = job_state(sq, job_id)
+            if state == "PD":
+                break
+            assert state != "R", (
+                f"job should not run after PrologSlurmctld failure\n{sq}"
+            )
+            time.sleep(1)
+        assert state == "PD", (
+            f"batch job should stay pending (requeued) after PrologSlurmctld "
+            f"failure, got {state}"
+        )
+
+        agent_prolog = cluster.read_output_on_any_node(
+            f"{cluster.remote_dir}/hook-out/prolog-{job_id}.log"
+        )
+        assert not agent_prolog.strip(), (
+            "agent-side prolog should never run when PrologSlurmctld fails"
+        )
+
+        content = cluster.read_output_on_any_node(out_path)
+        assert "SHOULD_NOT_RUN" not in content, (
+            "job script should never execute when PrologSlurmctld fails"
+        )
+
+        cluster.scancel(str(job_id))
+
+    def test_epilog_slurmctld_failure_is_nonfatal(self, unstarted_cluster):
+        """EpilogSlurmctld failure is logged but does not affect job or node state."""
+        cluster = unstarted_cluster
+        cluster.start(_setup_hooks(cluster, epilog_slurmctld=FAILING_HOOK))
+        out_path = f"{cluster.remote_dir}/ctld-epilog-nonfatal.out"
+        script = cluster.write_file("test.sh", "#!/bin/bash\necho NONFATAL_OK\n")
+        sb = cluster.sbatch(["-J", "ctld-epilog-nf", "-N", "1", "-o", out_path, script])
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+
+        state = wait_job(cluster, job_id, timeout=60)
+        assert state in ("CD", "GONE"), (
+            f"job should complete despite EpilogSlurmctld failure, got {state}"
+        )
+
+        content = cluster.read_output_on_any_node(out_path)
+        assert "NONFATAL_OK" in content
+
+        info = cluster.sinfo()
+        assert "drain" not in info.lower(), (
+            f"EpilogSlurmctld failure should not drain nodes:\n{info}"
+        )

--- a/tests/e2e/test_single_node.py
+++ b/tests/e2e/test_single_node.py
@@ -25,7 +25,7 @@ class TestClusterHealth:
 class TestJobBasics:
     def test_single_node_job_completes_with_output(self, cluster):
         out_path = f"{cluster.remote_dir}/basic.out"
-        script = cluster.write_script(
+        script = cluster.write_file(
             "test-basic.sh",
             '#!/bin/bash\necho "hostname=$(hostname)"\n'
             'echo "SPUR_JOB_ID=${SPUR_JOB_ID}"\necho SUCCESS\n',
@@ -43,7 +43,7 @@ class TestJobBasics:
 
     def test_failed_job_state(self, cluster):
         out_path = f"{cluster.remote_dir}/fail.out"
-        script = cluster.write_script(
+        script = cluster.write_file(
             "test-fail.sh",
             "#!/bin/bash\necho before-failure\nexit 42\n",
         )
@@ -60,7 +60,7 @@ class TestJobBasics:
     def test_custom_output_and_error_paths(self, cluster):
         out_path = f"{cluster.remote_dir}/custom-out.txt"
         err_path = f"{cluster.remote_dir}/custom-err.txt"
-        script = cluster.write_script(
+        script = cluster.write_file(
             "test-io.sh",
             "#!/bin/bash\necho stdout-line\necho stderr-line >&2\necho CUSTOM_IO_OK\n",
         )
@@ -75,7 +75,7 @@ class TestJobBasics:
         assert "stderr-line" in stderr
 
     def test_percent_j_output_substitution(self, cluster):
-        script = cluster.write_script("test-j.sh", "#!/bin/bash\necho J_OK\n")
+        script = cluster.write_file("test-j.sh", "#!/bin/bash\necho J_OK\n")
         pattern = f"{cluster.remote_dir}/spur-subst-%j.out"
         sb = cluster.sbatch(["-J", "test-subst", "-N", "1", "-o", pattern, script])
         job_id = parse_job_id(sb)
@@ -89,7 +89,7 @@ class TestJobBasics:
 
 class TestJobLifecycle:
     def test_job_cancel(self, cluster):
-        script = cluster.write_script("test-long.sh", "#!/bin/bash\nsleep 300\n")
+        script = cluster.write_file("test-long.sh", "#!/bin/bash\nsleep 300\n")
         sb = cluster.sbatch(["-J", "test-cancel", "-N", "1", script])
         job_id = parse_job_id(sb)
         assert job_id is not None
@@ -103,7 +103,7 @@ class TestJobLifecycle:
         assert state in ("CA", "F", None), f"expected cancelled, got {state}"
 
     def test_job_cancel_releases_resources(self, cluster):
-        script = cluster.write_script(
+        script = cluster.write_file(
             "test-cancel-res.sh",
             "#!/bin/bash\ntrap '' TERM\nsleep 300\n",
         )
@@ -124,7 +124,7 @@ class TestJobLifecycle:
 
     def test_job_hold_and_release(self, cluster):
         out_path = f"{cluster.remote_dir}/hold.out"
-        script = cluster.write_script("test-hold.sh", "#!/bin/bash\necho HOLD_OK\n")
+        script = cluster.write_file("test-hold.sh", "#!/bin/bash\necho HOLD_OK\n")
         sb = cluster.sbatch(["-J", "test-hold", "-N", "1", "-H", "-o", out_path, script])
         job_id = parse_job_id(sb)
         assert job_id is not None
@@ -141,11 +141,11 @@ class TestJobLifecycle:
 
     def test_job_dependency_afterok(self, cluster):
         out_b = f"{cluster.remote_dir}/dep-b.out"
-        script_a = cluster.write_script(
+        script_a = cluster.write_file(
             "dep-a.sh",
             "#!/bin/bash\necho DEP_A_START\nsleep 6\necho DEP_A_DONE\n",
         )
-        script_b = cluster.write_script("dep-b.sh", "#!/bin/bash\necho DEP_B_RAN\n")
+        script_b = cluster.write_file("dep-b.sh", "#!/bin/bash\necho DEP_B_RAN\n")
 
         sb_a = cluster.sbatch(["-J", "dep-a", "-N", "1", script_a])
         job_a = parse_job_id(sb_a)
@@ -172,7 +172,7 @@ class TestJobLifecycle:
 
     def test_time_limit_enforced(self, cluster):
         out_path = f"{cluster.remote_dir}/walltime.out"
-        script = cluster.write_script(
+        script = cluster.write_file(
             "walltime.sh",
             "#!/bin/bash\necho WALLTIME_STARTED\nsleep 300\necho WALLTIME_SHOULD_NOT_REACH\n",
         )
@@ -189,7 +189,7 @@ class TestJobLifecycle:
 
     def test_env_passthrough_export(self, cluster):
         out_path = f"{cluster.remote_dir}/env.out"
-        script = cluster.write_script(
+        script = cluster.write_file(
             "test-env.sh",
             '#!/bin/bash\necho "MYVAR=${MYVAR}"\necho "MULTIVAR=${MULTIVAR}"\necho ENV_OK\n',
         )


### PR DESCRIPTION
## Summary

Adds 11 end-to-end tests for the prolog/epilog hook framework introduced in #219. Tests cover all four hook types (prolog, epilog, prolog_slurmctld, epilog_slurmctld) across execution ordering, environment variable propagation, and failure semantics.

Also refactors the e2e cluster infrastructure to support custom configuration:
- Decouples cluster lifecycle into `provision()` / `start(config_overrides)` / `stop()` — tests that need custom config (like hooks) use `unstarted_cluster` fixture, write scripts, then call `start()`
- Replaces f-string config generation with `tomli-w` serialization + `deep_merge` for config overrides
- Writes `spur.conf` to all nodes and passes `-f` to `spurd` so agents load hooks config

### Tests added

**Hook execution (7 tests):**
- Prolog executes before epilog (nanosecond timestamp ordering)
- Prolog and epilog receive all expected environment variables (job ID, user, UID/GID, partition, nodelist, CPUs, memory, script context)
- Prolog nodelist matches allocated node when using `-w`
- All four hook types receive consistent job ID and correct `SPUR_SCRIPT_CONTEXT` values
- Multiple jobs trigger independent hooks with correct per-job IDs
- Both prolog and epilog run even when the job script exits non-zero

**Hook failure semantics (4 tests):**
- Prolog failure prevents job execution and drains the node
- Epilog failure drains the node but job output is preserved
- PrologSlurmctld failure requeues batch jobs (stays pending, never dispatched to agents)
- EpilogSlurmctld failure is non-fatal (job completes, no drain)

### Known limitation

`test_prolog_failure_fails_job_and_drains_node` accepts both `F` (Failed) and `PD` (Pending) states due to a race between the agent's `report_completion(JobFailed)` and the scheduler's `requeue_job` path. Slurm 25.11 requeues+holds the job on prolog failure — Spur doesn't hold. Tracked as a separate issue.

## Test plan

- [x] All 11 new tests pass on the 3-node bare-metal testbed (73s)
- [x] All 18 existing tests (test_single_node + test_multi_node) pass — no regressions
- [x] CI native-host E2E job passes