### PR TITLE
refactor(k8s): rename spur.ai domain prefix to spur.amd.com

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -499,7 +499,7 @@ jobs:
           kubectl delete namespace "$SPUR_TEST_NS" --ignore-not-found --timeout=120s || true
           kubectl delete clusterrolebinding spur-operator --ignore-not-found
           kubectl delete clusterrole spur-operator --ignore-not-found
-          kubectl delete crd spurjobs.spur.ai --ignore-not-found --timeout=120s || true
+          kubectl delete crd spurjobs.spur.amd.com --ignore-not-found --timeout=120s || true
 
       - name: Report status
         if: always()

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -544,7 +544,7 @@ fn default_k8s_namespace() -> String {
 }
 
 fn default_k8s_node_selector() -> String {
-    "spur.ai/managed=true".into()
+    "spur.amd.com/managed=true".into()
 }
 
 impl Default for KubernetesConfig {
@@ -553,7 +553,7 @@ impl Default for KubernetesConfig {
             enabled: false,
             kubeconfig: None,
             namespace: "spur".into(),
-            node_label_selector: "spur.ai/managed=true".into(),
+            node_label_selector: "spur.amd.com/managed=true".into(),
         }
     }
 }

--- a/crates/spur-k8s/src/agent.rs
+++ b/crates/spur-k8s/src/agent.rs
@@ -33,11 +33,11 @@ impl VirtualAgent {
         Self { client }
     }
 
-    /// Look up the namespace of the SpurJob labeled `spur.ai/job-id=<id>`.
+    /// Look up the namespace of the SpurJob labeled `spur.amd.com/job-id=<id>`.
     /// Fails loudly if not found so pods are never placed in the wrong namespace.
     async fn resolve_namespace(&self, job_id: u32) -> Result<String, Status> {
         let api: Api<SpurJob> = Api::all(self.client.clone());
-        let lp = ListParams::default().labels(&format!("spur.ai/job-id={}", job_id));
+        let lp = ListParams::default().labels(&format!("spur.amd.com/job-id={}", job_id));
 
         let result = tokio::time::timeout(
             NS_LOOKUP_BUDGET,
@@ -52,7 +52,9 @@ impl VirtualAgent {
                     .next()
                     .and_then(|j| j.metadata.namespace)
                     .ok_or_else(|| {
-                        Status::not_found(format!("spur.ai/job-id={job_id} label not yet visible"))
+                        Status::not_found(format!(
+                            "spur.amd.com/job-id={job_id} label not yet visible"
+                        ))
                     })
             })
             .retry(
@@ -71,7 +73,7 @@ impl VirtualAgent {
             Ok(Ok(ns)) => Ok(ns),
             Ok(Err(status)) => Err(status),
             Err(_elapsed) => Err(Status::deadline_exceeded(format!(
-                "namespace lookup for spur.ai/job-id={job_id} timed out after {}s",
+                "namespace lookup for spur.amd.com/job-id={job_id} timed out after {}s",
                 NS_LOOKUP_BUDGET.as_secs()
             ))),
         }
@@ -248,7 +250,8 @@ impl SlurmAgent for VirtualAgent {
         // secret values out of the SpurJob spec and Raft log.
         {
             let api: kube::Api<crate::crd::SpurJob> = kube::Api::all(self.client.clone());
-            let lp = kube::api::ListParams::default().labels(&format!("spur.ai/job-id={}", job_id));
+            let lp =
+                kube::api::ListParams::default().labels(&format!("spur.amd.com/job-id={}", job_id));
             if let Ok(list) = api.list(&lp).await {
                 if let Some(spurjob) = list.items.into_iter().next() {
                     for (env_name, secret_ref) in &spurjob.spec.secret_env {
@@ -342,16 +345,16 @@ impl SlurmAgent for VirtualAgent {
 
         // Build labels
         let mut labels = BTreeMap::new();
-        labels.insert("spur.ai/job-id".to_string(), job_id.to_string());
+        labels.insert("spur.amd.com/job-id".to_string(), job_id.to_string());
         labels.insert(
-            "spur.ai/managed-by".to_string(),
+            "spur.amd.com/managed-by".to_string(),
             "spur-k8s-operator".to_string(),
         );
         if !spec.name.is_empty() {
-            labels.insert("spur.ai/job-name".to_string(), spec.name.clone());
+            labels.insert("spur.amd.com/job-name".to_string(), spec.name.clone());
         }
         if !target_node.is_empty() {
-            labels.insert("spur.ai/target-node".to_string(), target_node.clone());
+            labels.insert("spur.amd.com/target-node".to_string(), target_node.clone());
         }
 
         // For multi-node jobs, create headless Service for DNS discovery
@@ -455,7 +458,7 @@ impl SlurmAgent for VirtualAgent {
 
         // Delete all pods for this job by label selector
         let pods: Api<Pod> = Api::namespaced(self.client.clone(), &ns);
-        let lp = ListParams::default().labels(&format!("spur.ai/job-id={}", job_id));
+        let lp = ListParams::default().labels(&format!("spur.amd.com/job-id={}", job_id));
 
         match pods.list(&lp).await {
             Ok(pod_list) => {
@@ -662,7 +665,7 @@ impl VirtualAgent {
         let services: Api<Service> = Api::namespaced(self.client.clone(), namespace);
         let svc_name = format!("spur-job-{}", job_id);
 
-        let selector = BTreeMap::from([("spur.ai/job-id".to_string(), job_id.to_string())]);
+        let selector = BTreeMap::from([("spur.amd.com/job-id".to_string(), job_id.to_string())]);
 
         let svc = Service {
             metadata: ObjectMeta {

--- a/crates/spur-k8s/src/crd.rs
+++ b/crates/spur-k8s/src/crd.rs
@@ -7,11 +7,11 @@ use serde::{Deserialize, Serialize};
 
 /// SpurJob CRD spec — Kubernetes-native way to submit GPU jobs to Spur.
 ///
-/// apiVersion: spur.ai/v1alpha1
+/// apiVersion: spur.amd.com/v1alpha1
 /// kind: SpurJob
 #[derive(CustomResource, Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[kube(
-    group = "spur.ai",
+    group = "spur.amd.com",
     version = "v1alpha1",
     kind = "SpurJob",
     namespaced,
@@ -586,10 +586,10 @@ mod tests {
     #[test]
     fn test_toleration_spec_serde_default_operator() {
         // When deserialized from JSON without an "operator" field, it should default to "Equal"
-        let json = r#"{"key": "spur.ai/gpu-node"}"#;
+        let json = r#"{"key": "spur.amd.com/gpu-node"}"#;
         let t: TolerationSpec = serde_json::from_str(json).unwrap();
         assert_eq!(t.operator, "Equal");
-        assert_eq!(t.key.as_deref(), Some("spur.ai/gpu-node"));
+        assert_eq!(t.key.as_deref(), Some("spur.amd.com/gpu-node"));
     }
 
     // --- SpurJobStatus ---
@@ -611,7 +611,7 @@ mod tests {
         use kube::CustomResourceExt;
         let crd = SpurJob::crd();
         let json = serde_json::to_string(&crd).unwrap();
-        assert!(json.contains("spur.ai"));
+        assert!(json.contains("spur.amd.com"));
         assert!(json.contains("SpurJob"));
         assert!(json.contains("v1alpha1"));
     }
@@ -645,7 +645,7 @@ mod tests {
             extra_resources: std::collections::HashMap::new(),
             secret_env: std::collections::HashMap::new(),
             tolerations: vec![TolerationSpec {
-                key: Some("spur.ai/gpu-node".into()),
+                key: Some("spur.amd.com/gpu-node".into()),
                 operator: "Exists".into(),
                 value: None,
                 effect: Some("NoSchedule".into()),
@@ -668,7 +668,7 @@ mod tests {
         assert_eq!(parsed.tolerations.len(), 1);
         assert_eq!(
             parsed.tolerations[0].key.as_deref(),
-            Some("spur.ai/gpu-node")
+            Some("spur.amd.com/gpu-node")
         );
         assert_eq!(parsed.tolerations[0].operator, "Exists");
         assert_eq!(parsed.node_selector.get("zone").unwrap(), "us-east");
@@ -715,7 +715,7 @@ mod tests {
             extra_resources: std::collections::HashMap::new(),
             secret_env: std::collections::HashMap::new(),
             tolerations: vec![TolerationSpec {
-                key: Some("spur.ai/gpu-node".into()),
+                key: Some("spur.amd.com/gpu-node".into()),
                 operator: "Exists".into(),
                 value: None,
                 effect: Some("NoSchedule".into()),

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -25,7 +25,7 @@ use spur_proto::proto::{
     CancelJobRequest, GetJobRequest, ReportJobStatusRequest, SubmitJobRequest,
 };
 
-const FINALIZER: &str = "spur.ai/cleanup";
+const FINALIZER: &str = "spur.amd.com/cleanup";
 const MAX_BACKOFF_SECS: u64 = 60;
 const LABEL_PATCH_BUDGET: Duration = Duration::from_secs(3);
 
@@ -129,7 +129,7 @@ async fn submit_to_controller(
         .metadata
         .annotations
         .as_ref()
-        .and_then(|a| a.get("spur.ai/user"))
+        .and_then(|a| a.get("spur.amd.com/user"))
         .cloned()
         .unwrap_or_else(|| "k8s".to_string());
 
@@ -235,7 +235,7 @@ async fn handle_job(
 }
 
 /// Handle SpurJob deletion: cancel Spur job, clean up Pods/Services.
-/// kube::runtime::finalizer removes spur.ai/cleanup automatically after this returns Ok.
+/// kube::runtime::finalizer removes spur.amd.com/cleanup automatically after this returns Ok.
 async fn handle_deletion(job: &SpurJob, ctx: &JobControllerCtx) -> Result<Action, ReconcileError> {
     let name = job.metadata.name.clone().unwrap_or_default();
     let ns = job
@@ -262,7 +262,7 @@ async fn handle_deletion(job: &SpurJob, ctx: &JobControllerCtx) -> Result<Action
 
         // Delete all Pods by label
         let pods: Api<Pod> = Api::namespaced(ctx.client.clone(), &ns);
-        let lp = ListParams::default().labels(&format!("spur.ai/job-id={}", job_id));
+        let lp = ListParams::default().labels(&format!("spur.amd.com/job-id={}", job_id));
         if let Ok(pod_list) = pods.list(&lp).await {
             for pod in pod_list {
                 let pod_name = pod.metadata.name.unwrap_or_default();
@@ -326,7 +326,7 @@ pub async fn run(
     Controller::new(spurjobs, WatcherConfig::default())
         .owns(
             pods,
-            WatcherConfig::default().labels("spur.ai/managed-by=spur-k8s-operator"),
+            WatcherConfig::default().labels("spur.amd.com/managed-by=spur-k8s-operator"),
         )
         .run(reconcile, error_policy, ctx)
         .for_each(|res| async move {
@@ -340,13 +340,14 @@ pub async fn run(
     Ok(())
 }
 
-/// Watch Pods labeled with spur.ai/job-id and report terminal states back to spurctld.
+/// Watch Pods labeled with spur.amd.com/job-id and report terminal states back to spurctld.
 async fn watch_pods(ctx: Arc<JobControllerCtx>) -> anyhow::Result<()> {
     let pods: Api<Pod> = Api::all(ctx.client.clone());
 
     let stream = kube::runtime::watcher::watcher(
         pods,
-        kube::runtime::watcher::Config::default().labels("spur.ai/managed-by=spur-k8s-operator"),
+        kube::runtime::watcher::Config::default()
+            .labels("spur.amd.com/managed-by=spur-k8s-operator"),
     );
     let mut stream = pin!(stream);
 
@@ -356,7 +357,7 @@ async fn watch_pods(ctx: Arc<JobControllerCtx>) -> anyhow::Result<()> {
         {
             let labels = pod.metadata.labels.as_ref();
             let job_id_str = labels
-                .and_then(|l| l.get("spur.ai/job-id"))
+                .and_then(|l| l.get("spur.amd.com/job-id"))
                 .cloned()
                 .unwrap_or_default();
             let job_id: u32 = match job_id_str.parse() {
@@ -552,7 +553,7 @@ async fn cleanup_orphan_pods(client: Client) {
     let pods: Api<Pod> = Api::all(client.clone());
     let spurjobs: Api<SpurJob> = Api::all(client.clone());
 
-    let lp = ListParams::default().labels("spur.ai/managed-by=spur-k8s-operator");
+    let lp = ListParams::default().labels("spur.amd.com/managed-by=spur-k8s-operator");
     let pod_list = match pods.list(&lp).await {
         Ok(list) => list,
         Err(e) => {
@@ -589,7 +590,7 @@ async fn cleanup_orphan_pods(client: Client) {
             .metadata
             .labels
             .as_ref()
-            .and_then(|l| l.get("spur.ai/job-id"))
+            .and_then(|l| l.get("spur.amd.com/job-id"))
             .cloned()
             .unwrap_or_default();
 
@@ -614,11 +615,11 @@ fn has_job_id_label(job: &SpurJob) -> bool {
     job.metadata
         .labels
         .as_ref()
-        .and_then(|l| l.get("spur.ai/job-id"))
+        .and_then(|l| l.get("spur.amd.com/job-id"))
         .is_some()
 }
 
-/// Ensure `spur.ai/job-id` is set on the SpurJob, retrying on transient API errors.
+/// Ensure `spur.amd.com/job-id` is set on the SpurJob, retrying on transient API errors.
 /// Returns Ok if the label is already present or was applied successfully.
 async fn ensure_job_id_label(
     job: &SpurJob,
@@ -631,7 +632,7 @@ async fn ensure_job_id_label(
     }
 
     let patch = serde_json::json!({
-        "metadata": { "labels": { "spur.ai/job-id": job_id.to_string() } }
+        "metadata": { "labels": { "spur.amd.com/job-id": job_id.to_string() } }
     });
 
     let result = tokio::time::timeout(
@@ -1231,7 +1232,7 @@ mod tests {
 
     #[test]
     fn test_has_job_id_label_present() {
-        let labels = BTreeMap::from([("spur.ai/job-id".into(), "42".into())]);
+        let labels = BTreeMap::from([("spur.amd.com/job-id".into(), "42".into())]);
         let job = make_spurjob(Some(labels), Some("default"));
         assert!(has_job_id_label(&job));
     }
@@ -1251,7 +1252,7 @@ mod tests {
     #[test]
     fn test_has_job_id_label_other_labels_only() {
         let labels = BTreeMap::from([
-            ("spur.ai/managed-by".into(), "spur-k8s-operator".into()),
+            ("spur.amd.com/managed-by".into(), "spur-k8s-operator".into()),
             ("app".into(), "training".into()),
         ]);
         let job = make_spurjob(Some(labels), Some("default"));
@@ -1261,8 +1262,8 @@ mod tests {
     #[test]
     fn test_has_job_id_label_among_others() {
         let labels = BTreeMap::from([
-            ("spur.ai/managed-by".into(), "spur-k8s-operator".into()),
-            ("spur.ai/job-id".into(), "99".into()),
+            ("spur.amd.com/managed-by".into(), "spur-k8s-operator".into()),
+            ("spur.amd.com/job-id".into(), "99".into()),
         ]);
         let job = make_spurjob(Some(labels), Some("default"));
         assert!(has_job_id_label(&job));

--- a/crates/spur-k8s/src/main.rs
+++ b/crates/spur-k8s/src/main.rs
@@ -43,7 +43,7 @@ struct Args {
     address: Option<String>,
 
     /// K8s node label selector
-    #[arg(long, default_value = "spur.ai/managed=true")]
+    #[arg(long, default_value = "spur.amd.com/managed=true")]
     node_selector: String,
 
     /// HTTP health/metrics server address

--- a/crates/spur-k8s/src/node_watcher.rs
+++ b/crates/spur-k8s/src/node_watcher.rs
@@ -240,7 +240,7 @@ fn extract_resources(node: &K8sNode) -> ResourceSet {
 
     // Use explicit label if set, otherwise default based on detected vendor
     let gpu_type = labels
-        .and_then(|l| l.get("spur.ai/gpu-type"))
+        .and_then(|l| l.get("spur.amd.com/gpu-type"))
         .cloned()
         .unwrap_or_else(|| match gpu_vendor {
             "amd" => "amd-gpu".into(),
@@ -250,13 +250,13 @@ fn extract_resources(node: &K8sNode) -> ResourceSet {
 
     // Read GPU memory from label if available
     let gpu_memory_mb: u64 = labels
-        .and_then(|l| l.get("spur.ai/gpu-memory-mb"))
+        .and_then(|l| l.get("spur.amd.com/gpu-memory-mb"))
         .and_then(|v| v.parse().ok())
         .unwrap_or(0);
 
     // Read link type from label
     let link_type: i32 = labels
-        .and_then(|l| l.get("spur.ai/gpu-link"))
+        .and_then(|l| l.get("spur.amd.com/gpu-link"))
         .map(|v| match v.as_str() {
             "xgmi" | "XGMI" => 1,     // GPU_LINK_XGMI
             "nvlink" | "NVLink" => 2, // GPU_LINK_NVLINK
@@ -387,7 +387,7 @@ mod tests {
             BTreeMap::new(),
             vec![
                 Taint {
-                    key: "spur.ai/gpu-node".into(),
+                    key: "spur.amd.com/gpu-node".into(),
                     effect: "NoSchedule".into(),
                     ..Default::default()
                 },
@@ -473,7 +473,7 @@ mod tests {
         alloc.insert("amd.com/gpu".into(), Quantity("8".into()));
 
         let mut labels = BTreeMap::new();
-        labels.insert("spur.ai/gpu-type".into(), "mi300x".into());
+        labels.insert("spur.amd.com/gpu-type".into(), "mi300x".into());
 
         let node = make_node("gpu-node", labels, alloc, vec![]);
         let res = extract_resources(&node);
@@ -492,7 +492,7 @@ mod tests {
         alloc.insert("nvidia.com/gpu".into(), Quantity("4".into()));
 
         let mut labels = BTreeMap::new();
-        labels.insert("spur.ai/gpu-type".into(), "h100".into());
+        labels.insert("spur.amd.com/gpu-type".into(), "h100".into());
 
         let node = make_node("nvidia-node", labels, alloc, vec![]);
         let res = extract_resources(&node);
@@ -530,8 +530,8 @@ mod tests {
         alloc.insert("amd.com/gpu".into(), Quantity("4".into()));
 
         let mut labels = BTreeMap::new();
-        labels.insert("spur.ai/gpu-type".into(), "mi300x".into());
-        labels.insert("spur.ai/gpu-memory-mb".into(), "196608".into()); // 192Gi
+        labels.insert("spur.amd.com/gpu-type".into(), "mi300x".into());
+        labels.insert("spur.amd.com/gpu-memory-mb".into(), "196608".into()); // 192Gi
 
         let node = make_node("gpu-node", labels, alloc, vec![]);
         let res = extract_resources(&node);
@@ -557,7 +557,7 @@ mod tests {
         alloc.insert("amd.com/gpu".into(), Quantity("2".into()));
 
         let mut labels = BTreeMap::new();
-        labels.insert("spur.ai/gpu-link".into(), "xgmi".into());
+        labels.insert("spur.amd.com/gpu-link".into(), "xgmi".into());
 
         let node = make_node("node", labels, alloc, vec![]);
         let res = extract_resources(&node);
@@ -570,7 +570,7 @@ mod tests {
         alloc.insert("nvidia.com/gpu".into(), Quantity("2".into()));
 
         let mut labels = BTreeMap::new();
-        labels.insert("spur.ai/gpu-link".into(), "NVLink".into());
+        labels.insert("spur.amd.com/gpu-link".into(), "NVLink".into());
 
         let node = make_node("node", labels, alloc, vec![]);
         let res = extract_resources(&node);
@@ -593,7 +593,7 @@ mod tests {
         alloc.insert("amd.com/gpu".into(), Quantity("1".into()));
 
         let mut labels = BTreeMap::new();
-        labels.insert("spur.ai/gpu-link".into(), "something-else".into());
+        labels.insert("spur.amd.com/gpu-link".into(), "something-else".into());
 
         let node = make_node("node", labels, alloc, vec![]);
         let res = extract_resources(&node);
@@ -666,9 +666,9 @@ mod tests {
         alloc.insert("amd.com/gpu".into(), Quantity("8".into()));
 
         let mut labels = BTreeMap::new();
-        labels.insert("spur.ai/gpu-type".into(), "mi300x".into());
-        labels.insert("spur.ai/gpu-memory-mb".into(), "196608".into());
-        labels.insert("spur.ai/gpu-link".into(), "xgmi".into());
+        labels.insert("spur.amd.com/gpu-type".into(), "mi300x".into());
+        labels.insert("spur.amd.com/gpu-memory-mb".into(), "196608".into());
+        labels.insert("spur.amd.com/gpu-link".into(), "xgmi".into());
 
         let node = make_node("mi300x-node", labels, alloc, vec![]);
         let res = extract_resources(&node);
@@ -688,9 +688,9 @@ mod tests {
         alloc.insert("amd.com/gpu".into(), Quantity("4".into()));
 
         let mut labels = BTreeMap::new();
-        labels.insert("spur.ai/gpu-type".into(), "mi250x".into());
-        labels.insert("spur.ai/gpu-memory-mb".into(), "131072".into());
-        labels.insert("spur.ai/gpu-link".into(), "xgmi".into());
+        labels.insert("spur.amd.com/gpu-type".into(), "mi250x".into());
+        labels.insert("spur.amd.com/gpu-memory-mb".into(), "131072".into());
+        labels.insert("spur.amd.com/gpu-link".into(), "xgmi".into());
 
         let node = make_node("mi250x-node", labels, alloc, vec![]);
         let res = extract_resources(&node);

--- a/crates/spur-tests/src/k8s/fixture.rs
+++ b/crates/spur-tests/src/k8s/fixture.rs
@@ -75,7 +75,7 @@ impl SuiteContext {
 
         let crds: Api<k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition> =
             Api::all(self.client.clone());
-        let _ = crds.delete("spurjobs.spur.ai", &dp).await;
+        let _ = crds.delete("spurjobs.spur.amd.com", &dp).await;
 
         let ns_api: Api<Namespace> = Api::all(self.client.clone());
         let _ = ns_api.delete(&self.namespace, &dp).await;
@@ -112,7 +112,7 @@ impl SuiteContext {
         let crds: Api<k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition> =
             Api::all(self.client.clone());
         crds.patch(
-            "spurjobs.spur.ai",
+            "spurjobs.spur.amd.com",
             &PatchParams::apply(APPLY_MANAGER).force(),
             &Patch::Apply(crd),
         )

--- a/crates/spur-tests/src/k8s/single_node/cross_namespace.rs
+++ b/crates/spur-tests/src/k8s/single_node/cross_namespace.rs
@@ -42,7 +42,7 @@ mod tests {
         if let Some(job_id) = completed.status.as_ref().and_then(|s| s.spur_job_id) {
             let spur_pods: Api<Pod> = Api::namespaced(client.clone(), f.namespace());
             let leaked = spur_pods
-                .list(&ListParams::default().labels(&format!("spur.ai/job-id={job_id}")))
+                .list(&ListParams::default().labels(&format!("spur.amd.com/job-id={job_id}")))
                 .await
                 .unwrap();
             assert!(

--- a/crates/spur-tests/src/k8s/single_node/spurjob.rs
+++ b/crates/spur-tests/src/k8s/single_node/spurjob.rs
@@ -129,7 +129,7 @@ mod tests {
             || {
                 let pods = pods.clone();
                 async move {
-                    pods.list(&ListParams::default().labels("spur.ai/job-name=it-cancel"))
+                    pods.list(&ListParams::default().labels("spur.amd.com/job-name=it-cancel"))
                         .await
                         .map(|list| list.items.is_empty())
                         .unwrap_or(false)

--- a/deploy/k8s/rbac.yaml
+++ b/deploy/k8s/rbac.yaml
@@ -24,7 +24,7 @@ rules:
     resources: [events]
     verbs: [create, patch]
   # SpurJob CRD
-  - apiGroups: [spur.ai]
+  - apiGroups: [spur.amd.com]
     resources: [spurjobs, spurjobs/status, spurjobs/finalizers]
     verbs: [get, list, watch, create, update, patch, delete]
   # PodDisruptionBudgets

--- a/deploy/k8s/spurd.yaml
+++ b/deploy/k8s/spurd.yaml
@@ -13,9 +13,9 @@ spec:
         app: spurd
     spec:
       nodeSelector:
-        spur.ai/compute: "true"
+        spur.amd.com/compute: "true"
       tolerations:
-        - key: spur.ai/gpu-node
+        - key: spur.amd.com/gpu-node
           operator: Exists
           effect: NoSchedule
       hostPID: true

--- a/docs/deployment/kubernetes.rst
+++ b/docs/deployment/kubernetes.rst
@@ -88,7 +88,7 @@ Jobs are submitted as ``SpurJob`` custom resources:
 
 .. code-block:: yaml
 
-   apiVersion: spur.ai/v1alpha1
+   apiVersion: spur.amd.com/v1alpha1
    kind: SpurJob
    metadata:
      name: training-run

--- a/plans/implementation-roadmap.md
+++ b/plans/implementation-roadmap.md
@@ -51,7 +51,7 @@ Spur becomes the scheduling brain for GPU workloads across both native-host and 
 Custom Resource Definition that maps Spur jobs to K8s resources:
 
 ```yaml
-apiVersion: spur.ai/v1
+apiVersion: spur.amd.com/v1
 kind: SpurJob
 metadata:
   name: training-run-42
@@ -83,7 +83,7 @@ Config:
 enabled = true
 kubeconfig = "/etc/spur/kubeconfig"
 namespace = "spur-jobs"
-node_selector = { "spur.ai/managed": "true" }
+node_selector = { "spur.amd.com/managed": "true" }
 ```
 
 ### 11.4 GPU Topology Scheduling (L)

--- a/plans/implementation-roadmap.md
+++ b/plans/implementation-roadmap.md
@@ -83,7 +83,7 @@ Config:
 enabled = true
 kubeconfig = "/etc/spur/kubeconfig"
 namespace = "spur-jobs"
-node_selector = { "spur.amd.com/managed": "true" }
+node_label_selector = "spur.amd.com/managed=true"
 ```
 
 ### 11.4 GPU Topology Scheduling (L)


### PR DESCRIPTION
## Summary

- Replace all `spur.ai` references with `spur.amd.com` across K8s integration code, manifests, tests, and documentation.
- `spur.ai` is a domain we do not own. Kubernetes [API conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md) recommend using a subdomain your organization owns for CRD API groups. The [official labels docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) similarly require that automated system components use a prefix they own. [Red Hat/OpenShift docs](https://docs.redhat.com/en/documentation/openshift_container_platform/3.11/html/cluster_administration/admin-guide-custom-resources) call this out explicitly: "A good practice is to use a fully-qualified-domain name of your organization."
- `spur.amd.com` is under AMD's control and follows these conventions.

## What changed

| Area | Before | After |
|---|---|---|
| CRD API group | `spur.ai` | `spur.amd.com` |
| CRD FQDN | `spurjobs.spur.ai` | `spurjobs.spur.amd.com` |
| Labels | `spur.ai/job-id`, `spur.ai/managed-by`, etc. | `spur.amd.com/job-id`, `spur.amd.com/managed-by`, etc. |
| Finalizer | `spur.ai/cleanup` | `spur.amd.com/cleanup` |
| Taints | `spur.ai/gpu-node` | `spur.amd.com/gpu-node` |
| Node selectors | `spur.ai/managed=true` | `spur.amd.com/managed=true` |
| RBAC apiGroups | `spur.ai` | `spur.amd.com` |

14 files changed, pure find-and-replace. Build and all tests pass.

## Breaking change

This is a **breaking change** for existing K8s deployments. The CRD FQDN changes from `spurjobs.spur.ai` to `spurjobs.spur.amd.com`, so existing SpurJob resources must be recreated. For pre-production clusters this is a no-op — just delete the old CRD and apply the new one.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test` — all tests pass
- [x] `cargo fmt --check --all` — clean
- [x] Verified zero remaining `spur.ai` occurrences in the repo