### PR TITLE
fix(spurd): add controller info in log message

### DIFF
--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -349,7 +349,12 @@ async fn report_completion(
                 };
                 match client.report_job_status(req).await {
                     Ok(_) => {
-                        info!(job_id, exit_code, "reported completion to controller");
+                        info!(
+                            job_id,
+                            exit_code,
+                            controller = %url,
+                            "reported completion to controller"
+                        );
                         return;
                     }
                     Err(e) => {


### PR DESCRIPTION
The controll info in the log message helps confirm that the job completion message from the agent is
targeted at the right controller.