### PR TITLE
ci(workflows): use dedicated spur-ci GHCR package for CI images

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Delete old CI images
         uses: actions/delete-package-versions@v5
         with:
-          package-name: spur
+          package-name: spur-ci
           package-type: container
           min-versions-to-keep: 20
           ignore-versions: "^(latest|v\\d+)"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -313,8 +313,8 @@ jobs:
           result-encoding: string
           script: |
             const sha = '${{ github.event.workflow_run.head_sha }}';
-            const repo = '${{ github.repository }}'.toLowerCase();
-            return `ghcr.io/${repo}:${sha}`;
+            const owner = '${{ github.repository_owner }}'.toLowerCase();
+            return `ghcr.io/${owner}/spur-ci:${sha}`;
 
       - name: Download image artifact
         uses: actions/download-artifact@v8
@@ -359,8 +359,8 @@ jobs:
           result-encoding: string
           script: |
             const sha = '${{ github.event.workflow_run.head_sha }}';
-            const repo = '${{ github.repository }}'.toLowerCase();
-            return `ghcr.io/${repo}:${sha}`;
+            const owner = '${{ github.repository_owner }}'.toLowerCase();
+            return `ghcr.io/${owner}/spur-ci:${sha}`;
 
       - name: Set SPUR_CI_IMAGE
         run: |


### PR DESCRIPTION
## Summary

- Moves CI container images to a dedicated `spur-ci` package on GHCR (`ghcr.io/rocm/spur-ci:<sha>`) instead of sharing the main `spur` package namespace.
- Updates the cleanup workflow to prune only the `spur-ci` package, leaving any future release images in `spur` untouched.