### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Supported Versions
+
+Spur is under active development. Security fixes are applied to the `main` branch only.
+
+| Version | Supported |
+|---------|-----------|
+| `main`  | ✅        |
+
+## Reporting a Vulnerability
+
+**Do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+Instead, use one of the following channels:
+
+- **GitHub (preferred)**: [Report a vulnerability](https://github.com/ROCm/spur/security/advisories/new) via GitHub's private vulnerability reporting
+- **Email**: [psirt@amd.com](mailto:psirt@amd.com) — AMD Product Security Team
+
+For details on AMD's vulnerability disclosure process, see [AMD Product Security](https://www.amd.com/en/resources/product-security.html).
+
+When reporting, please include:
+
+- Affected version, commit SHA, or branch
+- Description of the vulnerability and its potential impact
+- Steps to reproduce or a proof of concept
+
+## Response
+
+All reports are treated with the highest priority and resolved at the earliest based on severity. Reporters are kept updated throughout the process.


### PR DESCRIPTION
Add `SECURITY.md` with coordinated vulnerability disclosure instructions.

- Points reporters to GitHub private vulnerability reporting (preferred) and AMD PSIRT email as channels
- Links to AMD Product Security page for disclosure process details
- Includes guidance on what to include in a report