### PR TITLE
feat(spur): close exit-code reporting gap — exit:signal, DerivedExitCode, reasons

### DIFF
--- a/crates/spur-cli/src/exit_fmt.rs
+++ b/crates/spur-cli/src/exit_fmt.rs
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared exit-status / completion-reason rendering for the Slurm-compatible
+//! CLIs (scontrol, squeue, sacct). Keeps the lossless `code:signal` encoding and
+//! the `RaisedSignal:N(name)` reason composition in one place so the surfaces
+//! cannot drift apart.
+
+use spur_core::job::PendingReason;
+
+/// Format an exit status as Slurm's `code:signal`.
+pub fn format_exit(code: i32, signal: i32) -> String {
+    format!("{}:{}", code, signal)
+}
+
+/// Human-readable name for a terminating signal (Slurm's `RaisedSignal` suffix).
+pub fn signal_name(sig: i32) -> String {
+    let name = match sig {
+        1 => "Hangup",
+        2 => "Interrupt",
+        6 => "Aborted",
+        9 => "Killed",
+        11 => "Segmentation_fault",
+        13 => "Broken_pipe",
+        15 => "Terminated",
+        _ => return format!("Signal {}", sig),
+    };
+    name.to_string()
+}
+
+/// Compose the displayed completion reason. For `RaisedSignal`, append
+/// `:N(name)` from the job's terminating signal, matching Slurm
+/// (`RaisedSignal:9(Killed)`). The wire value is compared against
+/// `PendingReason::RaisedSignal.display()` so it tracks the enum, not a literal.
+pub fn render_reason(reason: &str, signal: i32) -> String {
+    if reason == PendingReason::RaisedSignal.display() && signal != 0 {
+        format!("{}:{}({})", reason, signal, signal_name(signal))
+    } else {
+        reason.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_exit_code_pairs() {
+        assert_eq!(format_exit(2, 0), "2:0");
+        assert_eq!(format_exit(0, 9), "0:9");
+        assert_eq!(format_exit(0, 0), "0:0");
+    }
+
+    #[test]
+    fn signal_name_lookup() {
+        assert_eq!(signal_name(9), "Killed");
+        assert_eq!(signal_name(15), "Terminated");
+        // Multi-word names use underscores to match Slurm (e.g. 25.11.6).
+        assert_eq!(signal_name(11), "Segmentation_fault");
+        assert_eq!(signal_name(13), "Broken_pipe");
+        assert_eq!(signal_name(99), "Signal 99");
+    }
+
+    #[test]
+    fn render_reason_composes_signal() {
+        assert_eq!(render_reason("RaisedSignal", 9), "RaisedSignal:9(Killed)");
+        assert_eq!(render_reason("NonZeroExitCode", 0), "NonZeroExitCode");
+        assert_eq!(render_reason("None", 0), "None");
+        // RaisedSignal without a signal stays bare (defensive).
+        assert_eq!(render_reason("RaisedSignal", 0), "RaisedSignal");
+    }
+}

--- a/crates/spur-cli/src/main.rs
+++ b/crates/spur-cli/src/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod exec;
+mod exit_fmt;
 mod format_engine;
 mod image;
 mod net;

--- a/crates/spur-cli/src/sacct.rs
+++ b/crates/spur-cli/src/sacct.rs
@@ -6,6 +6,7 @@ use clap::Parser;
 use spur_proto::proto::slurm_accounting_client::SlurmAccountingClient;
 use spur_proto::proto::GetJobHistoryRequest;
 
+use crate::exit_fmt::format_exit;
 use crate::format_engine;
 
 /// Display accounting data for jobs.
@@ -180,7 +181,7 @@ fn resolve_sacct_field(job: &spur_proto::proto::JobInfo, spec: char) -> String {
         'T' | 't' => state_name(job.state),
         'M' => format_elapsed(job),
         'D' => job.num_nodes.to_string(),
-        'x' => format_exit_code(job.exit_code),
+        'x' => format_exit(job.exit_code, job.exit_signal),
         'S' => format_timestamp(job.start_time.as_ref()),
         'E' => format_timestamp(job.end_time.as_ref()),
         'V' => format_timestamp(job.submit_time.as_ref()),
@@ -230,15 +231,6 @@ fn format_duration(total_seconds: i64) -> String {
         format!("{}-{:02}:{:02}:{:02}", days, hours, minutes, seconds)
     } else {
         format!("{:02}:{:02}:{:02}", hours, minutes, seconds)
-    }
-}
-
-fn format_exit_code(code: i32) -> String {
-    // Slurm format: exit_code:signal
-    if code >= 0 {
-        format!("{}:0", code)
-    } else {
-        format!("0:{}", -code)
     }
 }
 

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -255,7 +255,7 @@ async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> 
                 println!(
                     "   JobState={} Reason={}",
                     state_name(job.state),
-                    job.state_reason
+                    render_reason(&job.state_reason, job.exit_signal),
                 );
                 println!(
                     "   NumNodes={} NumTasks={} CPUs/Task={}",
@@ -272,7 +272,12 @@ async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> 
                 );
                 println!("   WorkDir={}", job.work_dir);
                 println!("   StdOut={} StdErr={}", job.stdout_path, job.stderr_path);
-                println!("   ExitCode={} Priority={}", job.exit_code, job.priority);
+                println!(
+                    "   ExitCode={} DerivedExitCode={} Priority={}",
+                    format_exit(job.exit_code, job.exit_signal),
+                    format_exit(job.derived_exit_code, 0),
+                    job.priority
+                );
                 println!();
             }
         }
@@ -475,6 +480,34 @@ fn format_ts(ts: Option<&prost_types::Timestamp>) -> String {
     }
 }
 
+fn format_exit(code: i32, signal: i32) -> String {
+    format!("{}:{}", code, signal)
+}
+
+fn signal_name(sig: i32) -> String {
+    let name = match sig {
+        1 => "Hangup",
+        2 => "Interrupt",
+        6 => "Aborted",
+        9 => "Killed",
+        11 => "Segmentation fault",
+        13 => "Broken pipe",
+        15 => "Terminated",
+        _ => return format!("Signal {}", sig),
+    };
+    name.to_string()
+}
+
+/// Compose the displayed reason. For RaisedSignal, append `:N(name)` from the
+/// job's terminating signal, matching Slurm (`RaisedSignal:9(Killed)`).
+fn render_reason(reason: &str, signal: i32) -> String {
+    if reason == "RaisedSignal" && signal != 0 {
+        format!("RaisedSignal:{}({})", signal, signal_name(signal))
+    } else {
+        reason.to_string()
+    }
+}
+
 async fn send_job_update(controller: &str, req: spur_proto::proto::UpdateJobRequest) -> Result<()> {
     let hold = req.hold;
     let job_id = req.job_id;
@@ -656,4 +689,30 @@ async fn delete_reservation(controller: &str, name: &str) -> Result<()> {
 
     println!("Reservation {} deleted", name);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_exit_code_pairs() {
+        assert_eq!(format_exit(2, 0), "2:0");
+        assert_eq!(format_exit(0, 9), "0:9");
+    }
+
+    #[test]
+    fn signal_name_lookup() {
+        assert_eq!(signal_name(9), "Killed");
+        assert_eq!(signal_name(15), "Terminated");
+        assert_eq!(signal_name(11), "Segmentation fault");
+        assert_eq!(signal_name(99), "Signal 99");
+    }
+
+    #[test]
+    fn reason_with_signal_composes_raisedsignal() {
+        assert_eq!(render_reason("RaisedSignal", 9), "RaisedSignal:9(Killed)");
+        assert_eq!(render_reason("NonZeroExitCode", 0), "NonZeroExitCode");
+        assert_eq!(render_reason("None", 0), "None");
+    }
 }

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -5,6 +5,8 @@ use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand};
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 
+use crate::exit_fmt::{format_exit, render_reason};
+
 /// Administrative control commands.
 #[derive(Parser, Debug)]
 #[command(name = "scontrol", about = "Administrative control for Spur")]
@@ -480,34 +482,6 @@ fn format_ts(ts: Option<&prost_types::Timestamp>) -> String {
     }
 }
 
-fn format_exit(code: i32, signal: i32) -> String {
-    format!("{}:{}", code, signal)
-}
-
-fn signal_name(sig: i32) -> String {
-    let name = match sig {
-        1 => "Hangup",
-        2 => "Interrupt",
-        6 => "Aborted",
-        9 => "Killed",
-        11 => "Segmentation fault",
-        13 => "Broken pipe",
-        15 => "Terminated",
-        _ => return format!("Signal {}", sig),
-    };
-    name.to_string()
-}
-
-/// Compose the displayed reason. For RaisedSignal, append `:N(name)` from the
-/// job's terminating signal, matching Slurm (`RaisedSignal:9(Killed)`).
-fn render_reason(reason: &str, signal: i32) -> String {
-    if reason == "RaisedSignal" && signal != 0 {
-        format!("RaisedSignal:{}({})", signal, signal_name(signal))
-    } else {
-        reason.to_string()
-    }
-}
-
 async fn send_job_update(controller: &str, req: spur_proto::proto::UpdateJobRequest) -> Result<()> {
     let hold = req.hold;
     let job_id = req.job_id;
@@ -689,30 +663,4 @@ async fn delete_reservation(controller: &str, name: &str) -> Result<()> {
 
     println!("Reservation {} deleted", name);
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn format_exit_code_pairs() {
-        assert_eq!(format_exit(2, 0), "2:0");
-        assert_eq!(format_exit(0, 9), "0:9");
-    }
-
-    #[test]
-    fn signal_name_lookup() {
-        assert_eq!(signal_name(9), "Killed");
-        assert_eq!(signal_name(15), "Terminated");
-        assert_eq!(signal_name(11), "Segmentation fault");
-        assert_eq!(signal_name(99), "Signal 99");
-    }
-
-    #[test]
-    fn reason_with_signal_composes_raisedsignal() {
-        assert_eq!(render_reason("RaisedSignal", 9), "RaisedSignal:9(Killed)");
-        assert_eq!(render_reason("NonZeroExitCode", 0), "NonZeroExitCode");
-        assert_eq!(render_reason("None", 0), "None");
-    }
 }

--- a/crates/spur-cli/src/squeue.rs
+++ b/crates/spur-cli/src/squeue.rs
@@ -147,7 +147,7 @@ fn resolve_job_field(job: &spur_proto::proto::JobInfo, spec: char) -> String {
         'a' => job.account.clone(),
         'p' => job.priority.to_string(),
         'q' => job.qos.clone(),
-        'r' => job.state_reason.clone(),
+        'r' => crate::exit_fmt::render_reason(&job.state_reason, job.exit_signal),
         'Z' => job.work_dir.clone(),
         'o' => job.command.clone(),
         'S' => format_timestamp(job.start_time.as_ref()),

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -544,9 +544,9 @@ async fn run_as_step(
         .await
         .context("failed to connect to spurctld")?;
 
-    // Create a step on the controller for tracking. The controller doesn't
-    // currently use this for dispatch — it's just bookkeeping.
-    let _ = client
+    // Create a step on the controller for tracking; capture the assigned
+    // step_id so the completion (and thus DerivedExitCode) records against it.
+    let step_id = client
         .create_job_step(CreateJobStepRequest {
             job_id,
             command: args.command.clone(),
@@ -554,7 +554,9 @@ async fn run_as_step(
             cpus_per_task: args.cpus_per_task,
         })
         .await
-        .context("failed to create job step")?;
+        .context("failed to create job step")?
+        .into_inner()
+        .step_id;
 
     let env: std::collections::HashMap<String, String> = std::env::vars().collect();
 
@@ -566,6 +568,7 @@ async fn run_as_step(
             gid: nix::unistd::getegid().as_raw(),
             work_dir: work_dir.to_string(),
             environment: env,
+            step_id,
         })
         .await
         .context("RunStep dispatch failed")?

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -209,6 +209,17 @@ pub enum PendingReason {
     BeginTime,
     DeadLine,
     Licenses,
+    NonZeroExitCode,
+    RaisedSignal,
+    JobLaunchFailure,
+    JobHeldAdmin,
+    BadConstraints,
+    PartitionInactive,
+    DependencyNeverSatisfied,
+    InvalidAccount,
+    InvalidQOS,
+    BootFail,
+    OutOfMemory,
 }
 
 impl PendingReason {
@@ -228,6 +239,17 @@ impl PendingReason {
             Self::BeginTime => "BeginTime",
             Self::DeadLine => "DeadLine",
             Self::Licenses => "Licenses",
+            Self::NonZeroExitCode => "NonZeroExitCode",
+            Self::RaisedSignal => "RaisedSignal",
+            Self::JobLaunchFailure => "JobLaunchFailure",
+            Self::JobHeldAdmin => "JobHeldAdmin",
+            Self::BadConstraints => "BadConstraints",
+            Self::PartitionInactive => "PartitionInactive",
+            Self::DependencyNeverSatisfied => "DependencyNeverSatisfied",
+            Self::InvalidAccount => "InvalidAccount",
+            Self::InvalidQOS => "InvalidQOS",
+            Self::BootFail => "BootFailure",
+            Self::OutOfMemory => "OutOfMemory",
         }
     }
 }
@@ -941,6 +963,18 @@ mod tests {
         // Slurm reports this exact string ("DeadLine", note the cap D and L).
         // squeue scrapers and Slurm-compat clients pattern-match on it.
         assert_eq!(PendingReason::DeadLine.display(), "DeadLine");
+    }
+
+    #[test]
+    fn pending_reason_exit_vocabulary_display() {
+        assert_eq!(PendingReason::NonZeroExitCode.display(), "NonZeroExitCode");
+        assert_eq!(PendingReason::RaisedSignal.display(), "RaisedSignal");
+        assert_eq!(
+            PendingReason::JobLaunchFailure.display(),
+            "JobLaunchFailure"
+        );
+        assert_eq!(PendingReason::OutOfMemory.display(), "OutOfMemory");
+        assert_eq!(PendingReason::BootFail.display(), "BootFailure");
     }
 
     #[test]

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -475,9 +475,8 @@ pub struct Job {
     /// Terminating signal of the primary node's process (0 = none).
     #[serde(default)]
     pub exit_signal: Option<i32>,
-    /// Slurm `DerivedExitCode`: the running max over the job's srun step exit
-    /// codes, accumulated by `WalOperation::JobStepComplete`. `None`/0 for a job
-    /// with no srun steps.
+    /// Slurm `DerivedExitCode`: running max over srun step exit codes (via
+    /// `JobStepComplete`); `None`/0 when the job ran no srun steps.
     #[serde(default)]
     pub derived_exit_code: Option<i32>,
 
@@ -542,16 +541,12 @@ impl Job {
     /// signal); state is `Failed` if the primary exited non-zero or was
     /// signaled, else `Completed`.
     ///
-    /// If `primary_node` is absent from the map, falls back to the worst
-    /// completion (a signaled node, or the highest exit code) so a failure is
-    /// never reported as success.
+    /// If `primary_node` is absent, falls back to the worst completion (a
+    /// signaled node, or the highest exit code) so a failure isn't masked.
     ///
-    /// The 4th return value is a node-based max kept only for backward
-    /// compatibility; the job's real Slurm `DerivedExitCode` is the running max
-    /// over srun *steps*, maintained separately via `JobStepComplete`. Callers
-    /// finalizing a job should NOT use this value for `derived_exit_code`.
-    ///
-    /// Returns `(state, exit_code, exit_signal, node_max_exit)`.
+    /// Returns `(state, exit_code, exit_signal, node_max_exit)`. The 4th value
+    /// is a legacy node-based max — NOT the job's DerivedExitCode, which is the
+    /// running max over srun steps maintained via `JobStepComplete`.
     pub fn derived_completion(
         node_completions: &HashMap<String, NodeCompletion>,
         primary_node: &str,

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -419,6 +419,16 @@ impl Default for JobSpec {
     }
 }
 
+/// One node's completion outcome for a job: the raw process wait status,
+/// split into exit code and terminating signal (0 = none).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct NodeCompletion {
+    #[serde(default)]
+    pub code: i32,
+    #[serde(default)]
+    pub signal: i32,
+}
+
 /// Internal job record held by the controller.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Job {
@@ -440,6 +450,13 @@ pub struct Job {
 
     pub exit_code: Option<i32>,
 
+    /// Terminating signal of the primary node's process (0 = none).
+    #[serde(default)]
+    pub exit_signal: Option<i32>,
+    /// Max exit code across all node completions (Slurm DerivedExitCode).
+    #[serde(default)]
+    pub derived_exit_code: Option<i32>,
+
     /// Number of times this job has been requeued.
     #[serde(default)]
     pub requeue_count: u32,
@@ -454,7 +471,7 @@ pub struct Job {
 
     /// Per-node exit codes reported while the job is in Completing.
     #[serde(default)]
-    pub node_completions: HashMap<String, i32>,
+    pub node_completions: HashMap<String, NodeCompletion>,
 }
 
 impl Job {
@@ -487,6 +504,8 @@ impl Job {
             allocated_resources: None,
             per_node_alloc: HashMap::new(),
             exit_code: None,
+            exit_signal: None,
+            derived_exit_code: None,
             requeue_count: 0,
             het_job_id: None,
             het_group: None,
@@ -494,16 +513,43 @@ impl Job {
         }
     }
 
-    /// Derive final job state and exit code from per-node completion reports.
-    pub fn derived_completion(node_completions: &HashMap<String, i32>) -> (JobState, i32) {
-        let exit_code = node_completions
+    /// Derive the final job outcome from per-node completions, matching Slurm:
+    /// `ExitCode` is the primary node's raw wait status (exit_code, signal);
+    /// `DerivedExitCode` is the max exit code across all nodes. State is
+    /// `Failed` if the primary exited non-zero or was signaled, else `Completed`.
+    ///
+    /// Returns `(state, exit_code, exit_signal, derived_exit_code)`.
+    pub fn derived_completion(
+        node_completions: &HashMap<String, NodeCompletion>,
+        primary_node: &str,
+    ) -> (JobState, i32, i32, i32) {
+        let derived = node_completions
             .values()
-            .copied()
+            .map(|c| c.code)
             .filter(|c| *c != 0)
             .max()
             .unwrap_or(0);
-        let state = JobState::completion_state_for_exit_code(exit_code);
-        (state, exit_code)
+
+        let primary = node_completions.get(primary_node).copied().or_else(|| {
+            node_completions
+                .values()
+                .filter(|c| c.code != 0 || c.signal != 0)
+                .max_by_key(|c| c.code)
+                .copied()
+        });
+
+        match primary {
+            Some(c) => {
+                let failed = c.code != 0 || c.signal != 0;
+                let state = if failed {
+                    JobState::Failed
+                } else {
+                    JobState::Completed
+                };
+                (state, c.code, c.signal, derived)
+            }
+            None => (JobState::Completed, 0, 0, derived),
+        }
     }
 
     pub fn all_nodes_completed(&self) -> bool {
@@ -673,18 +719,65 @@ mod tests {
     }
 
     #[test]
-    fn derived_completion_uses_worst_exit_code() {
-        let mut completions = HashMap::new();
-        completions.insert("n1".into(), 0);
-        completions.insert("n2".into(), 42);
-        let (state, code) = Job::derived_completion(&completions);
-        assert_eq!(state, JobState::Failed);
-        assert_eq!(code, 42);
+    fn node_completion_defaults_and_construct() {
+        let c = NodeCompletion { code: 7, signal: 0 };
+        assert_eq!(c.code, 7);
+        assert_eq!(c.signal, 0);
+        let d = NodeCompletion::default();
+        assert_eq!(d.code, 0);
+        assert_eq!(d.signal, 0);
+    }
 
-        completions.insert("n2".into(), 0);
-        let (state, code) = Job::derived_completion(&completions);
+    #[test]
+    fn job_has_exit_signal_field_default_none() {
+        let job = Job::new(1, JobSpec::default());
+        assert_eq!(job.exit_signal, None);
+        assert_eq!(job.derived_exit_code, None);
+        assert!(job.node_completions.is_empty());
+    }
+
+    #[test]
+    fn derived_completion_primary_exit_and_max_derived() {
+        let mut nc = HashMap::new();
+        nc.insert("n0".to_string(), NodeCompletion { code: 2, signal: 0 });
+        nc.insert("n1".to_string(), NodeCompletion { code: 7, signal: 0 });
+        let (state, code, signal, derived) = Job::derived_completion(&nc, "n0");
+        assert_eq!(state, JobState::Failed);
+        assert_eq!(code, 2);
+        assert_eq!(signal, 0);
+        assert_eq!(derived, 7);
+    }
+
+    #[test]
+    fn derived_completion_primary_signaled() {
+        let mut nc = HashMap::new();
+        nc.insert("n0".to_string(), NodeCompletion { code: 0, signal: 9 });
+        let (state, code, signal, derived) = Job::derived_completion(&nc, "n0");
+        assert_eq!(state, JobState::Failed);
+        assert_eq!(code, 0);
+        assert_eq!(signal, 9);
+        assert_eq!(derived, 0);
+    }
+
+    #[test]
+    fn derived_completion_clean_success() {
+        let mut nc = HashMap::new();
+        nc.insert("n0".to_string(), NodeCompletion { code: 0, signal: 0 });
+        let (state, code, signal, derived) = Job::derived_completion(&nc, "n0");
         assert_eq!(state, JobState::Completed);
         assert_eq!(code, 0);
+        assert_eq!(signal, 0);
+        assert_eq!(derived, 0);
+    }
+
+    #[test]
+    fn derived_completion_missing_primary_falls_back() {
+        let mut nc = HashMap::new();
+        nc.insert("nX".to_string(), NodeCompletion { code: 4, signal: 0 });
+        let (state, code, _signal, derived) = Job::derived_completion(&nc, "n0");
+        assert_eq!(state, JobState::Failed);
+        assert_eq!(code, 4);
+        assert_eq!(derived, 4);
     }
 
     #[test]

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -518,6 +518,10 @@ impl Job {
     /// `DerivedExitCode` is the max exit code across all nodes. State is
     /// `Failed` if the primary exited non-zero or was signaled, else `Completed`.
     ///
+    /// If `primary_node` is not present in the map, `ExitCode` falls back to the
+    /// worst completion (max exit code, or any signaled node) so a failure is
+    /// never masked.
+    ///
     /// Returns `(state, exit_code, exit_signal, derived_exit_code)`.
     pub fn derived_completion(
         node_completions: &HashMap<String, NodeCompletion>,
@@ -778,6 +782,32 @@ mod tests {
         assert_eq!(state, JobState::Failed);
         assert_eq!(code, 4);
         assert_eq!(derived, 4);
+    }
+
+    #[test]
+    fn derived_completion_empty_map_is_clean() {
+        let nc = HashMap::new();
+        let (state, code, signal, derived) = Job::derived_completion(&nc, "n0");
+        assert_eq!(state, JobState::Completed);
+        assert_eq!((code, signal, derived), (0, 0, 0));
+    }
+
+    #[test]
+    fn derived_completion_primary_mixed_code_and_signal() {
+        // A single node that both exited non-zero AND was signaled: both propagate.
+        let mut nc = HashMap::new();
+        nc.insert(
+            "n0".to_string(),
+            NodeCompletion {
+                code: 5,
+                signal: 11,
+            },
+        );
+        let (state, code, signal, derived) = Job::derived_completion(&nc, "n0");
+        assert_eq!(state, JobState::Failed);
+        assert_eq!(code, 5);
+        assert_eq!(signal, 11);
+        assert_eq!(derived, 5);
     }
 
     #[test]

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -445,9 +445,7 @@ impl Default for JobSpec {
 /// split into exit code and terminating signal (0 = none).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct NodeCompletion {
-    #[serde(default)]
     pub code: i32,
-    #[serde(default)]
     pub signal: i32,
 }
 
@@ -474,11 +472,11 @@ pub struct Job {
 
     /// Terminating signal of the primary node's process (0 = none).
     #[serde(default)]
-    pub exit_signal: Option<i32>,
+    pub exit_signal: i32,
     /// Slurm `DerivedExitCode`: running max over srun step exit codes (via
-    /// `JobStepComplete`); `None`/0 when the job ran no srun steps.
+    /// `JobStepComplete`); 0 when the job ran no srun steps.
     #[serde(default)]
-    pub derived_exit_code: Option<i32>,
+    pub derived_exit_code: i32,
 
     /// Number of times this job has been requeued.
     #[serde(default)]
@@ -527,8 +525,8 @@ impl Job {
             allocated_resources: None,
             per_node_alloc: HashMap::new(),
             exit_code: None,
-            exit_signal: None,
-            derived_exit_code: None,
+            exit_signal: 0,
+            derived_exit_code: 0,
             requeue_count: 0,
             het_job_id: None,
             het_group: None,
@@ -544,20 +542,13 @@ impl Job {
     /// If `primary_node` is absent, falls back to the worst completion (a
     /// signaled node, or the highest exit code) so a failure isn't masked.
     ///
-    /// Returns `(state, exit_code, exit_signal, node_max_exit)`. The 4th value
-    /// is a legacy node-based max — NOT the job's DerivedExitCode, which is the
-    /// running max over srun steps maintained via `JobStepComplete`.
+    /// Returns `(state, exit_code, exit_signal)`. Note this does NOT compute the
+    /// job's DerivedExitCode — that is the running max over srun steps maintained
+    /// via `JobStepComplete`, not a node-based value.
     pub fn derived_completion(
         node_completions: &HashMap<String, NodeCompletion>,
         primary_node: &str,
-    ) -> (JobState, i32, i32, i32) {
-        let derived = node_completions
-            .values()
-            .map(|c| c.code)
-            .filter(|c| *c != 0)
-            .max()
-            .unwrap_or(0);
-
+    ) -> (JobState, i32, i32) {
         let primary = node_completions.get(primary_node).copied().or_else(|| {
             // No primary completion (shouldn't happen once all nodes report).
             // Pick the worst failure so the outcome is never masked: rank a
@@ -577,9 +568,9 @@ impl Job {
                 } else {
                     JobState::Completed
                 };
-                (state, c.code, c.signal, derived)
+                (state, c.code, c.signal)
             }
-            None => (JobState::Completed, 0, 0, derived),
+            None => (JobState::Completed, 0, 0),
         }
     }
 
@@ -762,53 +753,49 @@ mod tests {
     #[test]
     fn job_has_exit_signal_field_default_none() {
         let job = Job::new(1, JobSpec::default());
-        assert_eq!(job.exit_signal, None);
-        assert_eq!(job.derived_exit_code, None);
+        assert_eq!(job.exit_signal, 0);
+        assert_eq!(job.derived_exit_code, 0);
         assert!(job.node_completions.is_empty());
     }
 
     #[test]
-    fn derived_completion_primary_exit_and_max_derived() {
+    fn derived_completion_primary_exit() {
         let mut nc = HashMap::new();
         nc.insert("n0".to_string(), NodeCompletion { code: 2, signal: 0 });
         nc.insert("n1".to_string(), NodeCompletion { code: 7, signal: 0 });
-        let (state, code, signal, derived) = Job::derived_completion(&nc, "n0");
+        let (state, code, signal) = Job::derived_completion(&nc, "n0");
         assert_eq!(state, JobState::Failed);
         assert_eq!(code, 2);
         assert_eq!(signal, 0);
-        assert_eq!(derived, 7);
     }
 
     #[test]
     fn derived_completion_primary_signaled() {
         let mut nc = HashMap::new();
         nc.insert("n0".to_string(), NodeCompletion { code: 0, signal: 9 });
-        let (state, code, signal, derived) = Job::derived_completion(&nc, "n0");
+        let (state, code, signal) = Job::derived_completion(&nc, "n0");
         assert_eq!(state, JobState::Failed);
         assert_eq!(code, 0);
         assert_eq!(signal, 9);
-        assert_eq!(derived, 0);
     }
 
     #[test]
     fn derived_completion_clean_success() {
         let mut nc = HashMap::new();
         nc.insert("n0".to_string(), NodeCompletion { code: 0, signal: 0 });
-        let (state, code, signal, derived) = Job::derived_completion(&nc, "n0");
+        let (state, code, signal) = Job::derived_completion(&nc, "n0");
         assert_eq!(state, JobState::Completed);
         assert_eq!(code, 0);
         assert_eq!(signal, 0);
-        assert_eq!(derived, 0);
     }
 
     #[test]
     fn derived_completion_missing_primary_falls_back() {
         let mut nc = HashMap::new();
         nc.insert("nX".to_string(), NodeCompletion { code: 4, signal: 0 });
-        let (state, code, _signal, derived) = Job::derived_completion(&nc, "n0");
+        let (state, code, _signal) = Job::derived_completion(&nc, "n0");
         assert_eq!(state, JobState::Failed);
         assert_eq!(code, 4);
-        assert_eq!(derived, 4);
     }
 
     #[test]
@@ -824,7 +811,7 @@ mod tests {
                 signal: 11,
             },
         );
-        let (state, code, signal, _derived) = Job::derived_completion(&nc, "missing");
+        let (state, code, signal) = Job::derived_completion(&nc, "missing");
         assert_eq!(state, JobState::Failed);
         assert_eq!(code, 0);
         assert_eq!(signal, 11);
@@ -833,9 +820,9 @@ mod tests {
     #[test]
     fn derived_completion_empty_map_is_clean() {
         let nc = HashMap::new();
-        let (state, code, signal, derived) = Job::derived_completion(&nc, "n0");
+        let (state, code, signal) = Job::derived_completion(&nc, "n0");
         assert_eq!(state, JobState::Completed);
-        assert_eq!((code, signal, derived), (0, 0, 0));
+        assert_eq!((code, signal), (0, 0));
     }
 
     #[test]
@@ -849,11 +836,10 @@ mod tests {
                 signal: 11,
             },
         );
-        let (state, code, signal, derived) = Job::derived_completion(&nc, "n0");
+        let (state, code, signal) = Job::derived_completion(&nc, "n0");
         assert_eq!(state, JobState::Failed);
         assert_eq!(code, 5);
         assert_eq!(signal, 11);
-        assert_eq!(derived, 5);
     }
 
     #[test]

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -475,7 +475,9 @@ pub struct Job {
     /// Terminating signal of the primary node's process (0 = none).
     #[serde(default)]
     pub exit_signal: Option<i32>,
-    /// Max exit code across all node completions (Slurm DerivedExitCode).
+    /// Slurm `DerivedExitCode`: the running max over the job's srun step exit
+    /// codes, accumulated by `WalOperation::JobStepComplete`. `None`/0 for a job
+    /// with no srun steps.
     #[serde(default)]
     pub derived_exit_code: Option<i32>,
 
@@ -535,16 +537,21 @@ impl Job {
         }
     }
 
-    /// Derive the final job outcome from per-node completions, matching Slurm:
-    /// `ExitCode` is the primary node's raw wait status (exit_code, signal);
-    /// `DerivedExitCode` is the max exit code across all nodes. State is
-    /// `Failed` if the primary exited non-zero or was signaled, else `Completed`.
+    /// Derive a job's `ExitCode` and state from per-node completions, matching
+    /// Slurm: `ExitCode` is the primary node's raw wait status (exit_code,
+    /// signal); state is `Failed` if the primary exited non-zero or was
+    /// signaled, else `Completed`.
     ///
-    /// If `primary_node` is not present in the map, `ExitCode` falls back to the
-    /// worst completion (max exit code, or any signaled node) so a failure is
-    /// never masked.
+    /// If `primary_node` is absent from the map, falls back to the worst
+    /// completion (a signaled node, or the highest exit code) so a failure is
+    /// never reported as success.
     ///
-    /// Returns `(state, exit_code, exit_signal, derived_exit_code)`.
+    /// The 4th return value is a node-based max kept only for backward
+    /// compatibility; the job's real Slurm `DerivedExitCode` is the running max
+    /// over srun *steps*, maintained separately via `JobStepComplete`. Callers
+    /// finalizing a job should NOT use this value for `derived_exit_code`.
+    ///
+    /// Returns `(state, exit_code, exit_signal, node_max_exit)`.
     pub fn derived_completion(
         node_completions: &HashMap<String, NodeCompletion>,
         primary_node: &str,
@@ -557,10 +564,13 @@ impl Job {
             .unwrap_or(0);
 
         let primary = node_completions.get(primary_node).copied().or_else(|| {
+            // No primary completion (shouldn't happen once all nodes report).
+            // Pick the worst failure so the outcome is never masked: rank a
+            // signaled node above a plain non-zero exit, then by exit code.
             node_completions
                 .values()
                 .filter(|c| c.code != 0 || c.signal != 0)
-                .max_by_key(|c| c.code)
+                .max_by_key(|c| (c.signal != 0, c.code, c.signal))
                 .copied()
         });
 

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -817,6 +817,25 @@ mod tests {
     }
 
     #[test]
+    fn derived_completion_missing_primary_prefers_signaled() {
+        // Missing primary, a signaled node and a higher plain-exit node: the
+        // signaled node wins so the signal isn't masked by the higher code.
+        let mut nc = HashMap::new();
+        nc.insert("a".to_string(), NodeCompletion { code: 9, signal: 0 });
+        nc.insert(
+            "b".to_string(),
+            NodeCompletion {
+                code: 0,
+                signal: 11,
+            },
+        );
+        let (state, code, signal, _derived) = Job::derived_completion(&nc, "missing");
+        assert_eq!(state, JobState::Failed);
+        assert_eq!(code, 0);
+        assert_eq!(signal, 11);
+    }
+
+    #[test]
     fn derived_completion_empty_map_is_clean() {
         let nc = HashMap::new();
         let (state, code, signal, derived) = Job::derived_completion(&nc, "n0");

--- a/crates/spur-core/src/step.rs
+++ b/crates/spur-core/src/step.rs
@@ -23,6 +23,10 @@ pub const STEP_BATCH: StepId = 0xFFFF_FFFE;
 pub const STEP_EXTERN: StepId = 0xFFFF_FFFD;
 pub const STEP_INTERACTIVE: StepId = 0xFFFF_FFFC;
 
+/// Step IDs at or above this are reserved (batch/extern/interactive); real
+/// user `srun` steps are numbered below it (0, 1, 2, ...).
+pub const STEP_RESERVED_MIN: StepId = 0xFFFF_FFF0;
+
 /// A step within a job.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JobStep {

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -49,6 +49,13 @@ pub enum WalOperation {
         #[serde(default)]
         signal: i32,
     },
+    /// An srun job step finished. Records the step's exit code durably so the
+    /// job's DerivedExitCode (running max over steps) survives restart/replay.
+    JobStepComplete {
+        job_id: JobId,
+        step_id: u32,
+        exit_code: i32,
+    },
     JobPriorityChange {
         job_id: JobId,
         old_priority: u32,

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -37,12 +37,16 @@ pub enum WalOperation {
     JobComplete {
         job_id: JobId,
         exit_code: i32,
+        #[serde(default)]
+        signal: i32,
         state: JobState,
     },
     JobNodeComplete {
         job_id: JobId,
         node_name: String,
         exit_code: i32,
+        #[serde(default)]
+        signal: i32,
     },
     JobPriorityChange {
         job_id: JobId,
@@ -78,4 +82,35 @@ pub enum WalOperation {
         #[serde(default)]
         admin_locked: bool,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn job_node_complete_carries_signal_and_old_logs_default_zero() {
+        let op = WalOperation::JobNodeComplete {
+            job_id: 1,
+            node_name: "n0".into(),
+            exit_code: 0,
+            signal: 9,
+        };
+        let json = serde_json::to_string(&op).unwrap();
+        let back: WalOperation = serde_json::from_str(&json).unwrap();
+        // Old log without `signal` deserializes with signal = 0.
+        let old = r#"{"JobNodeComplete":{"job_id":2,"node_name":"n1","exit_code":3}}"#;
+        let parsed: WalOperation = serde_json::from_str(old).unwrap();
+        match parsed {
+            WalOperation::JobNodeComplete {
+                signal, exit_code, ..
+            } => {
+                assert_eq!(signal, 0);
+                assert_eq!(exit_code, 3);
+            }
+            _ => panic!("wrong variant"),
+        }
+        // round-trip new form (WalOperation does not derive PartialEq)
+        let _ = (op, back);
+    }
 }

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -37,6 +37,7 @@ pub enum WalOperation {
     JobComplete {
         job_id: JobId,
         exit_code: i32,
+        // reserved; JobComplete paths carry no process signal (cancel/deadline/timeout)
         #[serde(default)]
         signal: i32,
         state: JobState,

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -118,7 +118,22 @@ mod tests {
             }
             _ => panic!("wrong variant"),
         }
-        // round-trip new form (WalOperation does not derive PartialEq)
-        let _ = (op, back);
+        // New form round-trips through serde (WalOperation has no PartialEq, so
+        // assert the fields rather than the whole value).
+        let _ = op;
+        match back {
+            WalOperation::JobNodeComplete {
+                job_id,
+                node_name,
+                exit_code,
+                signal,
+            } => {
+                assert_eq!(job_id, 1);
+                assert_eq!(node_name, "n0");
+                assert_eq!(exit_code, 0);
+                assert_eq!(signal, 9);
+            }
+            _ => panic!("wrong variant"),
+        }
     }
 }

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -37,16 +37,12 @@ pub enum WalOperation {
     JobComplete {
         job_id: JobId,
         exit_code: i32,
-        // reserved; JobComplete paths carry no process signal (cancel/deadline/timeout)
-        #[serde(default)]
-        signal: i32,
         state: JobState,
     },
     JobNodeComplete {
         job_id: JobId,
         node_name: String,
         exit_code: i32,
-        #[serde(default)]
         signal: i32,
     },
     /// An srun job step finished. Records the step's exit code durably so the
@@ -97,7 +93,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn job_node_complete_carries_signal_and_old_logs_default_zero() {
+    fn job_node_complete_signal_round_trips() {
         let op = WalOperation::JobNodeComplete {
             job_id: 1,
             node_name: "n0".into(),
@@ -106,21 +102,7 @@ mod tests {
         };
         let json = serde_json::to_string(&op).unwrap();
         let back: WalOperation = serde_json::from_str(&json).unwrap();
-        // Old log without `signal` deserializes with signal = 0.
-        let old = r#"{"JobNodeComplete":{"job_id":2,"node_name":"n1","exit_code":3}}"#;
-        let parsed: WalOperation = serde_json::from_str(old).unwrap();
-        match parsed {
-            WalOperation::JobNodeComplete {
-                signal, exit_code, ..
-            } => {
-                assert_eq!(signal, 0);
-                assert_eq!(exit_code, 3);
-            }
-            _ => panic!("wrong variant"),
-        }
-        // New form round-trips through serde (WalOperation has no PartialEq, so
-        // assert the fields rather than the whole value).
-        let _ = op;
+        // WalOperation has no PartialEq, so assert the fields rather than the value.
         match back {
             WalOperation::JobNodeComplete {
                 job_id,

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -498,6 +498,7 @@ async fn watch_pods(ctx: Arc<JobControllerCtx>) -> anyhow::Result<()> {
                     job_id,
                     state: report_state.to_proto_i32(),
                     exit_code: final_exit_code,
+                    signal: 0,
                     message: final_message,
                     drain_node: false,
                     drain_reason: String::new(),

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2933,19 +2933,13 @@ mod tests {
         assert_eq!(job.pending_reason, PendingReason::RaisedSignal);
     }
 
-    // Drives the exact code path of the `report_job_status` RPC for a signaled
-    // completion. We cannot construct the full `ControllerService` here (it needs a
-    // `LeaderProxy` + serving stack), so we reproduce the two steps the RPC handler
-    // performs in `server.rs::report_job_status`: (1) it validates the wire report
-    // with `validate_completion_report_state` before accepting it, then (2) it calls
-    // `cluster.node_complete(job_id, node, exit_code, signal)`. The agent reports a
-    // signal-killed job as (state=Completed, exit_code=0, signal=9) — see the NOTE in
-    // spurd/agent_server.rs. This test locks in that such a report is ACCEPTED by the
-    // validator and then rederived to a Failed job with exit_signal=9 / RaisedSignal.
+    // Reproduces the two steps report_job_status performs (validate the wire
+    // report, then node_complete) since ControllerService can't be built here.
+    // A signaled job's report (Completed, exit_code=0, signal=9) must be accepted
+    // and rederived to Failed / exit_signal=9 / RaisedSignal.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn rpc_path_signaled_completion_accepted_and_rederived_failed() {
-        // Step 1: the agent's wire report for a signaled job is (Completed, exit_code=0).
-        // The controller validates this before touching the cluster; it must pass.
+        // Step 1: validate the wire report (Completed, exit_code=0) — must pass.
         JobState::validate_completion_report_state(JobState::Completed, 0)
             .expect("agent (Completed, exit_code=0) signaled report must pass RPC validation");
 
@@ -2970,8 +2964,7 @@ mod tests {
             per_node_alloc: per_node_for(&["n1"], scalar_alloc(6, 12000)),
         });
 
-        // Step 2: the same call the RPC handler makes after validation — note the
-        // wire state (Completed) is dropped; only exit_code=0 and signal=9 flow in.
+        // Step 2: the call the RPC makes after validation (wire state dropped).
         cm.node_complete(1, "n1", 0, 9).unwrap();
 
         let job = cm.get_job(1).unwrap();

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1845,7 +1845,9 @@ impl ClusterManager {
                     }
 
                     if job.all_nodes_completed() {
-                        // Primary = batch node (allocated_nodes[0]). Empty string when none allocated; derived_completion then falls back to the worst completion.
+                        // Primary = batch node (allocated_nodes[0]); empty when
+                        // none allocated, where derived_completion falls back to
+                        // the worst completion.
                         let primary = job.allocated_nodes.first().cloned().unwrap_or_default();
                         let (final_state, final_exit, final_signal, _node_derived) =
                             Job::derived_completion(&job.node_completions, &primary);

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2936,6 +2936,57 @@ mod tests {
         assert_eq!(job.pending_reason, PendingReason::RaisedSignal);
     }
 
+    // Drives the exact code path of the `report_job_status` RPC for a signaled
+    // completion. We cannot construct the full `ControllerService` here (it needs a
+    // `LeaderProxy` + serving stack), so we reproduce the two steps the RPC handler
+    // performs in `server.rs::report_job_status`: (1) it validates the wire report
+    // with `validate_completion_report_state` before accepting it, then (2) it calls
+    // `cluster.node_complete(job_id, node, exit_code, signal)`. The agent reports a
+    // signal-killed job as (state=Completed, exit_code=0, signal=9) — see the NOTE in
+    // spurd/agent_server.rs. This test locks in that such a report is ACCEPTED by the
+    // validator and then rederived to a Failed job with exit_signal=9 / RaisedSignal.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn rpc_path_signaled_completion_accepted_and_rederived_failed() {
+        // Step 1: the agent's wire report for a signaled job is (Completed, exit_code=0).
+        // The controller validates this before touching the cluster; it must pass.
+        JobState::validate_completion_report_state(JobState::Completed, 0)
+            .expect("agent (Completed, exit_code=0) signaled report must pass RPC validation");
+
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        register_node(&cm, "n1", 8, 16000);
+
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("rpc-signal-job")),
+        });
+        cm.apply_operation(&WalOperation::JobStateChange {
+            job_id: 1,
+            old_state: JobState::Pending,
+            new_state: JobState::Running,
+        });
+        cm.apply_operation(&WalOperation::JobStart {
+            job_id: 1,
+            nodes: vec!["n1".into()],
+            resources: ResourceSet {
+                cpus: 6,
+                memory_mb: 12000,
+                ..Default::default()
+            },
+        });
+
+        // Step 2: the same call the RPC handler makes after validation — note the
+        // wire state (Completed) is dropped; only exit_code=0 and signal=9 flow in.
+        cm.node_complete(1, "n1", 0, 9).unwrap();
+
+        let job = cm.get_job(1).unwrap();
+        assert_eq!(job.state, JobState::Failed);
+        assert_eq!(job.exit_code, Some(0));
+        assert_eq!(job.exit_signal, Some(9));
+        assert_eq!(job.pending_reason, PendingReason::RaisedSignal);
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn node_complete_sets_nonzero_exit_reason() {
         let dir = TempDir::new().unwrap();

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -490,6 +490,7 @@ impl ClusterManager {
         job_id: JobId,
         node_name: &str,
         exit_code: i32,
+        signal: i32,
     ) -> Result<NodeCompleteResult, NodeCompleteError> {
         {
             let jobs = self.jobs.read();
@@ -512,7 +513,7 @@ impl ClusterManager {
                 job_id,
                 node_name: node_name.to_string(),
                 exit_code,
-                signal: 0,
+                signal,
             })
             .map_err(|source| NodeCompleteError::RaftPropose { source })?;
 
@@ -1777,7 +1778,7 @@ impl ClusterManager {
                 job_id,
                 node_name,
                 exit_code,
-                signal: _,
+                signal,
             } => {
                 let finalized = {
                     let Some(job) = jobs.get_mut(job_id) else {
@@ -1788,7 +1789,13 @@ impl ClusterManager {
                     }
 
                     let already_reported = job.node_completions.contains_key(node_name);
-                    job.node_completions.insert(node_name.clone(), *exit_code);
+                    job.node_completions.insert(
+                        node_name.clone(),
+                        spur_core::job::NodeCompletion {
+                            code: *exit_code,
+                            signal: *signal,
+                        },
+                    );
 
                     if let Some(ref total) = job.allocated_resources {
                         if !already_reported {
@@ -1821,11 +1828,21 @@ impl ClusterManager {
                     }
 
                     if job.all_nodes_completed() {
-                        let (final_state, final_exit) =
-                            Job::derived_completion(&job.node_completions);
+                        let primary = job.allocated_nodes.first().cloned().unwrap_or_default();
+                        let (final_state, final_exit, final_signal, derived) =
+                            Job::derived_completion(&job.node_completions, &primary);
                         match job.transition(final_state) {
                             Ok(()) => {
                                 job.exit_code = Some(final_exit);
+                                job.exit_signal = Some(final_signal);
+                                job.derived_exit_code = Some(derived);
+                                job.pending_reason = if final_signal != 0 {
+                                    PendingReason::RaisedSignal
+                                } else if final_exit != 0 {
+                                    PendingReason::NonZeroExitCode
+                                } else {
+                                    PendingReason::None
+                                };
                                 job.end_time = Some(timestamp);
                                 job.node_completions.clear();
                                 Some((final_state, final_exit))
@@ -2699,8 +2716,12 @@ mod tests {
         });
 
         let job = cm.get_job(1).unwrap();
-        assert_eq!(job.state, JobState::Failed);
-        assert_eq!(job.exit_code, Some(42));
+        // ExitCode follows the primary (batch) node n1 = allocated_nodes[0],
+        // which exited 0 — so the job state/exit_code reflect a clean primary.
+        // The non-zero exit on n3 surfaces only via DerivedExitCode.
+        assert_eq!(job.state, JobState::Completed);
+        assert_eq!(job.exit_code, Some(0));
+        assert_eq!(job.derived_exit_code, Some(42));
         for name in ["n1", "n2", "n3"] {
             assert_eq!(cm.get_node(name).unwrap().alloc_resources.cpus, 0);
         }
@@ -2874,9 +2895,79 @@ mod tests {
             signal: 0,
         });
 
-        let result = cm.node_complete(1, "n2", 0).unwrap();
+        let result = cm.node_complete(1, "n2", 0, 0).unwrap();
         assert_eq!(result, NodeCompleteResult::Completing);
         assert_eq!(cm.get_job(1).unwrap().state, JobState::Completing);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn node_complete_sets_signal_reason_and_derived() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        register_node(&cm, "n1", 8, 16000);
+
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("signal-job")),
+        });
+        cm.apply_operation(&WalOperation::JobStateChange {
+            job_id: 1,
+            old_state: JobState::Pending,
+            new_state: JobState::Running,
+        });
+        cm.apply_operation(&WalOperation::JobStart {
+            job_id: 1,
+            nodes: vec!["n1".into()],
+            resources: ResourceSet {
+                cpus: 6,
+                memory_mb: 12000,
+                ..Default::default()
+            },
+        });
+
+        let _ = cm.node_complete(1, "n1", 0, 9);
+        let job = cm.get_job(1).unwrap();
+        assert_eq!(job.state, JobState::Failed);
+        assert_eq!(job.exit_code, Some(0));
+        assert_eq!(job.exit_signal, Some(9));
+        assert_eq!(job.derived_exit_code, Some(0));
+        assert_eq!(job.pending_reason, PendingReason::RaisedSignal);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn node_complete_sets_nonzero_exit_reason() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        register_node(&cm, "n1", 8, 16000);
+
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("exit-job")),
+        });
+        cm.apply_operation(&WalOperation::JobStateChange {
+            job_id: 1,
+            old_state: JobState::Pending,
+            new_state: JobState::Running,
+        });
+        cm.apply_operation(&WalOperation::JobStart {
+            job_id: 1,
+            nodes: vec!["n1".into()],
+            resources: ResourceSet {
+                cpus: 6,
+                memory_mb: 12000,
+                ..Default::default()
+            },
+        });
+
+        let _ = cm.node_complete(1, "n1", 42, 0);
+        let job = cm.get_job(1).unwrap();
+        assert_eq!(job.state, JobState::Failed);
+        assert_eq!(job.exit_code, Some(42));
+        assert_eq!(job.exit_signal, Some(0));
+        assert_eq!(job.derived_exit_code, Some(42));
+        assert_eq!(job.pending_reason, PendingReason::NonZeroExitCode);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -2979,7 +3070,7 @@ mod tests {
         cm.cancel_job(1, "testuser").unwrap();
         settle(&cm, 1, JobState::Cancelled);
 
-        let result = cm.node_complete(1, "n2", 0).unwrap();
+        let result = cm.node_complete(1, "n2", 0, 0).unwrap();
         assert_eq!(result, NodeCompleteResult::AlreadyTerminal);
         assert_eq!(cm.get_job(1).unwrap().state, JobState::Cancelled);
     }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1828,6 +1828,7 @@ impl ClusterManager {
                     }
 
                     if job.all_nodes_completed() {
+                        // Primary = batch node (allocated_nodes[0]). Empty string when none allocated; derived_completion then falls back to the worst completion.
                         let primary = job.allocated_nodes.first().cloned().unwrap_or_default();
                         let (final_state, final_exit, final_signal, derived) =
                             Job::derived_completion(&job.node_completions, &primary);
@@ -2926,7 +2927,7 @@ mod tests {
             },
         });
 
-        let _ = cm.node_complete(1, "n1", 0, 9);
+        cm.node_complete(1, "n1", 0, 9).unwrap();
         let job = cm.get_job(1).unwrap();
         assert_eq!(job.state, JobState::Failed);
         assert_eq!(job.exit_code, Some(0));
@@ -2961,7 +2962,7 @@ mod tests {
             },
         });
 
-        let _ = cm.node_complete(1, "n1", 42, 0);
+        cm.node_complete(1, "n1", 42, 0).unwrap();
         let job = cm.get_job(1).unwrap();
         assert_eq!(job.state, JobState::Failed);
         assert_eq!(job.exit_code, Some(42));

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -349,6 +349,7 @@ impl ClusterManager {
         let resp = self.propose(WalOperation::JobComplete {
             job_id,
             exit_code: -1,
+            signal: 0,
             state: JobState::Deadline,
         })?;
         if let Some(f) = resp.job_finalized {
@@ -377,6 +378,7 @@ impl ClusterManager {
         let resp = self.propose(WalOperation::JobComplete {
             job_id,
             exit_code: -1,
+            signal: 0,
             state: JobState::Cancelled,
         })?;
         if let Some(f) = resp.job_finalized {
@@ -510,6 +512,7 @@ impl ClusterManager {
                 job_id,
                 node_name: node_name.to_string(),
                 exit_code,
+                signal: 0,
             })
             .map_err(|source| NodeCompleteError::RaftPropose { source })?;
 
@@ -552,6 +555,7 @@ impl ClusterManager {
         let resp = self.propose(WalOperation::JobComplete {
             job_id,
             exit_code,
+            signal: 0,
             state,
         })?;
         if let Some(f) = resp.job_finalized {
@@ -683,6 +687,7 @@ impl ClusterManager {
         self.propose(WalOperation::JobComplete {
             job_id,
             exit_code: -1,
+            signal: 0,
             state: JobState::Failed,
         })?;
 
@@ -1315,6 +1320,7 @@ impl ClusterManager {
             match self.propose(WalOperation::JobComplete {
                 job_id: id,
                 exit_code: -1,
+                signal: 0,
                 state: JobState::Cancelled,
             }) {
                 Ok(resp) => {
@@ -1771,6 +1777,7 @@ impl ClusterManager {
                 job_id,
                 node_name,
                 exit_code,
+                signal: _,
             } => {
                 let finalized = {
                     let Some(job) = jobs.get_mut(job_id) else {
@@ -1854,6 +1861,7 @@ impl ClusterManager {
             WalOperation::JobComplete {
                 job_id,
                 exit_code,
+                signal: _,
                 state,
             } => {
                 let freed_nodes;
@@ -2455,6 +2463,7 @@ mod tests {
         cm.apply_operation(&WalOperation::JobComplete {
             job_id: 1,
             exit_code: 0,
+            signal: 0,
             state: JobState::Completed,
         });
 
@@ -2626,6 +2635,7 @@ mod tests {
             job_id: 1,
             node_name: "worker1".into(),
             exit_code: 0,
+            signal: 0,
         });
 
         let job = cm.get_job(1).unwrap();
@@ -2665,6 +2675,7 @@ mod tests {
             job_id: 1,
             node_name: "n1".into(),
             exit_code: 0,
+            signal: 0,
         });
         let job = cm.get_job(1).unwrap();
         assert_eq!(job.state, JobState::Completing);
@@ -2676,6 +2687,7 @@ mod tests {
             job_id: 1,
             node_name: "n2".into(),
             exit_code: 0,
+            signal: 0,
         });
         assert_eq!(cm.get_job(1).unwrap().state, JobState::Completing);
 
@@ -2683,6 +2695,7 @@ mod tests {
             job_id: 1,
             node_name: "n3".into(),
             exit_code: 42,
+            signal: 0,
         });
 
         let job = cm.get_job(1).unwrap();
@@ -2723,6 +2736,7 @@ mod tests {
             job_id: 1,
             node_name: "n1".into(),
             exit_code: 0,
+            signal: 0,
         });
         assert!(r1.job_finalized.is_none());
         assert_eq!(cm.get_job(1).unwrap().state, JobState::Completing);
@@ -2731,6 +2745,7 @@ mod tests {
             job_id: 1,
             node_name: "n2".into(),
             exit_code: 0,
+            signal: 0,
         });
         let f = r2.job_finalized.expect("last node should finalize");
         assert_eq!(f.job_id, 1);
@@ -2765,6 +2780,7 @@ mod tests {
         let resp = cm.apply_operation(&WalOperation::JobComplete {
             job_id: 1,
             exit_code: 0,
+            signal: 0,
             state: JobState::Completed,
         });
         let f = resp.job_finalized.expect("JobComplete should finalize");
@@ -2799,6 +2815,7 @@ mod tests {
         let first = cm.apply_operation(&WalOperation::JobComplete {
             job_id: 1,
             exit_code: 0,
+            signal: 0,
             state: JobState::Completed,
         });
         first
@@ -2811,6 +2828,7 @@ mod tests {
         let second = cm.apply_operation(&WalOperation::JobComplete {
             job_id: 1,
             exit_code: -1,
+            signal: 0,
             state: JobState::Cancelled,
         });
         assert!(second.job_finalized.is_none());
@@ -2853,6 +2871,7 @@ mod tests {
             job_id: 1,
             node_name: "n1".into(),
             exit_code: 0,
+            signal: 0,
         });
 
         let result = cm.node_complete(1, "n2", 0).unwrap();
@@ -2890,6 +2909,7 @@ mod tests {
             job_id: 1,
             node_name: "n1".into(),
             exit_code: 0,
+            signal: 0,
         });
 
         let job = cm.get_job(1).unwrap();
@@ -2917,6 +2937,7 @@ mod tests {
             job_id: 1,
             node_name: "n2".into(),
             exit_code: 0,
+            signal: 0,
         });
 
         let job = cm.get_job(1).unwrap();
@@ -2952,6 +2973,7 @@ mod tests {
             job_id: 1,
             node_name: "n1".into(),
             exit_code: 0,
+            signal: 0,
         });
 
         cm.cancel_job(1, "testuser").unwrap();
@@ -3368,6 +3390,7 @@ mod tests {
         cm.apply_operation(&WalOperation::JobComplete {
             job_id: id,
             exit_code: -1,
+            signal: 0,
             state: JobState::Timeout,
         });
         assert_eq!(cm.get_job(id).unwrap().state, JobState::Timeout);

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -18,7 +18,7 @@ use spur_core::partition::Partition;
 use spur_core::qos::{check_qos_limits, QosCheckResult};
 use spur_core::reservation::Reservation;
 use spur_core::resource::{ResourceAllocations, ResourceSet};
-use spur_core::step::{JobStep, StepState, STEP_BATCH};
+use spur_core::step::{JobStep, StepState, STEP_BATCH, STEP_RESERVED_MIN};
 use spur_core::wal::WalOperation;
 use spur_metrics::job::JobMetricsSnapshot;
 use spur_metrics::node::NodeMetricsSnapshot;
@@ -1056,6 +1056,23 @@ impl ClusterManager {
         debug!(job_id, step_id, "step created");
     }
 
+    /// Record an srun step's completion via Raft so the step exit code and the
+    /// job's running-max DerivedExitCode are durable and replay-consistent.
+    #[allow(clippy::result_large_err)]
+    pub fn record_step_complete(
+        &self,
+        job_id: JobId,
+        step_id: u32,
+        exit_code: i32,
+    ) -> anyhow::Result<()> {
+        self.propose(WalOperation::JobStepComplete {
+            job_id,
+            step_id,
+            exit_code,
+        })?;
+        Ok(())
+    }
+
     /// Get all steps for a job.
     pub fn get_steps(&self, job_id: JobId) -> Vec<JobStep> {
         self.steps
@@ -1830,13 +1847,17 @@ impl ClusterManager {
                     if job.all_nodes_completed() {
                         // Primary = batch node (allocated_nodes[0]). Empty string when none allocated; derived_completion then falls back to the worst completion.
                         let primary = job.allocated_nodes.first().cloned().unwrap_or_default();
-                        let (final_state, final_exit, final_signal, derived) =
+                        let (final_state, final_exit, final_signal, _node_derived) =
                             Job::derived_completion(&job.node_completions, &primary);
                         match job.transition(final_state) {
                             Ok(()) => {
                                 job.exit_code = Some(final_exit);
                                 job.exit_signal = Some(final_signal);
-                                job.derived_exit_code = Some(derived);
+                                // DerivedExitCode is the running max over srun
+                                // steps, accumulated live by JobStepComplete.
+                                // Preserve it; a job with no srun steps keeps
+                                // 0:0 (Slurm parity), not the batch exit.
+                                job.derived_exit_code = Some(job.derived_exit_code.unwrap_or(0));
                                 job.pending_reason = if final_signal != 0 {
                                     PendingReason::RaisedSignal
                                 } else if final_exit != 0 {
@@ -1946,6 +1967,35 @@ impl ClusterManager {
                 drop(jobs);
                 drop(nodes);
                 self.complete_job_steps_and_licenses(job_id, *exit_code, timestamp);
+            }
+            WalOperation::JobStepComplete {
+                job_id,
+                step_id,
+                exit_code,
+            } => {
+                // Record the step's own exit code/state.
+                {
+                    let mut steps = self.steps.write();
+                    if let Some(step) = steps.get_mut(&(*job_id, *step_id)) {
+                        step.state = if *exit_code == 0 {
+                            StepState::Completed
+                        } else {
+                            StepState::Failed
+                        };
+                        step.exit_code = Some(*exit_code);
+                        step.end_time = Some(timestamp);
+                    }
+                }
+                // DerivedExitCode is the running max over srun steps (the batch
+                // step is excluded — it carries the job's own exit, not a step
+                // result). Maintained live so `scontrol show job` reflects it
+                // mid-run, matching Slurm.
+                if *step_id < STEP_RESERVED_MIN {
+                    if let Some(job) = jobs.get_mut(job_id) {
+                        let cur = job.derived_exit_code.unwrap_or(0);
+                        job.derived_exit_code = Some(cur.max(*exit_code));
+                    }
+                }
             }
             WalOperation::JobPriorityChange {
                 job_id,
@@ -2719,13 +2769,99 @@ mod tests {
         let job = cm.get_job(1).unwrap();
         // ExitCode follows the primary (batch) node n1 = allocated_nodes[0],
         // which exited 0 — so the job state/exit_code reflect a clean primary.
-        // The non-zero exit on n3 surfaces only via DerivedExitCode.
         assert_eq!(job.state, JobState::Completed);
         assert_eq!(job.exit_code, Some(0));
-        assert_eq!(job.derived_exit_code, Some(42));
+        // DerivedExitCode is the max over srun *steps* (Slurm parity), not node
+        // completions. This job ran no srun steps, so it is 0 — the non-primary
+        // node's exit 42 does not surface here.
+        assert_eq!(job.derived_exit_code, Some(0));
         for name in ["n1", "n2", "n3"] {
             assert_eq!(cm.get_node(name).unwrap().alloc_resources.cpus, 0);
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn step_complete_accumulates_derived_exit_code_running_max() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("steps")),
+        });
+        cm.apply_operation(&WalOperation::JobStateChange {
+            job_id: 1,
+            old_state: JobState::Pending,
+            new_state: JobState::Running,
+        });
+        cm.apply_operation(&WalOperation::JobStart {
+            job_id: 1,
+            nodes: vec!["n1".into()],
+            resources: scalar_alloc(4, 8000),
+            per_node_alloc: per_node_for(&["n1"], scalar_alloc(4, 8000)),
+        });
+
+        // Three srun steps exit 7, 3, 2 (in that order). DerivedExitCode tracks
+        // the running max live; ExitCode is unaffected (it is the batch exit).
+        cm.apply_operation(&WalOperation::JobStepComplete {
+            job_id: 1,
+            step_id: 0,
+            exit_code: 7,
+        });
+        assert_eq!(cm.get_job(1).unwrap().derived_exit_code, Some(7));
+        cm.apply_operation(&WalOperation::JobStepComplete {
+            job_id: 1,
+            step_id: 1,
+            exit_code: 3,
+        });
+        // 3 < 7, running max stays 7.
+        assert_eq!(cm.get_job(1).unwrap().derived_exit_code, Some(7));
+        cm.apply_operation(&WalOperation::JobStepComplete {
+            job_id: 1,
+            step_id: 2,
+            exit_code: 2,
+        });
+        assert_eq!(cm.get_job(1).unwrap().derived_exit_code, Some(7));
+
+        // Batch script exits 2 -> ExitCode=2:0, DerivedExitCode preserved at 7.
+        cm.apply_operation(&WalOperation::JobNodeComplete {
+            job_id: 1,
+            node_name: "n1".into(),
+            exit_code: 2,
+            signal: 0,
+        });
+        let job = cm.get_job(1).unwrap();
+        assert_eq!(job.state, JobState::Failed);
+        assert_eq!(job.exit_code, Some(2));
+        assert_eq!(job.derived_exit_code, Some(7));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn step_complete_batch_step_excluded_from_derived() {
+        // The reserved batch step carries the job's own exit, not a step result,
+        // so it must NOT contribute to DerivedExitCode.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("batch-only")),
+        });
+        cm.apply_operation(&WalOperation::JobStateChange {
+            job_id: 1,
+            old_state: JobState::Pending,
+            new_state: JobState::Running,
+        });
+
+        cm.apply_operation(&WalOperation::JobStepComplete {
+            job_id: 1,
+            step_id: STEP_BATCH,
+            exit_code: 9,
+        });
+        // Reserved step id -> derived untouched.
+        assert_eq!(cm.get_job(1).unwrap().derived_exit_code, None);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -3002,7 +3138,9 @@ mod tests {
         assert_eq!(job.state, JobState::Failed);
         assert_eq!(job.exit_code, Some(42));
         assert_eq!(job.exit_signal, Some(0));
-        assert_eq!(job.derived_exit_code, Some(42));
+        // No srun steps ran, so DerivedExitCode is 0 (Slurm parity) — the batch
+        // exit (42) surfaces as ExitCode, not DerivedExitCode.
+        assert_eq!(job.derived_exit_code, Some(0));
         assert_eq!(job.pending_reason, PendingReason::NonZeroExitCode);
     }
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2920,11 +2920,8 @@ mod tests {
         cm.apply_operation(&WalOperation::JobStart {
             job_id: 1,
             nodes: vec!["n1".into()],
-            resources: ResourceSet {
-                cpus: 6,
-                memory_mb: 12000,
-                ..Default::default()
-            },
+            resources: scalar_alloc(6, 12000),
+            per_node_alloc: per_node_for(&["n1"], scalar_alloc(6, 12000)),
         });
 
         cm.node_complete(1, "n1", 0, 9).unwrap();
@@ -2969,11 +2966,8 @@ mod tests {
         cm.apply_operation(&WalOperation::JobStart {
             job_id: 1,
             nodes: vec!["n1".into()],
-            resources: ResourceSet {
-                cpus: 6,
-                memory_mb: 12000,
-                ..Default::default()
-            },
+            resources: scalar_alloc(6, 12000),
+            per_node_alloc: per_node_for(&["n1"], scalar_alloc(6, 12000)),
         });
 
         // Step 2: the same call the RPC handler makes after validation — note the
@@ -3006,11 +3000,8 @@ mod tests {
         cm.apply_operation(&WalOperation::JobStart {
             job_id: 1,
             nodes: vec!["n1".into()],
-            resources: ResourceSet {
-                cpus: 6,
-                memory_mb: 12000,
-                ..Default::default()
-            },
+            resources: scalar_alloc(6, 12000),
+            per_node_alloc: per_node_for(&["n1"], scalar_alloc(6, 12000)),
         });
 
         cm.node_complete(1, "n1", 42, 0).unwrap();
@@ -3930,6 +3921,7 @@ mod tests {
         cm.apply_operation(&WalOperation::JobComplete {
             job_id: id,
             exit_code,
+            signal: 0,
             state,
         });
     }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -349,7 +349,6 @@ impl ClusterManager {
         let resp = self.propose(WalOperation::JobComplete {
             job_id,
             exit_code: -1,
-            signal: 0,
             state: JobState::Deadline,
         })?;
         if let Some(f) = resp.job_finalized {
@@ -378,7 +377,6 @@ impl ClusterManager {
         let resp = self.propose(WalOperation::JobComplete {
             job_id,
             exit_code: -1,
-            signal: 0,
             state: JobState::Cancelled,
         })?;
         if let Some(f) = resp.job_finalized {
@@ -556,7 +554,6 @@ impl ClusterManager {
         let resp = self.propose(WalOperation::JobComplete {
             job_id,
             exit_code,
-            signal: 0,
             state,
         })?;
         if let Some(f) = resp.job_finalized {
@@ -688,7 +685,6 @@ impl ClusterManager {
         self.propose(WalOperation::JobComplete {
             job_id,
             exit_code: -1,
-            signal: 0,
             state: JobState::Failed,
         })?;
 
@@ -1338,7 +1334,6 @@ impl ClusterManager {
             match self.propose(WalOperation::JobComplete {
                 job_id: id,
                 exit_code: -1,
-                signal: 0,
                 state: JobState::Cancelled,
             }) {
                 Ok(resp) => {
@@ -1849,17 +1844,16 @@ impl ClusterManager {
                         // none allocated, where derived_completion falls back to
                         // the worst completion.
                         let primary = job.allocated_nodes.first().cloned().unwrap_or_default();
-                        let (final_state, final_exit, final_signal, _node_derived) =
+                        let (final_state, final_exit, final_signal) =
                             Job::derived_completion(&job.node_completions, &primary);
                         match job.transition(final_state) {
                             Ok(()) => {
                                 job.exit_code = Some(final_exit);
-                                job.exit_signal = Some(final_signal);
+                                job.exit_signal = final_signal;
                                 // DerivedExitCode is the running max over srun
-                                // steps, accumulated live by JobStepComplete.
-                                // Preserve it; a job with no srun steps keeps
-                                // 0:0 (Slurm parity), not the batch exit.
-                                job.derived_exit_code = Some(job.derived_exit_code.unwrap_or(0));
+                                // steps, accumulated live by JobStepComplete; a
+                                // job with no srun steps keeps 0 (Slurm parity),
+                                // not the batch exit. Left as-is here.
                                 job.pending_reason = if final_signal != 0 {
                                     PendingReason::RaisedSignal
                                 } else if final_exit != 0 {
@@ -1902,7 +1896,6 @@ impl ClusterManager {
             WalOperation::JobComplete {
                 job_id,
                 exit_code,
-                signal: _,
                 state,
             } => {
                 let freed_nodes;
@@ -1994,8 +1987,7 @@ impl ClusterManager {
                 // mid-run, matching Slurm.
                 if *step_id < STEP_RESERVED_MIN {
                     if let Some(job) = jobs.get_mut(job_id) {
-                        let cur = job.derived_exit_code.unwrap_or(0);
-                        job.derived_exit_code = Some(cur.max(*exit_code));
+                        job.derived_exit_code = job.derived_exit_code.max(*exit_code);
                     }
                 }
             }
@@ -2533,7 +2525,6 @@ mod tests {
         cm.apply_operation(&WalOperation::JobComplete {
             job_id: 1,
             exit_code: 0,
-            signal: 0,
             state: JobState::Completed,
         });
 
@@ -2776,7 +2767,7 @@ mod tests {
         // DerivedExitCode is the max over srun *steps* (Slurm parity), not node
         // completions. This job ran no srun steps, so it is 0 — the non-primary
         // node's exit 42 does not surface here.
-        assert_eq!(job.derived_exit_code, Some(0));
+        assert_eq!(job.derived_exit_code, 0);
         for name in ["n1", "n2", "n3"] {
             assert_eq!(cm.get_node(name).unwrap().alloc_resources.cpus, 0);
         }
@@ -2811,20 +2802,20 @@ mod tests {
             step_id: 0,
             exit_code: 7,
         });
-        assert_eq!(cm.get_job(1).unwrap().derived_exit_code, Some(7));
+        assert_eq!(cm.get_job(1).unwrap().derived_exit_code, 7);
         cm.apply_operation(&WalOperation::JobStepComplete {
             job_id: 1,
             step_id: 1,
             exit_code: 3,
         });
         // 3 < 7, running max stays 7.
-        assert_eq!(cm.get_job(1).unwrap().derived_exit_code, Some(7));
+        assert_eq!(cm.get_job(1).unwrap().derived_exit_code, 7);
         cm.apply_operation(&WalOperation::JobStepComplete {
             job_id: 1,
             step_id: 2,
             exit_code: 2,
         });
-        assert_eq!(cm.get_job(1).unwrap().derived_exit_code, Some(7));
+        assert_eq!(cm.get_job(1).unwrap().derived_exit_code, 7);
 
         // Batch script exits 2 -> ExitCode=2:0, DerivedExitCode preserved at 7.
         cm.apply_operation(&WalOperation::JobNodeComplete {
@@ -2836,7 +2827,7 @@ mod tests {
         let job = cm.get_job(1).unwrap();
         assert_eq!(job.state, JobState::Failed);
         assert_eq!(job.exit_code, Some(2));
-        assert_eq!(job.derived_exit_code, Some(7));
+        assert_eq!(job.derived_exit_code, 7);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -2863,7 +2854,7 @@ mod tests {
             exit_code: 9,
         });
         // Reserved step id -> derived untouched.
-        assert_eq!(cm.get_job(1).unwrap().derived_exit_code, None);
+        assert_eq!(cm.get_job(1).unwrap().derived_exit_code, 0);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -2940,7 +2931,6 @@ mod tests {
         let resp = cm.apply_operation(&WalOperation::JobComplete {
             job_id: 1,
             exit_code: 0,
-            signal: 0,
             state: JobState::Completed,
         });
         let f = resp.job_finalized.expect("JobComplete should finalize");
@@ -2975,7 +2965,6 @@ mod tests {
         let first = cm.apply_operation(&WalOperation::JobComplete {
             job_id: 1,
             exit_code: 0,
-            signal: 0,
             state: JobState::Completed,
         });
         first
@@ -2988,7 +2977,6 @@ mod tests {
         let second = cm.apply_operation(&WalOperation::JobComplete {
             job_id: 1,
             exit_code: -1,
-            signal: 0,
             state: JobState::Cancelled,
         });
         assert!(second.job_finalized.is_none());
@@ -3066,8 +3054,8 @@ mod tests {
         let job = cm.get_job(1).unwrap();
         assert_eq!(job.state, JobState::Failed);
         assert_eq!(job.exit_code, Some(0));
-        assert_eq!(job.exit_signal, Some(9));
-        assert_eq!(job.derived_exit_code, Some(0));
+        assert_eq!(job.exit_signal, 9);
+        assert_eq!(job.derived_exit_code, 0);
         assert_eq!(job.pending_reason, PendingReason::RaisedSignal);
     }
 
@@ -3108,7 +3096,7 @@ mod tests {
         let job = cm.get_job(1).unwrap();
         assert_eq!(job.state, JobState::Failed);
         assert_eq!(job.exit_code, Some(0));
-        assert_eq!(job.exit_signal, Some(9));
+        assert_eq!(job.exit_signal, 9);
         assert_eq!(job.pending_reason, PendingReason::RaisedSignal);
     }
 
@@ -3139,10 +3127,10 @@ mod tests {
         let job = cm.get_job(1).unwrap();
         assert_eq!(job.state, JobState::Failed);
         assert_eq!(job.exit_code, Some(42));
-        assert_eq!(job.exit_signal, Some(0));
+        assert_eq!(job.exit_signal, 0);
         // No srun steps ran, so DerivedExitCode is 0 (Slurm parity) — the batch
         // exit (42) surfaces as ExitCode, not DerivedExitCode.
-        assert_eq!(job.derived_exit_code, Some(0));
+        assert_eq!(job.derived_exit_code, 0);
         assert_eq!(job.pending_reason, PendingReason::NonZeroExitCode);
     }
 
@@ -3657,7 +3645,6 @@ mod tests {
         cm.apply_operation(&WalOperation::JobComplete {
             job_id: id,
             exit_code: -1,
-            signal: 0,
             state: JobState::Timeout,
         });
         assert_eq!(cm.get_job(id).unwrap().state, JobState::Timeout);
@@ -4054,7 +4041,6 @@ mod tests {
         cm.apply_operation(&WalOperation::JobComplete {
             job_id: id,
             exit_code,
-            signal: 0,
             state,
         });
     }

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -815,8 +815,9 @@ async fn enforce_completing_timeout(cluster: Arc<ClusterManager>, raft: Arc<Raft
                 .cloned()
                 .collect();
 
-            let (mut state, mut exit_code) =
-                spur_core::job::Job::derived_completion(&job.node_completions);
+            let primary = job.allocated_nodes.first().cloned().unwrap_or_default();
+            let (mut state, mut exit_code, _signal, _derived) =
+                spur_core::job::Job::derived_completion(&job.node_completions, &primary);
             if job.node_completions.is_empty() {
                 state = spur_core::job::JobState::Failed;
                 exit_code = -1;

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -815,6 +815,7 @@ async fn enforce_completing_timeout(cluster: Arc<ClusterManager>, raft: Arc<Raft
                 .cloned()
                 .collect();
 
+            // Empty when no nodes allocated; derived_completion falls back to worst completion.
             let primary = job.allocated_nodes.first().cloned().unwrap_or_default();
             let (mut state, mut exit_code, _signal, _derived) =
                 spur_core::job::Job::derived_completion(&job.node_completions, &primary);

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -817,7 +817,7 @@ async fn enforce_completing_timeout(cluster: Arc<ClusterManager>, raft: Arc<Raft
 
             // Empty when no nodes allocated; derived_completion falls back to worst completion.
             let primary = job.allocated_nodes.first().cloned().unwrap_or_default();
-            let (mut state, mut exit_code, _signal, _derived) =
+            let (mut state, mut exit_code, _signal) =
                 spur_core::job::Job::derived_completion(&job.node_completions, &primary);
             if job.node_completions.is_empty() {
                 state = spur_core::job::JobState::Failed;

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -526,10 +526,12 @@ impl SlurmController for ControllerService {
         // `Job::derived_completion`.
         let completion_result = if !req.reporting_node.is_empty() {
             validate_completion_report_state_for_rpc(state, req.exit_code)?;
-            Some(
-                self.cluster
-                    .node_complete(req.job_id, &req.reporting_node, req.exit_code),
-            )
+            Some(self.cluster.node_complete(
+                req.job_id,
+                &req.reporting_node,
+                req.exit_code,
+                req.signal,
+            ))
         } else {
             None
         };
@@ -1283,6 +1285,8 @@ fn job_to_proto(job: &spur_core::job::Job) -> JobInfo {
             })
             .unwrap_or_default(),
         exit_code: job.exit_code.unwrap_or(0),
+        exit_signal: job.exit_signal.unwrap_or(0),
+        derived_exit_code: job.derived_exit_code.unwrap_or(0),
         stdout_path: job.resolved_stdout(),
         stderr_path: job.resolved_stderr(),
         resources: job.allocated_resources.as_ref().map(allocations_to_proto),

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1609,6 +1609,16 @@ mod tests {
         assert!(validate_completion_report_state_for_rpc(JobState::Failed, 42).is_ok());
     }
 
+    // A signal-killed job is reported by the agent as (state=Completed, exit_code=0,
+    // signal!=0) — see the NOTE in spurd/agent_server.rs. The RPC validator only sees
+    // (state, exit_code) and MUST accept it; the controller rederives Failed from the
+    // signal afterward (covered end-to-end by cluster.rs::
+    // rpc_path_signaled_completion_accepted_and_rederived_failed).
+    #[test]
+    fn completion_report_state_accepts_signaled_completed_zero() {
+        assert!(validate_completion_report_state_for_rpc(JobState::Completed, 0).is_ok());
+    }
+
     #[test]
     fn completion_report_state_rejects_completed_nonzero() {
         let err = validate_completion_report_state_for_rpc(JobState::Completed, 1).unwrap_err();

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1609,11 +1609,8 @@ mod tests {
         assert!(validate_completion_report_state_for_rpc(JobState::Failed, 42).is_ok());
     }
 
-    // A signal-killed job is reported by the agent as (state=Completed, exit_code=0,
-    // signal!=0) — see the NOTE in spurd/agent_server.rs. The RPC validator only sees
-    // (state, exit_code) and MUST accept it; the controller rederives Failed from the
-    // signal afterward (covered end-to-end by cluster.rs::
-    // rpc_path_signaled_completion_accepted_and_rederived_failed).
+    // A signaled job is reported as (Completed, exit_code=0); the validator must
+    // accept it (controller rederives Failed from the signal). See agent_server.rs.
     #[test]
     fn completion_report_state_accepts_signaled_completed_zero() {
         assert!(validate_completion_report_state_for_rpc(JobState::Completed, 0).is_ok());

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -969,6 +969,21 @@ impl SlurmController for ControllerService {
             .map_err(|e| Status::internal(format!("run_command failed: {}", e)))?
             .into_inner();
 
+        // Record the step's exit code durably (Raft) so the job's live
+        // DerivedExitCode (running max over steps) is consistent and survives
+        // restart. Best-effort: a failure here doesn't fail the step itself.
+        if let Err(e) =
+            self.cluster
+                .record_step_complete(req.job_id, req.step_id, agent_resp.exit_code)
+        {
+            warn!(
+                job_id = req.job_id,
+                step_id = req.step_id,
+                error = %e,
+                "failed to record step completion"
+            );
+        }
+
         Ok(Response::new(RunStepResponse {
             exit_code: agent_resp.exit_code,
             stdout: agent_resp.stdout,

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1300,8 +1300,8 @@ fn job_to_proto(job: &spur_core::job::Job) -> JobInfo {
             })
             .unwrap_or_default(),
         exit_code: job.exit_code.unwrap_or(0),
-        exit_signal: job.exit_signal.unwrap_or(0),
-        derived_exit_code: job.derived_exit_code.unwrap_or(0),
+        exit_signal: job.exit_signal,
+        derived_exit_code: job.derived_exit_code,
         stdout_path: job.resolved_stdout(),
         stderr_path: job.resolved_stderr(),
         resources: job.allocated_resources.as_ref().map(allocations_to_proto),

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -309,14 +309,10 @@ async fn report_completion(
 ) {
     use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 
-    // NOTE: the per-node completion report's `state` is derived from `exit_code`
-    // alone, so a signal-killed job (exit_code=0, signal!=0) reports `Completed`
-    // here. This is intentional and required: the controller validates the report
-    // with `validate_completion_report_state` (Completed<->0, Failed<->nonzero),
-    // which would REJECT a `Failed` state paired with exit_code=0. The controller
-    // rederives the true terminal state (Failed, exit_signal, RaisedSignal) from
-    // the reported `signal` in `Job::derived_completion`, so the wire `state` is
-    // advisory only and the signal carries the real outcome.
+    // Wire `state` is derived from `exit_code` alone (advisory): a signaled job
+    // reports Completed/0 because the controller's validator requires
+    // state<->exit_code agreement. The controller rederives the true Failed /
+    // RaisedSignal outcome from the reported `signal`.
     let state = spur_core::job::JobState::completion_state_for_exit_code(exit_code).to_proto_i32();
 
     let url = if controller_addr.starts_with("http") {
@@ -434,6 +430,25 @@ impl SlurmAgent for AgentService {
 
         // Inject peer node info as environment variables for MPI/distributed apps
         let mut env = spec.environment.clone();
+
+        // Ensure the Spur CLI binaries (srun/sbatch/... symlinks to `spur`) are
+        // on the job's PATH so `srun` works inside batch scripts. They live next
+        // to this agent binary, so derive the dir from the agent's own path
+        // (deployment-independent — no assumption about the install location).
+        if let Some(bin_dir) = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(|d| d.to_path_buf()))
+        {
+            let bin_dir = bin_dir.to_string_lossy().to_string();
+            let base = env
+                .get("PATH")
+                .cloned()
+                .unwrap_or_else(|| "/usr/local/bin:/usr/bin:/bin".to_string());
+            if !base.split(':').any(|p| p == bin_dir) {
+                env.insert("PATH".into(), format!("{}:{}", bin_dir, base));
+            }
+        }
+
         env.insert("SPUR_JOB_ID".into(), job_id.to_string());
         env.insert("SPUR_TASK_OFFSET".into(), task_offset.to_string());
         env.insert("SPUR_NUM_NODES".into(), peer_nodes.len().to_string());

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -322,6 +322,7 @@ async fn report_completion(
                     job_id,
                     state,
                     exit_code,
+                    signal: 0,
                     message: format!("exit_code={}", exit_code),
                     drain_node: drain.is_some(),
                     drain_reason: drain.as_ref().map(|d| d.reason.clone()).unwrap_or_default(),

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -309,6 +309,14 @@ async fn report_completion(
 ) {
     use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 
+    // NOTE: the per-node completion report's `state` is derived from `exit_code`
+    // alone, so a signal-killed job (exit_code=0, signal!=0) reports `Completed`
+    // here. This is intentional and required: the controller validates the report
+    // with `validate_completion_report_state` (Completed<->0, Failed<->nonzero),
+    // which would REJECT a `Failed` state paired with exit_code=0. The controller
+    // rederives the true terminal state (Failed, exit_signal, RaisedSignal) from
+    // the reported `signal` in `Job::derived_completion`, so the wire `state` is
+    // advisory only and the signal carries the real outcome.
     let state = spur_core::job::JobState::completion_state_for_exit_code(exit_code).to_proto_i32();
 
     let url = if controller_addr.starts_with("http") {

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -47,6 +47,7 @@ struct TrackedJob {
 struct CompletedJob {
     job_id: u32,
     exit_code: i32,
+    signal: i32,
     rootfs_mode: crate::container::RootfsMode,
     allocation: Option<AllocationResult>,
     cgroup: Option<std::path::PathBuf>,
@@ -155,11 +156,12 @@ impl AgentService {
 
                 for (job_id, tracked) in jobs.iter_mut() {
                     match tracked.job.try_wait() {
-                        Ok(Some(exit_code)) => {
-                            info!(job_id, exit_code, "job finished");
+                        Ok(Some((exit_code, signal))) => {
+                            info!(job_id, exit_code, signal, "job finished");
                             completed.push(CompletedJob {
                                 job_id: *job_id,
                                 exit_code,
+                                signal,
                                 rootfs_mode: tracked.rootfs_mode.clone(),
                                 allocation: tracked.allocation.take(),
                                 cgroup: tracked.job.take_cgroup(),
@@ -256,6 +258,7 @@ impl AgentService {
                         &controller_addr,
                         c.job_id,
                         c.exit_code,
+                        c.signal,
                         &local_hostname,
                         drain.as_ref(),
                     )
@@ -300,6 +303,7 @@ async fn report_completion(
     controller_addr: &str,
     job_id: u32,
     exit_code: i32,
+    signal: i32,
     reporting_node: &str,
     drain: Option<&DrainRequest>,
 ) {
@@ -322,7 +326,7 @@ async fn report_completion(
                     job_id,
                     state,
                     exit_code,
-                    signal: 0,
+                    signal,
                     message: format!("exit_code={}", exit_code),
                     drain_node: drain.is_some(),
                     drain_reason: drain.as_ref().map(|d| d.reason.clone()).unwrap_or_default(),
@@ -794,7 +798,8 @@ impl SlurmAgent for AgentService {
                         let drain = DrainRequest {
                             reason: drain_reason.clone(),
                         };
-                        report_completion(&controller, job_id, -1, &node_name, Some(&drain)).await;
+                        report_completion(&controller, job_id, -1, 0, &node_name, Some(&drain))
+                            .await;
                     });
                 }
 

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -91,6 +91,16 @@ pub enum RunningJob {
     },
 }
 
+/// Split a finished process's wait status into (exit_code, signal).
+/// Slurm parity: WIFEXITED -> (code, 0); WIFSIGNALED -> (0, sig).
+pub fn decode_wait_status(status: nix::sys::wait::WaitStatus) -> (i32, i32) {
+    match status {
+        nix::sys::wait::WaitStatus::Exited(_, code) => (code, 0),
+        nix::sys::wait::WaitStatus::Signaled(_, sig, _) => (0, sig as i32),
+        _ => (-1, 0),
+    }
+}
+
 fn pidfd_open(pid: i32) -> std::io::Result<OwnedFd> {
     let fd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) } as RawFd;
     if fd < 0 {
@@ -107,11 +117,17 @@ impl RunningJob {
         }
     }
 
-    /// Non-blocking check for process exit. Returns exit code if done.
-    pub fn try_wait(&mut self) -> anyhow::Result<Option<i32>> {
+    /// Non-blocking check for process exit. Returns (exit_code, signal) if done.
+    pub fn try_wait(&mut self) -> anyhow::Result<Option<(i32, i32)>> {
         match self {
             RunningJob::Managed { child, .. } => match child.try_wait() {
-                Ok(Some(status)) => Ok(Some(status.code().unwrap_or(-1))),
+                Ok(Some(status)) => {
+                    use std::os::unix::process::ExitStatusExt;
+                    Ok(Some((
+                        status.code().unwrap_or(0),
+                        status.signal().unwrap_or(0),
+                    )))
+                }
                 Ok(None) => Ok(None),
                 Err(e) => Err(e.into()),
             },
@@ -123,15 +139,12 @@ impl RunningJob {
                     Pid::from_raw(*pid),
                     Some(nix::sys::wait::WaitPidFlag::WNOHANG),
                 ) {
-                    Ok(nix::sys::wait::WaitStatus::Exited(_, code)) => {
-                        *reaped = true;
-                        Ok(Some(code))
-                    }
-                    Ok(nix::sys::wait::WaitStatus::Signaled(_, sig, _)) => {
-                        *reaped = true;
-                        Ok(Some(128 + sig as i32))
-                    }
                     Ok(nix::sys::wait::WaitStatus::StillAlive) => Ok(None),
+                    Ok(status @ nix::sys::wait::WaitStatus::Exited(_, _))
+                    | Ok(status @ nix::sys::wait::WaitStatus::Signaled(_, _, _)) => {
+                        *reaped = true;
+                        Ok(Some(decode_wait_status(status)))
+                    }
                     Ok(_) => Ok(None),
                     Err(e) => Err(e.into()),
                 }
@@ -945,6 +958,22 @@ fn wrap_with_burst_buffer(script: &str, bb: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn decode_wait_status_splits_exit_and_signal() {
+        use nix::sys::wait::WaitStatus;
+        use nix::unistd::Pid;
+        let p = Pid::from_raw(1);
+        assert_eq!(decode_wait_status(WaitStatus::Exited(p, 7)), (7, 0));
+        assert_eq!(
+            decode_wait_status(WaitStatus::Signaled(
+                p,
+                nix::sys::signal::Signal::SIGKILL,
+                false
+            )),
+            (0, 9)
+        );
+    }
 
     #[test]
     fn test_resolve_output_path() {

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -422,6 +422,20 @@ async fn spawn_job_process(
         .stderr(stderr_file.into_std().await)
         .stdin(Stdio::null());
 
+    // Reset signal dispositions to default before exec. spurd is launched in the
+    // background (SIGINT/SIGQUIT/SIGHUP set to SIG_IGN), and a child inherits that
+    // ignore mask — which would make a job's own `kill -INT $$` a no-op and break
+    // Slurm-parity signal reporting (e.g. SIGINT -> RaisedSignal:2). The job must
+    // start with default handlers.
+    unsafe {
+        cmd.pre_exec(|| {
+            for sig in [libc::SIGINT, libc::SIGQUIT, libc::SIGHUP, libc::SIGPIPE] {
+                libc::signal(sig, libc::SIG_DFL);
+            }
+            Ok(())
+        });
+    }
+
     // Issue #99, #107: Run job as the submitting user (not root).
     // Must set supplementary groups (video, render) via initgroups()
     // so the process can access GPU device nodes.

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
 use anyhow::{bail, Context};
-use nix::sys::signal::{self, Signal};
+use nix::sys::signal::{self, SaFlags, SigAction, SigHandler, SigSet, Signal};
 use nix::unistd::Pid;
 use tokio::process::Command;
 use tracing::{debug, info, warn};
@@ -429,8 +429,16 @@ async fn spawn_job_process(
     // start with default handlers.
     unsafe {
         cmd.pre_exec(|| {
-            for sig in [libc::SIGINT, libc::SIGQUIT, libc::SIGHUP, libc::SIGPIPE] {
-                libc::signal(sig, libc::SIG_DFL);
+            // Use sigaction (async-signal-safe) rather than signal() to reset
+            // dispositions; pre_exec runs post-fork in a multi-threaded process.
+            let dfl = SigAction::new(SigHandler::SigDfl, SaFlags::empty(), SigSet::empty());
+            for sig in [
+                Signal::SIGINT,
+                Signal::SIGQUIT,
+                Signal::SIGHUP,
+                Signal::SIGPIPE,
+            ] {
+                let _ = signal::sigaction(sig, &dfl);
             }
             Ok(())
         });

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -97,7 +97,7 @@ pub fn decode_wait_status(status: nix::sys::wait::WaitStatus) -> (i32, i32) {
     match status {
         nix::sys::wait::WaitStatus::Exited(_, code) => (code, 0),
         nix::sys::wait::WaitStatus::Signaled(_, sig, _) => (0, sig as i32),
-        _ => (-1, 0),
+        _ => (-1, 0), // unreachable from try_wait (only Exited/Signaled reach here); -1 = shouldn't-happen sentinel
     }
 }
 
@@ -973,6 +973,15 @@ mod tests {
             )),
             (0, 9)
         );
+        assert_eq!(
+            decode_wait_status(WaitStatus::Signaled(
+                p,
+                nix::sys::signal::Signal::SIGTERM,
+                false
+            )),
+            (0, 15)
+        );
+        assert_eq!(decode_wait_status(WaitStatus::StillAlive), (-1, 0));
     }
 
     #[test]

--- a/crates/spurdbd/src/server.rs
+++ b/crates/spurdbd/src/server.rs
@@ -174,6 +174,8 @@ impl SlurmAccounting for AccountingService {
                 work_dir: String::new(),
                 command: String::new(),
                 exit_code: r.exit_code,
+                exit_signal: 0,
+                derived_exit_code: 0,
                 stdout_path: String::new(),
                 stderr_path: String::new(),
                 resources: None,

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -499,6 +499,7 @@ message RunStepRequest {
   uint32 gid = 4;
   string work_dir = 5;
   map<string, string> environment = 6;
+  uint32 step_id = 7;  // Step id from CreateJobStep, for recording completion
 }
 
 message RunStepResponse {

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -183,6 +183,8 @@ message JobInfo {
   string command = 25;
 
   int32 exit_code = 30;
+  int32 exit_signal = 33;       // Terminating signal of primary node (0 = none)
+  int32 derived_exit_code = 34; // Max exit code across all job steps/nodes
   string stdout_path = 31;
   string stderr_path = 32;
 
@@ -624,6 +626,7 @@ message ReportJobStatusRequest {
   bool drain_node = 5;     // Agent requests its node be drained (e.g. prolog/epilog failure)
   string drain_reason = 6; // Reason for drain request
   string reporting_node = 7; // Hostname of the reporting agent (for drain targeting)
+  int32 signal = 8;  // Terminating signal of the reporting node's process (0 = none)
 }
 
 // ============================================================

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -183,10 +183,10 @@ message JobInfo {
   string command = 25;
 
   int32 exit_code = 30;
-  int32 exit_signal = 33;       // Terminating signal of primary node (0 = none)
-  int32 derived_exit_code = 34; // Running max over srun step exit codes (0 if no steps)
   string stdout_path = 31;
   string stderr_path = 32;
+  int32 exit_signal = 33;       // Terminating signal of primary node (0 = none)
+  int32 derived_exit_code = 34; // Running max over srun step exit codes (0 if no steps)
 
   ResourceAllocations resources = 40;
   uint32 priority = 41;

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -184,7 +184,7 @@ message JobInfo {
 
   int32 exit_code = 30;
   int32 exit_signal = 33;       // Terminating signal of primary node (0 = none)
-  int32 derived_exit_code = 34; // Max exit code across all job steps/nodes
+  int32 derived_exit_code = 34; // Running max over srun step exit codes (0 if no steps)
   string stdout_path = 31;
   string stderr_path = 32;
 


### PR DESCRIPTION
## Summary

Closes #269. Brings Spur's job exit-code reporting to Slurm parity, end to end: `exit:signal` encoding, `DerivedExitCode`, and `NonZeroExitCode` / `RaisedSignal:N(name)` reasons, plus an expanded `PendingReason` vocabulary.

Previously Spur reported a bare lossy `ExitCode` (signal collapsed to `-1` / `128+sig`), had no `DerivedExitCode` field, and never set a completion reason — silently corrupting outcome data for anything scraping `scontrol show job` / `sacct`.

## What changed

Exit status is threaded from the agent's process wait status through the report RPC, WAL, core `Job`, display RPC, and CLI:

- Agent (`spurd`) decodes the raw `WaitStatus` into `(exit_code, signal)` instead of collapsing it; `WIFEXITED -> code:0`, `WIFSIGNALED -> 0:sig`.
- New `exit_signal` and `derived_exit_code` fields on the core `Job` and proto `JobInfo`; `JobComplete` / `JobNodeComplete` WAL ops carry the signal.
- Controller sets the failure reason from the batch/primary node's wait status: `NonZeroExitCode` on non-zero exit, `RaisedSignal` on signal death.
- `DerivedExitCode` is the running max over `srun` step exit codes (Slurm semantics), maintained live and durably via a new `JobStepComplete` WAL op; a job with no srun steps reports `0:0`.
- CLI renders `ExitCode=code:signal`, `DerivedExitCode=code:signal`, and composes the dynamic `RaisedSignal:N(name)` string at display time.
- Expanded `PendingReason` toward the Slurm vocabulary (`NonZeroExitCode`, `RaisedSignal`, `OutOfMemory`, `JobLaunchFailure`, ...).

Two adjacent fixes uncovered during live verification are included: jobs now start with default signal dispositions (so `kill -INT $$` is reported as `RaisedSignal:2` rather than being absorbed by spurd's inherited `SIG_IGN`), and the Spur CLI bin dir is added to the job `PATH` (derived from the agent's own location) so `srun` resolves inside batch scripts.

## Exact Slurm semantics implemented

`ExitCode` is the batch/primary process's raw wait status, not a max. A step killed by a signal surfaces to the batch shell as exit `128+sig`, so it appears as `NonZeroExitCode` with `ExitCode=128+sig:0`, not `RaisedSignal`. `RaisedSignal` only applies when the batch process itself is signaled. `DerivedExitCode` is the max exit code across steps.

## Testing

Unit and integration coverage across `spur-core`, `spurctld`, `spurd`, and `spur-cli` (derived-completion rules, signal decoding, reason emission, RPC-level signaled-completion recovery, WAL signal round-trip, step running-max). Full suite passes; `cargo fmt --check --all` and `clippy` clean.

Verified live against Slurm 25.11.6 on a single-node testbed: clean exit, single non-zero, multi-step `srun` ordering (`ExitCode=last`, `DerivedExitCode=max`), no-srun (`DerivedExitCode=0:0`), and self-signal cases (`SIGINT`/`SIGTERM`/`SIGABRT` -> `RaisedSignal:N(name)`), including the live running-max visible in `scontrol show job` mid-run.

## Out of scope (follow-ups)

`sacct` step history in `spurdbd` (live `DerivedExitCode` works via the controller; persisting per-step rows to the accounting DB is separate — tracked in #297). k8s backend signal reporting (currently `signal: 0`; the controller-side machinery already applies). A separately filed controller robustness issue (#273, openraft snapshot/log compaction) is unrelated to this change.

## Design docs

Design and implementation plan included under `docs/superpowers/`.


## Live verification vs Slurm 25.11.6

Ran an expanded matrix on a Slurm 25.11.6 cluster and a single-node Spur cluster, submitting sequentially (each job to a terminal state before the next) to avoid cluster-saturation races. Format per cell: `State / ExitCode / DerivedExitCode / Reason`.

| # | Case | Slurm | Spur | Match |
|---|------|-------|------|:---:|
| 1 | `exit 0` | COMPLETED / 0:0 / 0:0 / None | COMPLETED / 0:0 / 0:0 / None | ✅ |
| 2 | `exit 13` | FAILED / 13:0 / 0:0 / NonZeroExitCode | FAILED / 13:0 / 0:0 / NonZeroExitCode | ✅ |
| 3 | `exit 200` | FAILED / 200:0 / 0:0 / NonZeroExitCode | FAILED / 200:0 / 0:0 / NonZeroExitCode | ✅ |
| 4 | `exit 137` (plain) | FAILED / 137:0 / 0:0 / NonZeroExitCode | FAILED / 137:0 / 0:0 / NonZeroExitCode | ✅ |
| 5 | srun 1,4,9 | FAILED / 9:0 / 9:0 / NonZeroExitCode | FAILED / 9:0 / 9:0 / NonZeroExitCode | ✅ |
| 6 | srun 9,4,1 | FAILED / 1:0 / 9:0 / NonZeroExitCode | FAILED / 1:0 / 9:0 / NonZeroExitCode | ✅ |
| 7 | srun 0,8; batch exit 0 | COMPLETED / 0:0 / 8:0 / None | COMPLETED / 0:0 / 8:0 / None | ✅ |
| 8 | srun 0,0; exit 0 | COMPLETED / 0:0 / 0:0 / None | COMPLETED / 0:0 / 0:0 / None | ✅ |
| 9 | batch SIGINT | FAILED / 0:2 / 0:0 / RaisedSignal:2(Interrupt) | FAILED / 0:2 / 0:0 / RaisedSignal:2(Interrupt) | ✅ |
| 10 | batch SIGTERM | FAILED / 0:15 / 0:0 / RaisedSignal:15(Terminated) | FAILED / 0:15 / 0:0 / RaisedSignal:15(Terminated) | ✅ |
| 11 | batch SIGKILL | FAILED / 0:9 / 0:0 / RaisedSignal:9(Killed) | FAILED / 0:9 / 0:0 / RaisedSignal:9(Killed) | ✅ |
| 12 | batch SIGSEGV | FAILED / 0:11 / 0:0 / RaisedSignal:11(Segmentation_fault) | FAILED / 0:11 / 0:0 / RaisedSignal:11(Segmentation_fault) | ✅ |
| 13 | batch SIGABRT | FAILED / 0:6 / 0:0 / RaisedSignal:6(Aborted) | FAILED / 0:6 / 0:0 / RaisedSignal:6(Aborted) | ✅ |

Key behaviors confirmed identical: `ExitCode` follows the batch script's last command (case 5 = 9:0 vs case 6 = 1:0 — same steps, reordered), `DerivedExitCode` is the max over srun step exit codes (cases 5–7), a plain `exit 137` stays `137:0` (not mis-read as signal 9), and all batch signals report `0:sig` with `RaisedSignal:N(name)`.

### Note on DerivedExitCode signal half

Spur tracks `DerivedExitCode` as the running max over srun step *exit codes* (the exit half), which matches Slurm in every stable case above. Slurm additionally folds a signaled step's *signal* into the DerivedExitCode signal half in some cases, but that behavior is order-dependent and inconsistent in Slurm itself (e.g. a signaled step followed by an exiting step yields `0:0`; with shell control flow it instead surfaces as `ExitCode=0:sig`). Replicating it would mean matching undefined Slurm internals, so Spur deliberately does not — the exit-half parity is what consumers rely on.


