### PR TITLE
fix(ci): add pre-cleanup step to native-host E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -144,6 +144,18 @@ jobs:
           done
           [ "$FAILED" -eq 0 ] || { echo "ERROR: not all nodes reachable"; exit 1; }
 
+      - name: Kill stale processes from previous runs
+        run: |
+          IFS=',' read -ra NODES <<< "$BM_NODES"
+          for node in "${NODES[@]}"; do
+            ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
+              "${BM_SSH_USER}@${node}" "
+              sudo pkill -f '${BM_REMOTE_BIN_DIR}/spurctld' 2>/dev/null || true
+              sudo pkill -f '${BM_REMOTE_BIN_DIR}/spurd' 2>/dev/null || true
+              sudo rm -rf /tmp/spur-e2e-* 2>/dev/null || true
+            " || true
+          done
+
       - name: Check if DNS injection needed
         id: dns-check
         run: |


### PR DESCRIPTION
## Summary

- Adds a pre-cleanup step to the native-host E2E job that kills stale `spurctld`/`spurd` processes and removes leftover `/tmp/spur-e2e-*` directories before test setup begins.
- Mirrors the existing post-cleanup step (which runs `if: always()` at job end) but executes at job start, right after verifying node connectivity.
- Prevents `OSError: Failure` (ETXTBSY) during binary upload when a previous run's cleanup didn't complete (e.g. runner crash or timeout left processes holding the binaries open).

## Context

The E2E / Native-Host check was failing intermittently because stale `spurd` processes from a prior run survived on the cluster nodes. When `ensure_bins` tried to SFTP-upload new binaries, the kernel refused to open the running executable for writing (`ETXTBSY`), which Paramiko surfaced as a generic `OSError: Failure`.
