### PR TITLE
ci(security): add Trivy container image and Dockerfile scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,3 +214,64 @@ jobs:
           name: e2e-assets
           path: /tmp/e2e-assets/trusted-repo
           retention-days: 1
+
+  trivy-image-scan:
+    name: Trivy image scan
+    needs: build-docker-image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: ${{ github.event_name == 'push' && 'write' || 'none' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: spur-image
+          path: /tmp
+
+      - name: Load image
+        run: docker load -i /tmp/spur-image.tar
+
+      - name: Scan image for vulnerabilities
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8
+        with:
+          image-ref: spur:ci
+          format: sarif
+          output: trivy-image.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "1"
+
+      - name: Upload SARIF to GitHub Security
+        if: always() && github.event_name == 'push'
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-image.sarif
+          category: trivy-image
+
+  trivy-dockerfile-scan:
+    name: Trivy Dockerfile scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: ${{ github.event_name == 'push' && 'write' || 'none' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Scan Dockerfile for misconfigurations
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8
+        with:
+          scan-type: config
+          scan-ref: .
+          format: sarif
+          output: trivy-config.sarif
+          severity: CRITICAL,HIGH
+          exit-code: "1"
+
+      - name: Upload SARIF to GitHub Security
+        if: always() && github.event_name == 'push'
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-config.sarif
+          category: trivy-config

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,10 +233,11 @@ jobs:
       - name: Load image
         run: docker load -i /tmp/spur-image.tar
 
-      - name: Scan image for vulnerabilities
+      - name: Scan image for vulnerabilities and secrets
         uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8
         with:
           image-ref: spur:ci
+          scanners: vuln,secret
           format: sarif
           output: trivy-image.sarif
           severity: CRITICAL,HIGH

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -170,8 +170,6 @@ jobs:
 
   trivy-nightly-scan:
     name: Trivy nightly rescan
-    needs: push-image
-    if: needs.build.outputs.skip != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -179,10 +177,24 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Scan nightly image for vulnerabilities
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build image for scanning
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          target: runtime
+          push: false
+          load: true
+          tags: spur:nightly-scan
+          cache-from: type=gha,scope=nightly-docker
+
+      - name: Scan image for vulnerabilities
         uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8
         with:
-          image-ref: rocm/spur:nightly
+          image-ref: spur:nightly-scan
           format: sarif
           output: trivy-nightly.sarif
           severity: CRITICAL,HIGH

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -168,6 +168,34 @@ jobs:
           cache-from: type=gha,scope=nightly-docker
           cache-to: type=gha,scope=nightly-docker,mode=max
 
+  trivy-nightly-scan:
+    name: Trivy nightly rescan
+    needs: push-image
+    if: needs.build.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Scan nightly image for vulnerabilities
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8
+        with:
+          image-ref: rocm/spur:nightly
+          format: sarif
+          output: trivy-nightly.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "0"
+
+      - name: Upload SARIF to GitHub Security
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-nightly.sarif
+          category: trivy-nightly
+
   release:
     name: Publish nightly
     needs: [build, verify, push-image]

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -191,10 +191,11 @@ jobs:
           tags: spur:nightly-scan
           cache-from: type=gha,scope=nightly-docker
 
-      - name: Scan image for vulnerabilities
+      - name: Scan image for vulnerabilities and secrets
         uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8
         with:
           image-ref: spur:nightly-scan
+          scanners: vuln,secret
           format: sarif
           output: trivy-nightly.sarif
           severity: CRITICAL,HIGH


### PR DESCRIPTION
## Summary

Add automated container security scanning to CI and nightly workflows using Trivy (Apache-2.0, SHA-pinned to v0.36.0).

**PR checks (ci.yml):**
- `trivy-image-scan` — scans the built Docker image for CRITICAL/HIGH OS package vulnerabilities and secrets baked into image layers. Fails the PR if findings exist.
- `trivy-dockerfile-scan` — scans the Dockerfile for misconfigurations (e.g. missing USER directive, ADD from remote URL). Fails the PR if findings exist.
- SARIF results are uploaded to the GitHub Security dashboard on push to main.

**Nightly rescan (nightly.yml):**
- `trivy-nightly-scan` — self-contained job that builds the image from current main and scans it against the latest vulnerability database. Runs every night unconditionally (not gated by commit activity), so newly disclosed CVEs are caught even when the codebase hasn't changed. Advisory mode (exit-code 0) with SARIF upload to the Security dashboard.

## Design decisions

- **SHA-pinned action** (`a9c7b0f`, v0.36.0) rather than mutable version tag, following the supply-chain incident remediation guidance. Dependabot will track version bumps.
- **Self-contained nightly scan** — builds its own image instead of pulling from Docker Hub, so the scan runs even if the nightly build was skipped (no new commits) or if the push failed.
- **Secret scanning enabled** via `scanners: vuln,secret` on image scans to detect accidentally baked-in credentials.
- **SARIF upload restricted** to push-to-main (CI) and always (nightly) to avoid permission issues on fork PRs.
