### PR TITLE
ci(deploy): push runtime image to Docker Hub on nightly and release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -139,6 +139,35 @@ jobs:
             echo "All binaries verified"
           '
 
+  push-image:
+    name: Push image to Docker Hub
+    needs: [build, verify]
+    if: needs.build.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          target: runtime
+          push: true
+          tags: |
+            rocm/spur:nightly
+            rocm/spur:nightly-${{ needs.build.outputs.date }}
+          cache-from: type=gha,scope=nightly-docker
+          cache-to: type=gha,scope=nightly-docker,mode=max
+
   release:
     name: Publish nightly
     needs: [build, verify]
@@ -175,6 +204,11 @@ jobs:
           ### Install
           \`\`\`bash
           curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/main/install.sh | bash -s -- nightly
+          \`\`\`
+
+          ### Docker
+          \`\`\`bash
+          docker pull rocm/spur:nightly
           \`\`\`
           EOF
           )" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Package binaries
         run: |
-          VERSION="${GITHUB_REF_NAME:-${{ github.event.inputs.tag }}}"
+          VERSION="${{ github.event.inputs.tag || github.ref_name }}"
           DIST="spur-${VERSION}-linux-amd64"
           mkdir -p "${DIST}/bin"
           for bin in spur spurctld spurd spurdbd spurrestd; do
@@ -119,7 +119,7 @@ jobs:
 
       - name: Determine tag
         id: tag
-        run: echo "tag=${GITHUB_REF_NAME:-${{ github.event.inputs.tag }}}" >> "$GITHUB_OUTPUT"
+        run: echo "tag=${{ github.event.inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v4
@@ -135,7 +135,6 @@ jobs:
           tags: |
             type=semver,pattern={{version}},value=${{ steps.tag.outputs.tag }}
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.tag.outputs.tag }}
-            type=raw,value=latest
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -162,7 +161,7 @@ jobs:
 
       - name: Determine tag
         id: tag
-        run: echo "tag=${GITHUB_REF_NAME:-${{ github.event.inputs.tag }}}" >> "$GITHUB_OUTPUT"
+        run: echo "tag=${{ github.event.inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
 
       - name: Create release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,47 @@ jobs:
             echo "All binaries verified"
           '
 
+  push-image:
+    name: Push image to Docker Hub
+    needs: [build, verify]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Determine tag
+        id: tag
+        run: echo "tag=${GITHUB_REF_NAME:-${{ github.event.inputs.tag }}}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: rocm/spur
+          tags: |
+            type=semver,pattern={{version}},value=${{ steps.tag.outputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.tag.outputs.tag }}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          target: runtime
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=release-docker
+          cache-to: type=gha,scope=release-docker,mode=max
+
   release:
     name: Create GitHub Release
     needs: [build, verify]


### PR DESCRIPTION
## Summary

- Add `push-image` jobs to nightly and release workflows that build the Dockerfile `runtime` target and push to `docker.io/rocm/spur`
- Nightly tags: `rocm/spur:nightly` (rolling), `rocm/spur:nightly-YYYYMMDD` (pinnable)
- Release tags: `rocm/spur:<version>`, `rocm/spur:<major>.<minor>`, `rocm/spur:latest` (via `docker/metadata-action` semver parsing)
- Nightly release notes now include `docker pull rocm/spur:nightly` instructions

## Prerequisites

Two repository secrets must be configured before merging:
- `DOCKERHUB_USERNAME` — Docker Hub org name (`rocm`)
- `DOCKERHUB_TOKEN` — Docker Hub Organization Access Token (`dckr_oat_*`)

## Details

The `push-image` jobs run in parallel with the existing `release` jobs (both depend on `build` + `verify`). They build the `runtime` Dockerfile target (Ubuntu 22.04 base with all binaries) — not the `dist` target (scratch, used for tarball extraction). GHA build cache is used with dedicated scopes (`nightly-docker`, `release-docker`) to avoid collisions with the existing `dist` build cache.

## Test plan

- [x] Verify secrets are configured in repo settings
- [ ] Trigger nightly workflow via `workflow_dispatch` and confirm image appears at `docker.io/rocm/spur:nightly`
- [ ] Verify `docker pull rocm/spur:nightly` works
