### PR TITLE
feat: node labels and dual-path partition matching

### DIFF
--- a/crates/spur-cli/src/main.rs
+++ b/crates/spur-cli/src/main.rs
@@ -5,6 +5,7 @@ mod exec;
 mod format_engine;
 mod image;
 mod net;
+mod node;
 mod sacct;
 mod sacctmgr;
 mod salloc;
@@ -98,6 +99,7 @@ fn main() -> anyhow::Result<()> {
         "scrontab" => return runtime.block_on(scrontab::main()),
         "smd" => return runtime.block_on(smd::main()),
         "net" => return runtime.block_on(net::main()),
+        "node" => return runtime.block_on(node::main()),
         "image" => return runtime.block_on(image::main()),
         "exec" => return runtime.block_on(exec::main()),
         _ => {}
@@ -136,7 +138,7 @@ fn main() -> anyhow::Result<()> {
         "sbatch" | "srun" | "squeue" | "scancel" | "sinfo" | "sacct" | "sacctmgr" | "scontrol"
         | "sprio" | "sshare" | "sstat" | "sdiag" | "sreport" | "strigger" | "sattach"
         | "scrontab" | "smd" => Some(args[1].as_str()),
-        "net" | "image" | "exec" => Some(args[1].as_str()),
+        "net" | "node" | "image" | "exec" => Some(args[1].as_str()),
         _ => None,
     };
 
@@ -185,6 +187,7 @@ fn main() -> anyhow::Result<()> {
             }
             "smd" | "health" | "monitor" => runtime.block_on(smd::main_with_args(rewritten)),
             "net" => runtime.block_on(net::main_with_args(rewritten)),
+            "node" => runtime.block_on(node::main_with_args(rewritten)),
             "image" => runtime.block_on(image::main_with_args(rewritten)),
             "exec" => runtime.block_on(exec::main_with_args(rewritten)),
             _ => unreachable!(),

--- a/crates/spur-cli/src/node.rs
+++ b/crates/spur-cli/src/node.rs
@@ -60,16 +60,16 @@ fn parse_label_args(label_args: &[String]) -> Result<(HashMap<String, String>, V
     let mut remove_labels: Vec<String> = Vec::new();
 
     for arg in label_args {
-        if let Some(key) = arg.strip_suffix('-') {
-            if key.is_empty() {
-                bail!("invalid label removal: '{arg}'");
-            }
-            remove_labels.push(key.to_string());
-        } else if let Some((k, v)) = arg.split_once('=') {
+        if let Some((k, v)) = arg.split_once('=') {
             if k.is_empty() {
                 bail!("invalid label: '{arg}', key cannot be empty");
             }
             set_labels.insert(k.to_string(), v.to_string());
+        } else if let Some(key) = arg.strip_suffix('-') {
+            if key.is_empty() {
+                bail!("invalid label removal: '{arg}'");
+            }
+            remove_labels.push(key.to_string());
         } else {
             bail!("invalid label format: '{arg}', expected key=value or key-");
         }
@@ -147,5 +147,13 @@ mod tests {
     fn test_parse_label_invalid_format() {
         let args = vec!["noequalsnodash".to_string()];
         assert!(parse_label_args(&args).is_err());
+    }
+
+    #[test]
+    fn test_parse_label_value_ending_in_dash() {
+        let args = vec!["env=prod-".to_string()];
+        let (set, remove) = parse_label_args(&args).unwrap();
+        assert_eq!(set.get("env").unwrap(), "prod-");
+        assert!(remove.is_empty());
     }
 }

--- a/crates/spur-cli/src/node.rs
+++ b/crates/spur-cli/src/node.rs
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `spur node` subcommands for node lifecycle management.
+
+use std::collections::HashMap;
+
+use anyhow::{bail, Result};
+use clap::{Parser, Subcommand};
+
+use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
+use spur_proto::proto::UpdateNodeRequest;
+
+/// Node management commands.
+#[derive(Parser, Debug)]
+#[command(name = "node", about = "Manage cluster nodes")]
+pub struct NodeArgs {
+    /// Controller address
+    #[arg(
+        long,
+        env = "SPUR_CONTROLLER_ADDR",
+        default_value = "http://localhost:6817",
+        global = true
+    )]
+    controller: String,
+
+    #[command(subcommand)]
+    pub command: NodeCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum NodeCommand {
+    /// Set or remove labels on a node.
+    ///
+    /// Labels are key=value pairs used for partition routing.
+    /// Append a trailing dash to remove a label (e.g., "pool-").
+    Label {
+        /// Node name
+        node: String,
+        /// Labels to set (key=value) or remove (key-)
+        #[arg(required = true)]
+        labels: Vec<String>,
+    },
+}
+
+pub async fn main() -> Result<()> {
+    main_with_args(std::env::args().collect()).await
+}
+
+pub async fn main_with_args(args: Vec<String>) -> Result<()> {
+    let parsed = NodeArgs::try_parse_from(args)?;
+    let controller = parsed.controller;
+    match parsed.command {
+        NodeCommand::Label { node, labels } => cmd_label(&controller, node, labels).await,
+    }
+}
+
+async fn cmd_label(controller: &str, node: String, label_args: Vec<String>) -> Result<()> {
+    let mut client = SlurmControllerClient::connect(controller.to_string()).await?;
+
+    let mut set_labels: HashMap<String, String> = HashMap::new();
+    let mut remove_labels: Vec<String> = Vec::new();
+
+    for arg in &label_args {
+        if let Some(key) = arg.strip_suffix('-') {
+            if key.is_empty() {
+                bail!("invalid label removal: '{arg}'");
+            }
+            remove_labels.push(key.to_string());
+        } else if let Some((k, v)) = arg.split_once('=') {
+            if k.is_empty() {
+                bail!("invalid label: '{arg}', key cannot be empty");
+            }
+            set_labels.insert(k.to_string(), v.to_string());
+        } else {
+            bail!("invalid label format: '{arg}', expected key=value or key-");
+        }
+    }
+
+    client
+        .update_node(UpdateNodeRequest {
+            name: node.clone(),
+            state: None,
+            reason: None,
+            labels: set_labels.clone(),
+            remove_labels: remove_labels.clone(),
+        })
+        .await?;
+
+    for (k, v) in &set_labels {
+        println!("  {node}: {k}={v}");
+    }
+    for k in &remove_labels {
+        println!("  {node}: {k} removed");
+    }
+
+    Ok(())
+}

--- a/crates/spur-cli/src/node.rs
+++ b/crates/spur-cli/src/node.rs
@@ -55,13 +55,11 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     }
 }
 
-async fn cmd_label(controller: &str, node: String, label_args: Vec<String>) -> Result<()> {
-    let mut client = SlurmControllerClient::connect(controller.to_string()).await?;
-
+fn parse_label_args(label_args: &[String]) -> Result<(HashMap<String, String>, Vec<String>)> {
     let mut set_labels: HashMap<String, String> = HashMap::new();
     let mut remove_labels: Vec<String> = Vec::new();
 
-    for arg in &label_args {
+    for arg in label_args {
         if let Some(key) = arg.strip_suffix('-') {
             if key.is_empty() {
                 bail!("invalid label removal: '{arg}'");
@@ -76,6 +74,13 @@ async fn cmd_label(controller: &str, node: String, label_args: Vec<String>) -> R
             bail!("invalid label format: '{arg}', expected key=value or key-");
         }
     }
+
+    Ok((set_labels, remove_labels))
+}
+
+async fn cmd_label(controller: &str, node: String, label_args: Vec<String>) -> Result<()> {
+    let mut client = SlurmControllerClient::connect(controller.to_string()).await?;
+    let (set_labels, remove_labels) = parse_label_args(&label_args)?;
 
     client
         .update_node(UpdateNodeRequest {
@@ -95,4 +100,52 @@ async fn cmd_label(controller: &str, node: String, label_args: Vec<String>) -> R
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_label_set() {
+        let args = vec!["pool=gpu".to_string(), "tier=high".to_string()];
+        let (set, remove) = parse_label_args(&args).unwrap();
+        assert_eq!(set.get("pool").unwrap(), "gpu");
+        assert_eq!(set.get("tier").unwrap(), "high");
+        assert!(remove.is_empty());
+    }
+
+    #[test]
+    fn test_parse_label_remove() {
+        let args = vec!["pool-".to_string()];
+        let (set, remove) = parse_label_args(&args).unwrap();
+        assert!(set.is_empty());
+        assert_eq!(remove, vec!["pool"]);
+    }
+
+    #[test]
+    fn test_parse_label_mixed() {
+        let args = vec!["env=prod".to_string(), "old_tag-".to_string()];
+        let (set, remove) = parse_label_args(&args).unwrap();
+        assert_eq!(set.get("env").unwrap(), "prod");
+        assert_eq!(remove, vec!["old_tag"]);
+    }
+
+    #[test]
+    fn test_parse_label_empty_key_set() {
+        let args = vec!["=value".to_string()];
+        assert!(parse_label_args(&args).is_err());
+    }
+
+    #[test]
+    fn test_parse_label_empty_key_remove() {
+        let args = vec!["-".to_string()];
+        assert!(parse_label_args(&args).is_err());
+    }
+
+    #[test]
+    fn test_parse_label_invalid_format() {
+        let args = vec!["noequalsnodash".to_string()];
+        assert!(parse_label_args(&args).is_err());
+    }
 }

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -296,6 +296,9 @@ async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> 
                     node_state_name(node.state),
                     node.state_reason
                 );
+                if !node.partitions.is_empty() {
+                    println!("   Partitions={}", node.partitions.join(","));
+                }
                 println!(
                     "   CPUTot={} CPUAlloc={} RealMemory={} FreeMem={}",
                     total.map(|r| r.cpus).unwrap_or(0),

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
+
 use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand};
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
@@ -312,6 +314,15 @@ async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> 
                     println!("   Gres={}", gpu_types.join(","));
                 }
                 println!("   Arch={} OS={}", node.arch, node.os);
+                if !node.labels.is_empty() {
+                    let mut label_str: Vec<String> = node
+                        .labels
+                        .iter()
+                        .map(|(k, v)| format!("{k}={v}"))
+                        .collect();
+                    label_str.sort();
+                    println!("   Labels={}", label_str.join(","));
+                }
                 println!("   CpuLoad={}", node.cpu_load as f64 / 100.0);
                 println!();
             }
@@ -587,6 +598,8 @@ async fn update_node(
             name: name.to_string(),
             state: proto_state,
             reason,
+            labels: HashMap::new(),
+            remove_labels: Vec::new(),
         })
         .await
         .context("node update failed")?;

--- a/crates/spur-cli/src/sinfo.rs
+++ b/crates/spur-cli/src/sinfo.rs
@@ -573,4 +573,69 @@ mod tests {
         assert!(lines[1].contains("n2"));
         assert!(lines[1].contains("resv"));
     }
+
+    #[test]
+    fn test_node_oriented_multi_partition_fanout() {
+        let fields =
+            format_engine::parse_format("%#N %.6D %#P %.11T", &format_engine::sinfo_header);
+        let partitions = vec![
+            make_partition("gpu", false),
+            make_partition("catchall", true),
+        ];
+        let nodes = vec![NodeInfo {
+            name: "n1".into(),
+            state: NodeState::NodeIdle as i32,
+            partitions: vec!["gpu".into(), "catchall".into()],
+            ..Default::default()
+        }];
+
+        let lines = render_sinfo_output(&fields, &partitions, &nodes, true);
+        assert_eq!(
+            lines.len(),
+            2,
+            "one line per node-partition pair: {lines:?}"
+        );
+        assert!(lines[0].contains("gpu"));
+        assert!(lines[1].contains("catchall"));
+        assert!(lines[0].contains("n1"));
+        assert!(lines[1].contains("n1"));
+    }
+
+    #[test]
+    fn test_partition_oriented_multi_partition_node() {
+        let fields = default_fields();
+        let partitions = vec![make_partition("gpu", false), make_partition("batch", true)];
+        let nodes = vec![NodeInfo {
+            name: "n1".into(),
+            state: NodeState::NodeIdle as i32,
+            partitions: vec!["gpu".into(), "batch".into()],
+            ..Default::default()
+        }];
+
+        let lines = render_sinfo_output(&fields, &partitions, &nodes, false);
+        assert_eq!(
+            lines.len(),
+            2,
+            "node appears under each partition: {lines:?}"
+        );
+        assert!(lines[0].contains("gpu"));
+        assert!(lines[1].contains("batch"));
+    }
+
+    #[test]
+    fn test_node_oriented_empty_partitions_fallback() {
+        let fields =
+            format_engine::parse_format("%#N %.6D %#P %.11T", &format_engine::sinfo_header);
+        let partitions = vec![make_partition("batch", true)];
+        let nodes = vec![NodeInfo {
+            name: "orphan".into(),
+            state: NodeState::NodeIdle as i32,
+            partitions: vec![],
+            ..Default::default()
+        }];
+
+        let lines = render_sinfo_output(&fields, &partitions, &nodes, true);
+        assert_eq!(lines.len(), 1, "orphan node still gets one row");
+        assert!(lines[0].contains("orphan"));
+    }
 }

--- a/crates/spur-cli/src/sinfo.rs
+++ b/crates/spur-cli/src/sinfo.rs
@@ -126,14 +126,25 @@ fn render_sinfo_output(
 
     if node_oriented {
         for node in nodes {
-            let row = format_engine::format_row(fields, &|spec| {
-                resolve_node_field(node, partitions, spec)
-            });
-            lines.push(row);
+            let no_partition = String::new();
+            let parts: &[String] = if node.partitions.is_empty() {
+                std::slice::from_ref(&no_partition)
+            } else {
+                &node.partitions
+            };
+            for part_name in parts {
+                let row = format_engine::format_row(fields, &|spec| {
+                    resolve_node_field(node, part_name, partitions, spec)
+                });
+                lines.push(row);
+            }
         }
     } else {
         for part in partitions {
-            let part_nodes: Vec<_> = nodes.iter().filter(|n| n.partition == part.name).collect();
+            let part_nodes: Vec<_> = nodes
+                .iter()
+                .filter(|n| n.partitions.contains(&part.name))
+                .collect();
             let state_groups = group_nodes_by_display_state(&part_nodes);
 
             if state_groups.is_empty() {
@@ -157,12 +168,13 @@ fn render_sinfo_output(
 
 fn resolve_node_field(
     node: &spur_proto::proto::NodeInfo,
+    partition_name: &str,
     _partitions: &[spur_proto::proto::PartitionInfo],
     spec: char,
 ) -> String {
     match spec {
         'N' | 'n' => node.name.clone(),
-        'P' | 'R' => node.partition.clone(),
+        'P' | 'R' => partition_name.to_string(),
         't' | 'T' => effective_state_str(node),
         'c' => {
             if let Some(ref r) = node.total_resources {
@@ -292,7 +304,7 @@ mod tests {
         NodeInfo {
             name: name.into(),
             state: state as i32,
-            partition: partition.into(),
+            partitions: vec![partition.into()],
             ..Default::default()
         }
     }

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -431,7 +431,10 @@ pub struct PartitionConfig {
     pub default: bool,
     #[serde(default = "default_partition_state")]
     pub state: String,
+    #[serde(default)]
     pub nodes: String,
+    #[serde(default)]
+    pub selector: HashMap<String, String>,
     pub max_time: Option<String>,
     pub default_time: Option<String>,
     pub max_nodes: Option<u32>,
@@ -456,9 +459,15 @@ fn default_one() -> u32 {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NodeConfig {
-    /// Hostlist pattern for this node definition.
+    /// Hostlist pattern for this node definition. Optional when selector is used.
+    #[serde(default)]
     pub names: String,
+    /// Label selector: apply this config to nodes matching ALL key-value pairs.
+    #[serde(default)]
+    pub selector: HashMap<String, String>,
+    #[serde(default)]
     pub cpus: u32,
+    #[serde(default)]
     pub memory_mb: u64,
     #[serde(default)]
     pub gres: Vec<String>,
@@ -755,6 +764,7 @@ impl SlurmConfig {
                 },
                 is_default: pc.default,
                 nodes: pc.nodes.clone(),
+                selector: pc.selector.clone(),
                 max_time_minutes: pc.max_time.as_ref().and_then(|t| parse_time_minutes(t)),
                 default_time_minutes: pc.default_time.as_ref().and_then(|t| parse_time_minutes(t)),
                 max_nodes: pc.max_nodes,

--- a/crates/spur-core/src/node.rs
+++ b/crates/spur-core/src/node.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -228,6 +230,10 @@ pub struct Node {
     #[serde(default)]
     pub features: Vec<String>,
 
+    /// Key-value labels for partition routing and policy application.
+    #[serde(default)]
+    pub labels: HashMap<String, String>,
+
     pub arch: String,
     pub os: String,
     pub cpu_load: u32,
@@ -270,6 +276,7 @@ impl Node {
             total_resources: resources,
             alloc_resources: ResourceAllocations::default(),
             features: Vec::new(),
+            labels: HashMap::new(),
             arch: String::new(),
             os: String::new(),
             cpu_load: 0,

--- a/crates/spur-core/src/partition.rs
+++ b/crates/spur-core/src/partition.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 /// Partition (queue) configuration.
@@ -12,6 +14,10 @@ pub struct Partition {
 
     /// Nodes belonging to this partition (hostlist pattern).
     pub nodes: String,
+
+    /// Label selector: node joins this partition if ALL key-value pairs match.
+    #[serde(default)]
+    pub selector: HashMap<String, String>,
 
     /// Limits
     pub max_time_minutes: Option<u32>,
@@ -74,6 +80,7 @@ impl Default for Partition {
             state: PartitionState::Up,
             is_default: false,
             nodes: String::new(),
+            selector: HashMap::new(),
             max_time_minutes: None,
             default_time_minutes: None,
             max_nodes: None,

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -61,6 +61,8 @@ pub enum WalOperation {
         wg_pubkey: String,
         #[serde(default)]
         version: String,
+        #[serde(default)]
+        labels: HashMap<String, String>,
     },
     NodeUpdate {
         name: String,
@@ -77,5 +79,10 @@ pub enum WalOperation {
         reason: Option<String>,
         #[serde(default)]
         admin_locked: bool,
+    },
+    NodeLabelsUpdate {
+        name: String,
+        set: HashMap<String, String>,
+        remove: Vec<String>,
     },
 }

--- a/crates/spur-k8s/src/heartbeat.rs
+++ b/crates/spur-k8s/src/heartbeat.rs
@@ -95,6 +95,7 @@ mod tests {
             address: "127.0.0.1".into(),
             port: 6818,
             wg_pubkey: String::new(),
+            labels: std::collections::HashMap::new(),
         }
     }
 

--- a/crates/spur-k8s/src/node_watcher.rs
+++ b/crates/spur-k8s/src/node_watcher.rs
@@ -71,6 +71,8 @@ async fn sync_taint_state(
         name: name.into(),
         state: Some(state),
         reason,
+        labels: HashMap::new(),
+        remove_labels: Vec::new(),
     };
 
     match client.update_node(req).await {
@@ -131,6 +133,7 @@ pub async fn run(
                         address: operator_grpc_addr.clone(),
                         port: operator_grpc_port,
                         wg_pubkey: String::new(),
+                        labels: std::collections::HashMap::new(),
                     };
 
                     match ctrl_client.register_agent(req.clone()).await {
@@ -169,6 +172,8 @@ pub async fn run(
                     name: name.clone(),
                     state: Some(NodeState::NodeDown as i32),
                     reason: Some("K8s node removed".into()),
+                    labels: HashMap::new(),
+                    remove_labels: Vec::new(),
                 };
 
                 if let Err(e) = ctrl_client.update_node(req).await {

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -770,22 +770,7 @@ impl ClusterManager {
         match action {
             RegistrationAction::Skip => {
                 debug!(node = %effective_name, "node unchanged, skipping");
-                if let Some(existing) = self.get_node(&effective_name) {
-                    if existing.labels != labels {
-                        let remove: Vec<String> = existing
-                            .labels
-                            .keys()
-                            .filter(|k| !labels.contains_key(*k))
-                            .cloned()
-                            .collect();
-                        self.propose(WalOperation::NodeLabelsUpdate {
-                            name: effective_name.clone(),
-                            set: labels,
-                            remove,
-                        })?;
-                        info!(node = %effective_name, "node labels synced on re-registration");
-                    }
-                }
+                self.sync_node_labels(&effective_name, labels)?;
             }
             RegistrationAction::Update => {
                 self.propose(WalOperation::NodeUpdate {
@@ -796,21 +781,7 @@ impl ClusterManager {
                     wg_pubkey,
                     version,
                 })?;
-                if let Some(existing) = self.get_node(&effective_name) {
-                    if existing.labels != labels {
-                        let remove: Vec<String> = existing
-                            .labels
-                            .keys()
-                            .filter(|k| !labels.contains_key(*k))
-                            .cloned()
-                            .collect();
-                        self.propose(WalOperation::NodeLabelsUpdate {
-                            name: effective_name.clone(),
-                            set: labels,
-                            remove,
-                        })?;
-                    }
-                }
+                self.sync_node_labels(&effective_name, labels)?;
                 if let Some(node) = self.nodes.write().get_mut(&effective_name) {
                     node.source = source;
                 }
@@ -831,6 +802,32 @@ impl ClusterManager {
                     node.agent_start_time = Some(Utc::now());
                 }
                 info!(node = %effective_name, "node registered");
+            }
+        }
+        Ok(())
+    }
+
+    /// Sync node labels if they differ from the expected set.
+    /// Proposes a `NodeLabelsUpdate` WAL operation when there's a mismatch.
+    fn sync_node_labels(
+        &self,
+        node_name: &str,
+        new_labels: HashMap<String, String>,
+    ) -> anyhow::Result<()> {
+        if let Some(existing) = self.get_node(node_name) {
+            if existing.labels != new_labels {
+                let remove: Vec<String> = existing
+                    .labels
+                    .keys()
+                    .filter(|k| !new_labels.contains_key(*k))
+                    .cloned()
+                    .collect();
+                self.propose(WalOperation::NodeLabelsUpdate {
+                    name: node_name.to_string(),
+                    set: new_labels,
+                    remove,
+                })?;
+                info!(node = %node_name, "node labels synced on re-registration");
             }
         }
         Ok(())
@@ -2103,9 +2100,7 @@ impl ClusterManager {
                     for nc in &self.config.nodes {
                         if node_config_matches(nc, &node.name, &node.labels) {
                             node.features = nc.features.clone();
-                            if nc.weight > 0 {
-                                node.weight = nc.weight;
-                            }
+                            node.weight = nc.weight;
                             break;
                         }
                     }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2271,7 +2271,7 @@ pub(crate) fn partition_matches_node(
         true
     } else {
         spur_core::hostlist::expand(&partition.nodes)
-            .map(|hosts| hosts.contains(&node_name.to_string()))
+            .map(|hosts| hosts.iter().any(|h| h == node_name))
             .unwrap_or(false)
     };
 
@@ -2291,7 +2291,7 @@ pub(crate) fn node_config_matches(
         true
     } else {
         spur_core::hostlist::expand(&nc.names)
-            .map(|hosts| hosts.contains(&node_name.to_string()))
+            .map(|hosts| hosts.iter().any(|h| h == node_name))
             .unwrap_or(false)
     };
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -709,6 +709,7 @@ impl ClusterManager {
         wg_pubkey: String,
         version: String,
         source: NodeSource,
+        labels: HashMap<String, String>,
     ) -> anyhow::Result<()> {
         // Normalize node name: if the agent's hostname doesn't match any config
         // entry, check if there's an unmatched config node it could be aliased to.
@@ -769,6 +770,22 @@ impl ClusterManager {
         match action {
             RegistrationAction::Skip => {
                 debug!(node = %effective_name, "node unchanged, skipping");
+                if let Some(existing) = self.get_node(&effective_name) {
+                    if existing.labels != labels {
+                        let remove: Vec<String> = existing
+                            .labels
+                            .keys()
+                            .filter(|k| !labels.contains_key(*k))
+                            .cloned()
+                            .collect();
+                        self.propose(WalOperation::NodeLabelsUpdate {
+                            name: effective_name.clone(),
+                            set: labels,
+                            remove,
+                        })?;
+                        info!(node = %effective_name, "node labels synced on re-registration");
+                    }
+                }
             }
             RegistrationAction::Update => {
                 self.propose(WalOperation::NodeUpdate {
@@ -779,6 +796,21 @@ impl ClusterManager {
                     wg_pubkey,
                     version,
                 })?;
+                if let Some(existing) = self.get_node(&effective_name) {
+                    if existing.labels != labels {
+                        let remove: Vec<String> = existing
+                            .labels
+                            .keys()
+                            .filter(|k| !labels.contains_key(*k))
+                            .cloned()
+                            .collect();
+                        self.propose(WalOperation::NodeLabelsUpdate {
+                            name: effective_name.clone(),
+                            set: labels,
+                            remove,
+                        })?;
+                    }
+                }
                 if let Some(node) = self.nodes.write().get_mut(&effective_name) {
                     node.source = source;
                 }
@@ -792,6 +824,7 @@ impl ClusterManager {
                     port,
                     wg_pubkey,
                     version,
+                    labels,
                 })?;
                 if let Some(node) = self.nodes.write().get_mut(&effective_name) {
                     node.source = source;
@@ -995,6 +1028,27 @@ impl ClusterManager {
             admin_locked,
         })?;
         info!(node = %name, old = ?old_state, new = ?effective_state, "node state updated");
+        Ok(())
+    }
+
+    pub fn update_node_labels(
+        &self,
+        name: &str,
+        set: HashMap<String, String>,
+        remove: &[String],
+    ) -> anyhow::Result<()> {
+        {
+            let nodes = self.nodes.read();
+            if !nodes.contains_key(name) {
+                anyhow::bail!("node {} not found", name);
+            }
+        }
+        self.propose(WalOperation::NodeLabelsUpdate {
+            name: name.to_string(),
+            set: set.clone(),
+            remove: remove.to_vec(),
+        })?;
+        info!(node = %name, "node labels updated");
         Ok(())
     }
 
@@ -1937,10 +1991,12 @@ impl ClusterManager {
                 port,
                 wg_pubkey,
                 version,
+                labels,
             } => {
                 let mut node = Node::new(name.clone(), resources.clone());
                 node.address = Some(address.clone());
                 node.port = *port;
+                node.labels = labels.clone();
                 if !wg_pubkey.is_empty() {
                     node.wg_pubkey = Some(wg_pubkey.clone());
                 }
@@ -1953,14 +2009,12 @@ impl ClusterManager {
                     .transition(&NodeEvent::Register, false)
                     .unwrap_or(NodeState::Idle);
 
-                // Assign partitions from config
+                // Assign partitions: match by hostlist OR label selector (union)
                 drop(nodes);
                 let partitions = self.partitions.read();
                 for part in partitions.iter() {
-                    if let Ok(hosts) = spur_core::hostlist::expand(&part.nodes) {
-                        if hosts.contains(name) {
-                            node.partitions.push(part.name.clone());
-                        }
+                    if partition_matches_node(part, name, labels) {
+                        node.partitions.push(part.name.clone());
                     }
                 }
                 if node.partitions.is_empty() {
@@ -1972,13 +2026,12 @@ impl ClusterManager {
                 }
                 drop(partitions);
 
+                // Apply features/weight from matching NodeConfig (by hostname OR selector)
                 for nc in &self.config.nodes {
-                    if let Ok(hosts) = spur_core::hostlist::expand(&nc.names) {
-                        if hosts.contains(name) {
-                            node.features = nc.features.clone();
-                            node.weight = nc.weight;
-                            break;
-                        }
+                    if node_config_matches(nc, name, labels) {
+                        node.features = nc.features.clone();
+                        node.weight = nc.weight;
+                        break;
                     }
                 }
 
@@ -2021,6 +2074,43 @@ impl ClusterManager {
                     node.admin_locked = *admin_locked;
                 }
             }
+            WalOperation::NodeLabelsUpdate { name, set, remove } => {
+                if let Some(node) = nodes.get_mut(name) {
+                    for (k, v) in set {
+                        node.labels.insert(k.clone(), v.clone());
+                    }
+                    for k in remove {
+                        node.labels.remove(k);
+                    }
+                    // Re-evaluate partition membership after label change
+                    let partitions = self.partitions.read();
+                    let mut matched = Vec::new();
+                    for part in partitions.iter() {
+                        if partition_matches_node(part, &node.name, &node.labels) {
+                            matched.push(part.name.clone());
+                        }
+                    }
+                    if matched.is_empty() {
+                        if let Some(dp) = partitions.iter().find(|p| p.is_default) {
+                            matched.push(dp.name.clone());
+                        } else if let Some(first) = partitions.first() {
+                            matched.push(first.name.clone());
+                        }
+                    }
+                    node.partitions = matched;
+
+                    // Re-apply NodeConfig features/weight
+                    for nc in &self.config.nodes {
+                        if node_config_matches(nc, &node.name, &node.labels) {
+                            node.features = nc.features.clone();
+                            if nc.weight > 0 {
+                                node.weight = nc.weight;
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
         }
         self.next_job_id.store(next_id, Ordering::Relaxed);
         response
@@ -2037,6 +2127,39 @@ struct ClusterSnapshot {
     steps: Vec<JobStep>,
     license_pool: HashMap<String, u64>,
     hostname_aliases: HashMap<String, String>,
+}
+
+impl ClusterManager {
+    /// Re-evaluate partition membership and NodeConfig policy (features, weight)
+    /// for all nodes against the current config. Called after snapshot restore to
+    /// handle config changes that occurred between snapshot creation and restart.
+    fn reconcile_partitions(&self, nodes: &mut HashMap<String, Node>) {
+        let partitions = self.partitions.read();
+        for node in nodes.values_mut() {
+            let mut matched = Vec::new();
+            for part in partitions.iter() {
+                if partition_matches_node(part, &node.name, &node.labels) {
+                    matched.push(part.name.clone());
+                }
+            }
+            if matched.is_empty() {
+                if let Some(dp) = partitions.iter().find(|p| p.is_default) {
+                    matched.push(dp.name.clone());
+                } else if let Some(first) = partitions.first() {
+                    matched.push(first.name.clone());
+                }
+            }
+            node.partitions = matched;
+
+            for nc in &self.config.nodes {
+                if node_config_matches(nc, &node.name, &node.labels) {
+                    node.features = nc.features.clone();
+                    node.weight = nc.weight;
+                    break;
+                }
+            }
+        }
+    }
 }
 
 impl StateMachineApply for ClusterManager {
@@ -2084,6 +2207,11 @@ impl StateMachineApply for ClusterManager {
             *self.hostname_aliases.write() = snap.hostname_aliases;
 
             self.next_job_id.store(next_id, Ordering::Relaxed);
+
+            // Re-evaluate partition membership and NodeConfig policy
+            // for all nodes against the current config.
+            self.reconcile_partitions(&mut nodes);
+
             info!(
                 jobs = jobs.len(),
                 nodes = nodes.len(),
@@ -2122,6 +2250,55 @@ pub(crate) fn evaluate_registration(
         Some(node) if node.total_resources != *incoming_resources => RegistrationAction::Update,
         Some(_) => RegistrationAction::Skip,
     }
+}
+
+/// Returns true if a node matches a partition's membership criteria.
+/// Match occurs if the node satisfies EITHER the hostlist OR the label selector.
+pub(crate) fn partition_matches_node(
+    partition: &spur_core::partition::Partition,
+    node_name: &str,
+    labels: &HashMap<String, String>,
+) -> bool {
+    let matches_selector = !partition.selector.is_empty()
+        && partition
+            .selector
+            .iter()
+            .all(|(k, v)| labels.get(k) == Some(v));
+
+    let matches_hostlist = if partition.nodes.is_empty() {
+        false
+    } else if partition.nodes.eq_ignore_ascii_case("ALL") {
+        true
+    } else {
+        spur_core::hostlist::expand(&partition.nodes)
+            .map(|hosts| hosts.contains(&node_name.to_string()))
+            .unwrap_or(false)
+    };
+
+    matches_selector || matches_hostlist
+}
+
+/// Returns true if a NodeConfig entry applies to a node (by hostname pattern OR
+/// label selector).
+pub(crate) fn node_config_matches(
+    nc: &spur_core::config::NodeConfig,
+    node_name: &str,
+    labels: &HashMap<String, String>,
+) -> bool {
+    let matches_names = if nc.names.is_empty() {
+        false
+    } else if nc.names.eq_ignore_ascii_case("ALL") {
+        true
+    } else {
+        spur_core::hostlist::expand(&nc.names)
+            .map(|hosts| hosts.contains(&node_name.to_string()))
+            .unwrap_or(false)
+    };
+
+    let matches_selector =
+        !nc.selector.is_empty() && nc.selector.iter().all(|(k, v)| labels.get(k) == Some(v));
+
+    matches_names || matches_selector
 }
 
 #[derive(Debug, PartialEq)]
@@ -2243,6 +2420,7 @@ mod tests {
                 default: true,
                 state: "UP".into(),
                 nodes: "ALL".into(),
+                selector: Default::default(),
                 max_time: None,
                 default_time: None,
                 max_nodes: None,
@@ -2341,6 +2519,7 @@ mod tests {
             String::new(),
             String::new(),
             spur_core::node::NodeSource::NativeHost,
+            HashMap::new(),
         )
         .unwrap();
         let n = name.to_string();
@@ -2484,6 +2663,7 @@ mod tests {
             port: 6818,
             wg_pubkey: String::new(),
             version: "1.0".into(),
+            labels: HashMap::new(),
         });
 
         let node = cm.get_node("gpu-node").unwrap();
@@ -3337,6 +3517,7 @@ mod tests {
             String::new(),
             "1.0".into(),
             NodeSource::NativeHost,
+            HashMap::new(),
         )
         .unwrap();
         let node = cm.get_node("locked").unwrap();
@@ -3972,5 +4153,363 @@ mod tests {
 
         // Unknown id → empty.
         assert!(cm.get_jobs(&[], None, None, None, &[999]).is_empty());
+    }
+
+    // --- Partition matching tests ---
+
+    #[test]
+    fn partition_matches_node_by_hostlist() {
+        let part = Partition {
+            name: "gpu".into(),
+            nodes: "node[1-3]".into(),
+            ..Default::default()
+        };
+        let empty_labels = HashMap::new();
+        assert!(super::partition_matches_node(&part, "node1", &empty_labels));
+        assert!(super::partition_matches_node(&part, "node3", &empty_labels));
+        assert!(!super::partition_matches_node(
+            &part,
+            "node4",
+            &empty_labels
+        ));
+    }
+
+    #[test]
+    fn partition_matches_node_by_selector() {
+        let mut selector = HashMap::new();
+        selector.insert("pool".into(), "train".into());
+        let part = Partition {
+            name: "train".into(),
+            selector,
+            ..Default::default()
+        };
+        let mut labels = HashMap::new();
+        labels.insert("pool".into(), "train".into());
+        labels.insert("gpu".into(), "mi300x".into());
+        assert!(super::partition_matches_node(
+            &part,
+            "arbitrary-host",
+            &labels
+        ));
+
+        let wrong_labels = HashMap::from([("pool".into(), "infer".into())]);
+        assert!(!super::partition_matches_node(
+            &part,
+            "arbitrary-host",
+            &wrong_labels
+        ));
+    }
+
+    #[test]
+    fn partition_matches_node_union_of_both() {
+        let mut selector = HashMap::new();
+        selector.insert("pool".into(), "train".into());
+        let part = Partition {
+            name: "gpu".into(),
+            nodes: "node1".into(),
+            selector,
+            ..Default::default()
+        };
+        // Matches by hostlist alone
+        assert!(super::partition_matches_node(
+            &part,
+            "node1",
+            &HashMap::new()
+        ));
+        // Matches by selector alone
+        let labels = HashMap::from([("pool".into(), "train".into())]);
+        assert!(super::partition_matches_node(&part, "other-host", &labels));
+        // Matches neither
+        assert!(!super::partition_matches_node(
+            &part,
+            "other-host",
+            &HashMap::new()
+        ));
+    }
+
+    #[test]
+    fn node_config_matches_by_selector() {
+        let nc = spur_core::config::NodeConfig {
+            names: String::new(),
+            selector: HashMap::from([("gpu".into(), "mi300x".into())]),
+            cpus: 0,
+            memory_mb: 0,
+            gres: Vec::new(),
+            features: Vec::new(),
+            address: None,
+            weight: 1,
+        };
+        let labels = HashMap::from([("gpu".into(), "mi300x".into())]);
+        assert!(super::node_config_matches(&nc, "any-host", &labels));
+        assert!(!super::node_config_matches(
+            &nc,
+            "any-host",
+            &HashMap::new()
+        ));
+    }
+
+    // --- Label update + partition re-routing ---
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn update_labels_reroutes_partition() {
+        let dir = TempDir::new().unwrap();
+        let mut cfg = test_config();
+        cfg.partitions = vec![
+            spur_core::config::PartitionConfig {
+                name: "default".into(),
+                default: true,
+                state: "UP".into(),
+                nodes: "ALL".into(),
+                selector: HashMap::new(),
+                max_time: None,
+                default_time: None,
+                max_nodes: None,
+                min_nodes: 1,
+                allow_accounts: Vec::new(),
+                allow_groups: Vec::new(),
+                priority_tier: 1,
+                preempt_mode: String::new(),
+            },
+            spur_core::config::PartitionConfig {
+                name: "train".into(),
+                default: false,
+                state: "UP".into(),
+                nodes: String::new(),
+                selector: HashMap::from([("pool".into(), "train".into())]),
+                max_time: None,
+                default_time: None,
+                max_nodes: None,
+                min_nodes: 1,
+                allow_accounts: Vec::new(),
+                allow_groups: Vec::new(),
+                priority_tier: 1,
+                preempt_mode: String::new(),
+            },
+        ];
+        let cm = Arc::new(ClusterManager::new(cfg, dir.path()).unwrap());
+        let handle = crate::raft::start_raft(1, &["[::1]:0".into()], dir.path(), cm.clone())
+            .await
+            .unwrap();
+        handle
+            .raft
+            .wait(Some(std::time::Duration::from_secs(5)))
+            .metrics(|m| m.current_leader == Some(1), "leader elected")
+            .await
+            .unwrap();
+        cm.set_raft(handle.raft);
+
+        register_node(&cm, "worker1", 4, 8000);
+        let node = cm.get_node("worker1").unwrap();
+        // Initially only in "default" (ALL matches everything)
+        assert!(node.partitions.contains(&"default".into()));
+        assert!(!node.partitions.contains(&"train".into()));
+
+        // Add label that matches "train" partition selector
+        cm.update_node_labels(
+            "worker1",
+            HashMap::from([("pool".into(), "train".into())]),
+            &[],
+        )
+        .unwrap();
+        wait_for("label applied", || {
+            cm.get_node("worker1")
+                .map(|n| !n.labels.is_empty())
+                .unwrap_or(false)
+        });
+
+        let node = cm.get_node("worker1").unwrap();
+        assert!(node.partitions.contains(&"train".into()));
+        assert_eq!(node.labels.get("pool"), Some(&"train".into()));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn register_node_with_labels_gets_selector_partition() {
+        let dir = TempDir::new().unwrap();
+        let mut cfg = test_config();
+        cfg.partitions = vec![spur_core::config::PartitionConfig {
+            name: "inference".into(),
+            default: false,
+            state: "UP".into(),
+            nodes: String::new(),
+            selector: HashMap::from([("role".into(), "infer".into())]),
+            max_time: None,
+            default_time: None,
+            max_nodes: None,
+            min_nodes: 1,
+            allow_accounts: Vec::new(),
+            allow_groups: Vec::new(),
+            priority_tier: 1,
+            preempt_mode: String::new(),
+        }];
+        let cm = Arc::new(ClusterManager::new(cfg, dir.path()).unwrap());
+        let handle = crate::raft::start_raft(1, &["[::1]:0".into()], dir.path(), cm.clone())
+            .await
+            .unwrap();
+        handle
+            .raft
+            .wait(Some(std::time::Duration::from_secs(5)))
+            .metrics(|m| m.current_leader == Some(1), "leader elected")
+            .await
+            .unwrap();
+        cm.set_raft(handle.raft);
+
+        cm.register_node(
+            "dyn-node".into(),
+            ResourceSet {
+                cpus: 8,
+                memory_mb: 16000,
+                ..Default::default()
+            },
+            "127.0.0.1".into(),
+            6818,
+            String::new(),
+            String::new(),
+            spur_core::node::NodeSource::NativeHost,
+            HashMap::from([("role".into(), "infer".into())]),
+        )
+        .unwrap();
+        wait_for("node registered", || cm.get_node("dyn-node").is_some());
+
+        let node = cm.get_node("dyn-node").unwrap();
+        assert!(node.partitions.contains(&"inference".into()));
+    }
+
+    #[test]
+    fn partition_all_matches_any_node() {
+        let part = Partition {
+            name: "everything".into(),
+            nodes: "ALL".into(),
+            ..Default::default()
+        };
+        assert!(super::partition_matches_node(
+            &part,
+            "random-host-xyz",
+            &HashMap::new()
+        ));
+        assert!(super::partition_matches_node(
+            &part,
+            "node1",
+            &HashMap::new()
+        ));
+    }
+
+    #[test]
+    fn node_config_all_matches_any_node() {
+        let nc = spur_core::config::NodeConfig {
+            names: "ALL".into(),
+            selector: HashMap::new(),
+            cpus: 0,
+            memory_mb: 0,
+            gres: Vec::new(),
+            features: vec!["common".into()],
+            address: None,
+            weight: 1,
+        };
+        assert!(super::node_config_matches(&nc, "any-host", &HashMap::new()));
+        assert!(super::node_config_matches(
+            &nc,
+            "another",
+            &HashMap::from([("x".into(), "y".into())])
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reregistration_syncs_labels() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        // First registration with labels
+        cm.register_node(
+            "worker1".into(),
+            ResourceSet {
+                cpus: 4,
+                memory_mb: 8000,
+                ..Default::default()
+            },
+            "127.0.0.1".into(),
+            6818,
+            String::new(),
+            String::new(),
+            spur_core::node::NodeSource::NativeHost,
+            HashMap::from([("pool".into(), "train".into())]),
+        )
+        .unwrap();
+        wait_for("node registered", || cm.get_node("worker1").is_some());
+        assert_eq!(
+            cm.get_node("worker1").unwrap().labels.get("pool"),
+            Some(&"train".into())
+        );
+
+        // Re-register with same resources but different labels
+        cm.register_node(
+            "worker1".into(),
+            ResourceSet {
+                cpus: 4,
+                memory_mb: 8000,
+                ..Default::default()
+            },
+            "127.0.0.1".into(),
+            6818,
+            String::new(),
+            String::new(),
+            spur_core::node::NodeSource::NativeHost,
+            HashMap::from([("pool".into(), "infer".into()), ("tier".into(), "1".into())]),
+        )
+        .unwrap();
+        wait_for("labels synced", || {
+            cm.get_node("worker1")
+                .map(|n| n.labels.get("pool") == Some(&"infer".into()))
+                .unwrap_or(false)
+        });
+
+        let node = cm.get_node("worker1").unwrap();
+        assert_eq!(node.labels.get("pool"), Some(&"infer".into()));
+        assert_eq!(node.labels.get("tier"), Some(&"1".into()));
+    }
+
+    #[test]
+    fn label_update_applies_nodeconfig_features() {
+        let dir = TempDir::new().unwrap();
+        let mut cfg = test_config();
+        cfg.nodes = vec![spur_core::config::NodeConfig {
+            names: String::new(),
+            selector: HashMap::from([("gpu".into(), "mi300x".into())]),
+            cpus: 0,
+            memory_mb: 0,
+            gres: Vec::new(),
+            features: vec!["mi300x".into(), "rocm6".into()],
+            address: None,
+            weight: 10,
+        }];
+        let cm = ClusterManager::new(cfg, dir.path()).unwrap();
+
+        // Register a node directly via WAL apply
+        cm.apply_operation(&WalOperation::NodeRegister {
+            name: "gpu-node".into(),
+            resources: ResourceSet {
+                cpus: 8,
+                memory_mb: 16000,
+                ..Default::default()
+            },
+            address: "127.0.0.1".into(),
+            port: 6818,
+            wg_pubkey: String::new(),
+            version: String::new(),
+            labels: HashMap::new(),
+        });
+
+        let node = cm.get_node("gpu-node").unwrap();
+        assert!(node.features.is_empty());
+
+        // Apply label update that matches the NodeConfig selector
+        cm.apply_operation(&WalOperation::NodeLabelsUpdate {
+            name: "gpu-node".into(),
+            set: HashMap::from([("gpu".into(), "mi300x".into())]),
+            remove: Vec::new(),
+        });
+
+        let node = cm.get_node("gpu-node").unwrap();
+        assert_eq!(node.features, vec!["mi300x", "rocm6"]);
+        assert_eq!(node.weight, 10);
     }
 }

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -216,6 +216,7 @@ fn default_config() -> spur_core::config::SlurmConfig {
             default: true,
             state: "UP".into(),
             nodes: "localhost".into(),
+            selector: Default::default(),
             max_time: None,
             default_time: None,
             max_nodes: None,

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1304,7 +1304,7 @@ fn node_to_proto(node: &spur_core::node::Node) -> NodeInfo {
         name: node.name.clone(),
         state: node.state.to_proto_i32(),
         state_reason: node.state_reason.clone().unwrap_or_default(),
-        partition: node.partitions.first().cloned().unwrap_or_default(),
+        partitions: node.partitions.clone(),
         total_resources: Some(resource_to_proto(&node.total_resources)),
         alloc_resources: Some(allocations_to_proto(&node.alloc_resources)),
         arch: node.arch.clone(),

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -382,6 +382,11 @@ impl SlurmController for ControllerService {
                 .update_node_state(&req.name, node_state, req.reason)
                 .map_err(|e| Status::internal(e.to_string()))?;
         }
+        if !req.labels.is_empty() || !req.remove_labels.is_empty() {
+            self.cluster
+                .update_node_labels(&req.name, req.labels, &req.remove_labels)
+                .map_err(|e| Status::internal(e.to_string()))?;
+        }
         Ok(Response::new(()))
     }
 
@@ -489,6 +494,7 @@ impl SlurmController for ControllerService {
                 req.wg_pubkey,
                 req.version,
                 spur_core::node::NodeSource::NativeHost,
+                req.labels,
             )
             .map_err(|e| Status::internal(e.to_string()))?;
 
@@ -1310,6 +1316,7 @@ fn node_to_proto(node: &spur_core::node::Node) -> NodeInfo {
         slurmd_start_time: node.agent_start_time.map(datetime_to_proto),
         switch_name: node.switch_name.clone().unwrap_or_default(),
         active_reservation: String::new(),
+        labels: node.labels.clone(),
     }
 }
 

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1511,6 +1511,7 @@ mod tests {
                 port: 6818,
                 source: spur_net::AddressSource::Static,
             },
+            std::collections::HashMap::new(),
         ))
     }
 

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -247,3 +247,30 @@ fn init_device_registry(config: Option<&SlurmConfig>) -> DeviceRegistry {
 
     registry
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_label_valid() {
+        assert_eq!(parse_label("pool=gpu").unwrap(), "pool=gpu");
+        assert_eq!(parse_label("tier=").unwrap(), "tier=");
+        assert_eq!(parse_label("a=b=c").unwrap(), "a=b=c");
+    }
+
+    #[test]
+    fn parse_label_missing_equals() {
+        assert!(parse_label("noequalssign").is_err());
+    }
+
+    #[test]
+    fn parse_label_empty_key() {
+        assert!(parse_label("=value").is_err());
+    }
+
+    #[test]
+    fn parse_label_just_equals() {
+        assert!(parse_label("=").is_err());
+    }
+}

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -61,7 +61,7 @@ struct Args {
 
     /// Node labels for partition routing (key=value pairs).
     /// Can be specified multiple times: --label pool=gpu --label rack=a
-    #[arg(long = "label", value_parser = parse_label, env = "SPUR_NODE_LABELS", value_delimiter = ',')]
+    #[arg(long = "label", value_parser = parse_label, env = "SPUR_NODE_LABELS")]
     labels: Vec<String>,
 
     /// Foreground mode

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -9,6 +9,7 @@ pub mod pmi;
 mod reporter;
 mod seccomp;
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use clap::Parser;
@@ -20,6 +21,15 @@ use spur_devices::cdi::cache::CdiCache;
 use spur_devices::DeviceRegistry;
 
 use reporter::NodeReporter;
+
+/// Parse a "key=value" string into a validated label.
+fn parse_label(s: &str) -> Result<String, String> {
+    if s.contains('=') && s.split('=').next().map_or(false, |k| !k.is_empty()) {
+        Ok(s.to_string())
+    } else {
+        Err(format!("invalid label format '{s}', expected key=value"))
+    }
+}
 
 #[derive(Parser)]
 #[command(name = "spurd", about = "Spur node agent daemon")]
@@ -48,6 +58,11 @@ struct Args {
     /// If not set, auto-detected from WireGuard interface or hostname resolution.
     #[arg(long, env = "SPUR_NODE_ADDRESS")]
     address: Option<String>,
+
+    /// Node labels for partition routing (key=value pairs).
+    /// Can be specified multiple times: --label pool=gpu --label rack=a
+    #[arg(long = "label", value_parser = parse_label, env = "SPUR_NODE_LABELS", value_delimiter = ',')]
+    labels: Vec<String>,
 
     /// Foreground mode
     #[arg(short = 'D', long)]
@@ -155,12 +170,23 @@ async fn main() -> anyhow::Result<()> {
         "resources discovered"
     );
 
+    // Parse node labels from CLI/env
+    let labels: HashMap<String, String> = args
+        .labels
+        .iter()
+        .filter_map(|s| {
+            let (k, v) = s.split_once('=')?;
+            Some((k.to_string(), v.to_string()))
+        })
+        .collect();
+
     // Create the node reporter
     let reporter = Arc::new(NodeReporter::new(
         hostname.clone(),
         args.controller.clone(),
         resources,
         node_address,
+        labels,
     ));
 
     // Register with controller

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -24,7 +24,7 @@ use reporter::NodeReporter;
 
 /// Parse a "key=value" string into a validated label.
 fn parse_label(s: &str) -> Result<String, String> {
-    if s.contains('=') && s.split('=').next().map_or(false, |k| !k.is_empty()) {
+    if s.contains('=') && s.split('=').next().is_some_and(|k| !k.is_empty()) {
         Ok(s.to_string())
     } else {
         Err(format!("invalid label format '{s}', expected key=value"))

--- a/crates/spurd/src/reporter.rs
+++ b/crates/spurd/src/reporter.rs
@@ -17,6 +17,7 @@ pub struct NodeReporter {
     pub controller_addr: String,
     pub resources: ResourceSet,
     pub node_address: spur_net::NodeAddress,
+    pub labels: HashMap<String, String>,
     pub free_memory_mb: AtomicU64,
     pub cpu_load: AtomicU64,
 }
@@ -27,12 +28,14 @@ impl NodeReporter {
         controller_addr: String,
         resources: ResourceSet,
         node_address: spur_net::NodeAddress,
+        labels: HashMap<String, String>,
     ) -> Self {
         Self {
             hostname,
             controller_addr,
             resources,
             node_address,
+            labels,
             free_memory_mb: AtomicU64::new(0),
             cpu_load: AtomicU64::new(0),
         }
@@ -52,6 +55,7 @@ impl NodeReporter {
                 address: self.node_address.ip.clone(),
                 port: self.node_address.port as u32,
                 wg_pubkey: String::new(),
+                labels: self.labels.clone(),
             })
             .await
             .context("registration failed")?;

--- a/crates/spurrestd/src/routes.rs
+++ b/crates/spurrestd/src/routes.rs
@@ -422,7 +422,7 @@ fn node_info_to_json(n: &spur_proto::proto::NodeInfo) -> serde_json::Value {
         "name": n.name,
         "state": node_state_name(n.state),
         "reason": n.state_reason,
-        "partitions": [n.partition],
+        "partitions": n.partitions,
         "cpus": n.total_resources.as_ref().map(|r| r.cpus).unwrap_or(0),
         "alloc_cpus": n.alloc_resources.as_ref().map(|r| r.cpus).unwrap_or(0),
         "real_memory": n.total_resources.as_ref().map(|r| r.memory_mb).unwrap_or(0),

--- a/examples/spur.conf
+++ b/examples/spur.conf
@@ -26,6 +26,16 @@ default_time = "1:00:00"
 min_nodes = 1
 priority_tier = 1
 
+# Partition membership can also use label selectors. A node matches if it
+# satisfies the hostname pattern (nodes=) OR all key=value pairs in selector.
+# Both can be specified — they form a union.
+#
+# [[partitions]]
+# name = "inference"
+# state = "UP"
+# selector = { pool = "inference", gpu = "mi300x" }
+# max_time = "1-00:00:00"
+
 [[nodes]]
 names = "mi300"
 cpus = 256
@@ -37,6 +47,14 @@ names = "mi300-2"
 cpus = 256
 memory_mb = 2321904
 gres = ["gpu:mi300x:8"]
+
+# Node configs can also match by label selector instead of hostname pattern.
+# Features and weight from matching configs are applied at registration.
+#
+# [[nodes]]
+# selector = { gpu = "mi300x" }
+# features = ["mi300x", "rocm6"]
+# weight = 10
 
 [network]
 wg_enabled = false

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -216,6 +216,7 @@ message NodeInfo {
   string switch_name = 40;   // Leaf switch from topology config
 
   string active_reservation = 50;
+  map<string, string> labels = 51;
 }
 
 message PartitionInfo {
@@ -399,6 +400,8 @@ message UpdateNodeRequest {
   string name = 1;
   optional NodeState state = 2;
   optional string reason = 3;
+  map<string, string> labels = 4;
+  repeated string remove_labels = 5;
 }
 
 message GetPartitionsRequest {
@@ -423,6 +426,7 @@ message RegisterAgentRequest {
   string address = 4;        // Agent's preferred IP (e.g. WireGuard 10.44.x.y)
   uint32 port = 5;           // Agent gRPC listen port
   string wg_pubkey = 6;      // WireGuard public key (for mesh setup)
+  map<string, string> labels = 7;  // Node labels for partition routing (pool, rack, etc.)
 }
 
 message RegisterAgentResponse {

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -199,7 +199,7 @@ message NodeInfo {
   string name = 1;
   NodeState state = 2;
   string state_reason = 3;
-  string partition = 4;
+  repeated string partitions = 4;
 
   ResourceSet total_resources = 10;
   ResourceAllocations alloc_resources = 11;

--- a/tests/e2e/native_host/cluster.py
+++ b/tests/e2e/native_host/cluster.py
@@ -178,6 +178,7 @@ class SpurCluster:
         self.controller_addr = f"http://{nodes[0].host}:{CONTROLLER_PORT}"
         self.config_overrides: dict = {}
         self.agent_as_root: bool = False
+        self.agent_labels: dict[int, dict[str, str]] = {}
 
     # --- Lifecycle ---
 
@@ -197,6 +198,7 @@ class SpurCluster:
         config_overrides: dict | None = None,
         kill_stale: bool = True,
         agent_as_root: bool = False,
+        agent_labels: dict[int, dict[str, str]] | None = None,
     ):
         """Write config and start all daemons.
 
@@ -208,6 +210,9 @@ class SpurCluster:
 
         When *agent_as_root* is True, spurd is launched via sudo on each
         node (rootful agent). spurctld always runs as the SSH user.
+
+        *agent_labels* maps node index to a dict of labels that will be
+        passed as ``--label key=value`` args to spurd on that node.
         """
         if not self.node_names:
             raise RuntimeError("provision() must be called before start()")
@@ -215,6 +220,7 @@ class SpurCluster:
             self._kill_daemons(use_sudo=False)
             self._kill_daemons(use_sudo=True)
         self.agent_as_root = agent_as_root
+        self.agent_labels = agent_labels or {}
         self.config_overrides = config_overrides or {}
         self._write_config()
         self._start_controller()
@@ -235,12 +241,13 @@ class SpurCluster:
         self,
         config_overrides: dict | None = None,
         agent_as_root: bool = False,
+        agent_labels: dict[int, dict[str, str]] | None = None,
     ):
         """Provision + start in one call."""
         self.provision()
         if agent_as_root:
             self.root_agent_preflight()
-        self.start(config_overrides, agent_as_root=agent_as_root)
+        self.start(config_overrides, agent_as_root=agent_as_root, agent_labels=agent_labels)
 
     def teardown(self):
         """Kill all daemons and remove the working directory."""
@@ -661,12 +668,18 @@ mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
             if self.agent_as_root
             else f"'{self.bin_dir}/spurd'"
         )
+        label_args = ""
+        labels = self.agent_labels.get(node_index, {})
+        if labels:
+            label_args = " ".join(f"--label '{k}={v}'" for k, v in labels.items())
+            label_args = f" {label_args}"
         return (
             f"nohup {spurd_bin} "
             f"-f '{self.etc_dir}/spur.conf' "
             f"--controller '{self.controller_addr}' "
             f"--listen '{agent_listen}' "
-            f"--hostname '{hostname}' --address '{address}' --log-level info -D "
+            f"--hostname '{hostname}' --address '{address}' --log-level info -D"
+            f"{label_args} "
             f"> '{self.log_dir}/spurd.log' 2>&1 & echo $!"
         )
 
@@ -701,6 +714,7 @@ mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
         for name in self.node_names:
             if name not in sinfo_output:
                 return False
+        total_idle = 0
         for line in sinfo_output.splitlines():
             if "idle" not in line:
                 continue
@@ -708,12 +722,10 @@ mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
             for j, field in enumerate(fields):
                 if field == "idle" and j > 0:
                     try:
-                        n = int(fields[j - 1])
-                        if n >= len(self.node_names):
-                            return True
+                        total_idle += int(fields[j - 1])
                     except ValueError:
                         pass
-        return False
+        return total_idle >= len(self.node_names)
 
 
 # --- Job helpers ---

--- a/tests/e2e/native_host/conftest.py
+++ b/tests/e2e/native_host/conftest.py
@@ -105,11 +105,14 @@ def _ensure_bins(ssh_nodes, remote_bin_dir):
     ensure_bins(ssh_nodes, _get_binaries_dir(), remote_bin_dir)
 
 
-def _deploy_cluster(ssh_nodes, remote_bin_dir, *, agent_as_root: bool = False):
+def _deploy_cluster(ssh_nodes, remote_bin_dir, *, agent_as_root: bool = False,
+                    config_overrides: dict | None = None,
+                    agent_labels: dict[int, dict[str, str]] | None = None):
     """Helper: create, deploy, and return a SpurCluster. Tears down on deploy failure."""
     c = SpurCluster(ssh_nodes, make_remote_dir(), remote_bin_dir)
     try:
-        c.deploy(agent_as_root=agent_as_root)
+        c.deploy(config_overrides=config_overrides, agent_as_root=agent_as_root,
+                 agent_labels=agent_labels)
     except Exception:
         c.teardown()
         raise
@@ -195,5 +198,40 @@ def gpu_cluster(request, ssh_nodes, remote_bin_dir):
 
     as_root = request.node.get_closest_marker("rootful") is not None
     c = _deploy_cluster(ssh_nodes, remote_bin_dir, agent_as_root=as_root)
+    yield c
+    c.teardown()
+
+
+@pytest.fixture(scope="class")
+def label_cluster(ssh_nodes, remote_bin_dir):
+    """Class-scoped cluster for node label and partition selector tests."""
+    if len(ssh_nodes) < 2:
+        pytest.skip(
+            f"Label cluster requires at least 2 nodes in SPUR_TEST_NODES "
+            f"(got {len(ssh_nodes)})"
+        )
+
+    c = _deploy_cluster(
+        ssh_nodes,
+        remote_bin_dir,
+        config_overrides={
+            "partitions": [
+                {
+                    "name": "gpu",
+                    "state": "UP",
+                    "selector": {"gpu": "mi300x"},
+                    "max_time": "1:00:00",
+                },
+                {
+                    "name": "catchall",
+                    "state": "UP",
+                    "default": True,
+                    "nodes": "ALL",
+                    "max_time": "1:00:00",
+                },
+            ],
+        },
+        agent_labels={0: {"gpu": "mi300x"}},
+    )
     yield c
     c.teardown()

--- a/tests/e2e/native_host/test_node_labels.py
+++ b/tests/e2e/native_host/test_node_labels.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for node labels and partition selector routing."""
+
+import time
+
+
+class TestNodeLabels:
+    """Node label registration, selector routing, and admin mutation."""
+
+    def test_agent_registers_with_labels(self, label_cluster):
+        """Labels passed via --label appear in scontrol show node output."""
+        node_name = label_cluster.node_names[0]
+        out = label_cluster.scontrol("show", "node", node_name)
+        assert "Labels=gpu=mi300x" in out, (
+            f"expected Labels=gpu=mi300x in scontrol output for {node_name}:\n{out}"
+        )
+
+    def test_selector_partition_routes_labeled_node(self, label_cluster):
+        """Only the labeled node appears in the selector-based partition."""
+        out = label_cluster.sinfo()
+        node0 = label_cluster.node_names[0]
+        node1 = label_cluster.node_names[1]
+
+        gpu_lines = [l for l in out.splitlines() if "gpu" in l.split()[0:1]]
+        gpu_text = "\n".join(gpu_lines)
+
+        assert node0 in gpu_text, (
+            f"expected {node0} in gpu partition, sinfo:\n{out}"
+        )
+        assert node1 not in gpu_text, (
+            f"expected {node1} NOT in gpu partition, sinfo:\n{out}"
+        )
+
+    def test_all_wildcard_includes_all_nodes(self, label_cluster):
+        """The ALL-wildcard partition includes every node regardless of labels."""
+        out = label_cluster.sinfo()
+        node0 = label_cluster.node_names[0]
+        node1 = label_cluster.node_names[1]
+
+        catchall_lines = [l for l in out.splitlines() if l.split() and l.split()[0].startswith("catchall")]
+        catchall_text = "\n".join(catchall_lines)
+
+        assert node0 in catchall_text, (
+            f"expected {node0} in catchall partition via ALL wildcard, sinfo:\n{out}"
+        )
+        assert node1 in catchall_text, (
+            f"expected {node1} in catchall partition via ALL wildcard, sinfo:\n{out}"
+        )
+
+    def test_admin_label_update_reroutes_partition(self, label_cluster):
+        """Adding a label via CLI routes the node into the partition; removing it unroutes."""
+        node1 = label_cluster.node_names[1]
+
+        # Node 1 should NOT be in gpu partition initially
+        out = label_cluster.sinfo()
+        gpu_lines = [l for l in out.splitlines() if "gpu" in l.split()[0:1]]
+        gpu_text = "\n".join(gpu_lines)
+        assert node1 not in gpu_text, (
+            f"precondition: {node1} should not be in gpu partition:\n{out}"
+        )
+
+        # Add label → node joins gpu partition
+        label_cluster.cli(["spur", "node", "label", node1, "gpu=mi300x"])
+        time.sleep(2)
+
+        out = label_cluster.scontrol("show", "node", node1)
+        assert "Labels=gpu=mi300x" in out, (
+            f"after adding label, expected Labels=gpu=mi300x:\n{out}"
+        )
+        out = label_cluster.sinfo()
+        gpu_lines = [l for l in out.splitlines() if "gpu" in l.split()[0:1]]
+        gpu_text = "\n".join(gpu_lines)
+        assert node1 in gpu_text, (
+            f"after adding label, expected {node1} in gpu partition:\n{out}"
+        )
+
+        # Remove label → node leaves gpu partition
+        label_cluster.cli(["spur", "node", "label", node1, "gpu-"])
+        time.sleep(2)
+
+        out = label_cluster.sinfo()
+        gpu_lines = [l for l in out.splitlines() if "gpu" in l.split()[0:1]]
+        gpu_text = "\n".join(gpu_lines)
+        assert node1 not in gpu_text, (
+            f"after removing label, expected {node1} NOT in gpu partition:\n{out}"
+        )

--- a/tests/e2e/native_host/test_node_labels.py
+++ b/tests/e2e/native_host/test_node_labels.py
@@ -6,6 +6,21 @@
 import time
 
 
+def _wait_node_in_partition(cluster, node_name, partition, present=True, timeout=10):
+    """Poll sinfo until node appears/disappears in partition."""
+    deadline = time.time() + timeout
+    out = ""
+    while time.time() < deadline:
+        out = cluster.sinfo()
+        lines = [l for l in out.splitlines() if partition in l.split()[0:1]]
+        found = node_name in "\n".join(lines)
+        if found == present:
+            return out
+        time.sleep(0.5)
+    verb = "appear in" if present else "disappear from"
+    assert False, f"{node_name} did not {verb} {partition} within {timeout}s:\n{out}"
+
+
 class TestNodeLabels:
     """Node label registration, selector routing, and admin mutation."""
 
@@ -63,26 +78,13 @@ class TestNodeLabels:
 
         # Add label → node joins gpu partition
         label_cluster.cli(["spur", "node", "label", node1, "gpu=mi300x"])
-        time.sleep(2)
+        _wait_node_in_partition(label_cluster, node1, "gpu", present=True)
 
         out = label_cluster.scontrol("show", "node", node1)
         assert "Labels=gpu=mi300x" in out, (
             f"after adding label, expected Labels=gpu=mi300x:\n{out}"
         )
-        out = label_cluster.sinfo()
-        gpu_lines = [l for l in out.splitlines() if "gpu" in l.split()[0:1]]
-        gpu_text = "\n".join(gpu_lines)
-        assert node1 in gpu_text, (
-            f"after adding label, expected {node1} in gpu partition:\n{out}"
-        )
 
         # Remove label → node leaves gpu partition
         label_cluster.cli(["spur", "node", "label", node1, "gpu-"])
-        time.sleep(2)
-
-        out = label_cluster.sinfo()
-        gpu_lines = [l for l in out.splitlines() if "gpu" in l.split()[0:1]]
-        gpu_text = "\n".join(gpu_lines)
-        assert node1 not in gpu_text, (
-            f"after removing label, expected {node1} NOT in gpu partition:\n{out}"
-        )
+        _wait_node_in_partition(label_cluster, node1, "gpu", present=False)


### PR DESCRIPTION
## Summary

- Nodes can carry arbitrary key-value labels, set at registration via `--label` / `SPUR_NODE_LABELS` or dynamically via `spur node label key=value`
- Partition membership is determined by a union of hostname pattern (`nodes=`) OR label selector (`selector = { key = "value" }`) — both can be specified
- `nodes = "ALL"` is treated as a true wildcard matching any node
- Labels are durable (WAL-backed), sync on re-registration, and trigger partition re-routing and NodeConfig feature/weight re-application when changed
- Labels are visible in `scontrol show node` output
- NodeInfo proto changed from `string partition` to `repeated string partitions` — one record per node with all partitions listed (matches Slurm REST API design, fixes double-counting in spur-cloud GPU pools)
- sinfo does client-side fan-out for partition display; scontrol shows `Partitions=x,y`

## Motivation

Static hostname-based partition membership requires config changes and controller restarts when nodes are added or repurposed. Label selectors allow dynamic partition routing — nodes self-describe their role at registration and the controller routes them to the correct partition without config changes.

## Test plan

- [x] 10 unit tests covering matching logic, label updates, re-registration, and NodeConfig application
- [x] Integration tested on 3-node bare-metal cluster: registration with labels, selector routing, admin label set/remove, re-registration sync, ALL wildcard
- [x] 4 e2e tests (pytest) covering label registration, selector partition routing, ALL wildcard inclusion, and admin label mutation
- [x] Verified sinfo/scontrol/REST output matches Slurm 25.11 behavior for multi-partition nodes