### PR TITLE
ci(coverage): add patch coverage reporting with Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,46 @@ jobs:
       - name: Test
         run: cargo test --locked
 
+  coverage:
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: ""
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install protobuf compiler
+        run: sudo apt-get install -y protobuf-compiler
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ github.job }}-
+            ${{ runner.os }}-cargo-
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Run tests with coverage
+        run: cargo llvm-cov --workspace --exclude spur-ffi --locked --lcov --output-path lcov.info
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
   build-docker-image:
     name: Build Docker Image
     runs-on: ubuntu-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+        target: 70%
+
+comment:
+  layout: "condensed_header, diff, flags"
+  behavior: default
+  require_changes: true
+
+ignore:
+  - "crates/spur-ffi/**"
+  - "crates/spur-proto/src/**"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "1.95.0"
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "llvm-tools-preview"]


### PR DESCRIPTION
Add a coverage job to the CI workflow that runs cargo-llvm-cov to collect LLVM source-based coverage and uploads the lcov report to Codecov. Both project and patch coverage statuses are informational (non-blocking) so PRs won't be gated until thresholds are calibrated.

- Add llvm-tools-preview component to rust-toolchain.toml
- Add coverage job: cargo-llvm-cov → lcov → codecov-action upload
- Exclude spur-ffi from instrumented build (matches clippy exclusion)
- Override RUSTFLAGS at job level to avoid -D warnings conflict
- Add codecov.yml: informational project + patch status, 70% patch target, ignore spur-ffi and generated proto code, PR comment on changes only
