### PR TITLE
fix(ci): use recursive glob for Dockerfile pathspecs in license checks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -18,7 +18,7 @@ fi
 
 # Check SPDX license headers on staged source files
 mapfile -t staged < <(
-    git diff --cached --name-only --diff-filter=d -- '*.rs' '*.proto' '*.py' '*.sh' 'Dockerfile' '*/Dockerfile' '*/Dockerfile.*'
+    git diff --cached --name-only --diff-filter=d -- '*.rs' '*.proto' '*.py' '*.sh' '**/Dockerfile*'
 )
 
 if [ ${#staged[@]} -gt 0 ]; then

--- a/scripts/check-license-headers.sh
+++ b/scripts/check-license-headers.sh
@@ -28,7 +28,7 @@ check_file() {
 if [ $# -gt 0 ]; then
     files=("$@")
 else
-    mapfile -t files < <(git ls-files -- '*.rs' '*.proto' '*.py' '*.sh' 'Dockerfile' '*/Dockerfile' '*/Dockerfile.*')
+    mapfile -t files < <(git ls-files -- '*.rs' '*.proto' '*.py' '*.sh' '**/Dockerfile*')
 fi
 
 failed=0


### PR DESCRIPTION
Use `**/Dockerfile*` instead of `*/Dockerfile` + `*/Dockerfile.*` so license header checks match Dockerfiles at any directory depth, not just one level deep.