### PR TITLE
fix(deploy): upgrade runtime base to Ubuntu 24.04 and run as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN echo "=== Required GLIBC versions ===" && \
         echo "  ${bin}: requires ${MAX:-none}"; \
     done
 
-FROM ubuntu:22.04 AS runtime
+FROM ubuntu:24.04 AS runtime
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
@@ -64,8 +64,12 @@ COPY --from=builder /build/target/release/spurd /usr/local/bin/
 COPY --from=builder /build/target/release/spurdbd /usr/local/bin/
 COPY --from=builder /build/target/release/spur-k8s-operator /usr/local/bin/
 
+RUN groupadd --gid 1001 spur && useradd --uid 1001 --gid spur --no-create-home --shell /usr/sbin/nologin spur
+USER spur
+
 # Multi-binary image: Kubernetes manifests must set container command per workload
-# (e.g. spurctld, spur-k8s-operator, spurd). No default ENTRYPOINT.
+# (e.g. spurctld, spur-k8s-operator, spurd). Workloads that need root (e.g. spurd
+# for seccomp/Landlock) should override with securityContext.runAsUser: 0.
 
 FROM scratch AS dist
 COPY --from=builder /build/target/release/spur /bin/

--- a/examples/k8s/spurctld.yaml
+++ b/examples/k8s/spurctld.yaml
@@ -35,6 +35,8 @@ spec:
       labels:
         app: spurctld
     spec:
+      securityContext:
+        fsGroup: 1001
       containers:
         - name: spurctld
           image: spur:latest

--- a/examples/k8s/spurd.yaml
+++ b/examples/k8s/spurd.yaml
@@ -30,6 +30,7 @@ spec:
             - containerPort: 6816
               name: grpc
           securityContext:
+            runAsUser: 0
             privileged: true
           volumeMounts:
             - name: spool

--- a/tests/k8s/e2e/manifests/spurctld.yaml
+++ b/tests/k8s/e2e/manifests/spurctld.yaml
@@ -32,6 +32,8 @@ spec:
       labels:
         app: spurctld
     spec:
+      securityContext:
+        fsGroup: 1001
       containers:
         - name: spurctld
           image: spur:latest


### PR DESCRIPTION
## Summary

- Upgrade the container runtime base from `ubuntu:22.04` to `ubuntu:24.04`, eliminating all CRITICAL/HIGH CVEs (including CVE-2026-45447 in libssl3) and extending base image support until April 2029.
- Add a non-root `spur` user (UID/GID 1001) as the default container user, resolving the Trivy DS-0002 misconfiguration finding (container runs as root).
- Update K8s manifests: `fsGroup: 1001` on spurctld StatefulSets for PVC write access, explicit `runAsUser: 0` on the spurd DaemonSet which requires root for seccomp/Landlock/hostPID.

## Motivation

A Trivy scan of the current image found:
- **CVE-2026-45447** (HIGH) — heap use-after-free in OpenSSL `PKCS7_verify()` in the ubuntu:22.04 base.
- **DS-0002** (HIGH) — no `USER` directive, all container processes run as root.

Ubuntu 24.04 ships patched packages and the non-root default follows container security best practices. The build stage (AlmaLinux 8, glibc 2.28) is unchanged — binaries remain compatible with Ubuntu 22.04+ hosts.

## Verification

Tested on the K8s dev testbed (4-node cluster, K8s v1.35):
- `spurctld` and `spur-k8s-operator` run as `uid=1001(spur)`.
- PVC-backed spool directory is writable via `fsGroup`.
- gRPC, Raft, REST, and scheduler all start and serve correctly.
- Trivy image scan: **0 CRITICAL/HIGH** vulnerabilities.
- Trivy Dockerfile scan: **0 CRITICAL/HIGH** misconfigurations.