### PR TITLE
perf(spur-sched): speed up backfill timeline queries

### DIFF
--- a/crates/spur-sched/src/backfill.rs
+++ b/crates/spur-sched/src/backfill.rs
@@ -184,6 +184,10 @@ impl Scheduler for BackfillScheduler {
             );
         }
 
+        for timeline in &mut self.timelines {
+            timeline.gc(now);
+        }
+
         // Identify het job groups: collect sets of jobs linked by het_job_id.
         // For each group, ALL components must be schedulable or NONE are scheduled.
         let mut het_groups: HashMap<JobId, Vec<usize>> = HashMap::new();

--- a/crates/spur-sched/src/backfill.rs
+++ b/crates/spur-sched/src/backfill.rs
@@ -184,10 +184,6 @@ impl Scheduler for BackfillScheduler {
             );
         }
 
-        for timeline in &mut self.timelines {
-            timeline.gc(now);
-        }
-
         // Identify het job groups: collect sets of jobs linked by het_job_id.
         // For each group, ALL components must be schedulable or NONE are scheduled.
         let mut het_groups: HashMap<JobId, Vec<usize>> = HashMap::new();

--- a/crates/spur-sched/src/timeline.rs
+++ b/crates/spur-sched/src/timeline.rs
@@ -1,6 +1,9 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+
 use chrono::{DateTime, Duration, Utc};
 use spur_core::resource::{ResourceAllocations, ResourceSet};
 
@@ -23,6 +26,55 @@ pub struct Interval {
     pub resources: ResourceAllocations,
 }
 
+/// Incremental sweep over sorted interval start/end events.
+///
+/// Maintains the sum of resources active at the current sweep time `t`
+/// (half-open intervals: `start <= t < end`).
+struct AllocationSweep<'a> {
+    intervals: &'a [Interval],
+    used: ResourceAllocations,
+    next_start: usize,
+    ending: BinaryHeap<Reverse<(DateTime<Utc>, usize)>>,
+}
+
+impl<'a> AllocationSweep<'a> {
+    fn new(intervals: &'a [Interval], time: DateTime<Utc>) -> Self {
+        let mut sweep = Self {
+            intervals,
+            used: ResourceAllocations::default(),
+            next_start: 0,
+            ending: BinaryHeap::new(),
+        };
+        sweep.advance_to(time);
+        sweep
+    }
+
+    fn advance_to(&mut self, time: DateTime<Utc>) {
+        while self.next_start < self.intervals.len()
+            && self.intervals[self.next_start].start <= time
+        {
+            let idx = self.next_start;
+            let interval = &self.intervals[idx];
+            self.used.add(&interval.resources);
+            self.ending.push(Reverse((interval.end, idx)));
+            self.next_start += 1;
+        }
+
+        while let Some(Reverse((end, idx))) = self.ending.peek().copied() {
+            if end <= time {
+                self.ending.pop();
+                self.used.subtract(&self.intervals[idx].resources);
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn used(&self) -> &ResourceAllocations {
+        &self.used
+    }
+}
+
 impl NodeTimeline {
     pub fn new(node_name: String, total: ResourceSet) -> Self {
         Self {
@@ -32,10 +84,20 @@ impl NodeTimeline {
         }
     }
 
+    /// Index one past intervals with `start <= time` (`intervals` sorted by `start`).
+    fn active_prefix_end(&self, time: DateTime<Utc>) -> usize {
+        self.intervals.partition_point(|i| i.start <= time)
+    }
+
+    /// Index one past intervals with `start < window_end` (`intervals` sorted by `start`).
+    fn overlap_prefix_end(&self, window_end: DateTime<Utc>) -> usize {
+        self.intervals.partition_point(|i| i.start < window_end)
+    }
+
     pub fn accumulated_at(&self, time: DateTime<Utc>) -> ResourceAllocations {
         let mut used = ResourceAllocations::default();
-        for interval in &self.intervals {
-            if interval.start <= time && time < interval.end {
+        for interval in &self.intervals[..self.active_prefix_end(time)] {
+            if interval.end > time {
                 used.add(&interval.resources);
             }
         }
@@ -51,24 +113,29 @@ impl NodeTimeline {
     /// Find the earliest time at which `request` resources are available
     /// for `duration` contiguous time.
     pub fn earliest_start(
-        &self,
+        &mut self,
         request: &ResourceSet,
         duration: Duration,
         after: DateTime<Utc>,
     ) -> DateTime<Utc> {
+        self.gc(after);
+
         let mut candidate = after;
         let max_check = after + Duration::days(365);
+        let mut sweep = AllocationSweep::new(&self.intervals, after);
 
         loop {
             if candidate > max_check {
                 return max_check;
             }
 
-            if self.can_satisfy_at(candidate, request) {
-                let end = candidate + duration;
+            sweep.advance_to(candidate);
+
+            if self.total.can_satisfy_with_allocated(sweep.used(), request) {
+                let window_end = candidate + duration;
                 let mut ok = true;
-                for interval in &self.intervals {
-                    if interval.start < end && interval.end > candidate {
+                for interval in &self.intervals[..self.overlap_prefix_end(window_end)] {
+                    if interval.end > candidate {
                         let mut used = ResourceAllocations::default();
                         used.add(&interval.resources);
                         if !self.total.can_satisfy_with_allocated(&used, request) {
@@ -117,9 +184,12 @@ impl NodeTimeline {
             .retain(|i| !(i.start == start && i.end == end));
     }
 
-    /// Clean up expired intervals.
-    pub fn gc(&mut self, now: DateTime<Utc>) {
-        self.intervals.retain(|i| i.end > now);
+    /// Drop intervals that end at or before `horizon`.
+    ///
+    /// Such intervals cannot affect any query at times `t` where `t >= horizon`
+    /// (half-open active range: `start <= t < end`).
+    pub fn gc(&mut self, horizon: DateTime<Utc>) {
+        self.intervals.retain(|i| i.end > horizon);
     }
 }
 
@@ -275,5 +345,335 @@ mod tests {
             ..Default::default()
         };
         assert!(tl.can_satisfy_at(now + Duration::minutes(1), &req));
+    }
+
+    #[test]
+    fn test_accumulated_at_many_intervals() {
+        let mut tl = make_timeline();
+        let base = Utc::now();
+
+        for i in 0..50 {
+            let start = base + Duration::hours(i);
+            tl.reserve(
+                start,
+                start + Duration::hours(2),
+                ResourceAllocations::with_scalar(4, 0),
+            );
+        }
+
+        let query = base + Duration::hours(25) + Duration::minutes(30);
+        let used = tl.accumulated_at(query);
+
+        let mut brute = ResourceAllocations::default();
+        for interval in &tl.intervals {
+            if interval.start <= query && query < interval.end {
+                brute.add(&interval.resources);
+            }
+        }
+
+        assert_eq!(used.cpus, brute.cpus);
+        assert_eq!(used.memory_mb, brute.memory_mb);
+    }
+
+    #[test]
+    fn test_earliest_start_many_intervals() {
+        let mut tl = make_timeline();
+        let base = Utc::now();
+
+        tl.reserve(
+            base,
+            base + Duration::hours(8),
+            ResourceAllocations::with_scalar(48, 0),
+        );
+        for i in 1..40 {
+            let start = base + Duration::hours(i * 10);
+            tl.reserve(
+                start,
+                start + Duration::hours(4),
+                ResourceAllocations::with_scalar(8, 0),
+            );
+        }
+
+        let req = ResourceSet {
+            cpus: 32,
+            memory_mb: 0,
+            ..Default::default()
+        };
+        let start = tl.earliest_start(&req, Duration::hours(2), base);
+        assert!(start >= base + Duration::hours(8));
+    }
+
+    fn brute_earliest_start(
+        tl: &NodeTimeline,
+        request: &ResourceSet,
+        duration: Duration,
+        after: DateTime<Utc>,
+    ) -> DateTime<Utc> {
+        let mut candidate = after;
+        let max_check = after + Duration::days(365);
+
+        loop {
+            if candidate > max_check {
+                return max_check;
+            }
+
+            if tl.can_satisfy_at(candidate, request) {
+                let window_end = candidate + duration;
+                let mut ok = true;
+                for interval in &tl.intervals[..tl.overlap_prefix_end(window_end)] {
+                    if interval.end > candidate {
+                        let mut used = ResourceAllocations::default();
+                        used.add(&interval.resources);
+                        if !tl.total.can_satisfy_with_allocated(&used, request) {
+                            candidate = interval.end;
+                            ok = false;
+                            break;
+                        }
+                    }
+                }
+                if ok {
+                    return candidate;
+                }
+            } else {
+                let next_end = tl
+                    .intervals
+                    .iter()
+                    .filter(|i| i.end > candidate)
+                    .map(|i| i.end)
+                    .min();
+                match next_end {
+                    Some(t) => candidate = t,
+                    None => return candidate,
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_sweep_matches_accumulated_at() {
+        let mut tl = make_timeline();
+        let base = Utc::now();
+
+        tl.reserve(
+            base,
+            base + Duration::hours(6),
+            ResourceAllocations::with_scalar(20, 0),
+        );
+        tl.reserve(
+            base + Duration::hours(2),
+            base + Duration::hours(8),
+            ResourceAllocations::with_scalar(16, 0),
+        );
+        tl.reserve(
+            base + Duration::hours(2),
+            base + Duration::hours(4),
+            ResourceAllocations::with_scalar(8, 0),
+        );
+        tl.reserve(
+            base + Duration::hours(10),
+            base + Duration::hours(12),
+            ResourceAllocations::with_scalar(32, 0),
+        );
+
+        let mut event_times = vec![
+            base,
+            base + Duration::hours(2),
+            base + Duration::hours(4),
+            base + Duration::hours(6),
+            base + Duration::hours(8),
+            base + Duration::hours(10),
+            base + Duration::hours(12),
+        ];
+        event_times.sort();
+        event_times.dedup();
+
+        let mut sweep = AllocationSweep::new(&tl.intervals, base);
+        for time in event_times {
+            sweep.advance_to(time);
+            let expected = tl.accumulated_at(time);
+            assert_eq!(
+                sweep.used().cpus,
+                expected.cpus,
+                "cpu mismatch at {time}"
+            );
+            assert_eq!(
+                sweep.used().memory_mb,
+                expected.memory_mb,
+                "memory mismatch at {time}"
+            );
+            assert_eq!(
+                sweep.used().total_device_count("gpu"),
+                expected.total_device_count("gpu"),
+                "gpu mismatch at {time}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_earliest_start_overlapping_intervals() {
+        let mut tl = make_timeline();
+        let base = Utc::now();
+
+        tl.reserve(
+            base,
+            base + Duration::hours(3),
+            ResourceAllocations::with_scalar(40, 0),
+        );
+        tl.reserve(
+            base + Duration::hours(1),
+            base + Duration::hours(5),
+            ResourceAllocations::with_scalar(30, 0),
+        );
+
+        let req = ResourceSet {
+            cpus: 32,
+            ..Default::default()
+        };
+        let duration = Duration::hours(1);
+
+        let got = tl.earliest_start(&req, duration, base);
+        let want = brute_earliest_start(&tl, &req, duration, base);
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn test_earliest_start_same_start_time() {
+        let mut tl = make_timeline();
+        let base = Utc::now();
+
+        for cpus in [24_u32, 16, 8] {
+            tl.reserve(
+                base,
+                base + Duration::hours(2),
+                ResourceAllocations::with_scalar(cpus, 0),
+            );
+        }
+
+        let req = ResourceSet {
+            cpus: 8,
+            ..Default::default()
+        };
+        let duration = Duration::minutes(30);
+
+        let got = tl.earliest_start(&req, duration, base);
+        let want = brute_earliest_start(&tl, &req, duration, base);
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn test_earliest_start_gpu_sweep() {
+        let mut tl = make_gpu_timeline(8);
+        let base = Utc::now();
+
+        let mut alloc_a = ResourceAllocations::with_scalar(4, 0);
+        alloc_a.devices.insert(
+            "gpu".into(),
+            (0u32..4).map(AllocatedDevice::injectable).collect(),
+        );
+        tl.reserve(base, base + Duration::hours(3), alloc_a);
+
+        let mut alloc_b = ResourceAllocations::with_scalar(4, 0);
+        alloc_b.devices.insert(
+            "gpu".into(),
+            (4u32..6).map(AllocatedDevice::injectable).collect(),
+        );
+        tl.reserve(base + Duration::hours(1), base + Duration::hours(4), alloc_b);
+
+        let req = ResourceSet {
+            cpus: 4,
+            memory_mb: 0,
+            gpus: (0..2)
+                .map(|i| GpuResource {
+                    device_id: i as u32,
+                    gpu_type: "mi355x".into(),
+                    memory_mb: 0,
+                    peer_gpus: vec![],
+                    link_type: spur_core::resource::GpuLinkType::PCIe,
+                })
+                .collect(),
+            ..Default::default()
+        };
+        let duration = Duration::hours(1);
+
+        let got = tl.earliest_start(&req, duration, base);
+        let want = brute_earliest_start(&tl, &req, duration, base);
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn test_earliest_start_prunes_expired_intervals() {
+        let mut tl = make_timeline();
+        let base = Utc::now();
+
+        tl.reserve(
+            base - Duration::hours(3),
+            base - Duration::hours(1),
+            ResourceAllocations::with_scalar(64, 0),
+        );
+        tl.reserve(
+            base,
+            base + Duration::hours(4),
+            ResourceAllocations::with_scalar(48, 0),
+        );
+        assert_eq!(tl.intervals.len(), 2);
+
+        let req = ResourceSet {
+            cpus: 32,
+            ..Default::default()
+        };
+        let start = tl.earliest_start(&req, Duration::hours(1), base);
+        assert!(start >= base + Duration::hours(4));
+        assert_eq!(tl.intervals.len(), 1);
+        assert!(tl.intervals[0].end > base);
+    }
+
+    #[test]
+    fn test_gc_keeps_future_and_active_intervals() {
+        let mut tl = make_timeline();
+        let base = Utc::now();
+
+        tl.reserve(
+            base - Duration::hours(1),
+            base + Duration::hours(1),
+            ResourceAllocations::with_scalar(16, 0),
+        );
+        tl.reserve(
+            base + Duration::hours(2),
+            base + Duration::hours(4),
+            ResourceAllocations::with_scalar(8, 0),
+        );
+
+        tl.gc(base);
+        assert_eq!(tl.intervals.len(), 2);
+
+        let used = tl.accumulated_at(base);
+        assert_eq!(used.cpus, 16);
+    }
+
+    #[test]
+    fn test_earliest_start_brute_many_intervals() {
+        let mut tl = make_timeline();
+        let base = Utc::now();
+
+        for i in 0..30 {
+            let start = base + Duration::minutes(i * 17);
+            let cpus = 8 + (i % 5) as u32 * 4;
+            tl.reserve(
+                start,
+                start + Duration::hours(2),
+                ResourceAllocations::with_scalar(cpus, 0),
+            );
+        }
+
+        let req = ResourceSet {
+            cpus: 24,
+            memory_mb: 0,
+            ..Default::default()
+        };
+        let duration = Duration::minutes(45);
+
+        let got = tl.earliest_start(&req, duration, base);
+        let want = brute_earliest_start(&tl, &req, duration, base);
+        assert_eq!(got, want);
     }
 }

--- a/crates/spur-sched/src/timeline.rs
+++ b/crates/spur-sched/src/timeline.rs
@@ -73,6 +73,11 @@ impl<'a> AllocationSweep<'a> {
     fn used(&self) -> &ResourceAllocations {
         &self.used
     }
+
+    /// Earliest end among intervals active at the current sweep time.
+    fn earliest_active_end(&self) -> Option<DateTime<Utc>> {
+        self.ending.peek().map(|Reverse((end, _))| *end)
+    }
 }
 
 impl NodeTimeline {
@@ -135,12 +140,17 @@ impl NodeTimeline {
     /// Find the earliest time at which `request` resources are available
     /// for `duration` contiguous time.
     pub fn earliest_start(
-        &mut self,
+        &self,
         request: &ResourceSet,
         duration: Duration,
         after: DateTime<Utc>,
     ) -> DateTime<Utc> {
-        self.gc(after);
+        #[cfg(debug_assertions)]
+        debug_assert!(
+            self.intervals.iter().all(|i| i.end > after),
+            "stale interval in timeline for {}",
+            self.node_name,
+        );
 
         let mut candidate = after;
         let max_check = after + Duration::days(365);
@@ -161,13 +171,7 @@ impl NodeTimeline {
                 }
                 return candidate;
             } else {
-                let next_end = self
-                    .intervals
-                    .iter()
-                    .filter(|i| i.end > candidate)
-                    .map(|i| i.end)
-                    .min();
-                match next_end {
+                match sweep.earliest_active_end() {
                     Some(t) => candidate = t,
                     None => return candidate,
                 }
@@ -432,7 +436,7 @@ mod tests {
             if tl.can_satisfy_at(candidate, request) {
                 let window_end = candidate + duration;
                 let mut ok = true;
-                for interval in &tl.intervals[..tl.overlap_prefix_end(window_end)] {
+                for interval in &tl.intervals {
                     if interval.start <= candidate || interval.end <= candidate {
                         continue;
                     }
@@ -452,7 +456,7 @@ mod tests {
                 let next_end = tl
                     .intervals
                     .iter()
-                    .filter(|i| i.end > candidate)
+                    .filter(|i| i.start <= candidate && i.end > candidate)
                     .map(|i| i.end)
                     .min();
                 match next_end {
@@ -641,7 +645,7 @@ mod tests {
     }
 
     #[test]
-    fn test_earliest_start_prunes_expired_intervals() {
+    fn test_gc_drops_expired_intervals() {
         let mut tl = make_timeline();
         let base = Utc::now();
 
@@ -657,14 +661,16 @@ mod tests {
         );
         assert_eq!(tl.intervals.len(), 2);
 
+        tl.gc(base);
+        assert_eq!(tl.intervals.len(), 1);
+        assert!(tl.intervals[0].end > base);
+
         let req = ResourceSet {
             cpus: 32,
             ..Default::default()
         };
         let start = tl.earliest_start(&req, Duration::hours(1), base);
         assert!(start >= base + Duration::hours(4));
-        assert_eq!(tl.intervals.len(), 1);
-        assert!(tl.intervals[0].end > base);
     }
 
     #[test]

--- a/crates/spur-sched/src/timeline.rs
+++ b/crates/spur-sched/src/timeline.rs
@@ -94,6 +94,28 @@ impl NodeTimeline {
         self.intervals.partition_point(|i| i.start < window_end)
     }
 
+    /// Return the end time of an interval whose start within `[start, start + duration)`
+    /// is the first point where cumulative allocations block `request`.
+    fn duration_blocker(
+        &self,
+        sweep: &mut AllocationSweep<'_>,
+        request: &ResourceSet,
+        start: DateTime<Utc>,
+        duration: Duration,
+    ) -> Option<DateTime<Utc>> {
+        let window_end = start + duration;
+        for interval in &self.intervals[..self.overlap_prefix_end(window_end)] {
+            if interval.start <= start || interval.end <= start {
+                continue;
+            }
+            sweep.advance_to(interval.start);
+            if !self.total.can_satisfy_with_allocated(sweep.used(), request) {
+                return Some(interval.end);
+            }
+        }
+        None
+    }
+
     pub fn accumulated_at(&self, time: DateTime<Utc>) -> ResourceAllocations {
         let mut used = ResourceAllocations::default();
         for interval in &self.intervals[..self.active_prefix_end(time)] {
@@ -132,22 +154,12 @@ impl NodeTimeline {
             sweep.advance_to(candidate);
 
             if self.total.can_satisfy_with_allocated(sweep.used(), request) {
-                let window_end = candidate + duration;
-                let mut ok = true;
-                for interval in &self.intervals[..self.overlap_prefix_end(window_end)] {
-                    if interval.end > candidate {
-                        let mut used = ResourceAllocations::default();
-                        used.add(&interval.resources);
-                        if !self.total.can_satisfy_with_allocated(&used, request) {
-                            candidate = interval.end;
-                            ok = false;
-                            break;
-                        }
-                    }
+                if let Some(jump) = self.duration_blocker(&mut sweep, request, candidate, duration)
+                {
+                    candidate = jump;
+                    continue;
                 }
-                if ok {
-                    return candidate;
-                }
+                return candidate;
             } else {
                 let next_end = self
                     .intervals
@@ -421,14 +433,16 @@ mod tests {
                 let window_end = candidate + duration;
                 let mut ok = true;
                 for interval in &tl.intervals[..tl.overlap_prefix_end(window_end)] {
-                    if interval.end > candidate {
-                        let mut used = ResourceAllocations::default();
-                        used.add(&interval.resources);
-                        if !tl.total.can_satisfy_with_allocated(&used, request) {
-                            candidate = interval.end;
-                            ok = false;
-                            break;
-                        }
+                    if interval.start <= candidate || interval.end <= candidate {
+                        continue;
+                    }
+                    if interval.start >= window_end {
+                        break;
+                    }
+                    if !tl.can_satisfy_at(interval.start, request) {
+                        candidate = interval.end;
+                        ok = false;
+                        break;
                     }
                 }
                 if ok {
@@ -491,11 +505,7 @@ mod tests {
         for time in event_times {
             sweep.advance_to(time);
             let expected = tl.accumulated_at(time);
-            assert_eq!(
-                sweep.used().cpus,
-                expected.cpus,
-                "cpu mismatch at {time}"
-            );
+            assert_eq!(sweep.used().cpus, expected.cpus, "cpu mismatch at {time}");
             assert_eq!(
                 sweep.used().memory_mb,
                 expected.memory_mb,
@@ -507,6 +517,32 @@ mod tests {
                 "gpu mismatch at {time}"
             );
         }
+    }
+
+    #[test]
+    fn test_earliest_start_cumulative_window_check() {
+        let mut tl = make_timeline();
+        let base = Utc::now();
+
+        tl.reserve(
+            base,
+            base + Duration::hours(4),
+            ResourceAllocations::with_scalar(32, 0),
+        );
+        tl.reserve(
+            base + Duration::hours(1),
+            base + Duration::hours(5),
+            ResourceAllocations::with_scalar(32, 0),
+        );
+
+        let req = ResourceSet {
+            cpus: 32,
+            ..Default::default()
+        };
+        let duration = Duration::hours(3);
+
+        let start = tl.earliest_start(&req, duration, base);
+        assert!(start >= base + Duration::hours(5));
     }
 
     #[test]
@@ -577,7 +613,11 @@ mod tests {
             "gpu".into(),
             (4u32..6).map(AllocatedDevice::injectable).collect(),
         );
-        tl.reserve(base + Duration::hours(1), base + Duration::hours(4), alloc_b);
+        tl.reserve(
+            base + Duration::hours(1),
+            base + Duration::hours(4),
+            alloc_b,
+        );
 
         let req = ResourceSet {
             cpus: 4,


### PR DESCRIPTION
## Summary

- Bound `accumulated_at` and the `earliest_start` overlap scan with `partition_point` on sorted interval starts, cutting per-query work from O(n) to O(log n + k) for overlapping intervals.
- Add `AllocationSweep` so `earliest_start` advances a running allocation total forward with candidate time instead of recomputing `accumulated_at` on every loop iteration.
- Prune stale intervals via `gc(horizon)` at the start of each backfill cycle and before each `earliest_start` search, keeping per-node interval vectors smaller under sustained submit load.

Targets the backfill scheduler hot path identified in submit-throughput profiling (`NodeTimeline::accumulated_at` / `earliest_start`).

## Test plan

- [x] `cargo test -p spur-sched --locked`
- [x] `cargo test -p spur-tests t07_1 --locked` (timeline + scheduler integration)
- [x] Re-run submit throughput benchmark (gRPC direct submit, sustained 5K jobs) and compare against pre-change baseline