### PR TITLE
feat(spur): emit PartitionConfig/PartitionInactive pending reasons

### DIFF
--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -243,6 +243,7 @@ pub enum PendingReason {
     QosMaxMemoryPerJob,
     QosMaxCpuPerUserLimit,
     QosMaxSubmitJobPerUserLimit,
+    PartitionConfig,
 }
 
 impl PendingReason {
@@ -279,6 +280,7 @@ impl PendingReason {
             Self::QosMaxMemoryPerJob => "QOSMaxMemoryPerJob",
             Self::QosMaxCpuPerUserLimit => "QOSMaxCpuPerUserLimit",
             Self::QosMaxSubmitJobPerUserLimit => "QOSMaxSubmitJobPerUserLimit",
+            Self::PartitionConfig => "PartitionConfig",
         }
     }
 }
@@ -1136,6 +1138,8 @@ mod tests {
             PendingReason::QosMaxSubmitJobPerUserLimit,
             "QOSMaxSubmitJobPerUserLimit",
         ),
+        (PendingReason::PartitionConfig, "PartitionConfig"),
+        (PendingReason::PartitionInactive, "PartitionInactive"),
     ];
 
     #[test]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -139,9 +139,6 @@ impl ClusterManager {
             None => anyhow::bail!("partition '{}' not found", partition_name),
         };
 
-        // Partition state and resource limits are not rejected here; the job
-        // pends with PartitionInactive/PartitionConfig instead (Slurm parity).
-
         // Check allow_accounts (if non-empty, user's account must be in the list)
         if !part.allow_accounts.is_empty() {
             let account = spec.account.as_deref().unwrap_or("");
@@ -2487,7 +2484,9 @@ fn partition_block(job: &Job, partitions: &[Partition]) -> Option<spur_core::job
     use spur_core::partition::PartitionState;
 
     let name = job.spec.partition.as_deref().filter(|p| !p.is_empty())?;
-    let part = partitions.iter().find(|p| p.name == name)?;
+    let Some(part) = partitions.iter().find(|p| p.name == name) else {
+        return Some(PendingReason::PartitionConfig);
+    };
 
     if part.state != PartitionState::Up {
         return Some(PendingReason::PartitionInactive);
@@ -4219,6 +4218,14 @@ mod tests {
             cm.get_job(n_id).unwrap().pending_reason,
             PendingReason::PartitionConfig,
             "num_nodes below partition min_nodes -> PartitionConfig"
+        );
+        assert!(
+            !cm.pending_jobs().iter().any(|j| j.job_id == t_id),
+            "time-blocked job must be dropped from scheduling"
+        );
+        assert!(
+            !cm.pending_jobs().iter().any(|j| j.job_id == n_id),
+            "min_nodes-blocked job must be dropped from scheduling"
         );
     }
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -139,11 +139,8 @@ impl ClusterManager {
             None => anyhow::bail!("partition '{}' not found", partition_name),
         };
 
-        // Partition state (Down/Drain/Inactive) and structural resource limits
-        // (max_nodes/max_time/min_nodes) are NOT rejected here: matching Slurm,
-        // the job is accepted and held PENDING with PartitionInactive /
-        // PartitionConfig (see partition_block + tag_blocked_pending_reasons), so
-        // it runs once the partition is brought back Up or its config changes.
+        // Partition state and resource limits are not rejected here; the job
+        // pends with PartitionInactive/PartitionConfig instead (Slurm parity).
 
         // Check allow_accounts (if non-empty, user's account must be in the list)
         if !part.allow_accounts.is_empty() {
@@ -1139,10 +1136,8 @@ impl ClusterManager {
             .cloned()
             .collect();
 
-        // Drop jobs structurally unschedulable in their target partition
-        // (inactive partition / request exceeds partition config). Shares
-        // partition_block() with tag_blocked_pending_reasons() so the drop
-        // decision and the shown PartitionInactive/PartitionConfig reason agree.
+        // Drop jobs blocked by partition state/config (shares partition_block()
+        // with tag_blocked_pending_reasons() so drop and shown reason agree).
         {
             let partitions = self.partitions.read();
             pending.retain(|job| partition_block(job, &partitions).is_none());
@@ -1464,10 +1459,8 @@ impl ClusterManager {
                         && job.pending_reason != PendingReason::DeadLine
                 })
                 .filter_map(|job| {
-                    // Same order pending_jobs() drops jobs, so the shown reason is
-                    // the one that actually removed it: Part -> Dep -> QoS -> Resv
-                    // -> Lic. partition_block is first: a structural partition
-                    // block is permanent, so it outranks the transient blocks.
+                    // Same drop order as pending_jobs(): Part -> Dep -> QoS ->
+                    // Resv -> Lic (partition block is permanent, so first).
                     partition_block(job, &partitions)
                         .or_else(|| dependency_block(job))
                         .or_else(|| qos_block_for(job, &jobs))
@@ -2486,13 +2479,9 @@ fn qos_block_for(job: &Job, jobs: &HashMap<JobId, Job>) -> Option<spur_core::job
     }
 }
 
-/// Reason a job can never run in its target partition as configured, or `None`.
-/// `PartitionInactive` when the partition is not accepting jobs (Down/Drain/
-/// Inactive); `PartitionConfig` when the request structurally exceeds the
-/// partition's node or time limits. Unlike `Resources` (a transient busy
-/// cluster), these are permanent given the current config. Shared by
-/// `pending_jobs()` and `tag_blocked_pending_reasons()` so the drop decision and
-/// the displayed reason agree.
+/// `PartitionInactive` if the partition is not Up, `PartitionConfig` if the
+/// request exceeds its node/time limits, else `None`. Shared by `pending_jobs()`
+/// and `tag_blocked_pending_reasons()` so drop and displayed reason agree.
 fn partition_block(job: &Job, partitions: &[Partition]) -> Option<spur_core::job::PendingReason> {
     use spur_core::job::PendingReason;
     use spur_core::partition::PartitionState;
@@ -4178,8 +4167,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn tag_blocked_sets_partition_config_reason() {
-        // A request that structurally exceeds the partition's max_nodes can never
-        // run there, so it is held PENDING with PartitionConfig (not Resources).
+        // Request exceeds partition max_nodes -> PartitionConfig, not Resources.
         let dir = TempDir::new().unwrap();
         let mut config = test_config();
         config.partitions[0].max_nodes = Some(1);
@@ -4204,8 +4192,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn tag_blocked_sets_partition_config_for_time_and_min_nodes() {
-        // max_time and min_nodes are independent PartitionConfig triggers; the
-        // max_nodes branch is covered separately above.
+        // max_time and min_nodes are independent PartitionConfig triggers.
         let dir = TempDir::new().unwrap();
         let mut config = test_config();
         config.partitions[0].max_time = Some("00:10:00".into()); // 10 min cap
@@ -4237,8 +4224,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn tag_blocked_sets_partition_inactive_when_not_up() {
-        // A partition that is not Up holds its jobs PENDING with PartitionInactive
-        // (admitted, not rejected at submit).
+        // Non-Up partition -> job admitted and held PENDING with PartitionInactive.
         let dir = TempDir::new().unwrap();
         let mut config = test_config();
         config.partitions[0].state = "DOWN".into();
@@ -4261,8 +4247,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn submit_still_rejects_nonexistent_partition() {
-        // Only inactive/over-config partitions pend; a typo'd/unknown partition
-        // must still be rejected at submit (not silently admitted).
+        // Unknown partition must still be rejected at submit, not held pending.
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         let mut spec = basic_spec("badpart");

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -139,10 +139,11 @@ impl ClusterManager {
             None => anyhow::bail!("partition '{}' not found", partition_name),
         };
 
-        // Check partition state
-        if part.state != spur_core::partition::PartitionState::Up {
-            anyhow::bail!("partition '{}' is {}", partition_name, part.state.display());
-        }
+        // Partition state (Down/Drain/Inactive) and structural resource limits
+        // (max_nodes/max_time/min_nodes) are NOT rejected here: matching Slurm,
+        // the job is accepted and held PENDING with PartitionInactive /
+        // PartitionConfig (see partition_block + tag_blocked_pending_reasons), so
+        // it runs once the partition is brought back Up or its config changes.
 
         // Check allow_accounts (if non-empty, user's account must be in the list)
         if !part.allow_accounts.is_empty() {
@@ -163,31 +164,6 @@ impl ClusterManager {
                     "account '{}' denied on partition '{}'",
                     account,
                     partition_name
-                );
-            }
-        }
-
-        // Check max_nodes
-        if let Some(max) = part.max_nodes {
-            if spec.num_nodes > max {
-                anyhow::bail!(
-                    "requested {} nodes exceeds partition '{}' max of {}",
-                    spec.num_nodes,
-                    partition_name,
-                    max
-                );
-            }
-        }
-
-        // Check max_time
-        if let (Some(max_mins), Some(ref tl)) = (part.max_time_minutes, &spec.time_limit) {
-            let requested_mins = tl.num_minutes() as u32;
-            if requested_mins > max_mins {
-                anyhow::bail!(
-                    "requested time {} min exceeds partition '{}' max of {} min",
-                    requested_mins,
-                    partition_name,
-                    max_mins
                 );
             }
         }
@@ -1163,6 +1139,15 @@ impl ClusterManager {
             .cloned()
             .collect();
 
+        // Drop jobs structurally unschedulable in their target partition
+        // (inactive partition / request exceeds partition config). Shares
+        // partition_block() with tag_blocked_pending_reasons() so the drop
+        // decision and the shown PartitionInactive/PartitionConfig reason agree.
+        {
+            let partitions = self.partitions.read();
+            pending.retain(|job| partition_block(job, &partitions).is_none());
+        }
+
         // Check dependencies
         let get_job = |id: JobId| -> Option<Job> { jobs.get(&id).cloned() };
         let get_array_tasks = |id: JobId| -> Vec<Job> {
@@ -1442,6 +1427,7 @@ impl ClusterManager {
             let reservations = self.get_reservations();
             let now = Utc::now();
             let available = self.available_licenses_with(&jobs);
+            let partitions = self.partitions.read();
 
             // Dependency outranks QoS/Licenses/Reservation in pending_jobs() and
             // is tagged just before this pass, so re-check it first (same closures).
@@ -1479,8 +1465,11 @@ impl ClusterManager {
                 })
                 .filter_map(|job| {
                     // Same order pending_jobs() drops jobs, so the shown reason is
-                    // the one that actually removed it: Dep -> QoS -> Resv -> Lic.
-                    dependency_block(job)
+                    // the one that actually removed it: Part -> Dep -> QoS -> Resv
+                    // -> Lic. partition_block is first: a structural partition
+                    // block is permanent, so it outranks the transient blocks.
+                    partition_block(job, &partitions)
+                        .or_else(|| dependency_block(job))
                         .or_else(|| qos_block_for(job, &jobs))
                         .or_else(|| reservation_block(job, &reservations, now))
                         .or_else(|| license_block(job, &available))
@@ -2495,6 +2484,39 @@ fn qos_block_for(job: &Job, jobs: &HashMap<JobId, Job>) -> Option<spur_core::job
         QosCheckResult::Allowed => None,
         QosCheckResult::Blocked(reason) => Some(reason),
     }
+}
+
+/// Reason a job can never run in its target partition as configured, or `None`.
+/// `PartitionInactive` when the partition is not accepting jobs (Down/Drain/
+/// Inactive); `PartitionConfig` when the request structurally exceeds the
+/// partition's node or time limits. Unlike `Resources` (a transient busy
+/// cluster), these are permanent given the current config. Shared by
+/// `pending_jobs()` and `tag_blocked_pending_reasons()` so the drop decision and
+/// the displayed reason agree.
+fn partition_block(job: &Job, partitions: &[Partition]) -> Option<spur_core::job::PendingReason> {
+    use spur_core::job::PendingReason;
+    use spur_core::partition::PartitionState;
+
+    let name = job.spec.partition.as_deref().filter(|p| !p.is_empty())?;
+    let part = partitions.iter().find(|p| p.name == name)?;
+
+    if part.state != PartitionState::Up {
+        return Some(PendingReason::PartitionInactive);
+    }
+    if let Some(max) = part.max_nodes {
+        if job.spec.num_nodes > max {
+            return Some(PendingReason::PartitionConfig);
+        }
+    }
+    if part.min_nodes > 0 && job.spec.num_nodes < part.min_nodes {
+        return Some(PendingReason::PartitionConfig);
+    }
+    if let (Some(max_mins), Some(tl)) = (part.max_time_minutes, &job.spec.time_limit) {
+        if tl.num_minutes() > i64::from(max_mins) {
+            return Some(PendingReason::PartitionConfig);
+        }
+    }
+    None
 }
 
 fn extract_license_requirements(spec: &JobSpec) -> HashMap<String, u64> {
@@ -4147,6 +4169,42 @@ mod tests {
         assert_eq!(
             cm.get_job(job_id).unwrap().pending_reason,
             PendingReason::NodeDown
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn tag_blocked_sets_partition_config_reason() {
+        // A request that structurally exceeds the partition's max_nodes can never
+        // run there, so it is held PENDING with PartitionConfig (not Resources).
+        let dir = TempDir::new().unwrap();
+        let mut config = test_config();
+        config.partitions[0].max_nodes = Some(1);
+        let cm = Arc::new(ClusterManager::new(config, dir.path()).unwrap());
+        let handle = crate::raft::start_raft(1, &["[::1]:0".into()], dir.path(), cm.clone())
+            .await
+            .unwrap();
+        handle
+            .raft
+            .wait(Some(std::time::Duration::from_secs(5)))
+            .metrics(|m| m.current_leader == Some(1), "leader elected")
+            .await
+            .expect("single-node raft did not self-elect within 5s");
+        cm.set_raft(handle.raft);
+
+        let mut spec = basic_spec("toobig");
+        spec.partition = Some("default".into());
+        spec.num_nodes = 2;
+        let job_id = submit_and_wait(&cm, spec);
+
+        cm.tag_blocked_pending_reasons();
+        assert_eq!(
+            cm.get_job(job_id).unwrap().pending_reason,
+            PendingReason::PartitionConfig
+        );
+        // pending_jobs() must agree: the job is dropped, not scheduled.
+        assert!(
+            !cm.pending_jobs().iter().any(|j| j.job_id == job_id),
+            "structurally-unschedulable job must be dropped from scheduling"
         );
     }
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2748,7 +2748,11 @@ mod tests {
     }
 
     async fn test_cluster(dir: &TempDir) -> Arc<ClusterManager> {
-        let cm = Arc::new(ClusterManager::new(test_config(), dir.path()).unwrap());
+        test_cluster_with_config(dir, test_config()).await
+    }
+
+    async fn test_cluster_with_config(dir: &TempDir, config: SlurmConfig) -> Arc<ClusterManager> {
+        let cm = Arc::new(ClusterManager::new(config, dir.path()).unwrap());
         let handle = crate::raft::start_raft(1, &["[::1]:0".into()], dir.path(), cm.clone())
             .await
             .unwrap();
@@ -4179,17 +4183,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let mut config = test_config();
         config.partitions[0].max_nodes = Some(1);
-        let cm = Arc::new(ClusterManager::new(config, dir.path()).unwrap());
-        let handle = crate::raft::start_raft(1, &["[::1]:0".into()], dir.path(), cm.clone())
-            .await
-            .unwrap();
-        handle
-            .raft
-            .wait(Some(std::time::Duration::from_secs(5)))
-            .metrics(|m| m.current_leader == Some(1), "leader elected")
-            .await
-            .expect("single-node raft did not self-elect within 5s");
-        cm.set_raft(handle.raft);
+        let cm = test_cluster_with_config(&dir, config).await;
 
         let mut spec = basic_spec("toobig");
         spec.partition = Some("default".into());
@@ -4205,6 +4199,77 @@ mod tests {
         assert!(
             !cm.pending_jobs().iter().any(|j| j.job_id == job_id),
             "structurally-unschedulable job must be dropped from scheduling"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn tag_blocked_sets_partition_config_for_time_and_min_nodes() {
+        // max_time and min_nodes are independent PartitionConfig triggers; the
+        // max_nodes branch is covered separately above.
+        let dir = TempDir::new().unwrap();
+        let mut config = test_config();
+        config.partitions[0].max_time = Some("00:10:00".into()); // 10 min cap
+        config.partitions[0].min_nodes = 2;
+        let cm = test_cluster_with_config(&dir, config).await;
+
+        let mut over_time = basic_spec("overtime");
+        over_time.partition = Some("default".into());
+        over_time.time_limit = Some(chrono::Duration::hours(1));
+        let t_id = submit_and_wait(&cm, over_time);
+
+        let mut under_nodes = basic_spec("undernodes");
+        under_nodes.partition = Some("default".into());
+        under_nodes.num_nodes = 1; // below min_nodes=2
+        let n_id = submit_and_wait(&cm, under_nodes);
+
+        cm.tag_blocked_pending_reasons();
+        assert_eq!(
+            cm.get_job(t_id).unwrap().pending_reason,
+            PendingReason::PartitionConfig,
+            "time_limit over partition max_time -> PartitionConfig"
+        );
+        assert_eq!(
+            cm.get_job(n_id).unwrap().pending_reason,
+            PendingReason::PartitionConfig,
+            "num_nodes below partition min_nodes -> PartitionConfig"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn tag_blocked_sets_partition_inactive_when_not_up() {
+        // A partition that is not Up holds its jobs PENDING with PartitionInactive
+        // (admitted, not rejected at submit).
+        let dir = TempDir::new().unwrap();
+        let mut config = test_config();
+        config.partitions[0].state = "DOWN".into();
+        let cm = test_cluster_with_config(&dir, config).await;
+
+        let mut spec = basic_spec("downpart");
+        spec.partition = Some("default".into());
+        let job_id = submit_and_wait(&cm, spec);
+
+        cm.tag_blocked_pending_reasons();
+        assert_eq!(
+            cm.get_job(job_id).unwrap().pending_reason,
+            PendingReason::PartitionInactive
+        );
+        assert!(
+            !cm.pending_jobs().iter().any(|j| j.job_id == job_id),
+            "job in a non-Up partition must be dropped from scheduling"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_still_rejects_nonexistent_partition() {
+        // Only inactive/over-config partitions pend; a typo'd/unknown partition
+        // must still be rejected at submit (not silently admitted).
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        let mut spec = basic_spec("badpart");
+        spec.partition = Some("does-not-exist".into());
+        assert!(
+            cm.submit_job(spec).is_err(),
+            "submitting to an unknown partition must error"
         );
     }
 


### PR DESCRIPTION
Group 3 of #307 (Partition/System pending reasons).

> ⚠️ **Stacked on #301** (`parity/reason-code-vocab`, unmerged). Until #301 lands, this diff includes #301's commits — review the `feat(spur): emit PartitionConfig/PartitionInactive` commit. Will rebase onto `main` once #301 merges.

## What
Hold jobs PENDING with a specific reason instead of rejecting at submit (Slurm parity — same pattern as reservation/license blocks):
- **`PartitionConfig`** — request structurally exceeds the partition config (`num_nodes > max_nodes`, `num_nodes < min_nodes`, `time_limit > max_time`).
- **`PartitionInactive`** — target partition is not `Up`. The variant existed (from #274) but was never emitted; now wired.

A shared `partition_block()` helper feeds BOTH `pending_jobs()` (drop) and `tag_blocked_pending_reasons()` (displayed reason). It's checked first in the chain — a structural partition block is permanent given current config. `validate_partition()` no longer rejects partition state / max_nodes / max_time at submit.

## Deliberately NOT added (would be dead variants)
- `SystemFailure` — no controller path holds a job *pending* on an internal error (launch failures route to terminal states).
- `AccountingPolicy` — QoS blocks already map to specific `QOS*` reasons; no real fallback site.

These land with their enforcement if/when a genuine trigger exists.

## Tests
`REASON_VOCAB` extended (Display + serde for both); integration test `tag_blocked_sets_partition_config_reason` (real ClusterManager, 2-node job vs `max_nodes=1` → `PartitionConfig`).

Static: build/clippy/fmt clean; spur-core 197, spurctld 140 pass.

## Live validation
Verified live on a Spur node: a 2-node job against a partition with `max_nodes=1` is held `PENDING Reason=PartitionConfig` (previously rejected at submit). `PartitionInactive` follows the same `partition_block` path; both Slurm strings are byte-exact from `job_state_reason.c`.

