### PR TITLE
ci(deploy): run release job after image push completes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -170,7 +170,7 @@ jobs:
 
   release:
     name: Publish nightly
-    needs: [build, verify]
+    needs: [build, verify, push-image]
     if: needs.build.outputs.skip != 'true'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
 
   release:
     name: Create GitHub Release
-    needs: [build, verify]
+    needs: [build, verify, push-image]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Make the `release` job in both nightly and release workflows depend on `push-image`, so the GitHub Release is only published after the Docker image is available on Docker Hub
- Previously `push-image` and `release` ran in parallel, meaning the release notes could go out before `docker pull` actually worked
