### PR TITLE
feat(spur): add OUT_OF_MEMORY job state from cgroup OOM detection

### DIFF
--- a/crates/spur-core/src/array.rs
+++ b/crates/spur-core/src/array.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 ///
 /// `None` while any task is non-terminal (or the slice is empty). Once all
 /// tasks are terminal: `Completed` iff all completed, else the worst terminal
-/// state by [`Failed > Deadline > NodeFail > Timeout > Cancelled`].
+/// state by [`OutOfMemory > Failed > Deadline > NodeFail > Timeout > Cancelled`].
 pub fn aggregate_array_state(task_states: &[JobState]) -> Option<JobState> {
     if task_states.is_empty() {
         return None;
@@ -33,7 +33,10 @@ pub fn aggregate_array_state(task_states: &[JobState]) -> Option<JobState> {
     // Worst-state precedence. Exhaustive (no catch-all) so a new JobState can't
     // be silently swallowed at rank 0, masking a failure.
     let rank = |s: &JobState| match s {
-        JobState::Failed | JobState::OutOfMemory => 5,
+        // OutOfMemory outranks Failed so it deterministically wins on ties
+        // rather than depending on iteration order.
+        JobState::OutOfMemory => 6,
+        JobState::Failed => 5,
         JobState::Deadline => 4,
         JobState::NodeFail => 3,
         JobState::Timeout => 2,
@@ -286,6 +289,19 @@ mod tests {
         assert_eq!(
             aggregate_array_state(&[JobState::Deadline, JobState::Failed]),
             Some(JobState::Failed)
+        );
+    }
+
+    #[test]
+    fn test_aggregate_oom_outranks_failed_regardless_of_order() {
+        // OOM must deterministically win over a generic Failed sibling.
+        assert_eq!(
+            aggregate_array_state(&[JobState::Failed, JobState::OutOfMemory]),
+            Some(JobState::OutOfMemory)
+        );
+        assert_eq!(
+            aggregate_array_state(&[JobState::OutOfMemory, JobState::Failed]),
+            Some(JobState::OutOfMemory)
         );
     }
 }

--- a/crates/spur-core/src/array.rs
+++ b/crates/spur-core/src/array.rs
@@ -33,7 +33,7 @@ pub fn aggregate_array_state(task_states: &[JobState]) -> Option<JobState> {
     // Worst-state precedence. Exhaustive (no catch-all) so a new JobState can't
     // be silently swallowed at rank 0, masking a failure.
     let rank = |s: &JobState| match s {
-        JobState::Failed => 5,
+        JobState::Failed | JobState::OutOfMemory => 5,
         JobState::Deadline => 4,
         JobState::NodeFail => 3,
         JobState::Timeout => 2,

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -26,7 +26,12 @@ pub enum JobState {
     Preempted,
     Suspended,
     Deadline,
+    OutOfMemory,
 }
+
+/// Sentinel bit spurd OR's into a completion `signal` for an OOM kill, so the
+/// controller maps it to `JobState::OutOfMemory`; low bits keep the real signal.
+pub const OOM_SIGNAL_FLAG: i32 = 0x1000;
 
 impl JobState {
     /// Short code used in squeue output (matches Slurm).
@@ -43,6 +48,7 @@ impl JobState {
             Self::Preempted => "PR",
             Self::Suspended => "S",
             Self::Deadline => "DL",
+            Self::OutOfMemory => "OOM",
         }
     }
 
@@ -60,6 +66,7 @@ impl JobState {
             Self::Preempted => "PREEMPTED",
             Self::Suspended => "SUSPENDED",
             Self::Deadline => "DEADLINE",
+            Self::OutOfMemory => "OUT_OF_MEMORY",
         }
     }
 
@@ -72,6 +79,7 @@ impl JobState {
                 | Self::Timeout
                 | Self::NodeFail
                 | Self::Deadline
+                | Self::OutOfMemory
         )
     }
 
@@ -113,7 +121,7 @@ impl JobState {
     }
 
     /// Every core variant, in proto discriminant order for iteration only.
-    pub const ALL: [JobState; 11] = [
+    pub const ALL: [JobState; 12] = [
         Self::Pending,
         Self::Running,
         Self::Completing,
@@ -125,6 +133,7 @@ impl JobState {
         Self::Preempted,
         Self::Suspended,
         Self::Deadline,
+        Self::OutOfMemory,
     ];
 
     pub const COUNT: usize = Self::ALL.len();
@@ -143,6 +152,7 @@ impl JobState {
             spur_proto::proto::JobState::JobPreempted => Self::Preempted,
             spur_proto::proto::JobState::JobSuspended => Self::Suspended,
             spur_proto::proto::JobState::JobDeadline => Self::Deadline,
+            spur_proto::proto::JobState::JobOutOfMemory => Self::OutOfMemory,
         }
     }
 
@@ -160,6 +170,7 @@ impl JobState {
             Self::Preempted => spur_proto::proto::JobState::JobPreempted,
             Self::Suspended => spur_proto::proto::JobState::JobSuspended,
             Self::Deadline => spur_proto::proto::JobState::JobDeadline,
+            Self::OutOfMemory => spur_proto::proto::JobState::JobOutOfMemory,
         }
     }
 
@@ -706,9 +717,11 @@ impl Job {
             (JobState::Running, JobState::NodeFail) => true,
             (JobState::Running, JobState::Preempted) => true,
             (JobState::Running, JobState::Suspended) => true,
+            (JobState::Running, JobState::OutOfMemory) => true,
             (JobState::Completing, JobState::Completed) => true,
             (JobState::Completing, JobState::Failed) => true,
             (JobState::Completing, JobState::Cancelled) => true,
+            (JobState::Completing, JobState::OutOfMemory) => true,
             (JobState::Suspended, JobState::Running) => true,
             (JobState::Suspended, JobState::Cancelled) => true,
             // Completion routes through Completing like a running job (Slurm JOB_COMPLETING).
@@ -720,6 +733,7 @@ impl Job {
             (JobState::Suspended, JobState::Failed) => true,
             (JobState::Suspended, JobState::Timeout) => true,
             (JobState::Suspended, JobState::NodeFail) => true,
+            (JobState::Suspended, JobState::OutOfMemory) => true,
             // Requeue transitions: terminal → Pending (for --requeue jobs)
             (JobState::Timeout, JobState::Pending) => true,
             (JobState::Preempted, JobState::Pending) => true,
@@ -1045,6 +1059,42 @@ mod tests {
     }
 
     #[test]
+    fn out_of_memory_state_terminal_and_reachable_from_active() {
+        assert!(JobState::OutOfMemory.is_terminal());
+        assert!(!JobState::OutOfMemory.is_active());
+        assert_eq!(JobState::OutOfMemory.code(), "OOM");
+        assert_eq!(JobState::OutOfMemory.display(), "OUT_OF_MEMORY");
+
+        // Running -> OutOfMemory (direct), Completing -> OutOfMemory, and
+        // Suspended -> OutOfMemory are all legal; Pending is not.
+        let mut r = make_job();
+        r.transition(JobState::Running).unwrap();
+        r.transition(JobState::OutOfMemory).unwrap();
+        assert_eq!(r.state, JobState::OutOfMemory);
+        assert!(r.end_time.is_some());
+
+        let mut c = make_job();
+        c.transition(JobState::Running).unwrap();
+        c.transition(JobState::Completing).unwrap();
+        c.transition(JobState::OutOfMemory).unwrap();
+        assert_eq!(c.state, JobState::OutOfMemory);
+
+        let mut p = make_job();
+        assert!(p.transition(JobState::OutOfMemory).is_err());
+    }
+
+    #[test]
+    #[allow(clippy::assertions_on_constants)]
+    fn oom_signal_flag_is_outside_real_signal_range() {
+        // The sentinel must not collide with any real terminating signal (1..=64)
+        // and must be cleanly strippable to recover the underlying SIGKILL.
+        assert!(OOM_SIGNAL_FLAG > 64);
+        let encoded = OOM_SIGNAL_FLAG | 9;
+        assert_ne!(encoded & OOM_SIGNAL_FLAG, 0);
+        assert_eq!(encoded & !OOM_SIGNAL_FLAG, 9);
+    }
+
+    #[test]
     fn deadline_reason_displays_slurm_string() {
         // Slurm reports this exact string ("DeadLine", note the cap D and L).
         // squeue scrapers and Slurm-compat clients pattern-match on it.
@@ -1100,6 +1150,7 @@ mod tests {
             (P::JobPreempted, JobState::Preempted),
             (P::JobSuspended, JobState::Suspended),
             (P::JobDeadline, JobState::Deadline),
+            (P::JobOutOfMemory, JobState::OutOfMemory),
         ];
 
         assert_eq!(TABLE.len(), JobState::COUNT);

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -492,8 +492,14 @@ async fn watch_pods(ctx: Arc<JobControllerCtx>) -> anyhow::Result<()> {
                 info!(job_id, pod = %pod_name, phase, "reporting Pod completion to spurctld");
 
                 let mut ctrl = ctx.ctrl_client.lock().await;
-                let report_state =
-                    spur_core::job::JobState::completion_state_for_exit_code(final_exit_code);
+                // Honor a specific failure state (e.g. OUT_OF_MEMORY from an
+                // OOMKilled container); otherwise derive from the exit code.
+                let report_state = if state == spur_core::job::JobState::OutOfMemory.to_proto_i32()
+                {
+                    spur_core::job::JobState::OutOfMemory
+                } else {
+                    spur_core::job::JobState::completion_state_for_exit_code(final_exit_code)
+                };
                 let req = ReportJobStatusRequest {
                     job_id,
                     state: report_state.to_proto_i32(),
@@ -552,7 +558,7 @@ fn extract_failure_details(pod: &Pod) -> (i32, i32, String) {
 
                     if reason == "OOMKilled" {
                         return (
-                            4,
+                            spur_core::job::JobState::OutOfMemory.to_proto_i32(),
                             exit_code,
                             "OOMKilled: container exceeded memory limit".into(),
                         );
@@ -926,7 +932,7 @@ mod tests {
         };
 
         let (state, exit_code, message) = extract_failure_details(&pod);
-        assert_eq!(state, 4);
+        assert_eq!(state, spur_core::job::JobState::OutOfMemory.to_proto_i32());
         assert_eq!(exit_code, 137);
         assert!(message.contains("OOMKilled"));
     }

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -59,6 +59,7 @@ pub(crate) struct PodTracker {
     expected: usize,
     completed: usize,
     failed: bool,
+    oom: bool,
     exit_code: i32,
     message: String,
 }
@@ -388,18 +389,19 @@ async fn watch_pods(ctx: Arc<JobControllerCtx>) -> anyhow::Result<()> {
                 false
             };
 
-            // Extract richer status from container statuses
-            let (state, exit_code, message) = if pending_failure {
+            // Extract richer status from container statuses. `oom` carries an
+            // OOMKilled container out-of-band; the wire state stays Failed.
+            let (state, exit_code, message, oom) = if pending_failure {
                 let msg = pod
                     .status
                     .as_ref()
                     .and_then(|s| s.message.as_deref())
                     .unwrap_or("Pod rejected by kubelet before starting")
                     .to_string();
-                (4i32, 1i32, msg) // JOB_FAILED
+                (4i32, 1i32, msg, false) // JOB_FAILED
             } else {
                 match phase {
-                    "Succeeded" => (3, 0, String::new()), // JOB_COMPLETED
+                    "Succeeded" => (3, 0, String::new(), false), // JOB_COMPLETED
                     "Failed" => extract_failure_details(&pod),
                     _ => continue,
                 }
@@ -419,6 +421,7 @@ async fn watch_pods(ctx: Arc<JobControllerCtx>) -> anyhow::Result<()> {
                         expected: 0, // unknown
                         completed: 0,
                         failed: false,
+                        oom: false,
                         exit_code: 0,
                         message: String::new(),
                     }
@@ -427,6 +430,7 @@ async fn watch_pods(ctx: Arc<JobControllerCtx>) -> anyhow::Result<()> {
                 if state == 4 {
                     // JOB_FAILED
                     entry.failed = true;
+                    entry.oom = oom;
                     entry.exit_code = exit_code;
                     entry.message = message.clone();
                     // Report immediately on first failure
@@ -447,6 +451,11 @@ async fn watch_pods(ctx: Arc<JobControllerCtx>) -> anyhow::Result<()> {
                         .get(&job_id)
                         .map(|t| if t.failed { t.exit_code } else { exit_code })
                         .unwrap_or(exit_code)
+                };
+
+                let final_oom = {
+                    let tracker = ctx.pod_tracker.lock().await;
+                    tracker.get(&job_id).map(|t| t.oom).unwrap_or(oom)
                 };
 
                 let final_message = {
@@ -492,19 +501,22 @@ async fn watch_pods(ctx: Arc<JobControllerCtx>) -> anyhow::Result<()> {
                 info!(job_id, pod = %pod_name, phase, "reporting Pod completion to spurctld");
 
                 let mut ctrl = ctx.ctrl_client.lock().await;
-                // Honor a specific failure state (e.g. OUT_OF_MEMORY from an
-                // OOMKilled container); otherwise derive from the exit code.
-                let report_state = if state == spur_core::job::JobState::OutOfMemory.to_proto_i32()
-                {
-                    spur_core::job::JobState::OutOfMemory
+                // OOM is encoded via the signal sentinel so the wire state stays a
+                // valid completion report; spurctld maps it to OUT_OF_MEMORY.
+                let (report_state, report_exit, report_signal) = if final_oom {
+                    (spur_core::job::JobState::Completed, 0, OOM_KILL_SIGNAL)
                 } else {
-                    spur_core::job::JobState::completion_state_for_exit_code(final_exit_code)
+                    (
+                        spur_core::job::JobState::completion_state_for_exit_code(final_exit_code),
+                        final_exit_code,
+                        0,
+                    )
                 };
                 let req = ReportJobStatusRequest {
                     job_id,
                     state: report_state.to_proto_i32(),
-                    exit_code: final_exit_code,
-                    signal: 0,
+                    exit_code: report_exit,
+                    signal: report_signal,
                     message: final_message,
                     drain_node: false,
                     drain_reason: String::new(),
@@ -524,6 +536,9 @@ async fn watch_pods(ctx: Arc<JobControllerCtx>) -> anyhow::Result<()> {
 
 const TARGET_NODE_LABEL: &str = "spur.ai/target-node";
 
+/// SIGKILL (9) with the OOM sentinel bit set; spurctld strips it and maps to OUT_OF_MEMORY.
+const OOM_KILL_SIGNAL: i32 = 9 | spur_core::job::OOM_SIGNAL_FLAG;
+
 /// Resolve the Spur node name for a terminal Pod completion report.
 fn resolve_reporting_node(pod: &Pod) -> Option<String> {
     pod.spec
@@ -542,10 +557,13 @@ fn resolve_reporting_node(pod: &Pod) -> Option<String> {
 }
 
 /// Extract failure details from a Failed pod's container statuses.
-fn extract_failure_details(pod: &Pod) -> (i32, i32, String) {
+/// Returns `(wire_state, exit_code, message, oom)`. OOMKilled keeps the wire
+/// state JOB_FAILED and flags `oom` so the caller can encode it via the signal
+/// sentinel; spurctld maps that to OUT_OF_MEMORY at finalization.
+fn extract_failure_details(pod: &Pod) -> (i32, i32, String, bool) {
     let status = match pod.status.as_ref() {
         Some(s) => s,
-        None => return (4, 1, "Pod failed (no status)".into()),
+        None => return (4, 1, "Pod failed (no status)".into(), false),
     };
 
     if let Some(container_statuses) = &status.container_statuses {
@@ -558,9 +576,10 @@ fn extract_failure_details(pod: &Pod) -> (i32, i32, String) {
 
                     if reason == "OOMKilled" {
                         return (
-                            spur_core::job::JobState::OutOfMemory.to_proto_i32(),
+                            4,
                             exit_code,
                             "OOMKilled: container exceeded memory limit".into(),
+                            true,
                         );
                     }
 
@@ -571,19 +590,19 @@ fn extract_failure_details(pod: &Pod) -> (i32, i32, String) {
                     } else {
                         format!("exit_code={}", exit_code)
                     };
-                    return (4, exit_code, msg);
+                    return (4, exit_code, msg, false);
                 }
                 if let Some(waiting) = &state.waiting {
                     let reason = waiting.reason.clone().unwrap_or_default();
                     if reason == "ImagePullBackOff" || reason == "ErrImagePull" {
-                        return (4, 1, format!("Image pull failed: {}", reason));
+                        return (4, 1, format!("Image pull failed: {}", reason), false);
                     }
                 }
             }
         }
     }
 
-    (4, 1, "Pod failed".into())
+    (4, 1, "Pod failed".into(), false)
 }
 
 /// Clean up orphan Pods on startup — Pods with spur labels but no matching SpurJob.
@@ -931,8 +950,9 @@ mod tests {
             }),
         };
 
-        let (state, exit_code, message) = extract_failure_details(&pod);
-        assert_eq!(state, spur_core::job::JobState::OutOfMemory.to_proto_i32());
+        let (state, exit_code, message, oom) = extract_failure_details(&pod);
+        assert_eq!(state, 4, "OOM keeps wire state JOB_FAILED");
+        assert!(oom, "OOM flagged out-of-band for the signal sentinel");
         assert_eq!(exit_code, 137);
         assert!(message.contains("OOMKilled"));
     }
@@ -964,7 +984,7 @@ mod tests {
             }),
         };
 
-        let (state, exit_code, message) = extract_failure_details(&pod);
+        let (state, exit_code, message, _oom) = extract_failure_details(&pod);
         assert_eq!(state, 4);
         assert_eq!(exit_code, 42);
         assert!(message.contains("exit_code=42"));
@@ -997,7 +1017,7 @@ mod tests {
             }),
         };
 
-        let (state, exit_code, message) = extract_failure_details(&pod);
+        let (state, exit_code, message, _oom) = extract_failure_details(&pod);
         assert_eq!(state, 4);
         assert_eq!(exit_code, 1);
         assert_eq!(message, "Error: segfault in main");
@@ -1030,7 +1050,7 @@ mod tests {
             }),
         };
 
-        let (_, _, message) = extract_failure_details(&pod);
+        let (_, _, message, _oom) = extract_failure_details(&pod);
         assert_eq!(message, "DeadlineExceeded");
     }
 
@@ -1059,7 +1079,7 @@ mod tests {
             }),
         };
 
-        let (state, exit_code, message) = extract_failure_details(&pod);
+        let (state, exit_code, message, _oom) = extract_failure_details(&pod);
         assert_eq!(state, 4);
         assert_eq!(exit_code, 1);
         assert!(message.contains("ImagePullBackOff"));
@@ -1090,7 +1110,7 @@ mod tests {
             }),
         };
 
-        let (state, _, message) = extract_failure_details(&pod);
+        let (state, _, message, _oom) = extract_failure_details(&pod);
         assert_eq!(state, 4);
         assert!(message.contains("ErrImagePull"));
     }
@@ -1102,7 +1122,7 @@ mod tests {
             spec: None,
             status: None,
         };
-        let (state, exit_code, message) = extract_failure_details(&pod);
+        let (state, exit_code, message, _oom) = extract_failure_details(&pod);
         assert_eq!(state, 4);
         assert_eq!(exit_code, 1);
         assert_eq!(message, "Pod failed (no status)");
@@ -1120,7 +1140,7 @@ mod tests {
                 ..Default::default()
             }),
         };
-        let (state, exit_code, message) = extract_failure_details(&pod);
+        let (state, exit_code, message, _oom) = extract_failure_details(&pod);
         assert_eq!(state, 4);
         assert_eq!(exit_code, 1);
         assert_eq!(message, "Pod failed");
@@ -1138,7 +1158,7 @@ mod tests {
                 ..Default::default()
             }),
         };
-        let (state, exit_code, message) = extract_failure_details(&pod);
+        let (state, exit_code, message, _oom) = extract_failure_details(&pod);
         assert_eq!(state, 4);
         assert_eq!(exit_code, 1);
         assert_eq!(message, "Pod failed");

--- a/crates/spur-metrics/src/export/jobs.rs
+++ b/crates/spur-metrics/src/export/jobs.rs
@@ -25,6 +25,7 @@ pub fn job_state_metric_suffix(state: JobState) -> &'static str {
         JobState::Preempted => "preempted",
         JobState::Suspended => "suspended",
         JobState::Deadline => "deadline",
+        JobState::OutOfMemory => "out_of_memory",
     }
 }
 

--- a/crates/spur-metrics/tests/fixtures/jobs.openmetrics_1_0.prom
+++ b/crates/spur-metrics/tests/fixtures/jobs.openmetrics_1_0.prom
@@ -34,6 +34,9 @@ spur_jobs_suspended 0
 # HELP spur_jobs_deadline Number of jobs in DEADLINE state.
 # TYPE spur_jobs_deadline gauge
 spur_jobs_deadline 0
+# HELP spur_jobs_out_of_memory Number of jobs in OUT_OF_MEMORY state.
+# TYPE spur_jobs_out_of_memory gauge
+spur_jobs_out_of_memory 0
 # HELP spur_jobs_cpus_alloc Total CPUs allocated to jobs in Running or Completing state.
 # TYPE spur_jobs_cpus_alloc gauge
 spur_jobs_cpus_alloc 4

--- a/crates/spur-metrics/tests/fixtures/jobs.slurm_0_0_4.prom
+++ b/crates/spur-metrics/tests/fixtures/jobs.slurm_0_0_4.prom
@@ -34,6 +34,9 @@ spur_jobs_suspended 0
 # HELP spur_jobs_deadline Number of jobs in DEADLINE state.
 # TYPE spur_jobs_deadline gauge
 spur_jobs_deadline 0
+# HELP spur_jobs_out_of_memory Number of jobs in OUT_OF_MEMORY state.
+# TYPE spur_jobs_out_of_memory gauge
+spur_jobs_out_of_memory 0
 # HELP spur_jobs_cpus_alloc Total CPUs allocated to jobs in Running or Completing state.
 # TYPE spur_jobs_cpus_alloc gauge
 spur_jobs_cpus_alloc 4

--- a/crates/spur-tests/src/t55_format.rs
+++ b/crates/spur-tests/src/t55_format.rs
@@ -64,6 +64,7 @@ mod tests {
             ("PR", "PREEMPTED"),
             ("S", "SUSPENDED"),
             ("DL", "DEADLINE"),
+            ("OOM", "OUT_OF_MEMORY"),
         ];
         assert_eq!(JobState::ALL.len(), expected.len());
         for (i, state) in JobState::ALL.iter().enumerate() {

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1964,8 +1964,21 @@ impl ClusterManager {
                         // none allocated, where derived_completion falls back to
                         // the worst completion.
                         let primary = job.allocated_nodes.first().cloned().unwrap_or_default();
-                        let (final_state, final_exit, final_signal) =
+                        // spurd flags an OOM kill via a sentinel bit in the signal;
+                        // detect it, then strip the bit so the stored signal is the
+                        // real SIGKILL and the job reports OUT_OF_MEMORY.
+                        let oom = job
+                            .node_completions
+                            .values()
+                            .any(|c| c.signal & spur_core::job::OOM_SIGNAL_FLAG != 0);
+                        let (derived_state, final_exit, raw_signal) =
                             Job::derived_completion(&job.node_completions, &primary);
+                        let final_signal = raw_signal & !spur_core::job::OOM_SIGNAL_FLAG;
+                        let final_state = if oom {
+                            JobState::OutOfMemory
+                        } else {
+                            derived_state
+                        };
                         match job.transition(final_state) {
                             Ok(()) => {
                                 job.exit_code = Some(final_exit);
@@ -1974,7 +1987,9 @@ impl ClusterManager {
                                 // steps, accumulated live by JobStepComplete; a
                                 // job with no srun steps keeps 0 (Slurm parity),
                                 // not the batch exit. Left as-is here.
-                                job.pending_reason = if final_signal != 0 {
+                                job.pending_reason = if oom {
+                                    PendingReason::OutOfMemory
+                                } else if final_signal != 0 {
                                     PendingReason::RaisedSignal
                                 } else if final_exit != 0 {
                                     PendingReason::NonZeroExitCode
@@ -3225,6 +3240,45 @@ mod tests {
         assert_eq!(job.state, JobState::Completed);
         assert_eq!(job.exit_code, Some(0));
         assert!(job.node_completions.is_empty());
+        assert_eq!(cm.get_node("worker1").unwrap().alloc_resources.cpus, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn apply_job_node_complete_oom_sets_out_of_memory() {
+        // spurd reports an OOM kill as SIGKILL with the OOM sentinel bit OR'd in.
+        // The job must finalize as OUT_OF_MEMORY / Reason=OutOfMemory, with the
+        // sentinel stripped so the stored signal is the real SIGKILL (9).
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("oom")),
+        });
+        cm.apply_operation(&WalOperation::JobStateChange {
+            job_id: 1,
+            old_state: JobState::Pending,
+            new_state: JobState::Running,
+        });
+        let alloc = scalar_alloc(2, 4000);
+        cm.apply_operation(&WalOperation::JobStart {
+            job_id: 1,
+            nodes: vec!["worker1".into()],
+            resources: alloc.clone(),
+            per_node_alloc: per_node_for(&["worker1"], alloc),
+        });
+
+        cm.apply_operation(&WalOperation::JobNodeComplete {
+            job_id: 1,
+            node_name: "worker1".into(),
+            exit_code: 0,
+            signal: spur_core::job::OOM_SIGNAL_FLAG | 9,
+        });
+
+        let job = cm.get_job(1).unwrap();
+        assert_eq!(job.state, JobState::OutOfMemory);
+        assert_eq!(job.pending_reason, PendingReason::OutOfMemory);
+        assert_eq!(job.exit_signal, 9, "OOM sentinel must be stripped");
         assert_eq!(cm.get_node("worker1").unwrap().alloc_resources.cpus, 0);
     }
 

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -156,7 +156,17 @@ impl AgentService {
 
                 for (job_id, tracked) in jobs.iter_mut() {
                     match tracked.job.try_wait() {
-                        Ok(Some((exit_code, signal))) => {
+                        Ok(Some((exit_code, mut signal))) => {
+                            // Disambiguate an OOM kill (cgroup memory.events) from
+                            // a plain SIGKILL by OR'ing a sentinel into the reported
+                            // signal; read before cleanup_cgroup removes the dir.
+                            let cgroup = tracked.job.take_cgroup();
+                            if let Some(ref cg) = cgroup {
+                                if crate::executor::cgroup_oom_killed(cg) {
+                                    warn!(job_id, "job OOM-killed (cgroup oom_kill > 0)");
+                                    signal |= spur_core::job::OOM_SIGNAL_FLAG;
+                                }
+                            }
                             info!(job_id, exit_code, signal, "job finished");
                             completed.push(CompletedJob {
                                 job_id: *job_id,
@@ -164,7 +174,7 @@ impl AgentService {
                                 signal,
                                 rootfs_mode: tracked.rootfs_mode.clone(),
                                 allocation: tracked.allocation.take(),
-                                cgroup: tracked.job.take_cgroup(),
+                                cgroup,
                                 work_dir: tracked.work_dir.clone(),
                                 uid: tracked.uid,
                                 gid: tracked.gid,

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -542,10 +542,25 @@ fn setup_cgroup(
     memory_mb: u64,
     cpu_ids: &[u32],
 ) -> anyhow::Result<Option<PathBuf>> {
-    let cgroup_path = PathBuf::from(CGROUP_ROOT).join(format!("job_{}", job_id));
+    let cgroup_root = PathBuf::from(CGROUP_ROOT);
+    let cgroup_path = cgroup_root.join(format!("job_{}", job_id));
 
-    // Try to create cgroup — when running as root, failure is fatal.
-    // Non-root is expected to fail (development/test environments).
+    // Delegate controllers to children: in cgroup-v2 a child only gets
+    // memory.*/cpu.*/pids.* files if the parent lists them in subtree_control;
+    // without this the per-job memory limit is never enforced. Root failure fatal.
+    if let Err(e) = std::fs::create_dir_all(&cgroup_root) {
+        if nix::unistd::geteuid().is_root() {
+            anyhow::bail!("cgroup root creation failed as root: {}", e);
+        }
+        warn!(job_id, error = %e, "cgroup creation failed (not root), running without isolation");
+        return Ok(None);
+    }
+    let subtree = cgroup_root.join("cgroup.subtree_control");
+    for ctrl in ["+memory", "+cpu", "+pids", "+cpuset"] {
+        if let Err(e) = std::fs::write(&subtree, ctrl) {
+            warn!(job_id, controller = ctrl, error = %e, "failed to delegate cgroup controller");
+        }
+    }
     if let Err(e) = std::fs::create_dir_all(&cgroup_path) {
         if nix::unistd::geteuid().is_root() {
             anyhow::bail!("cgroup creation failed as root: {}", e);
@@ -626,6 +641,18 @@ fn move_to_cgroup(cgroup_path: &Path, pid: u32) -> bool {
 }
 
 /// Clean up a job's cgroup.
+/// Whether the job's cgroup recorded an OOM kill (cgroup-v2 `memory.events`).
+/// False if the file is absent/unreadable. Call before `cleanup_cgroup`.
+pub fn cgroup_oom_killed(cgroup_path: &Path) -> bool {
+    let Ok(events) = std::fs::read_to_string(cgroup_path.join("memory.events")) else {
+        return false;
+    };
+    events.lines().any(|line| {
+        let mut it = line.split_whitespace();
+        matches!((it.next(), it.next()), (Some("oom_kill"), Some(n)) if n != "0")
+    })
+}
+
 pub fn cleanup_cgroup(cgroup_path: &Path) {
     // Kill any remaining processes
     if let Ok(pids) = std::fs::read_to_string(cgroup_path.join("cgroup.procs")) {
@@ -1024,6 +1051,27 @@ mod tests {
             "/var/log/job-42.log"
         );
         assert_eq!(resolve_output_path("", 42, "/tmp"), "/tmp/spur-42.out");
+    }
+
+    #[test]
+    fn cgroup_oom_killed_parses_memory_events() {
+        let dir = tempfile::tempdir().unwrap();
+        // Missing file (no cgroup isolation) -> not OOM.
+        assert!(!cgroup_oom_killed(dir.path()));
+        // oom_kill 0 -> not OOM.
+        std::fs::write(
+            dir.path().join("memory.events"),
+            "low 0\nhigh 0\nmax 5\noom 0\noom_kill 0\n",
+        )
+        .unwrap();
+        assert!(!cgroup_oom_killed(dir.path()));
+        // oom_kill > 0 -> OOM.
+        std::fs::write(
+            dir.path().join("memory.events"),
+            "low 0\nhigh 0\nmax 12\noom 1\noom_kill 1\n",
+        )
+        .unwrap();
+        assert!(cgroup_oom_killed(dir.path()));
     }
 
     #[test]

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -640,7 +640,6 @@ fn move_to_cgroup(cgroup_path: &Path, pid: u32) -> bool {
     }
 }
 
-/// Clean up a job's cgroup.
 /// Whether the job's cgroup recorded an OOM kill (cgroup-v2 `memory.events`).
 /// False if the file is absent/unreadable. Call before `cleanup_cgroup`.
 pub fn cgroup_oom_killed(cgroup_path: &Path) -> bool {
@@ -653,6 +652,7 @@ pub fn cgroup_oom_killed(cgroup_path: &Path) -> bool {
     })
 }
 
+/// Kill any leftover processes in the job's cgroup and remove the directory.
 pub fn cleanup_cgroup(cgroup_path: &Path) {
     // Kill any remaining processes
     if let Ok(pids) = std::fs::read_to_string(cgroup_path.join("cgroup.procs")) {

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -61,6 +61,7 @@ enum JobState {
   JOB_PREEMPTED = 8;
   JOB_SUSPENDED = 9;
   JOB_DEADLINE = 10;
+  JOB_OUT_OF_MEMORY = 11;
 }
 
 enum NodeState {


### PR DESCRIPTION
Closes #308.

Adds the `OUT_OF_MEMORY` job state so OOM-killed jobs report `JobState=OUT_OF_MEMORY` / `Reason=OutOfMemory` instead of a generic `Failed` (or an undisambiguated SIGKILL), matching Slurm.

## How it works

- **Node agent (spurd).** After a job's processes exit, spurd reads `memory.events:oom_kill` from the job's cgroup (`cgroup_oom_killed`) before teardown. An OOM kill arrives as SIGKILL/9 — indistinguishable from a plain kill — so spurd OR's a sentinel bit (`OOM_SIGNAL_FLAG`) into the reported signal.
- **Controller (spurctld).** Detects the sentinel in the `JobNodeComplete` completion, strips it (keeping the real SIGKILL), and finalizes the job as `JobState::OutOfMemory` with `Reason=OutOfMemory`. Reuses the existing exit/signal channel — no new WAL fields; the only proto addition is the `JOB_OUT_OF_MEMORY` enum value.
- **cgroup fix.** spurd built a per-job cgroup-v2 but never delegated controllers to it, so on a systemd host the per-job `memory.max`/`memory.oom.group` had no effect and OOM was never bounded. `setup_cgroup` now enables `+memory/+cpu/+pids/+cpuset` on the cgroup root's `subtree_control` before creating the job cgroup.
- **k8s backend.** Maps its existing `OOMKilled` detection to the new state instead of generic `Failed`.

## Tests

- spur-core: state transition/terminal/display + sentinel encode/strip
- spurctld: OOM completion mapping (`OUT_OF_MEMORY` + reason + stripped signal)
- spurd: `memory.events` parser
- spur-k8s: `OOMKilled` mapping
- updated golden metrics + format/proto-discriminant tables

Full workspace: 1304 pass, 0 fail; clippy + fmt clean.

## Live verification (cgroup-v2 host, root spurd)

- `--mem 64` job allocating unbounded memory → `JobState=OUT_OF_MEMORY Reason=OutOfMemory ExitCode=0:9`
- normal job still `COMPLETED` `ExitCode=0:0` (no regression)

## Notes

- OOM detection requires spurd to run as root (cgroup creation + controller delegation); non-root falls back to "no isolation" as before.
- The k8s path is mapped but not exercised in CI (no cluster in the test env).
