### PR TITLE
fix(spur): resolve semantic merge conflict between #262 and #263

### DIFF
--- a/crates/spur-tests/src/t06_cancel.rs
+++ b/crates/spur-tests/src/t06_cancel.rs
@@ -44,7 +44,6 @@ mod tests {
 
     #[test]
     fn t06_6_deadline_from_pending() {
-        reset_job_ids();
         let mut job = make_job("test");
         assert_transition_ok(&mut job, JobState::Deadline);
         assert!(job.state.is_terminal());
@@ -55,7 +54,6 @@ mod tests {
 
     #[test]
     fn t06_7_cannot_deadline_running() {
-        reset_job_ids();
         let mut job = make_job("test");
         assert_transition_ok(&mut job, JobState::Running);
         assert_transition_err(&mut job, JobState::Deadline);
@@ -65,7 +63,6 @@ mod tests {
 
     #[test]
     fn t06_8_cannot_deadline_completed() {
-        reset_job_ids();
         let mut job = make_job("test");
         assert_transition_ok(&mut job, JobState::Running);
         assert_transition_ok(&mut job, JobState::Completed);

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2905,13 +2905,14 @@ mod tests {
         register_node(&cm, "worker1", 4, 8000);
 
         let job_id = submit_and_wait(&cm, basic_spec("running"));
-        let resources = ResourceSet {
-            cpus: 1,
-            memory_mb: 1000,
-            ..Default::default()
-        };
-        cm.start_job(job_id, vec!["worker1".into()], resources)
-            .unwrap();
+        let resources = scalar_alloc(1, 1000);
+        cm.start_job(
+            job_id,
+            vec!["worker1".into()],
+            resources.clone(),
+            per_node_for(&["worker1"], resources),
+        )
+        .unwrap();
         settle(&cm, job_id, JobState::Running);
 
         assert!(cm.deadline_job(job_id).is_err());


### PR DESCRIPTION
## Summary

- Fixes CI on main broken by a semantic merge conflict between #262 (CDI devices) and #263 (DEADLINE state). Git merged cleanly but the result doesn't compile: #263 added tests calling `reset_job_ids()` (removed by #262) and `start_job()` with the old 3-arg `ResourceSet` signature (changed to 4-arg `ResourceAllocations` by #262).

## Test plan

- [x] `cargo build --all-targets --locked`
- [x] `cargo test --locked`