### PR TITLE
fix(spur-core): serialize hook tests to avoid ETXTBSY flakiness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -103,7 +103,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -884,7 +884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2038,7 +2038,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2865,7 +2865,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2923,7 +2923,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3159,6 +3159,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3298,7 +3323,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3347,6 +3372,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serial_test",
  "spur-proto",
  "tempfile",
  "thiserror 2.0.18",
@@ -3867,7 +3893,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4708,7 +4734,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ tar = "0.4"
 semver = "1"
 sha2 = "0.11"
 base64 = "0.22"
+serial_test = "3"
 
 # Internal
 spur-update = { path = "crates/spur-update" }

--- a/crates/spur-core/Cargo.toml
+++ b/crates/spur-core/Cargo.toml
@@ -24,6 +24,7 @@ nix = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
+serial_test = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/spur-core/src/hooks.rs
+++ b/crates/spur-core/src/hooks.rs
@@ -109,6 +109,7 @@ fn resolve_username(uid: u32) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::io::Write;
     use tempfile::NamedTempFile;
 
@@ -141,6 +142,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial(run_hooks)]
     async fn hook_success() {
         let script = make_script("exit 0");
         let ctx = test_ctx();
@@ -149,6 +151,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial(run_hooks)]
     async fn hook_failure_returns_error() {
         let script = make_script("exit 1");
         let ctx = test_ctx();
@@ -158,6 +161,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial(run_hooks)]
     async fn hook_nonexistent_script() {
         let ctx = test_ctx();
         let result = run_hook("/nonexistent/hook.sh", &ctx).await;
@@ -165,6 +169,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial(run_hooks)]
     async fn hook_receives_env_vars() {
         let marker = tempfile::NamedTempFile::new().unwrap();
         let marker_path = marker.path().to_str().unwrap().to_string();
@@ -187,6 +192,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial(run_hooks)]
     async fn hook_stderr_does_not_prevent_success() {
         let script = make_script("echo 'warning message' >&2\nexit 0");
         let ctx = test_ctx();


### PR DESCRIPTION
## Problem

Hook tests are flaky (~9% failure rate) due to `ETXTBSY` — a multi-threaded fork+exec race where another test thread's `fork()` inherits a write fd to the temp script before it's closed. This is test-only; production never writes and execs a script in the same process.

## Before (100 runs of `cargo test -p spur-core`)

| Test | Failures |
|------|----------|
| `hook_receives_env_vars` | 3 |
| `hook_success` | 3 |
| `hook_stderr_does_not_prevent_success` | 3 |
| **Total suite failures** | **9 / 100** |

## After (100 runs of `cargo test -p spur-core`)

| Test | Failures |
|------|----------|
| `hook_receives_env_vars` | 0 |
| `hook_success` | 0 |
| `hook_stderr_does_not_prevent_success` | 0 |
| **Total suite failures** | **0 / 100** |

## Fix

Added `#[serial(run_hooks)]` to all hook tests. Only these 5 tests serialize with each other; the other ~119 tests remain parallel. Production `run_hook` is untouched.