### PR TITLE
fix(spurd): resolve stdout/stderr paths after work_dir fallback

### DIFF
--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -745,18 +745,6 @@ impl SlurmAgent for AgentService {
             .map(|a| a.cpu_ids.clone())
             .unwrap_or_default();
 
-        // Resolve stdout/stderr paths
-        let stdout_path = if spec.stdout_path.is_empty() {
-            format!("{}/spur-{}.out", work_dir, job_id)
-        } else {
-            spec.stdout_path.clone()
-        };
-        let stderr_path = if spec.stderr_path.is_empty() {
-            format!("{}/spur-{}.out", work_dir, job_id)
-        } else {
-            spec.stderr_path.clone()
-        };
-
         // Build container launch config if this is a containerized job
         let container_launch = if !spec.container_image.is_empty() {
             Some(executor::ContainerLaunchConfig {
@@ -772,8 +760,8 @@ impl SlurmAgent for AgentService {
             script: launch_script,
             work_dir: work_dir.clone(),
             environment: env,
-            stdout_path,
-            stderr_path,
+            stdout_path: spec.stdout_path.clone(),
+            stderr_path: spec.stderr_path.clone(),
             cpus: spec.cpus_per_task.max(1),
             memory_mb: spec.memory_per_node_mb,
             gpu_devices: allocated_device_ids,
@@ -793,17 +781,17 @@ impl SlurmAgent for AgentService {
         };
 
         match executor::launch_job(&launch_cfg, (*self.spank).as_ref()).await {
-            Ok(running_job) => {
+            Ok(result) => {
                 let mut jobs = self.running.lock().await;
                 info!(job_id, gpus = ?launch_cfg.gpu_devices, "job launched successfully");
                 jobs.insert(
                     job_id,
                     TrackedJob {
-                        job: running_job,
+                        job: result.job,
                         rootfs_mode: rootfs_mode.clone(),
                         allocation: alloc_result,
-                        stdout_path: launch_cfg.stdout_path,
-                        stderr_path: launch_cfg.stderr_path,
+                        stdout_path: result.stdout_path,
+                        stderr_path: result.stderr_path,
                         has_pid_namespace: nix::unistd::geteuid().is_root(),
                         work_dir: launch_cfg.work_dir,
                         uid: launch_cfg.uid,

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -74,6 +74,12 @@ pub struct JobLaunchConfig {
     pub host_device_plan: Option<spur_devices::inject::HostInjectionPlan>,
 }
 
+pub struct LaunchResult {
+    pub job: RunningJob,
+    pub stdout_path: String,
+    pub stderr_path: String,
+}
+
 /// A running job process — either a tokio-managed child or a raw-forked container.
 pub enum RunningJob {
     /// Non-container jobs managed by tokio::process::Child.
@@ -196,7 +202,7 @@ impl RunningJob {
 pub async fn launch_job(
     cfg: &JobLaunchConfig,
     spank: Option<&SpankHost>,
-) -> Result<RunningJob, LaunchError> {
+) -> Result<LaunchResult, LaunchError> {
     // Run prolog before anything else
     if let Some(ref prolog) = cfg.prolog_script {
         let ctx = spur_core::hooks::HookContext {
@@ -224,7 +230,7 @@ pub async fn launch_job(
 async fn spawn_job_process(
     cfg: &JobLaunchConfig,
     spank: Option<&SpankHost>,
-) -> anyhow::Result<RunningJob> {
+) -> anyhow::Result<LaunchResult> {
     let JobLaunchConfig {
         job_id,
         ref script,
@@ -358,7 +364,7 @@ async fn spawn_job_process(
 
     // Container jobs: use explicit fork() + container_init() instead of bash wrapper.
     if let Some(ctn) = container {
-        return launch_container_job(
+        let job = launch_container_job(
             cfg,
             ctn,
             &env,
@@ -366,7 +372,12 @@ async fn spawn_job_process(
             &stdout_resolved,
             &stderr_resolved,
         )
-        .await;
+        .await?;
+        return Ok(LaunchResult {
+            job,
+            stdout_path: stdout_resolved,
+            stderr_path: stderr_resolved,
+        });
     }
 
     // --- Non-container jobs: existing tokio::Command path ---
@@ -520,7 +531,11 @@ async fn spawn_job_process(
         "job process spawned"
     );
 
-    Ok(RunningJob::Managed { child, cgroup_path })
+    Ok(LaunchResult {
+        job: RunningJob::Managed { child, cgroup_path },
+        stdout_path: stdout_resolved,
+        stderr_path: stderr_resolved,
+    })
 }
 
 /// Set up a cgroups v2 hierarchy for a job.


### PR DESCRIPTION
## Summary

- Jobs failed with "failed to create stdout file" when the submitter's working directory didn't exist on the compute node. The agent server pre-resolved stdout/stderr to absolute paths using the submitter's `work_dir` before the executor's `/tmp` fallback ran, so the fallback never affected the output file paths.
- Moved stdout/stderr path resolution entirely into the executor (after the work_dir fallback) and introduced `LaunchResult` to return the resolved paths back for log streaming (`StreamOutput` RPC).

## Test plan

- [x] All unit tests pass (`cargo test --locked`)
- [x] `cargo clippy` and `cargo fmt --check` clean
- [x] Reproduced on bare-metal testbed: submitted jobs to nodes where submitter's work_dir doesn't exist — all stuck before fix, all RUNNING after
- [x] Verified default stdout (`/tmp/spur-<id>.out`) and explicit `--output=/tmp/custom_%j.log` both resolve correctly
- [x] Verified job reaches COMPLETED state
- [x] Audited for regressions: `TrackedJob` stores resolved absolute paths for `StreamOutput` RPC (log tailing)