### PR TITLE
fix(install): avoid pipefail+SIGPIPE breaking glibc version check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -103,7 +103,10 @@ ARCH=$(uname -m)
 [ "$ARCH" = "x86_64" ] || err "Spur currently supports x86_64 only (got ${ARCH})"
 
 # --- glibc check (binaries built on AlmaLinux 8, require glibc >= 2.28) ---
-GLIBC_VER=$(ldd --version 2>&1 | head -1 | grep -oE '[0-9]+\.[0-9]+$' || echo "0")
+# Two-step extraction avoids pipefail + SIGPIPE interaction (head -1 closes
+# early, ldd gets SIGPIPE, pipeline exit != 0, fallback echo "0" appends).
+_ldd_line=$(ldd --version 2>&1 | head -1 || true)
+GLIBC_VER=$(echo "$_ldd_line" | grep -oE '[0-9]+\.[0-9]+$' || echo "0")
 if [ "$(printf '%s\n' "2.28" "${GLIBC_VER}" | sort -V | head -1)" != "2.28" ]; then
     err "Spur requires glibc >= 2.28 (found ${GLIBC_VER}). Supported: Ubuntu 20.04+, Debian 10+, RHEL 8+, Fedora 28+"
 fi


### PR DESCRIPTION
## Summary

- Fix `install.sh` glibc version detection failing on systems with glibc >= 2.28 (e.g. Ubuntu 24.04 with glibc 2.39).
- Root cause: `set -o pipefail` combined with `ldd --version | head -1 | grep` causes `head -1` to close early, sending SIGPIPE to `ldd`. This makes the pipeline exit non-zero, triggering the `|| echo "0"` fallback even though `grep` already wrote the correct version. The result is a two-line `GLIBC_VER` ("2.39\n0") that breaks the `sort -V` comparison.
- Fix splits the pipeline into two steps: first capture `ldd` output (absorbing any SIGPIPE with `|| true`), then grep the version in an isolated pipeline.

## Test plan

- [x] Reproduced the bug on Ubuntu 24.04 (glibc 2.39) — `install.sh nightly` fails with `ERROR: Spur requires glibc >= 2.28 (found 2.39\n0)`
- [x] Verified the fix — `install.sh nightly` succeeds, downloads and installs binaries, checksum passes
- [x] Ran full quickstart flow after install: `spurctld -D`, `spurd -D`, `spur run -- echo hello`, `spur queue` — all working