### PR TITLE
fix(e2e): resolve deploy paths via SPUR_DEPLOY_DIR

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,8 +3,8 @@
 # the CI workflow completes successfully.
 #
 # No untrusted code is checked out or compiled here.  Binaries, container
-# image, and E2E assets (tests/e2e, deploy/k8s, deploy/native-host, scripts)
-# are uploaded by the CI workflow for the same commit and downloaded here.
+# image, and E2E assets (tests/e2e, deploy/, scripts) from the same commit
+# are uploaded by CI and downloaded here.  Jobs set SPUR_DEPLOY_DIR=trusted-repo/deploy.
 name: E2E
 
 on:
@@ -193,6 +193,7 @@ jobs:
 
       - name: Run native-host E2E tests
         env:
+          SPUR_DEPLOY_DIR: trusted-repo/deploy
           SPUR_TEST_NODES: ${{ env.BM_NODES }}
           SPUR_TEST_SSH_USER: ${{ env.BM_SSH_USER }}
           SPUR_TEST_BINARIES_DIR: /tmp/release-binaries
@@ -350,6 +351,7 @@ jobs:
       STATUS_CONTEXT: "E2E / K8s"
       KUBECONFIG: /home/amd/.kube/config
       SPUR_TEST_NS: spur-ci-${{ github.event.workflow_run.id }}
+      SPUR_DEPLOY_DIR: trusted-repo/deploy
       RUST_LOG: info
     steps:
       - name: Compute GHCR image reference
@@ -455,7 +457,7 @@ jobs:
         run: |
           set -euo pipefail
           sed "s/namespace: spur/namespace: $SPUR_TEST_NS/g" \
-            trusted-repo/deploy/k8s/rbac.yaml | kubectl apply -f -
+            "${SPUR_DEPLOY_DIR}/k8s/rbac.yaml" | kubectl apply -f -
 
       - name: Verify cluster can pull CI image
         run: |
@@ -475,8 +477,6 @@ jobs:
           kubectl delete pod image-pull-check -n "$SPUR_TEST_NS" --ignore-not-found --wait=true
 
       - name: Run K8s E2E tests
-        env:
-          SPUR_DEPLOY_DIR: trusted-repo/deploy/k8s
         run: |
           pytest trusted-repo/tests/e2e/k8s/ -v
 

--- a/docs/developer/building.rst
+++ b/docs/developer/building.rst
@@ -31,11 +31,6 @@ All tests are self-contained. No external services needed (no database, no netwo
 
    The E2E suites do not support parallel test execution. Do not use ``pytest-xdist``.
 
-CI integration
-~~~~~~~~~~~~~~
-
-The ``E2E`` workflow (after ``CI`` succeeds) downloads artifacts from that CI run: release binaries, the container image, and an ``e2e-assets`` bundle with ``tests/e2e``, ``deploy/k8s``, ``deploy/native-host``, and ``scripts`` from the **same commit** as the build. You can add or change E2E tests and deploy manifests in the same PR as the feature.
-
 End-to-End Tests (Native-Host)
 ------------------------------
 
@@ -71,8 +66,11 @@ Environment Variables
      - Path to SSH private key. If neither password nor key is set, ssh-agent is used.
      - ``~/.ssh/id_ed25519``
    * - ``SPUR_TEST_BINARIES_DIR`` *(optional)*
-     - Path to release binaries (local). Defaults to ``target/release``.
-     - ``./target/release``
+     - Path to release binaries on the test runner. Defaults to ``{repo}/target/release`` (repo root is derived from the test layout, not the shell working directory).
+     - ``/home/user/spur/target/release``
+   * - ``SPUR_DEPLOY_DIR`` *(optional)*
+     - Path to the ``deploy/`` directory (not a suite subdirectory). This suite loads assets from ``{SPUR_DEPLOY_DIR}/native-host/``. Defaults to ``{repo}/deploy`` when unset. If set manually, use an absolute path.
+     - ``/home/user/spur/deploy``
    * - ``SPUR_TEST_REMOTE_BIN_DIR`` *(optional)*
      - Fixed remote path for binaries on nodes. If set, not cleaned up (useful for CI + AppArmor). If unset, an ephemeral temp path is used and cleaned up after the session.
      - ``/tmp/spur-e2e-bin``
@@ -176,8 +174,8 @@ Export these so the test process can read them:
      - Kubernetes namespace for the test run. Defaults to ``spur-ci-{pid}-{timestamp}``. Set explicitly for local runs so cleanup and log inspection are predictable.
      - ``spur-ci-local``
    * - ``SPUR_DEPLOY_DIR`` *(optional)*
-     - Path to ``deploy/k8s/`` manifests. Auto-detected from the workspace if unset.
-     - ``./deploy/k8s``
+     - Path to the ``deploy/`` directory (not a suite subdirectory). This suite loads manifests from ``{SPUR_DEPLOY_DIR}/k8s/``. Defaults to ``{repo}/deploy`` when unset. If set manually, use an absolute path.
+     - ``/home/user/spur/deploy``
 
 Setup
 ~~~~~

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -7,8 +7,6 @@ End-to-end test suites for Spur, organized by deployment target:
 | `native_host/` | Native-Host / SSH | Deploys spurctld + spurd on remote nodes via SSH |
 | `k8s/` | Kubernetes | Deploys controller + operator into a K8s cluster, submits SpurJob CRDs |
 
-Both suites use pytest and share this directory's `pytest.ini`, `requirements.txt`, and top-level `conftest.py`.
-
 For setup instructions, environment variables, and how to run the tests, see the [Building guide](../../docs/developer/building.rst).
 
 ```bash

--- a/tests/e2e/k8s/k8s_cluster.py
+++ b/tests/e2e/k8s/k8s_cluster.py
@@ -20,6 +20,8 @@ from kubernetes.client.rest import ApiException
 from kubernetes.stream import stream
 from kubernetes.utils import create_from_dict
 
+from paths import k8s_deploy_dir
+
 logger = logging.getLogger(__name__)
 
 SPUR_JOB_GROUP = "spur.amd.com"
@@ -46,14 +48,8 @@ def wait_until(
     raise TimeoutError(f"timed out after {timeout}s: {msg}")
 
 
-def repo_root() -> Path:
-    return Path(__file__).resolve().parent.parent.parent.parent
-
-
 def deploy_root() -> Path:
-    if env := os.environ.get("SPUR_DEPLOY_DIR"):
-        return Path(env)
-    return repo_root() / "deploy" / "k8s"
+    return k8s_deploy_dir()
 
 
 def spur_namespace() -> str:

--- a/tests/e2e/native_host/conftest.py
+++ b/tests/e2e/native_host/conftest.py
@@ -9,15 +9,11 @@ See docs/developer/building.rst for full environment variable reference.
 
 import os
 import time
-from pathlib import Path
 
 import pytest
 
 from cluster import SshNode, SpurCluster, ensure_bins, make_remote_dir
-
-
-def _repo_root() -> Path:
-    return Path(__file__).resolve().parent.parent.parent.parent
+from paths import repo_root
 
 
 def _get_nodes_config() -> list[str]:
@@ -47,7 +43,7 @@ def _get_ssh_key() -> str | None:
 def _get_binaries_dir() -> str:
     return os.environ.get(
         "SPUR_TEST_BINARIES_DIR",
-        str(_repo_root() / "target" / "release"),
+        str(repo_root() / "target" / "release"),
     )
 
 

--- a/tests/e2e/native_host/test_gpu.py
+++ b/tests/e2e/native_host/test_gpu.py
@@ -12,14 +12,9 @@ provision it (requires python3-venv + network access on nodes).
 """
 
 import os
-from pathlib import Path
 
 from cluster import SpurCluster, parse_job_id, wait_job
-
-
-def _deploy_dir() -> Path:
-    """Path to deploy/native-host with GPU test scripts."""
-    return Path(__file__).resolve().parent.parent.parent / "deploy" / "native-host"
+from paths import native_host_deploy_dir
 
 
 def _resolve_gpu_venv(cluster: SpurCluster) -> str:
@@ -52,7 +47,7 @@ class TestGpuSingleNode:
         cluster.gpu_preflight(1)
 
         # Compile HIP gpu_test on the node if source and hipcc are available
-        deploy = _deploy_dir()
+        deploy = native_host_deploy_dir()
         hip_src = deploy / "gpu_test.hip"
         if hip_src.is_file():
             cluster.ship_file_to_all(hip_src, "gpu_test.hip")
@@ -85,7 +80,7 @@ class TestGpuMultiNode:
         cluster = gpu_cluster
         cluster.gpu_preflight(2)
 
-        deploy = _deploy_dir()
+        deploy = native_host_deploy_dir()
         hip_src = deploy / "gpu_test.hip"
         if hip_src.is_file():
             cluster.ship_file_to_all(hip_src, "gpu_test.hip")
@@ -117,7 +112,7 @@ class TestGpuMultiNode:
 
         venv_path = _resolve_gpu_venv(cluster)
         rd = cluster.remote_dir
-        deploy = _deploy_dir()
+        deploy = native_host_deploy_dir()
 
         # Ship the test script
         src = deploy / "distributed_test.py"
@@ -152,7 +147,7 @@ class TestGpuMultiNode:
 
         venv_path = _resolve_gpu_venv(cluster)
         rd = cluster.remote_dir
-        deploy = _deploy_dir()
+        deploy = native_host_deploy_dir()
 
         # Ship the test script
         src = deploy / "inference_test.py"

--- a/tests/e2e/paths.py
+++ b/tests/e2e/paths.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deploy asset path resolution for E2E tests."""
+
+import os
+from pathlib import Path
+
+_E2E_ROOT = Path(__file__).resolve().parent
+_LOCAL_REPO_ROOT = _E2E_ROOT.parent.parent
+
+
+def repo_root() -> Path:
+    """Git checkout root for local runs (parent of ``tests/``)."""
+    return _LOCAL_REPO_ROOT
+
+
+def _deploy_root() -> Path:
+    if env := os.environ.get("SPUR_DEPLOY_DIR"):
+        return Path(env)
+    return _LOCAL_REPO_ROOT / "deploy"
+
+
+def k8s_deploy_dir() -> Path:
+    return _deploy_root() / "k8s"
+
+
+def native_host_deploy_dir() -> Path:
+    return _deploy_root() / "native-host"

--- a/tests/e2e/pytest.ini
+++ b/tests/e2e/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+pythonpath = .
 testpaths = native_host k8s
 python_files = test_*.py
 python_classes = Test*


### PR DESCRIPTION
## Summary

- Add `tests/e2e/paths.py` so deploy assets resolve via `SPUR_DEPLOY_DIR` (the `deploy/` directory) with suite subdirs appended (`k8s/`, `native-host/`).
- Fix native-host GPU E2E failures (exit 127) after the `native_host/` move by using `native_host_deploy_dir()` instead of fragile `.parent` path math.
- Set `SPUR_DEPLOY_DIR=trusted-repo/deploy` in both E2E jobs; align K8s RBAC step and document env vars in `building.rst`.