### PR TITLE
feat(spurctld): enforce real QoS limits via controller-side QosCache

### DIFF
--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -238,6 +238,7 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
                         .and_then(|v| v.parse().ok())
                         .unwrap_or(0),
                     max_tres_per_user: p.get("maxtresperuser").cloned().unwrap_or_default(),
+                    grp_tres: p.get("grptres").cloned().unwrap_or_default(),
                 })
                 .await
                 .context("CreateQos RPC failed")?;
@@ -391,6 +392,7 @@ async fn modify(entity: &str, params: &[String], addr: &str) -> Result<()> {
                         .and_then(|v| v.parse().ok())
                         .unwrap_or(0),
                     max_tres_per_user: p.get("maxtresperuser").cloned().unwrap_or_default(),
+                    grp_tres: p.get("grptres").cloned().unwrap_or_default(),
                 })
                 .await
                 .context("CreateQos (modify) RPC failed")?;

--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -233,6 +233,11 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
                     max_jobs_per_user: max_jobs,
                     max_wall_minutes: max_wall,
                     max_tres_per_job: max_tres,
+                    max_submit_jobs_per_user: p
+                        .get("maxsubmitjobsperuser")
+                        .and_then(|v| v.parse().ok())
+                        .unwrap_or(0),
+                    max_tres_per_user: p.get("maxtresperuser").cloned().unwrap_or_default(),
                 })
                 .await
                 .context("CreateQos RPC failed")?;
@@ -381,6 +386,11 @@ async fn modify(entity: &str, params: &[String], addr: &str) -> Result<()> {
                         .and_then(|v| parse_wall_time(v))
                         .unwrap_or(0),
                     max_tres_per_job: p.get("maxtresperjob").cloned().unwrap_or_default(),
+                    max_submit_jobs_per_user: p
+                        .get("maxsubmitjobsperuser")
+                        .and_then(|v| v.parse().ok())
+                        .unwrap_or(0),
+                    max_tres_per_user: p.get("maxtresperuser").cloned().unwrap_or_default(),
                 })
                 .await
                 .context("CreateQos (modify) RPC failed")?;

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -244,6 +244,10 @@ pub enum PendingReason {
     QosMaxCpuPerUserLimit,
     QosMaxSubmitJobPerUserLimit,
     PartitionConfig,
+    QosMaxNodePerJobLimit,
+    QosGrpCpuLimit,
+    QosGrpMemLimit,
+    QosGrpNodeLimit,
 }
 
 impl PendingReason {
@@ -281,6 +285,10 @@ impl PendingReason {
             Self::QosMaxCpuPerUserLimit => "QOSMaxCpuPerUserLimit",
             Self::QosMaxSubmitJobPerUserLimit => "QOSMaxSubmitJobPerUserLimit",
             Self::PartitionConfig => "PartitionConfig",
+            Self::QosMaxNodePerJobLimit => "QOSMaxNodePerJobLimit",
+            Self::QosGrpCpuLimit => "QOSGrpCpuLimit",
+            Self::QosGrpMemLimit => "QOSGrpMemLimit",
+            Self::QosGrpNodeLimit => "QOSGrpNodeLimit",
         }
     }
 }
@@ -1140,6 +1148,13 @@ mod tests {
         ),
         (PendingReason::PartitionConfig, "PartitionConfig"),
         (PendingReason::PartitionInactive, "PartitionInactive"),
+        (
+            PendingReason::QosMaxNodePerJobLimit,
+            "QOSMaxNodePerJobLimit",
+        ),
+        (PendingReason::QosGrpCpuLimit, "QOSGrpCpuLimit"),
+        (PendingReason::QosGrpMemLimit, "QOSGrpMemLimit"),
+        (PendingReason::QosGrpNodeLimit, "QOSGrpNodeLimit"),
     ];
 
     #[test]

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -226,6 +226,7 @@ pub enum PendingReason {
     JobHeldAdmin,
     BadConstraints,
     PartitionInactive,
+    PartitionConfig,
     DependencyNeverSatisfied,
     InvalidAccount,
     InvalidQOS,
@@ -243,7 +244,6 @@ pub enum PendingReason {
     QosMaxMemoryPerJob,
     QosMaxCpuPerUserLimit,
     QosMaxSubmitJobPerUserLimit,
-    PartitionConfig,
     QosMaxNodePerJobLimit,
     QosGrpCpuLimit,
     QosGrpMemLimit,
@@ -273,6 +273,7 @@ impl PendingReason {
             Self::JobHeldAdmin => "JobHeldAdmin",
             Self::BadConstraints => "BadConstraints",
             Self::PartitionInactive => "PartitionInactive",
+            Self::PartitionConfig => "PartitionConfig",
             Self::DependencyNeverSatisfied => "DependencyNeverSatisfied",
             Self::InvalidAccount => "InvalidAccount",
             Self::InvalidQOS => "InvalidQOS",
@@ -284,7 +285,6 @@ impl PendingReason {
             Self::QosMaxMemoryPerJob => "QOSMaxMemoryPerJob",
             Self::QosMaxCpuPerUserLimit => "QOSMaxCpuPerUserLimit",
             Self::QosMaxSubmitJobPerUserLimit => "QOSMaxSubmitJobPerUserLimit",
-            Self::PartitionConfig => "PartitionConfig",
             Self::QosMaxNodePerJobLimit => "QOSMaxNodePerJobLimit",
             Self::QosGrpCpuLimit => "QOSGrpCpuLimit",
             Self::QosGrpMemLimit => "QOSGrpMemLimit",
@@ -1131,6 +1131,8 @@ mod tests {
 
     /// (variant, exact Slurm 25.11.6 string) for every parity addition.
     const REASON_VOCAB: &[(PendingReason, &str)] = &[
+        (PendingReason::PartitionConfig, "PartitionConfig"),
+        (PendingReason::PartitionInactive, "PartitionInactive"),
         (PendingReason::Reservation, "Reservation"),
         (PendingReason::QosMaxCpuPerJobLimit, "QOSMaxCpuPerJobLimit"),
         (
@@ -1146,8 +1148,6 @@ mod tests {
             PendingReason::QosMaxSubmitJobPerUserLimit,
             "QOSMaxSubmitJobPerUserLimit",
         ),
-        (PendingReason::PartitionConfig, "PartitionConfig"),
-        (PendingReason::PartitionInactive, "PartitionInactive"),
         (
             PendingReason::QosMaxNodePerJobLimit,
             "QOSMaxNodePerJobLimit",

--- a/crates/spur-core/src/qos.rs
+++ b/crates/spur-core/src/qos.rs
@@ -87,7 +87,6 @@ pub fn check_qos_limits(
         }
     }
 
-    // Group TRES across all running jobs in the QOS (GrpCPU/Mem/Node).
     if let Some(ref grp) = limits.grp_tres {
         let job_cpus = (job.spec.num_tasks * job.spec.cpus_per_task) as u64;
         if grp.get(TresType::Cpu) > 0

--- a/crates/spur-core/src/qos.rs
+++ b/crates/spur-core/src/qos.rs
@@ -19,14 +19,15 @@ pub enum QosCheckResult {
 
 /// Check if a job would violate QOS limits.
 ///
-/// `running_jobs` = currently running jobs from the same user+QOS.
-/// `pending_jobs` = currently pending jobs from the same user+QOS.
+/// `user_running_*` aggregate the requesting user's load; `qos_running_tres`
+/// aggregates all running jobs in the QOS (for the `Grp*` group limits).
 pub fn check_qos_limits(
     job: &Job,
     qos: &Qos,
     user_running_count: u32,
     user_submitted_count: u32,
     user_running_tres: &TresRecord,
+    qos_running_tres: &TresRecord,
 ) -> QosCheckResult {
     let limits = &qos.limits;
 
@@ -64,6 +65,11 @@ pub fn check_qos_limits(
             return QosCheckResult::Blocked(PendingReason::QosMaxCpuPerJobLimit);
         }
 
+        let job_nodes = job.spec.num_nodes as u64;
+        if max_tres.get(TresType::Node) > 0 && job_nodes > max_tres.get(TresType::Node) {
+            return QosCheckResult::Blocked(PendingReason::QosMaxNodePerJobLimit);
+        }
+
         if let Some(mem) = job.spec.memory_per_node_mb {
             let total_mem = mem * job.spec.num_nodes as u64;
             if max_tres.get(TresType::Memory) > 0 && total_mem > max_tres.get(TresType::Memory) {
@@ -78,6 +84,32 @@ pub fn check_qos_limits(
         let new_total_cpu = user_running_tres.get(TresType::Cpu) + job_cpus;
         if max_tres.get(TresType::Cpu) > 0 && new_total_cpu > max_tres.get(TresType::Cpu) {
             return QosCheckResult::Blocked(PendingReason::QosMaxCpuPerUserLimit);
+        }
+    }
+
+    // Group TRES across all running jobs in the QOS (GrpCPU/Mem/Node).
+    if let Some(ref grp) = limits.grp_tres {
+        let job_cpus = (job.spec.num_tasks * job.spec.cpus_per_task) as u64;
+        if grp.get(TresType::Cpu) > 0
+            && qos_running_tres.get(TresType::Cpu) + job_cpus > grp.get(TresType::Cpu)
+        {
+            return QosCheckResult::Blocked(PendingReason::QosGrpCpuLimit);
+        }
+
+        let job_nodes = job.spec.num_nodes as u64;
+        if grp.get(TresType::Node) > 0
+            && qos_running_tres.get(TresType::Node) + job_nodes > grp.get(TresType::Node)
+        {
+            return QosCheckResult::Blocked(PendingReason::QosGrpNodeLimit);
+        }
+
+        if let Some(mem) = job.spec.memory_per_node_mb {
+            let job_mem = mem * job.spec.num_nodes as u64;
+            if grp.get(TresType::Memory) > 0
+                && qos_running_tres.get(TresType::Memory) + job_mem > grp.get(TresType::Memory)
+            {
+                return QosCheckResult::Blocked(PendingReason::QosGrpMemLimit);
+            }
         }
     }
 
@@ -126,7 +158,7 @@ mod tests {
     fn test_allowed_when_no_limits() {
         let qos = make_qos(None, None);
         let job = make_test_job();
-        let result = check_qos_limits(&job, &qos, 0, 0, &TresRecord::new());
+        let result = check_qos_limits(&job, &qos, 0, 0, &TresRecord::new(), &TresRecord::new());
         assert_eq!(result, QosCheckResult::Allowed);
     }
 
@@ -134,7 +166,7 @@ mod tests {
     fn test_blocked_by_max_jobs() {
         let qos = make_qos(Some(5), None);
         let job = make_test_job();
-        let result = check_qos_limits(&job, &qos, 5, 5, &TresRecord::new());
+        let result = check_qos_limits(&job, &qos, 5, 5, &TresRecord::new(), &TresRecord::new());
         assert_eq!(
             result,
             QosCheckResult::Blocked(PendingReason::QoSMaxJobsPerUser)
@@ -145,7 +177,7 @@ mod tests {
     fn test_allowed_under_max_jobs() {
         let qos = make_qos(Some(5), None);
         let job = make_test_job();
-        let result = check_qos_limits(&job, &qos, 3, 3, &TresRecord::new());
+        let result = check_qos_limits(&job, &qos, 3, 3, &TresRecord::new(), &TresRecord::new());
         assert_eq!(result, QosCheckResult::Allowed);
     }
 
@@ -153,7 +185,7 @@ mod tests {
     fn test_blocked_by_max_wall() {
         let qos = make_qos(None, Some(60)); // 1 hour max
         let job = make_test_job(); // 2 hour job
-        let result = check_qos_limits(&job, &qos, 0, 0, &TresRecord::new());
+        let result = check_qos_limits(&job, &qos, 0, 0, &TresRecord::new(), &TresRecord::new());
         assert_eq!(
             result,
             QosCheckResult::Blocked(PendingReason::QosMaxWallDurationPerJobLimit)
@@ -173,7 +205,7 @@ mod tests {
             ..Default::default()
         };
         let job = make_test_job(); // 4 CPUs
-        let result = check_qos_limits(&job, &qos, 0, 0, &TresRecord::new());
+        let result = check_qos_limits(&job, &qos, 0, 0, &TresRecord::new(), &TresRecord::new());
         assert_eq!(
             result,
             QosCheckResult::Blocked(PendingReason::QosMaxCpuPerJobLimit)
@@ -195,7 +227,7 @@ mod tests {
         let mut job = make_test_job();
         job.spec.num_nodes = 1;
         job.spec.memory_per_node_mb = Some(2048); // 2 GiB
-        let result = check_qos_limits(&job, &qos, 0, 0, &TresRecord::new());
+        let result = check_qos_limits(&job, &qos, 0, 0, &TresRecord::new(), &TresRecord::new());
         assert_eq!(
             result,
             QosCheckResult::Blocked(PendingReason::QosMaxMemoryPerJob)
@@ -217,7 +249,7 @@ mod tests {
         let job = make_test_job(); // needs 4 CPUs
         let mut running = TresRecord::new();
         running.set(TresType::Cpu, 6); // already using 6; 6 + 4 > 8
-        let result = check_qos_limits(&job, &qos, 0, 0, &running);
+        let result = check_qos_limits(&job, &qos, 0, 0, &running, &TresRecord::new());
         assert_eq!(
             result,
             QosCheckResult::Blocked(PendingReason::QosMaxCpuPerUserLimit)
@@ -235,10 +267,53 @@ mod tests {
             ..Default::default()
         };
         let job = make_test_job();
-        let result = check_qos_limits(&job, &qos, 0, 3, &TresRecord::new());
+        let result = check_qos_limits(&job, &qos, 0, 3, &TresRecord::new(), &TresRecord::new());
         assert_eq!(
             result,
             QosCheckResult::Blocked(PendingReason::QosMaxSubmitJobPerUserLimit)
+        );
+    }
+
+    #[test]
+    fn test_blocked_by_max_node_per_job() {
+        let mut tres = TresRecord::new();
+        tres.set(TresType::Node, 1); // max 1 node per job
+        let qos = Qos {
+            name: "restricted".into(),
+            limits: QosLimits {
+                max_tres_per_job: Some(tres),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut job = make_test_job();
+        job.spec.num_nodes = 4;
+        let result = check_qos_limits(&job, &qos, 0, 0, &TresRecord::new(), &TresRecord::new());
+        assert_eq!(
+            result,
+            QosCheckResult::Blocked(PendingReason::QosMaxNodePerJobLimit)
+        );
+    }
+
+    #[test]
+    fn test_blocked_by_grp_cpu() {
+        let mut grp = TresRecord::new();
+        grp.set(TresType::Cpu, 8); // QOS-wide cap 8
+        let qos = Qos {
+            name: "grp".into(),
+            limits: QosLimits {
+                grp_tres: Some(grp),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let job = make_test_job(); // needs 4 CPUs
+        let mut qos_running = TresRecord::new();
+        qos_running.set(TresType::Cpu, 6); // 6 already in the QOS; 6 + 4 > 8
+        let result = check_qos_limits(&job, &qos, 0, 0, &TresRecord::new(), &qos_running);
+        assert_eq!(
+            result,
+            QosCheckResult::Blocked(PendingReason::QosGrpCpuLimit)
         );
     }
 

--- a/crates/spur-core/src/qos.rs
+++ b/crates/spur-core/src/qos.rs
@@ -317,6 +317,53 @@ mod tests {
     }
 
     #[test]
+    fn test_blocked_by_grp_node() {
+        let mut grp = TresRecord::new();
+        grp.set(TresType::Node, 4); // QOS-wide cap 4 nodes
+        let qos = Qos {
+            name: "grp".into(),
+            limits: QosLimits {
+                grp_tres: Some(grp),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut job = make_test_job();
+        job.spec.num_nodes = 3;
+        let mut qos_running = TresRecord::new();
+        qos_running.set(TresType::Node, 2); // 2 nodes already running; 2 + 3 > 4
+        let result = check_qos_limits(&job, &qos, 0, 0, &TresRecord::new(), &qos_running);
+        assert_eq!(
+            result,
+            QosCheckResult::Blocked(PendingReason::QosGrpNodeLimit)
+        );
+    }
+
+    #[test]
+    fn test_blocked_by_grp_mem() {
+        let mut grp = TresRecord::new();
+        grp.set(TresType::Memory, 4096); // QOS-wide cap 4 GiB
+        let qos = Qos {
+            name: "grp".into(),
+            limits: QosLimits {
+                grp_tres: Some(grp),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut job = make_test_job();
+        job.spec.num_nodes = 1;
+        job.spec.memory_per_node_mb = Some(3000); // job needs 3 GiB
+        let mut qos_running = TresRecord::new();
+        qos_running.set(TresType::Memory, 2000); // 2 GiB already running; 2000 + 3000 > 4096
+        let result = check_qos_limits(&job, &qos, 0, 0, &TresRecord::new(), &qos_running);
+        assert_eq!(
+            result,
+            QosCheckResult::Blocked(PendingReason::QosGrpMemLimit)
+        );
+    }
+
+    #[test]
     fn test_qos_priority_adjustment() {
         let qos = Qos {
             priority: 500,

--- a/crates/spur-tests/src/t21_acctmgr.rs
+++ b/crates/spur-tests/src/t21_acctmgr.rs
@@ -131,7 +131,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let result = check_qos_limits(&job, &qos, 0, 0, &TresRecord::new());
+        let result = check_qos_limits(&job, &qos, 0, 0, &TresRecord::new(), &TresRecord::new());
         assert_eq!(result, QosCheckResult::Allowed);
     }
 
@@ -154,7 +154,7 @@ mod tests {
             },
         );
         // User already has 2 running
-        let result = check_qos_limits(&job, &qos, 2, 2, &TresRecord::new());
+        let result = check_qos_limits(&job, &qos, 2, 2, &TresRecord::new(), &TresRecord::new());
         assert_eq!(
             result,
             QosCheckResult::Blocked(PendingReason::QoSMaxJobsPerUser)
@@ -180,7 +180,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let result = check_qos_limits(&job, &qos, 0, 0, &TresRecord::new());
+        let result = check_qos_limits(&job, &qos, 0, 0, &TresRecord::new(), &TresRecord::new());
         // QOS wall-clock cap uses the QOS-specific reason, not PartitionTimeLimit.
         assert_eq!(
             result,
@@ -210,7 +210,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let result = check_qos_limits(&job, &qos, 0, 0, &TresRecord::new());
+        let result = check_qos_limits(&job, &qos, 0, 0, &TresRecord::new(), &TresRecord::new());
         // QOS MaxTRES (CPU) cap uses the specific QOS reason, not generic Resources.
         assert_eq!(
             result,

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2472,15 +2472,13 @@ fn license_block(job: &Job, pool: &HashMap<String, u64>) -> Option<spur_core::jo
     None
 }
 
-/// The specific `QOS*` limit a job trips, or `None` if within limits. The caller
-/// resolves the `Qos` (see `resolve_qos`). Shared by `pending_jobs()` and
-/// `tag_blocked_pending_reasons()` so drop and displayed reason agree.
+/// Shared by `pending_jobs()` and `tag_blocked_pending_reasons()` so the drop
+/// decision and displayed reason always agree. Caller resolves the `Qos`.
 fn qos_block_for(
     job: &Job,
     qos: &Qos,
     jobs: &HashMap<JobId, Job>,
 ) -> Option<spur_core::job::PendingReason> {
-    // No QoS -> no QoS-based block.
     let qos_name = job.spec.qos.as_ref()?;
     let user = &job.spec.user;
     let running_count = jobs
@@ -2493,7 +2491,6 @@ fn qos_block_for(
             (j.state == JobState::Pending || j.state == JobState::Running) && j.spec.user == *user
         })
         .count() as u32;
-    // Per-user running TRES (MaxTRESPerUser) and QOS-wide running TRES (Grp*).
     let user_running_tres = sum_running_tres(jobs, |j| j.spec.user == *user);
     let qos_running_tres =
         sum_running_tres(jobs, |j| j.spec.qos.as_deref() == Some(qos_name.as_str()));
@@ -2542,7 +2539,6 @@ fn partition_block(job: &Job, partitions: &[Partition]) -> Option<spur_core::job
     None
 }
 
-/// Sum cpu/node/mem TRES over running jobs matching `pred`.
 fn sum_running_tres(jobs: &HashMap<JobId, Job>, pred: impl Fn(&Job) -> bool) -> TresRecord {
     let mut tres = TresRecord::new();
     let (mut cpu, mut node, mut mem) = (0u64, 0u64, 0u64);

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2483,15 +2483,23 @@ fn qos_block_for(
     let user = &job.spec.user;
     let running_count = jobs
         .values()
-        .filter(|j| j.state == JobState::Running && j.spec.user == *user)
+        .filter(|j| {
+            j.state == JobState::Running
+                && j.spec.user == *user
+                && j.spec.qos.as_deref() == Some(qos_name.as_str())
+        })
         .count() as u32;
     let submitted_count = jobs
         .values()
         .filter(|j| {
-            (j.state == JobState::Pending || j.state == JobState::Running) && j.spec.user == *user
+            (j.state == JobState::Pending || j.state == JobState::Running)
+                && j.spec.user == *user
+                && j.spec.qos.as_deref() == Some(qos_name.as_str())
         })
         .count() as u32;
-    let user_running_tres = sum_running_tres(jobs, |j| j.spec.user == *user);
+    let user_running_tres = sum_running_tres(jobs, |j| {
+        j.spec.user == *user && j.spec.qos.as_deref() == Some(qos_name.as_str())
+    });
     let qos_running_tres =
         sum_running_tres(jobs, |j| j.spec.qos.as_deref() == Some(qos_name.as_str()));
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2481,7 +2481,7 @@ fn qos_block_for(
     jobs: &HashMap<JobId, Job>,
 ) -> Option<spur_core::job::PendingReason> {
     // No QoS -> no QoS-based block.
-    job.spec.qos.as_ref()?;
+    let qos_name = job.spec.qos.as_ref()?;
     let user = &job.spec.user;
     let running_count = jobs
         .values()
@@ -2493,15 +2493,19 @@ fn qos_block_for(
             (j.state == JobState::Pending || j.state == JobState::Running) && j.spec.user == *user
         })
         .count() as u32;
-    let mut running_tres = TresRecord::new();
-    let running_cpus: u64 = jobs
-        .values()
-        .filter(|j| j.state == JobState::Running && j.spec.user == *user)
-        .map(|j| (j.spec.num_tasks * j.spec.cpus_per_task) as u64)
-        .sum();
-    running_tres.set(TresType::Cpu, running_cpus);
+    // Per-user running TRES (MaxTRESPerUser) and QOS-wide running TRES (Grp*).
+    let user_running_tres = sum_running_tres(jobs, |j| j.spec.user == *user);
+    let qos_running_tres =
+        sum_running_tres(jobs, |j| j.spec.qos.as_deref() == Some(qos_name.as_str()));
 
-    match check_qos_limits(job, qos, running_count, submitted_count, &running_tres) {
+    match check_qos_limits(
+        job,
+        qos,
+        running_count,
+        submitted_count,
+        &user_running_tres,
+        &qos_running_tres,
+    ) {
         QosCheckResult::Allowed => None,
         QosCheckResult::Blocked(reason) => Some(reason),
     }
@@ -2536,6 +2540,26 @@ fn partition_block(job: &Job, partitions: &[Partition]) -> Option<spur_core::job
         }
     }
     None
+}
+
+/// Sum cpu/node/mem TRES over running jobs matching `pred`.
+fn sum_running_tres(jobs: &HashMap<JobId, Job>, pred: impl Fn(&Job) -> bool) -> TresRecord {
+    let mut tres = TresRecord::new();
+    let (mut cpu, mut node, mut mem) = (0u64, 0u64, 0u64);
+    for j in jobs.values() {
+        if j.state != JobState::Running || !pred(j) {
+            continue;
+        }
+        cpu += (j.spec.num_tasks * j.spec.cpus_per_task) as u64;
+        node += j.spec.num_nodes as u64;
+        if let Some(m) = j.spec.memory_per_node_mb {
+            mem += m * j.spec.num_nodes as u64;
+        }
+    }
+    tres.set(TresType::Cpu, cpu);
+    tres.set(TresType::Node, node);
+    tres.set(TresType::Memory, mem);
+    tres
 }
 
 fn extract_license_requirements(spec: &JobSpec) -> HashMap<String, u64> {
@@ -4351,6 +4375,51 @@ mod tests {
         assert_eq!(
             cm.get_job(job_id).unwrap().pending_reason,
             PendingReason::QosMaxWallDurationPerJobLimit
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn tag_blocked_sets_qos_grp_cpu_reason() {
+        // GrpCPU aggregates across all running jobs in the QOS: a running 4-cpu
+        // job fills a grp_tres cpu=4 cap, so the next job in the same QOS blocks
+        // with QOSGrpCpuLimit (the group reason, not the per-job/per-user one).
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+        let mut grp = TresRecord::new();
+        grp.set(TresType::Cpu, 4);
+        cm.qos_cache().insert(Qos {
+            name: "grp".into(),
+            limits: spur_core::accounting::QosLimits {
+                grp_tres: Some(grp),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let mut s1 = basic_spec("g1");
+        s1.qos = Some("grp".into());
+        s1.num_tasks = 4;
+        let j1 = submit_and_wait(&cm, s1);
+        let res = scalar_alloc(4, 1000);
+        cm.start_job(
+            j1,
+            vec!["n1".into()],
+            res.clone(),
+            per_node_for(&["n1"], res),
+        )
+        .unwrap();
+        settle(&cm, j1, JobState::Running);
+
+        let mut s2 = basic_spec("g2");
+        s2.qos = Some("grp".into());
+        s2.num_tasks = 1;
+        let j2 = submit_and_wait(&cm, s2);
+
+        cm.tag_blocked_pending_reasons();
+        assert_eq!(
+            cm.get_job(j2).unwrap().pending_reason,
+            PendingReason::QosGrpCpuLimit
         );
     }
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -26,6 +26,7 @@ use spur_metrics::node::NodeMetricsSnapshot;
 
 use crate::accounting::AccountingNotifier;
 use crate::fairshare_cache::FairshareCache;
+use crate::limits_cache::QosCache;
 use crate::raft::{ClientResponse, JobFinalized, SpurRaft, StateMachineApply};
 
 /// Result of recording a per-node completion report.
@@ -59,6 +60,7 @@ pub struct ClusterManager {
     raft: RwLock<Option<SpurRaft>>,
     accounting: RwLock<Option<AccountingNotifier>>,
     fairshare_cache: Arc<FairshareCache>,
+    qos_cache: Arc<QosCache>,
     /// Wake signal for the scheduler loop.
     pub(crate) scheduler_notify: Arc<Notify>,
 }
@@ -68,6 +70,7 @@ impl ClusterManager {
         let partitions = config.build_partitions();
         let license_pool = config.licenses.clone();
         let fairshare_cache = Arc::new(FairshareCache::new());
+        let qos_cache = Arc::new(QosCache::new());
 
         let cm = Self {
             config,
@@ -82,6 +85,7 @@ impl ClusterManager {
             raft: RwLock::new(None),
             accounting: RwLock::new(None),
             fairshare_cache,
+            qos_cache,
             scheduler_notify: Arc::new(Notify::new()),
         };
 
@@ -1221,7 +1225,7 @@ impl ClusterManager {
         // QoS enforcement: check per-user limits for jobs with a QoS. Shares
         // the eligibility logic with tag_blocked_pending_reasons() via
         // qos_block_for() so the drop decision and the displayed reason agree.
-        pending.retain(|job| qos_block_for(job, &jobs).is_none());
+        pending.retain(|job| qos_block_for(job, &self.resolve_qos(job), &jobs).is_none());
 
         // License enforcement is applied after the priority sort below, so scarce
         // licenses are reserved highest-priority-first and a single pass cannot
@@ -1473,7 +1477,7 @@ impl ClusterManager {
                     // Resv -> Lic (partition block is permanent, so first).
                     partition_block(job, &partitions)
                         .or_else(|| dependency_block(job))
-                        .or_else(|| qos_block_for(job, &jobs))
+                        .or_else(|| qos_block_for(job, &self.resolve_qos(job), &jobs))
                         .or_else(|| reservation_block(job, &reservations, now))
                         .or_else(|| license_block(job, &available))
                         .map(|reason| (job.job_id, reason))
@@ -1793,6 +1797,18 @@ impl ClusterManager {
 
     pub fn fairshare_cache(&self) -> &Arc<FairshareCache> {
         &self.fairshare_cache
+    }
+
+    pub fn qos_cache(&self) -> &Arc<QosCache> {
+        &self.qos_cache
+    }
+
+    /// Resolve a job's QoS from the cache; unknown/absent name → limitless default.
+    fn resolve_qos(&self, job: &Job) -> Qos {
+        match job.spec.qos.as_deref() {
+            Some(name) => self.qos_cache.get(name).unwrap_or_default(),
+            None => Qos::default(),
+        }
     }
 
     /// Persist a mutation via Raft consensus. The apply callback
@@ -2456,11 +2472,14 @@ fn license_block(job: &Job, pool: &HashMap<String, u64>) -> Option<spur_core::jo
     None
 }
 
-/// The specific `QOS*` limit a job trips, or `None` if within limits. QoS is not
-/// yet sourced from the accounting DB (a limitless default is used), so this is
-/// wired but inert until real QoS configs exist. Shared by `pending_jobs()` and
-/// `tag_blocked_pending_reasons()`.
-fn qos_block_for(job: &Job, jobs: &HashMap<JobId, Job>) -> Option<spur_core::job::PendingReason> {
+/// The specific `QOS*` limit a job trips, or `None` if within limits. The caller
+/// resolves the `Qos` (see `resolve_qos`). Shared by `pending_jobs()` and
+/// `tag_blocked_pending_reasons()` so drop and displayed reason agree.
+fn qos_block_for(
+    job: &Job,
+    qos: &Qos,
+    jobs: &HashMap<JobId, Job>,
+) -> Option<spur_core::job::PendingReason> {
     // No QoS -> no QoS-based block.
     job.spec.qos.as_ref()?;
     let user = &job.spec.user;
@@ -2482,8 +2501,7 @@ fn qos_block_for(job: &Job, jobs: &HashMap<JobId, Job>) -> Option<spur_core::job
         .sum();
     running_tres.set(TresType::Cpu, running_cpus);
 
-    let qos = Qos::default();
-    match check_qos_limits(job, &qos, running_count, submitted_count, &running_tres) {
+    match check_qos_limits(job, qos, running_count, submitted_count, &running_tres) {
         QosCheckResult::Allowed => None,
         QosCheckResult::Blocked(reason) => Some(reason),
     }
@@ -4306,6 +4324,33 @@ mod tests {
         assert_eq!(
             cm.get_job(job_id).unwrap().pending_reason,
             PendingReason::Licenses
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn tag_blocked_sets_qos_reason_from_cache() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        // Seed the cache with a QoS that caps wall time at 1 min, then submit a
+        // job to that QoS asking for more — the specific QOS reason must surface
+        // through resolve_qos -> qos_block_for (not the old limitless default).
+        cm.qos_cache().insert(Qos {
+            name: "short".into(),
+            limits: spur_core::accounting::QosLimits {
+                max_wall_minutes: Some(1),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        let mut spec = basic_spec("qos");
+        spec.qos = Some("short".into());
+        spec.time_limit = Some(chrono::Duration::hours(1));
+        let job_id = submit_and_wait(&cm, spec);
+
+        cm.tag_blocked_pending_reasons();
+        assert_eq!(
+            cm.get_job(job_id).unwrap().pending_reason,
+            PendingReason::QosMaxWallDurationPerJobLimit
         );
     }
 

--- a/crates/spurctld/src/limits_cache.rs
+++ b/crates/spurctld/src/limits_cache.rs
@@ -101,7 +101,7 @@ impl Default for QosCache {
 }
 
 /// Zero/empty limit fields mean "no limit" — the accounting daemon encodes absent limits this way.
-pub fn qos_from_proto(info: QosInfo) -> Qos {
+fn qos_from_proto(info: QosInfo) -> Qos {
     let opt_u32 = |v: u32| if v == 0 { None } else { Some(v) };
     let opt_tres = |s: &str| {
         if s.is_empty() {
@@ -156,13 +156,14 @@ mod tests {
     }
 
     #[test]
-    fn test_proto_to_qos_parses_all_five_limits() {
+    fn test_proto_to_qos_parses_all_limits() {
         let mut p = proto("limited");
         p.max_jobs_per_user = 4;
         p.max_submit_jobs_per_user = 8;
         p.max_wall_minutes = 60;
         p.max_tres_per_job = "cpu=2".into();
         p.max_tres_per_user = "cpu=16".into();
+        p.grp_tres = "cpu=64".into();
 
         let qos = qos_from_proto(p);
         assert_eq!(qos.limits.max_jobs_per_user, Some(4));
@@ -181,6 +182,10 @@ mod tests {
                 .as_ref()
                 .map(|t| t.get(TresType::Cpu)),
             Some(16)
+        );
+        assert_eq!(
+            qos.limits.grp_tres.as_ref().map(|t| t.get(TresType::Cpu)),
+            Some(64)
         );
     }
 

--- a/crates/spurctld/src/limits_cache.rs
+++ b/crates/spurctld/src/limits_cache.rs
@@ -127,7 +127,7 @@ pub fn qos_from_proto(info: QosInfo) -> Qos {
             max_submit_jobs_per_user: opt_u32(info.max_submit_jobs_per_user),
             max_tres_per_job: opt_tres(&info.max_tres_per_job),
             max_tres_per_user: opt_tres(&info.max_tres_per_user),
-            grp_tres: None,
+            grp_tres: opt_tres(&info.grp_tres),
             max_wall_minutes: opt_u32(info.max_wall_minutes),
             grp_wall_minutes: None,
         },
@@ -154,6 +154,7 @@ mod tests {
             max_tres_per_job: String::new(),
             max_submit_jobs_per_user: 0,
             max_tres_per_user: String::new(),
+            grp_tres: String::new(),
         }
     }
 
@@ -228,7 +229,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        let result = check_qos_limits(&job, &qos, 0, 2, &TresRecord::new());
+        let result = check_qos_limits(&job, &qos, 0, 2, &TresRecord::new(), &TresRecord::new());
         assert_eq!(
             result,
             QosCheckResult::Blocked(PendingReason::QosMaxSubmitJobPerUserLimit)
@@ -256,7 +257,7 @@ mod tests {
         );
         let mut running = TresRecord::new();
         running.set(TresType::Cpu, 6);
-        let result = check_qos_limits(&job, &qos, 0, 0, &running);
+        let result = check_qos_limits(&job, &qos, 0, 0, &running, &TresRecord::new());
         assert_eq!(
             result,
             QosCheckResult::Blocked(PendingReason::QosMaxCpuPerUserLimit)

--- a/crates/spurctld/src/limits_cache.rs
+++ b/crates/spurctld/src/limits_cache.rs
@@ -30,7 +30,6 @@ impl QosCache {
         }
     }
 
-    /// Look up a QoS by name, returning a clone if present.
     pub fn get(&self, name: &str) -> Option<Qos> {
         self.qos.read().get(name).cloned()
     }
@@ -39,8 +38,7 @@ impl QosCache {
         *self.qos.write() = new_qos;
     }
 
-    /// Insert a single QoS. Test-only seam to populate the cache without the
-    /// accounting daemon.
+    /// Test-only seam: populates the cache without the accounting daemon.
     #[cfg(test)]
     pub(crate) fn insert(&self, qos: Qos) {
         self.qos.write().insert(qos.name.clone(), qos);
@@ -102,8 +100,7 @@ impl Default for QosCache {
     }
 }
 
-/// Convert a `QosInfo` proto into a core `Qos`. A zero/empty limit field means
-/// "no limit" (mirrors how the accounting daemon encodes absent limits).
+/// Zero/empty limit fields mean "no limit" — the accounting daemon encodes absent limits this way.
 pub fn qos_from_proto(info: QosInfo) -> Qos {
     let opt_u32 = |v: u32| if v == 0 { None } else { Some(v) };
     let opt_tres = |s: &str| {

--- a/crates/spurctld/src/limits_cache.rs
+++ b/crates/spurctld/src/limits_cache.rs
@@ -1,0 +1,265 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Controller-side cache of QoS definitions loaded from the accounting daemon.
+//!
+//! Mirrors `fairshare_cache`: an `RwLock<HashMap>` refreshed on a background
+//! loop that retains stale data on error. The scheduler's `qos_block_for` reads
+//! this cache so the dormant `QOS*` pending-reasons fire against real limits.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::RwLock;
+use tonic::transport::Channel;
+use tracing::{info, warn};
+
+use spur_core::accounting::{Qos, QosLimits, QosPreemptMode, TresRecord};
+use spur_proto::proto::slurm_accounting_client::SlurmAccountingClient;
+use spur_proto::proto::{ListQosRequest, QosInfo};
+
+pub struct QosCache {
+    qos: RwLock<HashMap<String, Qos>>,
+}
+
+impl QosCache {
+    pub fn new() -> Self {
+        Self {
+            qos: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Look up a QoS by name, returning a clone if present.
+    pub fn get(&self, name: &str) -> Option<Qos> {
+        self.qos.read().get(name).cloned()
+    }
+
+    fn replace(&self, new_qos: HashMap<String, Qos>) {
+        *self.qos.write() = new_qos;
+    }
+
+    /// Insert a single QoS. Test-only seam to populate the cache without the
+    /// accounting daemon.
+    #[cfg(test)]
+    pub(crate) fn insert(&self, qos: Qos) {
+        self.qos.write().insert(qos.name.clone(), qos);
+    }
+
+    pub fn spawn_refresh_loop(self: &Arc<Self>, host: String, refresh_interval_secs: u64) {
+        let cache = Arc::clone(self);
+        let interval = Duration::from_secs(refresh_interval_secs.max(10));
+
+        tokio::spawn(async move {
+            let uri = if host.starts_with("http://") || host.starts_with("https://") {
+                host.clone()
+            } else {
+                format!("http://{}", host)
+            };
+
+            match tokio::time::timeout(Duration::from_secs(5), Self::fetch(&uri)).await {
+                Ok(Ok(qos)) => {
+                    info!(count = qos.len(), "qos cache initialized");
+                    cache.replace(qos);
+                }
+                Ok(Err(e)) => {
+                    warn!(error = %e, "initial qos fetch failed, will retry in background");
+                }
+                Err(_) => {
+                    warn!("initial qos fetch timed out, will retry in background");
+                }
+            }
+
+            loop {
+                tokio::time::sleep(interval).await;
+
+                match tokio::time::timeout(Duration::from_secs(10), Self::fetch(&uri)).await {
+                    Ok(Ok(qos)) => cache.replace(qos),
+                    Ok(Err(e)) => warn!(error = %e, "qos refresh failed, retaining stale data"),
+                    Err(_) => warn!("qos refresh timed out, retaining stale data"),
+                }
+            }
+        });
+    }
+
+    async fn fetch(uri: &str) -> anyhow::Result<HashMap<String, Qos>> {
+        let mut client: SlurmAccountingClient<Channel> =
+            SlurmAccountingClient::connect(uri.to_owned()).await?;
+        let resp = client.list_qos(ListQosRequest {}).await?;
+        let qos = resp
+            .into_inner()
+            .qos_list
+            .into_iter()
+            .map(|info| (info.name.clone(), qos_from_proto(info)))
+            .collect();
+        Ok(qos)
+    }
+}
+
+impl Default for QosCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Convert a `QosInfo` proto into a core `Qos`. A zero/empty limit field means
+/// "no limit" (mirrors how the accounting daemon encodes absent limits).
+pub fn qos_from_proto(info: QosInfo) -> Qos {
+    let opt_u32 = |v: u32| if v == 0 { None } else { Some(v) };
+    let opt_tres = |s: &str| {
+        if s.is_empty() {
+            None
+        } else {
+            Some(TresRecord::parse(s))
+        }
+    };
+
+    Qos {
+        name: info.name,
+        description: info.description,
+        priority: info.priority,
+        preempt_mode: info
+            .preempt_mode
+            .parse::<QosPreemptMode>()
+            .unwrap_or_default(),
+        limits: QosLimits {
+            max_jobs_per_user: opt_u32(info.max_jobs_per_user),
+            max_submit_jobs_per_user: opt_u32(info.max_submit_jobs_per_user),
+            max_tres_per_job: opt_tres(&info.max_tres_per_job),
+            max_tres_per_user: opt_tres(&info.max_tres_per_user),
+            grp_tres: None,
+            max_wall_minutes: opt_u32(info.max_wall_minutes),
+            grp_wall_minutes: None,
+        },
+        usage_factor: info.usage_factor,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spur_core::accounting::TresType;
+    use spur_core::job::{Job, JobSpec, PendingReason};
+    use spur_core::qos::{check_qos_limits, QosCheckResult};
+
+    fn proto(name: &str) -> QosInfo {
+        QosInfo {
+            name: name.into(),
+            description: String::new(),
+            priority: 0,
+            preempt_mode: "off".into(),
+            usage_factor: 1.0,
+            max_jobs_per_user: 0,
+            max_wall_minutes: 0,
+            max_tres_per_job: String::new(),
+            max_submit_jobs_per_user: 0,
+            max_tres_per_user: String::new(),
+        }
+    }
+
+    #[test]
+    fn test_proto_to_qos_parses_all_five_limits() {
+        let mut p = proto("limited");
+        p.max_jobs_per_user = 4;
+        p.max_submit_jobs_per_user = 8;
+        p.max_wall_minutes = 60;
+        p.max_tres_per_job = "cpu=2".into();
+        p.max_tres_per_user = "cpu=16".into();
+
+        let qos = qos_from_proto(p);
+        assert_eq!(qos.limits.max_jobs_per_user, Some(4));
+        assert_eq!(qos.limits.max_submit_jobs_per_user, Some(8));
+        assert_eq!(qos.limits.max_wall_minutes, Some(60));
+        assert_eq!(
+            qos.limits
+                .max_tres_per_job
+                .as_ref()
+                .map(|t| t.get(TresType::Cpu)),
+            Some(2)
+        );
+        assert_eq!(
+            qos.limits
+                .max_tres_per_user
+                .as_ref()
+                .map(|t| t.get(TresType::Cpu)),
+            Some(16)
+        );
+    }
+
+    #[test]
+    fn test_proto_to_qos_zero_means_no_limit() {
+        let qos = qos_from_proto(proto("empty"));
+        assert!(qos.limits.max_jobs_per_user.is_none());
+        assert!(qos.limits.max_submit_jobs_per_user.is_none());
+        assert!(qos.limits.max_tres_per_job.is_none());
+        assert!(qos.limits.max_tres_per_user.is_none());
+        assert!(qos.limits.max_wall_minutes.is_none());
+    }
+
+    #[test]
+    fn test_cache_get_returns_converted_qos() {
+        let cache = QosCache::new();
+        let mut p = proto("normal");
+        p.max_submit_jobs_per_user = 3;
+        cache.replace(HashMap::from([("normal".to_string(), qos_from_proto(p))]));
+
+        assert!(cache.get("missing").is_none());
+        let got = cache.get("normal").expect("present");
+        assert_eq!(got.limits.max_submit_jobs_per_user, Some(3));
+    }
+
+    // A cache-sourced limited Qos drives check_qos_limits to the specific reason.
+    #[test]
+    fn test_cached_qos_fires_submit_limit_reason() {
+        let cache = QosCache::new();
+        let mut p = proto("strict");
+        p.max_submit_jobs_per_user = 2;
+        cache.replace(HashMap::from([("strict".to_string(), qos_from_proto(p))]));
+
+        let qos = cache.get("strict").expect("present");
+        let job = Job::new(
+            1,
+            JobSpec {
+                name: "j".into(),
+                user: "alice".into(),
+                num_tasks: 1,
+                cpus_per_task: 1,
+                qos: Some("strict".into()),
+                ..Default::default()
+            },
+        );
+        let result = check_qos_limits(&job, &qos, 0, 2, &TresRecord::new());
+        assert_eq!(
+            result,
+            QosCheckResult::Blocked(PendingReason::QosMaxSubmitJobPerUserLimit)
+        );
+    }
+
+    #[test]
+    fn test_cached_qos_fires_cpu_per_user_reason() {
+        let cache = QosCache::new();
+        let mut p = proto("cpucap");
+        p.max_tres_per_user = "cpu=8".into();
+        cache.replace(HashMap::from([("cpucap".to_string(), qos_from_proto(p))]));
+
+        let qos = cache.get("cpucap").expect("present");
+        let job = Job::new(
+            2,
+            JobSpec {
+                name: "j".into(),
+                user: "bob".into(),
+                num_tasks: 4,
+                cpus_per_task: 1,
+                qos: Some("cpucap".into()),
+                ..Default::default()
+            },
+        );
+        let mut running = TresRecord::new();
+        running.set(TresType::Cpu, 6);
+        let result = check_qos_limits(&job, &qos, 0, 0, &running);
+        assert_eq!(
+            result,
+            QosCheckResult::Blocked(PendingReason::QosMaxCpuPerUserLimit)
+        );
+    }
+}

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -4,6 +4,7 @@
 mod accounting;
 mod cluster;
 mod fairshare_cache;
+mod limits_cache;
 mod metrics_proto;
 mod metrics_server;
 mod raft;
@@ -158,6 +159,12 @@ async fn main() -> anyhow::Result<()> {
     cluster.fairshare_cache().spawn_refresh_loop(
         config.accounting.host.clone(),
         config.scheduler.fairshare_halflife_days,
+        config.accounting.fairshare_refresh_secs as u64,
+    );
+
+    // QoS limits refresh loop (shares the accounting host + cadence).
+    cluster.qos_cache().spawn_refresh_loop(
+        config.accounting.host.clone(),
         config.accounting.fairshare_refresh_secs as u64,
     );
 

--- a/crates/spurdbd/src/db.rs
+++ b/crates/spurdbd/src/db.rs
@@ -568,17 +568,18 @@ pub async fn upsert_qos(
     max_tres_per_job: Option<&str>,
     max_submit_per_user: Option<i32>,
     max_tres_per_user: Option<&str>,
+    grp_tres: Option<&str>,
 ) -> anyhow::Result<()> {
     sqlx::query(
         r#"
         INSERT INTO qos (name, description, priority, preempt_mode, usage_factor,
                          max_jobs_per_user, max_wall_min, max_tres_per_job,
-                         max_submit_per_user, max_tres_per_user)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+                         max_submit_per_user, max_tres_per_user, grp_tres)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
         ON CONFLICT (name) DO UPDATE SET
             description = $2, priority = $3, preempt_mode = $4, usage_factor = $5,
             max_jobs_per_user = $6, max_wall_min = $7, max_tres_per_job = $8,
-            max_submit_per_user = $9, max_tres_per_user = $10
+            max_submit_per_user = $9, max_tres_per_user = $10, grp_tres = $11
         "#,
     )
     .bind(name)
@@ -591,6 +592,7 @@ pub async fn upsert_qos(
     .bind(max_tres_per_job)
     .bind(max_submit_per_user)
     .bind(max_tres_per_user)
+    .bind(grp_tres)
     .execute(pool)
     .await?;
     Ok(())
@@ -608,7 +610,7 @@ pub async fn delete_qos(pool: &PgPool, name: &str) -> anyhow::Result<()> {
 /// List all QOS.
 pub async fn list_qos(pool: &PgPool) -> anyhow::Result<Vec<QosRecord>> {
     let rows = sqlx::query(
-        "SELECT name, description, priority, preempt_mode, usage_factor, max_jobs_per_user, max_wall_min, max_tres_per_job, max_submit_per_user, max_tres_per_user FROM qos ORDER BY name"
+        "SELECT name, description, priority, preempt_mode, usage_factor, max_jobs_per_user, max_wall_min, max_tres_per_job, max_submit_per_user, max_tres_per_user, grp_tres FROM qos ORDER BY name"
     ).fetch_all(pool).await?;
 
     Ok(rows
@@ -625,6 +627,7 @@ pub async fn list_qos(pool: &PgPool) -> anyhow::Result<Vec<QosRecord>> {
             max_tres_per_job: r.get("max_tres_per_job"),
             max_submit_per_user: r.get("max_submit_per_user"),
             max_tres_per_user: r.get("max_tres_per_user"),
+            grp_tres: r.get("grp_tres"),
         })
         .collect())
 }
@@ -641,6 +644,7 @@ pub struct QosRecord {
     pub max_tres_per_job: Option<String>,
     pub max_submit_per_user: Option<i32>,
     pub max_tres_per_user: Option<String>,
+    pub grp_tres: Option<String>,
 }
 
 #[cfg(test)]
@@ -777,6 +781,7 @@ mod job_history_tests {
             Some("cpu=2"),
             Some(4),
             Some("cpu=16"),
+            Some("cpu=64"),
         )
         .await?;
 
@@ -792,6 +797,7 @@ mod job_history_tests {
         assert_eq!(got.max_tres_per_job.as_deref(), Some("cpu=2"));
         assert_eq!(got.max_submit_per_user, Some(4));
         assert_eq!(got.max_tres_per_user.as_deref(), Some("cpu=16"));
+        assert_eq!(got.grp_tres.as_deref(), Some("cpu=64"));
 
         sqlx::query("DELETE FROM qos WHERE name = $1")
             .bind(&name)

--- a/crates/spurdbd/src/db.rs
+++ b/crates/spurdbd/src/db.rs
@@ -566,15 +566,19 @@ pub async fn upsert_qos(
     max_jobs_per_user: Option<i32>,
     max_wall_min: Option<i32>,
     max_tres_per_job: Option<&str>,
+    max_submit_per_user: Option<i32>,
+    max_tres_per_user: Option<&str>,
 ) -> anyhow::Result<()> {
     sqlx::query(
         r#"
         INSERT INTO qos (name, description, priority, preempt_mode, usage_factor,
-                         max_jobs_per_user, max_wall_min, max_tres_per_job)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+                         max_jobs_per_user, max_wall_min, max_tres_per_job,
+                         max_submit_per_user, max_tres_per_user)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
         ON CONFLICT (name) DO UPDATE SET
             description = $2, priority = $3, preempt_mode = $4, usage_factor = $5,
-            max_jobs_per_user = $6, max_wall_min = $7, max_tres_per_job = $8
+            max_jobs_per_user = $6, max_wall_min = $7, max_tres_per_job = $8,
+            max_submit_per_user = $9, max_tres_per_user = $10
         "#,
     )
     .bind(name)
@@ -585,6 +589,8 @@ pub async fn upsert_qos(
     .bind(max_jobs_per_user)
     .bind(max_wall_min)
     .bind(max_tres_per_job)
+    .bind(max_submit_per_user)
+    .bind(max_tres_per_user)
     .execute(pool)
     .await?;
     Ok(())
@@ -602,7 +608,7 @@ pub async fn delete_qos(pool: &PgPool, name: &str) -> anyhow::Result<()> {
 /// List all QOS.
 pub async fn list_qos(pool: &PgPool) -> anyhow::Result<Vec<QosRecord>> {
     let rows = sqlx::query(
-        "SELECT name, description, priority, preempt_mode, usage_factor, max_jobs_per_user, max_wall_min, max_tres_per_job FROM qos ORDER BY name"
+        "SELECT name, description, priority, preempt_mode, usage_factor, max_jobs_per_user, max_wall_min, max_tres_per_job, max_submit_per_user, max_tres_per_user FROM qos ORDER BY name"
     ).fetch_all(pool).await?;
 
     Ok(rows
@@ -612,10 +618,13 @@ pub async fn list_qos(pool: &PgPool) -> anyhow::Result<Vec<QosRecord>> {
             description: r.get("description"),
             priority: r.get("priority"),
             preempt_mode: r.get("preempt_mode"),
-            usage_factor: r.get("usage_factor"),
+            // Column is REAL (f32) in the schema; widen to the struct's f64.
+            usage_factor: r.get::<f32, _>("usage_factor") as f64,
             max_jobs_per_user: r.get("max_jobs_per_user"),
             max_wall_min: r.get("max_wall_min"),
             max_tres_per_job: r.get("max_tres_per_job"),
+            max_submit_per_user: r.get("max_submit_per_user"),
+            max_tres_per_user: r.get("max_tres_per_user"),
         })
         .collect())
 }
@@ -630,6 +639,8 @@ pub struct QosRecord {
     pub max_jobs_per_user: Option<i32>,
     pub max_wall_min: Option<i32>,
     pub max_tres_per_job: Option<String>,
+    pub max_submit_per_user: Option<i32>,
+    pub max_tres_per_user: Option<String>,
 }
 
 #[cfg(test)]
@@ -738,6 +749,54 @@ mod job_history_tests {
         assert_eq!(limited[0].job_id, id2);
 
         delete_jobs(&pool, &ids).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL and PostgreSQL"]
+    async fn list_qos_round_trips_all_limits() -> anyhow::Result<()> {
+        // Regression: usage_factor is REAL (f32) in the schema; decoding it as
+        // f64 panicked the worker and broke ListQos (and the controller's QoS
+        // cache) until widened. Exercise the full upsert -> list path.
+        let pool = test_pool().await?;
+        let name = format!("spur_qos_{}", std::process::id());
+        sqlx::query("DELETE FROM qos WHERE name = $1")
+            .bind(&name)
+            .execute(&pool)
+            .await?;
+
+        upsert_qos(
+            &pool,
+            &name,
+            "d",
+            5,
+            "cluster",
+            1.5,
+            Some(3),
+            Some(60),
+            Some("cpu=2"),
+            Some(4),
+            Some("cpu=16"),
+        )
+        .await?;
+
+        let got = list_qos(&pool)
+            .await?
+            .into_iter()
+            .find(|q| q.name == name)
+            .expect("qos present");
+        assert_eq!(got.usage_factor, 1.5);
+        assert_eq!(got.priority, 5);
+        assert_eq!(got.max_jobs_per_user, Some(3));
+        assert_eq!(got.max_wall_min, Some(60));
+        assert_eq!(got.max_tres_per_job.as_deref(), Some("cpu=2"));
+        assert_eq!(got.max_submit_per_user, Some(4));
+        assert_eq!(got.max_tres_per_user.as_deref(), Some("cpu=16"));
+
+        sqlx::query("DELETE FROM qos WHERE name = $1")
+            .bind(&name)
+            .execute(&pool)
+            .await?;
         Ok(())
     }
 }

--- a/crates/spurdbd/src/server.rs
+++ b/crates/spurdbd/src/server.rs
@@ -396,6 +396,11 @@ impl SlurmAccounting for AccountingService {
         } else {
             Some(req.max_tres_per_user.as_str())
         };
+        let grp_tres = if req.grp_tres.is_empty() {
+            None
+        } else {
+            Some(req.grp_tres.as_str())
+        };
         db::upsert_qos(
             &self.pool,
             &req.name,
@@ -408,6 +413,7 @@ impl SlurmAccounting for AccountingService {
             max_tres,
             max_submit,
             max_tres_user,
+            grp_tres,
         )
         .await
         .map_err(|e| Status::internal(e.to_string()))?;
@@ -443,6 +449,7 @@ impl SlurmAccounting for AccountingService {
                 max_tres_per_job: r.max_tres_per_job.unwrap_or_default(),
                 max_submit_jobs_per_user: r.max_submit_per_user.unwrap_or(0) as u32,
                 max_tres_per_user: r.max_tres_per_user.unwrap_or_default(),
+                grp_tres: r.grp_tres.unwrap_or_default(),
             })
             .collect();
 

--- a/crates/spurdbd/src/server.rs
+++ b/crates/spurdbd/src/server.rs
@@ -374,12 +374,18 @@ impl SlurmAccounting for AccountingService {
         let max_jobs = if req.max_jobs_per_user == 0 {
             None
         } else {
-            Some(req.max_jobs_per_user as i32)
+            Some(
+                i32::try_from(req.max_jobs_per_user)
+                    .map_err(|_| Status::invalid_argument("max_jobs_per_user exceeds i32::MAX"))?,
+            )
         };
         let max_wall = if req.max_wall_minutes == 0 {
             None
         } else {
-            Some(req.max_wall_minutes as i32)
+            Some(
+                i32::try_from(req.max_wall_minutes)
+                    .map_err(|_| Status::invalid_argument("max_wall_minutes exceeds i32::MAX"))?,
+            )
         };
         let max_tres = if req.max_tres_per_job.is_empty() {
             None
@@ -389,7 +395,11 @@ impl SlurmAccounting for AccountingService {
         let max_submit = if req.max_submit_jobs_per_user == 0 {
             None
         } else {
-            Some(req.max_submit_jobs_per_user as i32)
+            Some(
+                i32::try_from(req.max_submit_jobs_per_user).map_err(|_| {
+                    Status::invalid_argument("max_submit_jobs_per_user exceeds i32::MAX")
+                })?,
+            )
         };
         let max_tres_user = if req.max_tres_per_user.is_empty() {
             None

--- a/crates/spurdbd/src/server.rs
+++ b/crates/spurdbd/src/server.rs
@@ -386,6 +386,16 @@ impl SlurmAccounting for AccountingService {
         } else {
             Some(req.max_tres_per_job.as_str())
         };
+        let max_submit = if req.max_submit_jobs_per_user == 0 {
+            None
+        } else {
+            Some(req.max_submit_jobs_per_user as i32)
+        };
+        let max_tres_user = if req.max_tres_per_user.is_empty() {
+            None
+        } else {
+            Some(req.max_tres_per_user.as_str())
+        };
         db::upsert_qos(
             &self.pool,
             &req.name,
@@ -396,6 +406,8 @@ impl SlurmAccounting for AccountingService {
             max_jobs,
             max_wall,
             max_tres,
+            max_submit,
+            max_tres_user,
         )
         .await
         .map_err(|e| Status::internal(e.to_string()))?;
@@ -429,6 +441,8 @@ impl SlurmAccounting for AccountingService {
                 max_jobs_per_user: r.max_jobs_per_user.unwrap_or(0) as u32,
                 max_wall_minutes: r.max_wall_min.unwrap_or(0) as u32,
                 max_tres_per_job: r.max_tres_per_job.unwrap_or_default(),
+                max_submit_jobs_per_user: r.max_submit_per_user.unwrap_or(0) as u32,
+                max_tres_per_user: r.max_tres_per_user.unwrap_or_default(),
             })
             .collect();
 

--- a/crates/spurdbd/src/server.rs
+++ b/crates/spurdbd/src/server.rs
@@ -395,11 +395,9 @@ impl SlurmAccounting for AccountingService {
         let max_submit = if req.max_submit_jobs_per_user == 0 {
             None
         } else {
-            Some(
-                i32::try_from(req.max_submit_jobs_per_user).map_err(|_| {
-                    Status::invalid_argument("max_submit_jobs_per_user exceeds i32::MAX")
-                })?,
-            )
+            Some(i32::try_from(req.max_submit_jobs_per_user).map_err(|_| {
+                Status::invalid_argument("max_submit_jobs_per_user exceeds i32::MAX")
+            })?)
         };
         let max_tres_user = if req.max_tres_per_user.is_empty() {
             None

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -780,6 +780,7 @@ message CreateQosRequest {
   string max_tres_per_job = 8;
   uint32 max_submit_jobs_per_user = 9;
   string max_tres_per_user = 10;
+  string grp_tres = 11;
 }
 
 message DeleteQosRequest {
@@ -803,6 +804,7 @@ message QosInfo {
   string max_tres_per_job = 8;
   uint32 max_submit_jobs_per_user = 9;
   string max_tres_per_user = 10;
+  string grp_tres = 11;
 }
 
 // ============================================================

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -778,6 +778,8 @@ message CreateQosRequest {
   uint32 max_jobs_per_user = 6;
   uint32 max_wall_minutes = 7;
   string max_tres_per_job = 8;
+  uint32 max_submit_jobs_per_user = 9;
+  string max_tres_per_user = 10;
 }
 
 message DeleteQosRequest {
@@ -799,6 +801,8 @@ message QosInfo {
   uint32 max_jobs_per_user = 6;
   uint32 max_wall_minutes = 7;
   string max_tres_per_job = 8;
+  uint32 max_submit_jobs_per_user = 9;
+  string max_tres_per_user = 10;
 }
 
 // ============================================================

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -712,8 +712,8 @@ mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
             ],
         }
         if self.accounting_enabled:
-            # Controller dials spurdbd on node 0. The QoS/limit cache floors
-            # the refresh interval at ~10s, which the tests poll around.
+            # Controller dials spurdbd on node 0; refresh fast so QoS/limit
+            # changes show up within a test's patience window.
             cfg["accounting"] = {
                 "host": f"{self.nodes[0].host}:{ACCOUNTING_PORT}",
                 "database_url": self._db_url,

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -712,8 +712,8 @@ mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
             ],
         }
         if self.accounting_enabled:
-            # Controller dials spurdbd on node 0; refresh fast so QoS/limit
-            # changes show up within a test's patience window.
+            # Controller dials spurdbd on node 0. The QoS/limit cache floors
+            # the refresh interval at ~10s, which the tests poll around.
             cfg["accounting"] = {
                 "host": f"{self.nodes[0].host}:{ACCOUNTING_PORT}",
                 "database_url": self._db_url,

--- a/tests/native_host/e2e/test_accounting.py
+++ b/tests/native_host/e2e/test_accounting.py
@@ -57,7 +57,8 @@ class TestQosLimitReasons:
 
         # Define a QoS that caps wall time at 1 minute.
         c.sacctmgr(["add", "qos", "name=short", "maxwall=1"])
-        # The controller refreshes its QoS cache every ~2s; wait for it.
+        # The controller refreshes its QoS cache every ~10s (floor); the poll
+        # loop below waits it out.
         time.sleep(6)
 
         # A job in that QoS asking for 1h exceeds the cap, so it stays PENDING

--- a/tests/native_host/e2e/test_accounting.py
+++ b/tests/native_host/e2e/test_accounting.py
@@ -57,9 +57,8 @@ class TestQosLimitReasons:
 
         # Define a QoS that caps wall time at 1 minute.
         c.sacctmgr(["add", "qos", "name=short", "maxwall=1"])
-        # The controller refreshes its QoS cache every ~10s (floor); the poll
-        # loop below waits it out.
-        time.sleep(6)
+        # Wait past the QoS cache refresh floor (10s) before submitting, else the job starts before the cap loads.
+        time.sleep(15)
 
         # A job in that QoS asking for 1h exceeds the cap, so it stays PENDING
         # with the specific QoS reason (not generic Resources/PartitionTimeLimit).

--- a/tests/native_host/e2e/test_accounting.py
+++ b/tests/native_host/e2e/test_accounting.py
@@ -1,11 +1,14 @@
 # Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""E2E tests for sacct accounting: exit:signal and DerivedExitCode.
+"""E2E tests for accounting: sacct exit reporting and QoS pending reasons.
 
 Requires spurdbd + Postgres on node 0 (the accounting_cluster fixture, which
 skips when Docker or the accounting binaries are unavailable).
 """
+
+import re
+import time
 
 from cluster import parse_job_id, wait_job, wait_sacct_row
 
@@ -40,3 +43,38 @@ class TestSacctExitReporting:
         fields = row.split()
         assert fields[1] == "3:0", f"expected ExitCode 3:0, got {fields!r}"
         assert fields[2] == "7:0", f"expected DerivedExitCode 7:0, got {fields!r}"
+
+
+def _reason(cluster, job_id: int) -> str:
+    out = cluster.scontrol("show", "job", str(job_id))
+    m = re.search(r"Reason=(\S+)", out)
+    return m.group(1) if m else ""
+
+
+class TestQosLimitReasons:
+    def test_wall_cap_sets_qos_pending_reason(self, accounting_cluster):
+        c = accounting_cluster
+
+        # Define a QoS that caps wall time at 1 minute.
+        c.sacctmgr(["add", "qos", "name=short", "maxwall=1"])
+        # The controller refreshes its QoS cache every ~2s; wait for it.
+        time.sleep(6)
+
+        # A job in that QoS asking for 1h exceeds the cap, so it stays PENDING
+        # with the specific QoS reason (not generic Resources/PartitionTimeLimit).
+        script = c.write_file("qos-job.sh", "#!/bin/bash\nsleep 30\n")
+        job_id = parse_job_id(
+            c.sbatch(["-J", "qos-wall", "-N", "1", "-q", "short", "-t", "60", script])
+        )
+        assert job_id is not None
+
+        deadline = time.time() + 30
+        reason = ""
+        while time.time() < deadline:
+            reason = _reason(c, job_id)
+            if reason == "QOSMaxWallDurationPerJobLimit":
+                break
+            time.sleep(2)
+        assert reason == "QOSMaxWallDurationPerJobLimit", (
+            f"expected QOSMaxWallDurationPerJobLimit, got {reason!r}"
+        )


### PR DESCRIPTION
**Draft** — scoped slice of #307 (QoS group of the pending-reason emission umbrella).

> ⚠️ **Stacked on #301** (`parity/reason-code-vocab`), which is not yet merged. Until #301 lands, this PR's diff includes #301's commits. Review the QoS-emission commit (`feat(spurctld): enforce real QoS limits via controller-side QosCache`) — the rest belongs to #301. Will rebase onto `main` once #301 merges.

## Problem
#301 landed 5 QoS pending-reasons that were **wired but inert**: `qos_block_for` used a limitless `Qos::default()`, so they never fired.

## Changes
- **new `limits_cache.rs`**: `QosCache` mirroring `fairshare_cache` — `RwLock<HashMap<String, Qos>>`, `ListQos` refresh loop (timeout + stale retention), `QosInfo`→`Qos` converter.
- **cluster.rs**: `qos_cache` field + `resolve_qos()`; `qos_block_for` takes the resolved `Qos`; both call sites (`pending_jobs`, `tag_blocked_pending_reasons`) updated.
- **proto/spurdbd/sacctmgr**: extend `QosInfo` + `CreateQosRequest` with `max_submit_jobs_per_user` and `max_tres_per_user` (fields 9/10) so all five limits round-trip.
- **fix(spurdbd)**: `list_qos` decoded `usage_factor` (schema `REAL`/f32) as `f64` and **panicked**, resetting the `ListQos` h2 stream and leaving the QoS cache permanently empty. Read as `f32` and widen. **Found via live testing** — offline tests miss it because they don't cross the gRPC+Postgres boundary.

## Tests
- Unit: 5 in `limits_cache.rs` (proto→Qos, zero-means-none, cache get, end-to-end composition for submit + cpu-per-user reasons).
- Integration: `tag_blocked_sets_qos_reason_from_cache` (real `ClusterManager`, cache-seeded, asserts `QOSMaxWallDurationPerJobLimit`).
- Regression: `#[ignore]`-gated `list_qos_round_trips_all_limits` (would have caught the f32 panic).
- e2e: `test_accounting.py` QoS wall-cap reason.

## Live validation (Spur node)
- 4-cpu job in a `cpu=2` QoS → `PENDING Reason=QOSMaxCpuPerJobLimit` ✅
- 10-min job (`-t 00:10:00`) in a 1-min QoS → `PENDING Reason=QOSMaxWallDurationPerJobLimit` ✅
- Confirmed the f32 fix: before it, every `ListQos` panicked spurdbd and the cache stayed empty (jobs ran unblocked); after, QoS loads and reasons fire.

## Out of scope (boundary)
Associations (#283), partition/system limits, burst buffer (#309), unknown-QoS rejection (#282 — unknown names still get the limitless default, preserving prior behavior).

Verification: `cargo build`/`test`/`clippy --all-targets`/`fmt --check` clean; spur-core 197, spurctld 145, spurdbd 1 (+2 ignored), spur-cli 51 pass.

