### PR TITLE
ci(e2e): use dedicated runner labels for parallel BM and K8s jobs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -64,7 +64,7 @@ jobs:
 
   native-host:
     name: Native-Host
-    runs-on: [self-hosted, amd-aac02-rocm]
+    runs-on: [self-hosted, bare-metal-cluster]
     if: github.event.workflow_run.conclusion == 'success'
     concurrency:
       group: native-host-cluster
@@ -341,7 +341,7 @@ jobs:
 
   k8s:
     name: K8s
-    runs-on: [self-hosted, amd-aac02-rocm]
+    runs-on: [self-hosted, k8s-cluster]
     needs: push-image
     concurrency:
       group: k8s-integration


### PR DESCRIPTION
## Summary

- Split the single `amd-aac02-rocm` self-hosted runner into two dedicated instances (`bare-metal-cluster` and `k8s-cluster`) so native-host and K8s E2E jobs run in parallel instead of being serialized by a single runner process.

## Prerequisites

Two runner instances must be registered on aac02 before merging:
- `amd-aac02-bm` with label `bare-metal-cluster` (dir: `/home/amd/actions-runner-spur-bm`)
- `amd-aac02-k8s` with label `k8s-cluster` (dir: `/home/amd/actions-runner-spur-k8s`)