### PR TITLE
feat(spurdbd): persist exit_signal and derived_exit_code for sacct

### DIFF
--- a/crates/spur-cli/src/sacct.rs
+++ b/crates/spur-cli/src/sacct.rs
@@ -67,7 +67,8 @@ pub struct SacctArgs {
 }
 
 const SACCT_DEFAULT_FORMAT: &str = "%.8i %.15j %.10u %.10a %.10P %.8T %10M %.8D %6x";
-const SACCT_LONG_FORMAT: &str = "%.8i %.15j %.10u %.10a %.10P %.8T %10M %.8D %6x %.19S %.19E %.10l";
+const SACCT_LONG_FORMAT: &str =
+    "%.8i %.15j %.10u %.10a %.10P %.8T %10M %.8D %6x %.10X %.19S %.19E %.10l";
 const SACCT_BRIEF_FORMAT: &str = "%.8i %.8T %6x";
 
 pub fn sacct_header(spec: char) -> &'static str {
@@ -82,6 +83,7 @@ pub fn sacct_header(spec: char) -> &'static str {
         'M' => "Elapsed",
         'D' => "NNodes",
         'x' => "ExitCode",
+        'X' => "DerivedExitCode",
         'S' => "Start",
         'E' => "End",
         'V' => "Submit",
@@ -182,6 +184,7 @@ fn resolve_sacct_field(job: &spur_proto::proto::JobInfo, spec: char) -> String {
         'M' => format_elapsed(job),
         'D' => job.num_nodes.to_string(),
         'x' => format_exit(job.exit_code, job.exit_signal),
+        'X' => format_exit(job.derived_exit_code, 0),
         'S' => format_timestamp(job.start_time.as_ref()),
         'E' => format_timestamp(job.end_time.as_ref()),
         'V' => format_timestamp(job.submit_time.as_ref()),
@@ -292,7 +295,27 @@ fn datetime_to_proto(dt: chrono::DateTime<chrono::Utc>) -> prost_types::Timestam
 #[cfg(test)]
 mod tests {
     use super::*;
-    use spur_proto::proto::JobState;
+    use spur_proto::proto::{JobInfo, JobState};
+
+    fn job(exit_code: i32, exit_signal: i32, derived_exit_code: i32) -> JobInfo {
+        JobInfo {
+            exit_code,
+            exit_signal,
+            derived_exit_code,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn exit_and_derived_fields_render() {
+        // %x is Slurm's code:signal (signal half must survive from accounting);
+        // %X is DerivedExitCode (running max over steps), signal half always 0.
+        let j = job(3, 9, 7);
+        assert_eq!(resolve_sacct_field(&j, 'x'), "3:9");
+        assert_eq!(resolve_sacct_field(&j, 'X'), "7:0");
+        assert_eq!(resolve_sacct_field(&job(0, 0, 0), 'x'), "0:0");
+        assert_eq!(sacct_header('X'), "DerivedExitCode");
+    }
 
     #[test]
     fn parse_acct_state_maps_deadline() {

--- a/crates/spur-cli/src/sacct.rs
+++ b/crates/spur-cli/src/sacct.rs
@@ -326,7 +326,10 @@ mod tests {
         // %l resolves to a formatted duration, or UNLIMITED when unset/zero.
         let mut j = job(0, 0, 0);
         assert_eq!(resolve_sacct_field(&j, 'l'), "UNLIMITED");
-        j.time_limit = Some(prost_types::Duration { seconds: 3600, nanos: 0 });
+        j.time_limit = Some(prost_types::Duration {
+            seconds: 3600,
+            nanos: 0,
+        });
         assert_eq!(resolve_sacct_field(&j, 'l'), format_duration(3600));
     }
 

--- a/crates/spur-cli/src/sacct.rs
+++ b/crates/spur-cli/src/sacct.rs
@@ -50,7 +50,7 @@ pub struct SacctArgs {
     pub brief: bool,
 
     /// Don't print header
-    #[arg(long)]
+    #[arg(short = 'n', long)]
     pub noheader: bool,
 
     /// Max records

--- a/crates/spur-cli/src/sacct.rs
+++ b/crates/spur-cli/src/sacct.rs
@@ -185,6 +185,10 @@ fn resolve_sacct_field(job: &spur_proto::proto::JobInfo, spec: char) -> String {
         'D' => job.num_nodes.to_string(),
         'x' => format_exit(job.exit_code, job.exit_signal),
         'X' => format_exit(job.derived_exit_code, 0),
+        'l' => match job.time_limit.as_ref() {
+            Some(d) if d.seconds > 0 => format_duration(d.seconds),
+            _ => "UNLIMITED".into(),
+        },
         'S' => format_timestamp(job.start_time.as_ref()),
         'E' => format_timestamp(job.end_time.as_ref()),
         'V' => format_timestamp(job.submit_time.as_ref()),
@@ -315,6 +319,15 @@ mod tests {
         assert_eq!(resolve_sacct_field(&j, 'X'), "7:0");
         assert_eq!(resolve_sacct_field(&job(0, 0, 0), 'x'), "0:0");
         assert_eq!(sacct_header('X'), "DerivedExitCode");
+    }
+
+    #[test]
+    fn time_limit_field_renders() {
+        // %l resolves to a formatted duration, or UNLIMITED when unset/zero.
+        let mut j = job(0, 0, 0);
+        assert_eq!(resolve_sacct_field(&j, 'l'), "UNLIMITED");
+        j.time_limit = Some(prost_types::Duration { seconds: 3600, nanos: 0 });
+        assert_eq!(resolve_sacct_field(&j, 'l'), format_duration(3600));
     }
 
     #[test]

--- a/crates/spurctld/src/accounting.rs
+++ b/crates/spurctld/src/accounting.rs
@@ -58,12 +58,16 @@ impl AccountingNotifier {
         state: JobState,
         exit_code: i32,
         end_time: DateTime<Utc>,
+        exit_signal: i32,
+        derived_exit_code: i32,
     ) {
         let req = RecordJobEndRequest {
             job_id,
             final_state: state.to_proto_i32(),
             exit_code,
             end_time: Some(datetime_to_proto(end_time)),
+            exit_signal,
+            derived_exit_code,
         };
         let mut client = self.client.clone();
         tokio::spawn(async move {

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -669,7 +669,20 @@ impl ClusterManager {
         }
 
         if let Some(ref notifier) = *self.accounting.read() {
-            notifier.notify_job_end(job_id, state, exit_code, Utc::now());
+            let (exit_signal, derived_exit_code) = self
+                .jobs
+                .read()
+                .get(&job_id)
+                .map(|j| (j.exit_signal, j.derived_exit_code))
+                .unwrap_or((0, 0));
+            notifier.notify_job_end(
+                job_id,
+                state,
+                exit_code,
+                Utc::now(),
+                exit_signal,
+                derived_exit_code,
+            );
         }
 
         let should_requeue = matches!(

--- a/crates/spurdbd/src/db.rs
+++ b/crates/spurdbd/src/db.rs
@@ -34,6 +34,8 @@ CREATE TABLE IF NOT EXISTS jobs (
     qos             TEXT NOT NULL DEFAULT '',
     state           TEXT NOT NULL DEFAULT 'PENDING',
     exit_code       INTEGER NOT NULL DEFAULT 0,
+    exit_signal     INTEGER NOT NULL DEFAULT 0,
+    derived_exit_code INTEGER NOT NULL DEFAULT 0,
     num_nodes       INTEGER NOT NULL DEFAULT 1,
     num_tasks       INTEGER NOT NULL DEFAULT 1,
     cpus_per_task   INTEGER NOT NULL DEFAULT 1,
@@ -124,6 +126,9 @@ CREATE INDEX IF NOT EXISTS idx_jobs_start_time ON jobs(start_time);
 CREATE INDEX IF NOT EXISTS idx_usage_period ON usage(period_start, period_end);
 CREATE INDEX IF NOT EXISTS idx_assoc_user ON associations(user_name);
 CREATE INDEX IF NOT EXISTS idx_assoc_account ON associations(account);
+
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS exit_signal INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS derived_exit_code INTEGER NOT NULL DEFAULT 0;
 "#;
 
 /// Record a job start in the database.
@@ -164,16 +169,19 @@ pub async fn record_job_start(
 }
 
 /// Record a job completion in the database.
+#[allow(clippy::too_many_arguments)]
 pub async fn record_job_end(
     pool: &PgPool,
     job_id: i32,
     state: &str,
     exit_code: i32,
     end_time: DateTime<Utc>,
+    exit_signal: i32,
+    derived_exit_code: i32,
 ) -> anyhow::Result<()> {
     let result = sqlx::query(
         r#"
-        UPDATE jobs SET state = $2, exit_code = $3, end_time = $4
+        UPDATE jobs SET state = $2, exit_code = $3, end_time = $4, exit_signal = $5, derived_exit_code = $6
         WHERE job_id = $1
         "#,
     )
@@ -181,6 +189,8 @@ pub async fn record_job_end(
     .bind(state)
     .bind(exit_code)
     .bind(end_time)
+    .bind(exit_signal)
+    .bind(derived_exit_code)
     .execute(pool)
     .await?;
 
@@ -258,6 +268,8 @@ pub struct JobRecord {
     pub partition: String,
     pub state: String,
     pub exit_code: i32,
+    pub exit_signal: i32,
+    pub derived_exit_code: i32,
     pub num_nodes: i32,
     pub num_tasks: i32,
     pub nodelist: String,
@@ -278,7 +290,8 @@ pub async fn get_job_history(
 ) -> anyhow::Result<Vec<JobRecord>> {
     let mut qb = QueryBuilder::<sqlx::Postgres>::new(
         "SELECT job_id, name, user_name, account, partition_name, state, exit_code, \
-         num_nodes, num_tasks, nodelist, submit_time, start_time, end_time \
+         exit_signal, derived_exit_code, num_nodes, num_tasks, nodelist, \
+         submit_time, start_time, end_time \
          FROM jobs WHERE 1=1",
     );
 
@@ -319,6 +332,8 @@ pub async fn get_job_history(
             partition: row.get("partition_name"),
             state: row.get("state"),
             exit_code: row.get("exit_code"),
+            exit_signal: row.get("exit_signal"),
+            derived_exit_code: row.get("derived_exit_code"),
             num_nodes: row.get("num_nodes"),
             num_tasks: row.get("num_tasks"),
             nodelist: row.get("nodelist"),
@@ -665,13 +680,13 @@ mod job_history_tests {
         delete_jobs(&pool, &ids).await.ok();
 
         record_job_start(&pool, id0, &user_a, &account_one, "debug", 1, 1, 1, 0, t1).await?;
-        record_job_end(&pool, id0, "COMPLETED", 0, t1 + Duration::minutes(5)).await?;
+        record_job_end(&pool, id0, "COMPLETED", 0, t1 + Duration::minutes(5), 0, 0).await?;
 
         record_job_start(&pool, id1, &user_b, &account_one, "debug", 1, 1, 1, 0, t1).await?;
-        record_job_end(&pool, id1, "FAILED", 1, t1 + Duration::minutes(5)).await?;
+        record_job_end(&pool, id1, "FAILED", 137, t1 + Duration::minutes(5), 9, 137).await?;
 
         record_job_start(&pool, id2, &user_a, &account_two, "debug", 1, 1, 1, 0, t2).await?;
-        record_job_end(&pool, id2, "COMPLETED", 0, t2 + Duration::minutes(5)).await?;
+        record_job_end(&pool, id2, "COMPLETED", 0, t2 + Duration::minutes(5), 0, 0).await?;
 
         let by_user = get_job_history(&pool, Some(&user_a), None, None, None, &[], 100).await?;
         assert_eq!(by_user.len(), 2);
@@ -711,6 +726,8 @@ mod job_history_tests {
         .await?;
         assert_eq!(failed.len(), 1);
         assert_eq!(failed[0].job_id, id1);
+        assert_eq!(failed[0].exit_signal, 9);
+        assert_eq!(failed[0].derived_exit_code, 137);
 
         let after = get_job_history(&pool, Some(&user_a), None, Some(t2), None, &[], 100).await?;
         assert_eq!(after.len(), 1);

--- a/crates/spurdbd/src/server.rs
+++ b/crates/spurdbd/src/server.rs
@@ -80,6 +80,8 @@ impl SlurmAccounting for AccountingService {
             state_str,
             req.exit_code,
             end_time,
+            req.exit_signal,
+            req.derived_exit_code,
         )
         .await
         .map_err(|e| Status::internal(e.to_string()))?;
@@ -174,8 +176,8 @@ impl SlurmAccounting for AccountingService {
                 work_dir: String::new(),
                 command: String::new(),
                 exit_code: r.exit_code,
-                exit_signal: 0,
-                derived_exit_code: 0,
+                exit_signal: r.exit_signal,
+                derived_exit_code: r.derived_exit_code,
                 stdout_path: String::new(),
                 stderr_path: String::new(),
                 resources: None,

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -641,6 +641,8 @@ message RecordJobEndRequest {
   JobState final_state = 2;
   int32 exit_code = 3;
   google.protobuf.Timestamp end_time = 4;
+  int32 exit_signal = 5;        // Terminating signal of primary node (0 = none)
+  int32 derived_exit_code = 6;  // Running max over srun step exit codes (0 if no steps)
 }
 
 message GetJobHistoryRequest {

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -24,9 +24,13 @@ logger = logging.getLogger(__name__)
 
 BINARIES = ["spurctld", "spurd", "spur"]
 CLI_SYMLINKS = ["sbatch", "srun", "squeue", "scancel", "sinfo", "scontrol"]
+# Extra binaries/symlinks pulled in only when accounting (spurdbd) is enabled.
+ACCOUNTING_BINARIES = ["spurdbd"]
+ACCOUNTING_SYMLINKS = ["sacct", "sacctmgr"]
 
 CONTROLLER_PORT = int(os.environ.get("SPUR_TEST_CONTROLLER_PORT", "6817"))
 AGENT_PORT = int(os.environ.get("SPUR_TEST_AGENT_PORT", "6818"))
+ACCOUNTING_PORT = int(os.environ.get("SPUR_TEST_ACCOUNTING_PORT", "6819"))
 
 
 def make_remote_dir() -> str:
@@ -117,15 +121,22 @@ class SshNode:
         self.client.close()
 
 
-def ensure_bins(nodes: list[SshNode], binaries_dir: str, bin_dir: str):
+def ensure_bins(nodes: list[SshNode], binaries_dir: str, bin_dir: str,
+                with_accounting: bool = False):
     """
     Upload binaries to all nodes if not already present (or size differs).
     bin_dir is the remote directory where binaries are installed.
+
+    When *with_accounting* is True, also upload spurdbd and create the
+    sacct/sacctmgr symlinks.
     """
     for node in nodes:
         node.exec(f"mkdir -p '{bin_dir}'")
 
-    for name in BINARIES:
+    binaries = BINARIES + (ACCOUNTING_BINARIES if with_accounting else [])
+    symlinks = CLI_SYMLINKS + (ACCOUNTING_SYMLINKS if with_accounting else [])
+
+    for name in binaries:
         local_path = Path(binaries_dir) / name
         if not local_path.is_file():
             raise FileNotFoundError(
@@ -151,7 +162,7 @@ def ensure_bins(nodes: list[SshNode], binaries_dir: str, bin_dir: str):
     # Create CLI symlinks
     symlink_cmd = (
         f"cd '{bin_dir}' && "
-        + " && ".join(f"ln -sf spur {cmd} 2>/dev/null || true" for cmd in CLI_SYMLINKS)
+        + " && ".join(f"ln -sf spur {cmd} 2>/dev/null || true" for cmd in symlinks)
     )
     for node in nodes:
         node.exec_allow_fail(symlink_cmd)
@@ -180,6 +191,14 @@ class SpurCluster:
         self.agent_as_root: bool = False
         self.agent_labels: dict[int, dict[str, str]] = {}
         self.agent_token: str | None = None
+        # Accounting (spurdbd + Postgres) runs on node 0 only, opt-in.
+        self.accounting_enabled: bool = False
+        self.accounting_addr = f"http://{nodes[0].host}:{ACCOUNTING_PORT}"
+        self._pg_container = f"spur-e2e-pg-{os.getpid()}-{time.time_ns()}"
+        self._pg_port = int(os.environ.get("SPUR_TEST_PG_PORT", "55432"))
+        self._db_url = (
+            f"postgresql://spur:spur@127.0.0.1:{self._pg_port}/spur"
+        )
 
     # --- Lifecycle ---
 
@@ -223,6 +242,8 @@ class SpurCluster:
             self._kill_controller()
             self._kill_agents(use_sudo=False)
             self._kill_agents(use_sudo=True)  # best-effort for rootful
+        if self.accounting_enabled:
+            self._start_accounting()
         self.start_controller(config_overrides, kill_stale=False)
         self.start_agents(kill_stale=False)
         self.wait_ready()
@@ -236,6 +257,8 @@ class SpurCluster:
         """Kill all daemons but keep the working directory intact."""
         self.stop_agents()
         self.stop_controller()
+        if self.accounting_enabled:
+            self._stop_accounting()
 
     def start_controller(self, config_overrides: dict | None = None, kill_stale: bool = True):
         """Start only spurctld. Writes config and waits for it to be ready.
@@ -257,6 +280,18 @@ class SpurCluster:
         if kill_stale:
             self._kill_agents(use_sudo=self.agent_as_root)
         self._start_agents()
+
+    def enable_accounting(self):
+        """Opt in to spurdbd + Postgres. Call before provision()/start().
+
+        Requires Docker and the spurdbd/sacct/sacctmgr binaries on node 0.
+        Raises RuntimeError if the prerequisites are missing — callers (the
+        accounting_cluster fixture) translate that into a pytest skip.
+        """
+        node = self.nodes[0]
+        if node.exec_allow_fail("command -v docker >/dev/null 2>&1 && echo ok").strip() != "ok":
+            raise RuntimeError("docker not available on node 0; cannot run accounting")
+        self.accounting_enabled = True
 
     def stop_controller(self):
         """Kill spurctld only."""
@@ -323,6 +358,12 @@ class SpurCluster:
 
     def scontrol(self, *args: str) -> str:
         return self.cli(["scontrol"] + list(args))
+
+    def sacct(self, args: list[str]) -> str:
+        return self.cli(["sacct", "--accounting", self.accounting_addr] + args)
+
+    def sacctmgr(self, args: list[str]) -> str:
+        return self.cli(["sacctmgr", "--accounting", self.accounting_addr] + args)
 
     def write_file(self, name: str, body: str, *,
                    all_nodes: bool = False, executable: bool = True) -> str:
@@ -649,7 +690,7 @@ mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
 
     def _default_config(self) -> dict:
         nodes_list = ",".join(self.node_names)
-        return {
+        cfg = {
             "cluster_name": "e2e-test",
             "scheduler": {"interval_secs": 1, "plugin": "backfill"},
             "auth": {"plugin": "none"},
@@ -669,6 +710,15 @@ mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
                 for name in self.node_names
             ],
         }
+        if self.accounting_enabled:
+            # Controller dials spurdbd on node 0; refresh fast so QoS/limit
+            # changes show up within a test's patience window.
+            cfg["accounting"] = {
+                "host": f"{self.nodes[0].host}:{ACCOUNTING_PORT}",
+                "database_url": self._db_url,
+                "fairshare_refresh_secs": 2,
+            }
+        return cfg
 
     def _write_config(self):
         cfg = self._default_config()
@@ -688,6 +738,43 @@ mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
         )
         pid = self.nodes[0].exec(cmd).strip()
         logger.info("spurctld started on %s (pid %s)", self.node_names[0], pid)
+
+    def _start_accounting(self):
+        """Bring up Postgres (Docker) + spurdbd on node 0, in that order."""
+        node = self.nodes[0]
+        node.exec_allow_fail(f"docker rm -f '{self._pg_container}' 2>/dev/null || true")
+        node.exec(
+            f"docker run -d --name '{self._pg_container}' "
+            f"-e POSTGRES_USER=spur -e POSTGRES_PASSWORD=spur -e POSTGRES_DB=spur "
+            f"-p {self._pg_port}:5432 postgres:16-alpine"
+        )
+        self._wait_pg(node)
+        cmd = (
+            f"nohup '{self.bin_dir}/spurdbd' "
+            f"--database-url '{self._db_url}' "
+            f"--listen '[::]:{ACCOUNTING_PORT}' --log-level info -D "
+            f"> '{self.log_dir}/spurdbd.log' 2>&1 & echo $!"
+        )
+        pid = node.exec(cmd).strip()
+        logger.info("spurdbd started on %s (pid %s)", self.node_names[0], pid)
+        time.sleep(2)
+
+    def _wait_pg(self, node: SshNode, timeout: int = 60):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            ready = node.exec_allow_fail(
+                f"docker exec '{self._pg_container}' pg_isready -U spur 2>/dev/null "
+                f"&& echo ready || true"
+            )
+            if "ready" in ready:
+                return
+            time.sleep(2)
+        raise RuntimeError("Postgres did not become ready in time")
+
+    def _stop_accounting(self):
+        node = self.nodes[0]
+        self._pkill(node, f"{self.bin_dir}/spurdbd")
+        node.exec_allow_fail(f"docker rm -f '{self._pg_container}' 2>/dev/null || true")
 
     def _sudo_prefix(self) -> str:
         pw = os.environ.get("SPUR_TEST_SSH_PASSWORD", "")
@@ -835,4 +922,27 @@ def wait_job(cluster: SpurCluster, job_id: int, timeout: int = 120) -> str:
         time.sleep(2)
     raise TimeoutError(
         f"Job {job_id} did not finish within {timeout}s (last state: {last})"
+    )
+
+
+def wait_sacct_row(cluster: SpurCluster, job_id: int, fmt: str,
+                   timeout: int = 60) -> str:
+    """Poll `sacct -j <id> -n -o <fmt>` until the job's row appears.
+
+    Job history reaches spurdbd asynchronously after the job ends, so callers
+    must poll. Returns the matching row (whitespace-joined). Raises TimeoutError.
+    """
+    deadline = time.time() + timeout
+    id_str = str(job_id)
+    last = ""
+    while time.time() < deadline:
+        out = cluster.sacct(["-j", id_str, "-n", "-o", fmt])
+        for line in out.splitlines():
+            fields = line.split()
+            if fields and fields[0] == id_str:
+                return " ".join(fields)
+        last = out
+        time.sleep(2)
+    raise TimeoutError(
+        f"Job {job_id} did not appear in sacct within {timeout}s (last: {last!r})"
     )

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -289,8 +289,9 @@ class SpurCluster:
         accounting_cluster fixture) translate that into a pytest skip.
         """
         node = self.nodes[0]
-        if node.exec_allow_fail("command -v docker >/dev/null 2>&1 && echo ok").strip() != "ok":
-            raise RuntimeError("docker not available on node 0; cannot run accounting")
+        # `docker info` (not `command -v docker`) so an unreachable daemon socket skips, not errors.
+        if node.exec_allow_fail("docker info >/dev/null 2>&1 && echo ok").strip() != "ok":
+            raise RuntimeError("docker not usable on node 0; cannot run accounting")
         self.accounting_enabled = True
 
     def stop_controller(self):

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -711,8 +711,8 @@ mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
             ],
         }
         if self.accounting_enabled:
-            # Controller dials spurdbd on node 0; refresh fast so QoS/limit
-            # changes show up within a test's patience window.
+            # Controller dials spurdbd on node 0. The QoS/limit cache floors
+            # the refresh interval at ~10s, which the tests poll around.
             cfg["accounting"] = {
                 "host": f"{self.nodes[0].host}:{ACCOUNTING_PORT}",
                 "database_url": self._db_url,
@@ -751,7 +751,7 @@ mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
         self._wait_pg(node)
         cmd = (
             f"nohup '{self.bin_dir}/spurdbd' "
-            f"--database-url '{self._db_url}' "
+            f"--database-url '{self._db_url}' --migrate "
             f"--listen '[::]:{ACCOUNTING_PORT}' --log-level info -D "
             f"> '{self.log_dir}/spurdbd.log' 2>&1 & echo $!"
         )

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -758,7 +758,20 @@ mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
         )
         pid = node.exec(cmd).strip()
         logger.info("spurdbd started on %s (pid %s)", self.node_names[0], pid)
-        time.sleep(2)
+        # spurctld connects to accounting once at startup, so spurdbd must be
+        # accepting connections before the controller starts — wait for the port.
+        self._wait_port(node, ACCOUNTING_PORT)
+
+    def _wait_port(self, node: SshNode, port: int, timeout: int = 30):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            ok = node.exec_allow_fail(
+                f"bash -c '</dev/tcp/127.0.0.1/{port}' 2>/dev/null && echo ready || true"
+            )
+            if "ready" in ok:
+                return
+            time.sleep(1)
+        raise RuntimeError(f"spurdbd did not listen on port {port} within {timeout}s")
 
     def _wait_pg(self, node: SshNode, timeout: int = 60):
         deadline = time.time() + timeout

--- a/tests/native_host/e2e/conftest.py
+++ b/tests/native_host/e2e/conftest.py
@@ -173,6 +173,37 @@ def multi_node_cluster(ssh_nodes, remote_bin_dir):
     spur_cluster.teardown()
 
 
+@pytest.fixture
+def accounting_cluster(ssh_nodes, remote_bin_dir):
+    """
+    Per-test fixture: a running cluster with spurdbd + Postgres on node 0.
+
+    Skips if node 0 lacks Docker or the accounting binaries, so the suite
+    degrades gracefully where the DB backend is unavailable.
+    """
+    if len(ssh_nodes) < 1:
+        pytest.skip("accounting tests require at least one node")
+    # spurdbd/sacct/sacctmgr are not part of the session-scoped base upload.
+    try:
+        ensure_bins(ssh_nodes[:1], _get_binaries_dir(), remote_bin_dir,
+                    with_accounting=True)
+    except FileNotFoundError as e:
+        pytest.skip(f"accounting binaries unavailable: {e}")
+
+    c = SpurCluster(ssh_nodes, make_remote_dir(), remote_bin_dir)
+    try:
+        c.enable_accounting()
+    except RuntimeError as e:
+        pytest.skip(str(e))
+    try:
+        c.deploy()
+    except Exception:
+        c.teardown()
+        raise
+    yield c
+    c.teardown()
+
+
 def _any_node_has_gpu(nodes: list[SshNode]) -> bool:
     for node in nodes:
         probe = node.exec_allow_fail(

--- a/tests/native_host/e2e/test_accounting.py
+++ b/tests/native_host/e2e/test_accounting.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for sacct accounting: exit:signal and DerivedExitCode (issue #297).
+
+Requires spurdbd + Postgres on node 0 (the accounting_cluster fixture, which
+skips when Docker or the accounting binaries are unavailable).
+"""
+
+from cluster import parse_job_id, wait_job, wait_sacct_row
+
+
+class TestSacctExitReporting:
+    def test_signal_half_and_derived_exit_code(self, accounting_cluster):
+        c = accounting_cluster
+
+        # (1) A job killed by a signal: sacct must show the signal half (0:9),
+        # not 0:0. SIGKILL the batch shell itself.
+        sig = c.write_file("acct-signal.sh", "#!/bin/bash\nkill -9 $$\n")
+        sig_id = parse_job_id(c.sbatch(["-J", "acct-sig", "-N", "1", sig]))
+        assert sig_id is not None
+        wait_job(c, sig_id, timeout=60)
+        row = wait_sacct_row(c, sig_id, "JobID,ExitCode")
+        # ExitCode renders code:signal; the signal half is the parity fix.
+        assert row.split()[1].endswith(":9"), f"expected signal half :9, got {row!r}"
+
+        # (2) A multi-step job (steps exit 0, 7, 3): Slurm reports
+        # ExitCode=last (3:0) and DerivedExitCode=max (7:0).
+        multi = c.write_file(
+            "acct-multi.sh",
+            "#!/bin/bash\n"
+            "srun bash -c 'exit 0'\n"
+            "srun bash -c 'exit 7'\n"
+            "srun bash -c 'exit 3'\n",
+        )
+        m_id = parse_job_id(c.sbatch(["-J", "acct-multi", "-N", "1", multi]))
+        assert m_id is not None
+        wait_job(c, m_id, timeout=90)
+        row = wait_sacct_row(c, m_id, "JobID,ExitCode,DerivedExitCode")
+        fields = row.split()
+        assert fields[1] == "3:0", f"expected ExitCode 3:0, got {fields!r}"
+        assert fields[2] == "7:0", f"expected DerivedExitCode 7:0, got {fields!r}"

--- a/tests/native_host/e2e/test_accounting.py
+++ b/tests/native_host/e2e/test_accounting.py
@@ -20,7 +20,7 @@ class TestSacctExitReporting:
         sig_id = parse_job_id(c.sbatch(["-J", "acct-sig", "-N", "1", sig]))
         assert sig_id is not None
         wait_job(c, sig_id, timeout=60)
-        row = wait_sacct_row(c, sig_id, "JobID,ExitCode")
+        row = wait_sacct_row(c, sig_id, "%i %x")
         # ExitCode renders code:signal; the signal half is the parity fix.
         assert row.split()[1].endswith(":9"), f"expected signal half :9, got {row!r}"
 
@@ -36,7 +36,7 @@ class TestSacctExitReporting:
         m_id = parse_job_id(c.sbatch(["-J", "acct-multi", "-N", "1", multi]))
         assert m_id is not None
         wait_job(c, m_id, timeout=90)
-        row = wait_sacct_row(c, m_id, "JobID,ExitCode,DerivedExitCode")
+        row = wait_sacct_row(c, m_id, "%i %x %X")
         fields = row.split()
         assert fields[1] == "3:0", f"expected ExitCode 3:0, got {fields!r}"
         assert fields[2] == "7:0", f"expected DerivedExitCode 7:0, got {fields!r}"

--- a/tests/native_host/e2e/test_accounting.py
+++ b/tests/native_host/e2e/test_accounting.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""E2E tests for sacct accounting: exit:signal and DerivedExitCode (issue #297).
+"""E2E tests for sacct accounting: exit:signal and DerivedExitCode.
 
 Requires spurdbd + Postgres on node 0 (the accounting_cluster fixture, which
 skips when Docker or the accounting binaries are unavailable).


### PR DESCRIPTION
**Draft** — closes #297. Deferred follow-up from #274 (exit-code/signal parity).

## Problem
`DerivedExitCode` and the `exit:signal` half are computed in the controller (from #274) and shown by `scontrol`/`squeue`, but were dropped on the way to spurdbd. So `sacct` rendered the signal half as `:0` and could not show `DerivedExitCode` at all.

## Changes
- **proto**: `RecordJobEndRequest` gains `exit_signal` (5) and `derived_exit_code` (6).
- **controller**: `notify_job_end` threads both from the in-memory `Job`.
- **spurdbd**: new `exit_signal`/`derived_exit_code` columns (idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` for existing DBs), persisted in `record_job_end`, returned in `get_job_history` instead of hardcoded `0`.
- **sacct**: new `DerivedExitCode` (`%X`) format field + header so the persisted value is displayable (meets the issue's `sacct -o ...,DerivedExitCode` acceptance).

## Tests
- Unit: sacct field rendering (`%x` code:signal, `%X` derived).
- Integration: `#[ignore]`-gated DB round-trip asserting `exit_signal=9`/`derived_exit_code=137`.
- e2e: `tests/native_host/e2e/test_accounting.py` — signal job + multi-step job. New `accounting_cluster` fixture brings up spurdbd + Postgres (Docker) on node 0 and **skips** when Docker/binaries are unavailable.

## Live validation (Spur node vs Slurm 25.11.6 cluster)
- Signal job: Spur `ExitCode=0:9`, DB `exit_signal=9` — matches Slurm `scontrol` `ExitCode=0:9`.
- Multi-step (exit 0,7,3): Spur `ExitCode=3:0 DerivedExitCode=7:0`, DB `derived_exit_code=7` — matches Slurm `ExitCode=3:0` (Slurm's sacct is disabled on the bed, so DerivedExitCode compared via scontrol).
- Migration path validated against the pre-existing DB.

## Notes / pre-existing bugs surfaced (not regressions)
- `sacct -o` only accepts `%`-letter format strings, not Slurm field-name syntax (`JobID,State,...` renders blank).
- `sacct -j <id>` accepts the flag but does not filter server-side.

Verification: `cargo build`/`test`/`clippy --all-targets`/`fmt --check` clean; spur-cli 52, spurctld 131, spurdbd 1 (+1 ignored) pass.

