### PR TITLE
feat(metrics): add controller RPC handler statistics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3677,6 +3677,7 @@ dependencies = [
  "clap",
  "dashmap",
  "hostname",
+ "http",
  "http-body-util",
  "openraft",
  "parking_lot",

--- a/crates/spur-cli/src/sdiag.rs
+++ b/crates/spur-cli/src/sdiag.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 use spur_core::job::JobState as CoreJobState;
 use spur_core::node::NodeState as CoreNodeState;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
-use spur_proto::proto::{JobMetrics, NodeMetrics};
+use spur_proto::proto::{JobMetrics, NodeMetrics, RpcOperationStats, RpcStats};
 
 /// Display scheduler diagnostics and statistics.
 #[derive(Parser, Debug)]
@@ -15,6 +15,10 @@ pub struct SdiagArgs {
     /// Don't print header
     #[arg(long)]
     pub noheader: bool,
+
+    /// Reset RPC statistics counters on the controller
+    #[arg(long)]
+    pub reset: bool,
 
     /// Controller address
     #[arg(
@@ -36,6 +40,13 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         .await
         .context("failed to connect to spurctld")?;
 
+    if args.reset {
+        client
+            .reset_rpc_stats(())
+            .await
+            .context("failed to reset RPC statistics")?;
+    }
+
     let ping_resp = client.ping(()).await.context("failed to ping controller")?;
     let ping = ping_resp.into_inner();
 
@@ -49,6 +60,12 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         .get_node_metrics(())
         .await
         .context("failed to get node metrics")?
+        .into_inner();
+
+    let rpc_stats = client
+        .get_rpc_stats(())
+        .await
+        .context("failed to get RPC statistics")?
         .into_inner();
 
     let server_time = ping
@@ -80,6 +97,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
 
     print_job_statistics(&job_metrics);
     print_node_statistics(&node_metrics);
+    print_rpc_statistics(&rpc_stats);
 
     Ok(())
 }
@@ -192,6 +210,36 @@ fn print_node_statistics(metrics: &NodeMetrics) {
     println!("  Allocated GPUs    : {}", metrics.alloc_gpus);
 }
 
+fn rpc_statistics_lines(stats: &RpcStats) -> Vec<String> {
+    let mut lines = vec![
+        String::new(),
+        "Remote Procedure Call statistics by operation:".to_string(),
+    ];
+
+    if stats.by_operation.is_empty() {
+        lines.push("  (no RPC calls recorded)".to_string());
+        return lines;
+    }
+
+    let mut ops: Vec<&RpcOperationStats> = stats.by_operation.iter().collect();
+    ops.sort_by_key(|b| std::cmp::Reverse(b.total_time_us));
+
+    for op in ops {
+        lines.push(format!(
+            "  {:24} count:{:8}  ave_time_us:{:8}  total_time_us:{}",
+            op.operation, op.count, op.avg_time_us, op.total_time_us
+        ));
+    }
+
+    lines
+}
+
+fn print_rpc_statistics(stats: &RpcStats) {
+    for line in rpc_statistics_lines(stats) {
+        println!("{line}");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -274,5 +322,41 @@ mod tests {
 
         assert_eq!(finished, 3); // NODE_FAIL + 2 COMPLETED
         assert_eq!(active, 2); // RUNNING + SUSPENDED
+    }
+
+    #[test]
+    fn rpc_statistics_lines_empty_state() {
+        let lines = rpc_statistics_lines(&RpcStats::default());
+        assert!(lines.iter().any(|l| l == "  (no RPC calls recorded)"));
+        assert!(lines
+            .iter()
+            .any(|l| l == "Remote Procedure Call statistics by operation:"));
+    }
+
+    #[test]
+    fn rpc_statistics_lines_sorted_by_total_time_us() {
+        let stats = RpcStats {
+            by_operation: vec![
+                RpcOperationStats {
+                    operation: "GetJobs".into(),
+                    count: 5,
+                    total_time_us: 250,
+                    avg_time_us: 50,
+                },
+                RpcOperationStats {
+                    operation: "SubmitJob".into(),
+                    count: 2,
+                    total_time_us: 3000,
+                    avg_time_us: 1500,
+                },
+            ],
+        };
+        let lines = rpc_statistics_lines(&stats);
+        let data_lines: Vec<&String> = lines.iter().filter(|l| l.contains("count:")).collect();
+        assert_eq!(data_lines.len(), 2);
+        assert!(data_lines[0].contains("SubmitJob"));
+        assert!(data_lines[1].contains("GetJobs"));
+        assert!(data_lines[0].contains("ave_time_us:"));
+        assert!(data_lines[0].contains("total_time_us:3000"));
     }
 }

--- a/crates/spur-metrics/src/export/mod.rs
+++ b/crates/spur-metrics/src/export/mod.rs
@@ -14,6 +14,7 @@ pub const CONTENT_TYPE: &str = "application/openmetrics-text; version=1.0.0; cha
 pub mod jobs;
 pub mod nodes;
 pub mod partitions;
+pub mod rpc;
 pub mod scheduler;
 
 /// Register a scalar `u64` gauge with an initial value.

--- a/crates/spur-metrics/src/export/rpc.rs
+++ b/crates/spur-metrics/src/export/rpc.rs
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! RPC handler gauge registration for `/metrics/rpc`.
+
+use prometheus_client::encoding::EncodeLabelSet;
+use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::gauge::Gauge;
+use prometheus_client::registry::Registry;
+use std::sync::atomic::AtomicU64;
+
+use crate::export::encode_registered;
+use crate::rpc::RpcStatsSnapshot;
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct OperationLabel {
+    operation: String,
+}
+
+fn set_family_gauge(
+    family: &Family<OperationLabel, Gauge<u64, AtomicU64>>,
+    operation: &str,
+    value: u64,
+) {
+    family
+        .get_or_create(&OperationLabel {
+            operation: operation.to_string(),
+        })
+        .set(value);
+}
+
+/// Register RPC handler gauges into `registry` from `snap`.
+pub fn register_rpc(registry: &mut Registry, snap: &RpcStatsSnapshot) {
+    let count_family = Family::<OperationLabel, Gauge<u64, AtomicU64>>::default();
+    let avg_family = Family::<OperationLabel, Gauge<u64, AtomicU64>>::default();
+    let total_family = Family::<OperationLabel, Gauge<u64, AtomicU64>>::default();
+
+    for op in &snap.by_operation {
+        set_family_gauge(&count_family, &op.operation, op.count);
+        set_family_gauge(&avg_family, &op.operation, op.avg_time_us());
+        set_family_gauge(&total_family, &op.operation, op.total_time_us);
+    }
+
+    registry.register(
+        "spur_rpc_stats",
+        "RPC call count by operation",
+        count_family,
+    );
+    registry.register(
+        "spur_rpc_stats_avg_time",
+        "Average RPC handler time in microseconds by operation",
+        avg_family,
+    );
+    registry.register(
+        "spur_rpc_stats_total_time",
+        "Cumulative RPC handler time in microseconds by operation",
+        total_family,
+    );
+}
+
+/// Encode RPC metrics for `/metrics/rpc` as OpenMetrics 1.0 text.
+pub fn encode_rpc_metrics(snap: &RpcStatsSnapshot) -> String {
+    encode_registered(|registry| register_rpc(registry, snap))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rpc::RpcOperationSnapshot;
+
+    fn sample_snapshot() -> RpcStatsSnapshot {
+        RpcStatsSnapshot {
+            by_operation: vec![
+                RpcOperationSnapshot {
+                    operation: "GetJobs".into(),
+                    count: 10,
+                    total_time_us: 500,
+                },
+                RpcOperationSnapshot {
+                    operation: "SubmitJob".into(),
+                    count: 2,
+                    total_time_us: 3000,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn export_includes_labeled_operation_metrics() {
+        let body = encode_rpc_metrics(&sample_snapshot());
+        assert!(body.contains("spur_rpc_stats{operation=\"SubmitJob\"} 2"));
+        assert!(body.contains("spur_rpc_stats_avg_time{operation=\"SubmitJob\"} 1500"));
+        assert!(body.contains("spur_rpc_stats_total_time{operation=\"SubmitJob\"} 3000"));
+        assert!(body.ends_with("# EOF\n"));
+    }
+
+    #[test]
+    fn empty_snapshot_produces_no_operation_labels() {
+        let body = encode_rpc_metrics(&RpcStatsSnapshot::default());
+        assert!(!body.contains("operation="));
+        assert!(body.ends_with("# EOF\n"));
+    }
+}

--- a/crates/spur-metrics/src/lib.rs
+++ b/crates/spur-metrics/src/lib.rs
@@ -6,10 +6,13 @@
 pub mod export;
 pub mod job;
 pub mod node;
+pub mod rpc;
 
 pub use export::jobs::{encode_job_metrics, job_state_metric_suffix};
 pub use export::nodes::encode_nodes_metrics;
 pub use export::partitions::encode_partitions_metrics;
+pub use export::rpc::encode_rpc_metrics;
 pub use export::scheduler::encode_scheduler_metrics;
 pub use export::CONTENT_TYPE;
 pub use node::node_state_metric_suffix;
+pub use rpc::{RpcOperationSnapshot, RpcStatsSnapshot};

--- a/crates/spur-metrics/src/rpc.rs
+++ b/crates/spur-metrics/src/rpc.rs
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Per-operation RPC handler statistics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RpcOperationSnapshot {
+    pub operation: String,
+    pub count: u64,
+    pub total_time_us: u64,
+}
+
+impl RpcOperationSnapshot {
+    pub fn avg_time_us(&self) -> u64 {
+        self.total_time_us.checked_div(self.count).unwrap_or(0)
+    }
+}
+
+/// Snapshot of controller RPC handler statistics.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RpcStatsSnapshot {
+    pub by_operation: Vec<RpcOperationSnapshot>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn avg_time_us_is_zero_when_count_zero() {
+        let op = RpcOperationSnapshot {
+            operation: "Ping".into(),
+            count: 0,
+            total_time_us: 100,
+        };
+        assert_eq!(op.avg_time_us(), 0);
+    }
+
+    #[test]
+    fn avg_time_us_divides_total_by_count() {
+        let op = RpcOperationSnapshot {
+            operation: "SubmitJob".into(),
+            count: 4,
+            total_time_us: 1000,
+        };
+        assert_eq!(op.avg_time_us(), 250);
+    }
+}

--- a/crates/spur-metrics/tests/fixtures/rpc.prom
+++ b/crates/spur-metrics/tests/fixtures/rpc.prom
@@ -1,0 +1,13 @@
+# HELP spur_rpc_stats RPC call count by operation.
+# TYPE spur_rpc_stats gauge
+spur_rpc_stats{operation="GetJobs"} 10
+spur_rpc_stats{operation="SubmitJob"} 2
+# HELP spur_rpc_stats_avg_time Average RPC handler time in microseconds by operation.
+# TYPE spur_rpc_stats_avg_time gauge
+spur_rpc_stats_avg_time{operation="GetJobs"} 50
+spur_rpc_stats_avg_time{operation="SubmitJob"} 1500
+# HELP spur_rpc_stats_total_time Cumulative RPC handler time in microseconds by operation.
+# TYPE spur_rpc_stats_total_time gauge
+spur_rpc_stats_total_time{operation="GetJobs"} 500
+spur_rpc_stats_total_time{operation="SubmitJob"} 3000
+# EOF

--- a/crates/spur-metrics/tests/rpc_export_golden.rs
+++ b/crates/spur-metrics/tests/rpc_export_golden.rs
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Golden tests for RPC metrics export.
+
+use spur_metrics::{encode_rpc_metrics, RpcOperationSnapshot, RpcStatsSnapshot};
+use std::path::PathBuf;
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures")
+}
+
+fn normalize_exposition(body: &str) -> String {
+    let mut out = String::new();
+    let mut block: Vec<&str> = Vec::new();
+
+    fn flush(out: &mut String, block: &mut Vec<&str>) {
+        if block.is_empty() {
+            return;
+        }
+
+        let mut headers: Vec<&str> = Vec::new();
+        let mut samples: Vec<&str> = Vec::new();
+        for &line in block.iter() {
+            if line.starts_with("# HELP ") || line.starts_with("# TYPE ") {
+                headers.push(line);
+            } else if !line.is_empty() {
+                samples.push(line);
+            }
+        }
+        samples.sort_unstable();
+
+        for h in headers {
+            out.push_str(h);
+            out.push('\n');
+        }
+        for s in samples {
+            out.push_str(s);
+            out.push('\n');
+        }
+
+        block.clear();
+    }
+
+    for line in body.lines() {
+        if line.starts_with("# HELP ") {
+            flush(&mut out, &mut block);
+        }
+        if line == "# EOF" {
+            flush(&mut out, &mut block);
+            out.push_str("# EOF\n");
+            continue;
+        }
+        block.push(line);
+    }
+    flush(&mut out, &mut block);
+    out
+}
+
+fn sample_snapshot() -> RpcStatsSnapshot {
+    RpcStatsSnapshot {
+        by_operation: vec![
+            RpcOperationSnapshot {
+                operation: "GetJobs".into(),
+                count: 10,
+                total_time_us: 500,
+            },
+            RpcOperationSnapshot {
+                operation: "SubmitJob".into(),
+                count: 2,
+                total_time_us: 3000,
+            },
+        ],
+    }
+}
+
+#[test]
+fn golden_rpc_metrics() {
+    let body = normalize_exposition(&encode_rpc_metrics(&sample_snapshot()));
+    let path = fixtures_dir().join("rpc.prom");
+    let expected =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    assert_eq!(body, expected);
+}
+
+/// Regenerate `tests/fixtures/rpc.prom` after intentional encoder changes:
+/// `cargo test -p spur-metrics --test rpc_export_golden refresh_golden_fixtures -- --ignored --exact`
+#[test]
+#[ignore = "manual fixture refresh"]
+fn refresh_golden_fixtures() {
+    let body = normalize_exposition(&encode_rpc_metrics(&sample_snapshot()));
+    std::fs::write(fixtures_dir().join("rpc.prom"), body).expect("write golden fixture");
+}

--- a/crates/spurctld/Cargo.toml
+++ b/crates/spurctld/Cargo.toml
@@ -31,6 +31,8 @@ serde_json = { workspace = true }
 hostname = "0.4.2"
 openraft = { workspace = true }
 axum = { workspace = true }
+http = "1"
+tower = { workspace = true }
 tower-http = { workspace = true }
 
 [dev-dependencies]

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -10,6 +10,8 @@ mod metrics_server;
 mod raft;
 mod raft_server;
 mod rest;
+mod rpc_middleware;
+mod rpc_stats;
 mod scheduler_loop;
 mod server;
 
@@ -20,6 +22,7 @@ use clap::Parser;
 use tracing::info;
 
 use cluster::ClusterManager;
+use rpc_stats::RpcStatsCollector;
 
 #[derive(Parser)]
 #[command(name = "spurctld", about = "Spur controller daemon (spurctld)")]
@@ -189,6 +192,8 @@ async fn main() -> anyhow::Result<()> {
         }
     });
 
+    let rpc_stats = Arc::new(RpcStatsCollector::new());
+
     if config.metrics.enabled {
         let metrics_addr = config
             .metrics
@@ -196,8 +201,15 @@ async fn main() -> anyhow::Result<()> {
             .map_err(|e| anyhow::anyhow!(e))?;
         let metrics_cluster = cluster.clone();
         let metrics_raft = raft_handle.clone();
+        let metrics_rpc_stats = rpc_stats.clone();
         tokio::spawn(async move {
-            if let Err(e) = metrics_server::serve(metrics_addr, metrics_cluster, metrics_raft).await
+            if let Err(e) = metrics_server::serve(
+                metrics_addr,
+                metrics_cluster,
+                metrics_raft,
+                metrics_rpc_stats,
+            )
+            .await
             {
                 tracing::error!(error = %e, "OpenMetrics metrics server failed");
             }
@@ -218,7 +230,7 @@ async fn main() -> anyhow::Result<()> {
     // Start gRPC server
     let addr = listen_addr.parse()?;
     info!(%addr, "gRPC server listening");
-    server::serve(addr, cluster, raft_handle).await?;
+    server::serve(addr, cluster, raft_handle, rpc_stats).await?;
 
     sched_handle.abort();
     Ok(())

--- a/crates/spurctld/src/metrics_proto.rs
+++ b/crates/spurctld/src/metrics_proto.rs
@@ -7,7 +7,26 @@ use spur_core::job::JobState;
 use spur_core::node::NodeState;
 use spur_metrics::job::JobMetricsSnapshot;
 use spur_metrics::node::NodeMetricsSnapshot;
-use spur_proto::proto::{JobMetrics, JobStateCount, NodeMetrics, NodeMetricsEntry, NodeStateCount};
+use spur_metrics::RpcStatsSnapshot;
+use spur_proto::proto::{
+    JobMetrics, JobStateCount, NodeMetrics, NodeMetricsEntry, NodeStateCount, RpcOperationStats,
+    RpcStats,
+};
+
+pub fn rpc_stats_to_proto(snap: &RpcStatsSnapshot) -> RpcStats {
+    let by_operation = snap
+        .by_operation
+        .iter()
+        .map(|op| RpcOperationStats {
+            operation: op.operation.clone(),
+            count: op.count,
+            total_time_us: op.total_time_us,
+            avg_time_us: op.avg_time_us(),
+        })
+        .collect();
+
+    RpcStats { by_operation }
+}
 
 pub fn job_metrics_to_proto(snap: &JobMetricsSnapshot) -> JobMetrics {
     let by_state = JobState::ALL
@@ -73,8 +92,10 @@ mod tests {
     use spur_core::resource::{GpuLinkType, GpuResource, ResourceAllocations, ResourceSet};
     use spur_metrics::export::jobs::{encode_job_metrics, job_state_metric_suffix};
     use spur_metrics::export::nodes::encode_nodes_metrics;
+    use spur_metrics::export::rpc::encode_rpc_metrics;
     use spur_metrics::job::JobMetricsSnapshot;
     use spur_metrics::node::NodeMetricsSnapshot;
+    use spur_metrics::{RpcOperationSnapshot, RpcStatsSnapshot};
 
     use super::*;
 
@@ -193,5 +214,64 @@ mod tests {
         );
         assert_eq!(proto.total, 2);
         assert_eq!(proto.per_node.len(), 2);
+    }
+
+    #[test]
+    fn rpc_proto_matches_http_gauges() {
+        let snap = RpcStatsSnapshot {
+            by_operation: vec![
+                RpcOperationSnapshot {
+                    operation: "SubmitJob".into(),
+                    count: 2,
+                    total_time_us: 3000,
+                },
+                RpcOperationSnapshot {
+                    operation: "GetJobs".into(),
+                    count: 5,
+                    total_time_us: 250,
+                },
+            ],
+        };
+        let proto = rpc_stats_to_proto(&snap);
+        let body = encode_rpc_metrics(&snap);
+
+        for op in &proto.by_operation {
+            let prefix = format!("spur_rpc_stats{{operation=\"{}\"}}", op.operation);
+            let count_line = body
+                .lines()
+                .find(|line| line.starts_with(&prefix))
+                .unwrap_or_else(|| panic!("missing count line for {}", op.operation));
+            let count: u64 = count_line
+                .split_whitespace()
+                .nth(1)
+                .unwrap()
+                .parse()
+                .unwrap();
+            assert_eq!(count, op.count);
+
+            let avg_prefix = format!("spur_rpc_stats_avg_time{{operation=\"{}\"}}", op.operation);
+            let avg_line = body
+                .lines()
+                .find(|line| line.starts_with(&avg_prefix))
+                .unwrap();
+            let avg: u64 = avg_line.split_whitespace().nth(1).unwrap().parse().unwrap();
+            assert_eq!(avg, op.avg_time_us);
+
+            let total_prefix = format!(
+                "spur_rpc_stats_total_time{{operation=\"{}\"}}",
+                op.operation
+            );
+            let total_line = body
+                .lines()
+                .find(|line| line.starts_with(&total_prefix))
+                .unwrap();
+            let total: u64 = total_line
+                .split_whitespace()
+                .nth(1)
+                .unwrap()
+                .parse()
+                .unwrap();
+            assert_eq!(total, op.total_time_us);
+        }
     }
 }

--- a/crates/spurctld/src/metrics_server.rs
+++ b/crates/spurctld/src/metrics_server.rs
@@ -12,17 +12,19 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::Router;
 use spur_metrics::{
-    encode_job_metrics, encode_nodes_metrics, encode_partitions_metrics, encode_scheduler_metrics,
-    CONTENT_TYPE,
+    encode_job_metrics, encode_nodes_metrics, encode_partitions_metrics, encode_rpc_metrics,
+    encode_scheduler_metrics, CONTENT_TYPE,
 };
 use tracing::info;
 
 use crate::cluster::ClusterManager;
 use crate::raft::RaftHandle;
+use crate::rpc_stats::RpcStatsCollector;
 
 struct MetricsState {
     cluster: Arc<ClusterManager>,
     raft: Arc<RaftHandle>,
+    rpc_stats: Arc<RpcStatsCollector>,
 }
 
 /// Start the metrics HTTP server. Runs until the listener is closed.
@@ -30,14 +32,20 @@ pub async fn serve(
     listen: SocketAddr,
     cluster: Arc<ClusterManager>,
     raft: Arc<RaftHandle>,
+    rpc_stats: Arc<RpcStatsCollector>,
 ) -> anyhow::Result<()> {
-    let state = Arc::new(MetricsState { cluster, raft });
+    let state = Arc::new(MetricsState {
+        cluster,
+        raft,
+        rpc_stats,
+    });
 
     let app = Router::new()
         .route("/metrics", get(metrics_jobs))
         .route("/metrics/jobs", get(metrics_jobs))
         .route("/metrics/nodes", get(metrics_nodes))
         .route("/metrics/partitions", get(metrics_partitions))
+        .route("/metrics/rpc", get(metrics_rpc))
         .route("/metrics/scheduler", get(metrics_scheduler))
         .route("/metrics/jobs-users-accts", get(metrics_jobs_users_accts))
         .with_state(state);
@@ -68,6 +76,13 @@ async fn metrics_partitions(State(state): State<Arc<MetricsState>>) -> Response 
         return not_leader_response();
     }
     metrics_response(encode_partitions_metrics())
+}
+
+async fn metrics_rpc(State(state): State<Arc<MetricsState>>) -> Response {
+    if !state.raft.is_leader() {
+        return not_leader_response();
+    }
+    metrics_response(encode_rpc_metrics(&state.rpc_stats.snapshot()))
 }
 
 async fn metrics_scheduler(State(state): State<Arc<MetricsState>>) -> Response {
@@ -116,6 +131,7 @@ mod tests {
     use tower::ServiceExt;
 
     use crate::cluster::ClusterManager;
+    use crate::rpc_stats::RpcStatsCollector;
 
     fn test_config() -> SlurmConfig {
         SlurmConfig {
@@ -177,15 +193,63 @@ mod tests {
         let state = Arc::new(MetricsState {
             cluster: cm,
             raft: Arc::new(handle),
+            rpc_stats: Arc::new(RpcStatsCollector::new()),
         });
         let app = Router::new()
             .route("/metrics/jobs", get(metrics_jobs))
             .route("/metrics/nodes", get(metrics_nodes))
             .route("/metrics/partitions", get(metrics_partitions))
+            .route("/metrics/rpc", get(metrics_rpc))
             .route("/metrics/scheduler", get(metrics_scheduler))
             .route("/metrics/jobs-users-accts", get(metrics_jobs_users_accts))
             .with_state(state);
         (app, dir)
+    }
+
+    async fn two_node_raft(
+        dir: &TempDir,
+    ) -> (Arc<crate::raft::RaftHandle>, Arc<crate::raft::RaftHandle>) {
+        let listener1 = tokio::net::TcpListener::bind("[::1]:0").await.unwrap();
+        let addr1 = listener1.local_addr().unwrap();
+        let listener2 = tokio::net::TcpListener::bind("[::1]:0").await.unwrap();
+        let addr2 = listener2.local_addr().unwrap();
+        drop(listener1);
+        drop(listener2);
+
+        let peers = vec![addr1.to_string(), addr2.to_string()];
+
+        let cm1 = Arc::new(ClusterManager::new(test_config(), &dir.path().join("n1")).unwrap());
+        let leader_handle = crate::raft::start_raft(1, &peers, &dir.path().join("n1"), cm1)
+            .await
+            .unwrap();
+        let cm2 = Arc::new(ClusterManager::new(test_config(), &dir.path().join("n2")).unwrap());
+        let follower_handle = crate::raft::start_raft(2, &peers, &dir.path().join("n2"), cm2)
+            .await
+            .unwrap();
+
+        let leader_raft = leader_handle.raft.clone();
+        let follower_raft = follower_handle.raft.clone();
+        tokio::spawn(async move {
+            let _ = crate::raft_server::serve_raft(addr1, leader_raft).await;
+        });
+        tokio::spawn(async move {
+            let _ = crate::raft_server::serve_raft(addr2, follower_raft).await;
+        });
+
+        leader_handle
+            .raft
+            .wait(Some(Duration::from_secs(10)))
+            .metrics(|m| m.current_leader.is_some(), "leader elected")
+            .await
+            .expect("two-node raft did not elect a leader within 10s");
+
+        let leader = Arc::new(leader_handle);
+        let follower = Arc::new(follower_handle);
+        assert!(leader.is_leader() ^ follower.is_leader());
+        if follower.is_leader() {
+            return (follower, leader);
+        }
+        (leader, follower)
     }
 
     #[tokio::test]
@@ -246,6 +310,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn metrics_rpc_returns_ok() {
+        let (app, _dir) = test_app().await;
+        let resp = app
+            .oneshot(
+                axum::http::Request::get("/metrics/rpc")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            CONTENT_TYPE
+        );
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+        assert!(text.ends_with("# EOF\n"));
+    }
+
+    #[tokio::test]
     async fn metrics_scheduler_returns_ok() {
         let (app, _dir) = test_app().await;
         let resp = app
@@ -261,6 +346,23 @@ mod tests {
             resp.headers().get(header::CONTENT_TYPE).unwrap(),
             CONTENT_TYPE
         );
+    }
+
+    #[tokio::test]
+    async fn metrics_rpc_returns_503_on_follower() {
+        use axum::extract::State;
+
+        let dir = TempDir::new().unwrap();
+        let (leader, follower) = two_node_raft(&dir).await;
+        let _leader = leader;
+        let cm = Arc::new(ClusterManager::new(test_config(), &dir.path().join("cm")).unwrap());
+        let state = Arc::new(MetricsState {
+            cluster: cm,
+            raft: follower,
+            rpc_stats: Arc::new(RpcStatsCollector::new()),
+        });
+        let resp = metrics_rpc(State(state)).await;
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[tokio::test]

--- a/crates/spurctld/src/rpc_middleware.rs
+++ b/crates/spurctld/src/rpc_middleware.rs
@@ -1,0 +1,248 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tower middleware that records controller RPC handler durations on the leader.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Instant;
+
+use http::{Request, Response};
+use tower::{Layer, Service};
+
+use crate::raft::RaftHandle;
+use crate::rpc_stats::RpcStatsCollector;
+
+#[derive(Clone)]
+pub struct RpcStatsLayer {
+    stats: Arc<RpcStatsCollector>,
+    raft: Arc<RaftHandle>,
+}
+
+impl RpcStatsLayer {
+    pub fn new(stats: Arc<RpcStatsCollector>, raft: Arc<RaftHandle>) -> Self {
+        Self { stats, raft }
+    }
+}
+
+impl<S> Layer<S> for RpcStatsLayer {
+    type Service = RpcStatsMiddleware<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RpcStatsMiddleware {
+            inner,
+            stats: self.stats.clone(),
+            raft: self.raft.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct RpcStatsMiddleware<S> {
+    inner: S,
+    stats: Arc<RpcStatsCollector>,
+    raft: Arc<RaftHandle>,
+}
+
+impl<S, B> Service<Request<B>> for RpcStatsMiddleware<S>
+where
+    S: Service<Request<B>, Response = Response<tonic::body::Body>> + Clone + Send + 'static,
+    S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    S::Future: Send + 'static,
+    B: Send + 'static,
+{
+    type Response = Response<tonic::body::Body>;
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, req: Request<B>) -> Self::Future {
+        let operation = grpc_operation_name(req.uri().path());
+        let record = self.raft.is_leader() && should_record_operation(&operation);
+        let stats = self.stats.clone();
+        let start = Instant::now();
+        let mut inner = self.inner.clone();
+
+        Box::pin(async move {
+            let result = inner.call(req).await;
+            if record {
+                stats.record(&operation, start.elapsed());
+            }
+            result.map_err(Into::into)
+        })
+    }
+}
+
+/// Diagnostic RPCs excluded so reads and `sdiag` polling do not skew accumulators.
+fn should_record_operation(operation: &str) -> bool {
+    !matches!(
+        operation,
+        "GetRpcStats" | "ResetRpcStats" | "GetJobMetrics" | "GetNodeMetrics" | "Ping"
+    )
+}
+
+/// Extract the gRPC method name from an HTTP/2 `:path` value.
+pub(crate) fn grpc_operation_name(path: &str) -> String {
+    path.rsplit('/')
+        .next()
+        .filter(|segment| !segment.is_empty())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grpc_operation_name_parses_method_from_path() {
+        assert_eq!(
+            grpc_operation_name("/slurm.SlurmController/SubmitJob"),
+            "SubmitJob"
+        );
+        assert_eq!(grpc_operation_name("/unknown"), "unknown");
+    }
+
+    #[test]
+    fn should_record_operation_skips_diagnostic_rpcs() {
+        assert!(should_record_operation("SubmitJob"));
+        assert!(should_record_operation("GetJobs"));
+        assert!(!should_record_operation("GetRpcStats"));
+        assert!(!should_record_operation("ResetRpcStats"));
+        assert!(!should_record_operation("GetJobMetrics"));
+        assert!(!should_record_operation("GetNodeMetrics"));
+        assert!(!should_record_operation("Ping"));
+    }
+
+    #[tokio::test]
+    async fn middleware_records_leader_rpc_and_skips_diagnostic_names() {
+        use std::collections::HashMap;
+        use std::convert::Infallible;
+
+        use http::Request;
+        use tempfile::TempDir;
+        use tower::ServiceExt;
+
+        use crate::cluster::ClusterManager;
+        use crate::raft::start_raft;
+        use spur_core::config::SlurmConfig;
+
+        #[derive(Clone, Default)]
+        struct OkService;
+
+        impl<B> Service<Request<B>> for OkService
+        where
+            B: Send + 'static,
+        {
+            type Response = Response<tonic::body::Body>;
+            type Error = Infallible;
+            type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
+
+            fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+                Poll::Ready(Ok(()))
+            }
+
+            fn call(&mut self, _req: Request<B>) -> Self::Future {
+                std::future::ready(Ok(Response::new(tonic::body::Body::empty())))
+            }
+        }
+
+        fn test_config() -> SlurmConfig {
+            SlurmConfig {
+                cluster_name: "test".into(),
+                controller: spur_core::config::ControllerConfig {
+                    first_job_id: 1,
+                    ..Default::default()
+                },
+                accounting: Default::default(),
+                scheduler: Default::default(),
+                auth: Default::default(),
+                partitions: vec![spur_core::config::PartitionConfig {
+                    name: "default".into(),
+                    default: true,
+                    state: "UP".into(),
+                    nodes: "ALL".into(),
+                    selector: Default::default(),
+                    max_time: None,
+                    default_time: None,
+                    max_nodes: None,
+                    min_nodes: 1,
+                    allow_accounts: Vec::new(),
+                    allow_groups: Vec::new(),
+                    priority_tier: 1,
+                    preempt_mode: String::new(),
+                }],
+                nodes: Vec::new(),
+                network: Default::default(),
+                logging: Default::default(),
+                kubernetes: Default::default(),
+                notifications: Default::default(),
+                power: Default::default(),
+                federation: Default::default(),
+                topology: None,
+                isolation: Default::default(),
+                licenses: HashMap::new(),
+                update: Default::default(),
+                metrics: Default::default(),
+                rest_api: Default::default(),
+                hooks: Default::default(),
+                devices: Default::default(),
+                admission: Default::default(),
+                burst_buffer: Default::default(),
+            }
+        }
+
+        let dir = TempDir::new().unwrap();
+        let cm = Arc::new(ClusterManager::new(test_config(), dir.path()).unwrap());
+        let handle = start_raft(1, &["[::1]:0".into()], dir.path(), cm)
+            .await
+            .unwrap();
+        handle
+            .raft
+            .wait(Some(std::time::Duration::from_secs(5)))
+            .metrics(|m| m.current_leader == Some(1), "leader elected")
+            .await
+            .expect("single-node raft did not self-elect within 5s");
+
+        let stats = Arc::new(RpcStatsCollector::new());
+        let raft = Arc::new(handle);
+
+        let submit = Request::builder()
+            .uri("/slurm.SlurmController/SubmitJob")
+            .body(())
+            .unwrap();
+        RpcStatsMiddleware {
+            inner: OkService,
+            stats: stats.clone(),
+            raft: raft.clone(),
+        }
+        .oneshot(submit)
+        .await
+        .unwrap();
+
+        let snap = stats.snapshot();
+        assert_eq!(snap.by_operation.len(), 1);
+        assert_eq!(snap.by_operation[0].operation, "SubmitJob");
+        assert_eq!(snap.by_operation[0].count, 1);
+
+        let ping = Request::builder()
+            .uri("/slurm.SlurmController/Ping")
+            .body(())
+            .unwrap();
+        RpcStatsMiddleware {
+            inner: OkService,
+            stats: stats.clone(),
+            raft,
+        }
+        .oneshot(ping)
+        .await
+        .unwrap();
+        assert_eq!(stats.snapshot().by_operation.len(), 1);
+    }
+}

--- a/crates/spurctld/src/rpc_stats.rs
+++ b/crates/spurctld/src/rpc_stats.rs
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! In-memory accumulator for controller RPC handler timings.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use parking_lot::Mutex;
+use spur_metrics::{RpcOperationSnapshot, RpcStatsSnapshot};
+
+#[derive(Debug, Default)]
+struct OpAccum {
+    count: u64,
+    total_time_us: u64,
+}
+
+/// Leader-side RPC handler statistics since process start or the last reset.
+#[derive(Debug, Default)]
+pub struct RpcStatsCollector {
+    ops: Mutex<HashMap<String, OpAccum>>,
+}
+
+impl RpcStatsCollector {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn record(&self, operation: &str, duration: Duration) {
+        let micros = duration.as_micros().min(u64::MAX as u128) as u64;
+        let mut ops = self.ops.lock();
+        if let Some(accum) = ops.get_mut(operation) {
+            accum.count += 1;
+            accum.total_time_us = accum.total_time_us.saturating_add(micros);
+        } else {
+            ops.insert(
+                operation.to_string(),
+                OpAccum {
+                    count: 1,
+                    total_time_us: micros,
+                },
+            );
+        }
+    }
+
+    pub fn snapshot(&self) -> RpcStatsSnapshot {
+        let mut by_operation: Vec<RpcOperationSnapshot> = self
+            .ops
+            .lock()
+            .iter()
+            .map(|(operation, accum)| RpcOperationSnapshot {
+                operation: operation.clone(),
+                count: accum.count,
+                total_time_us: accum.total_time_us,
+            })
+            .collect();
+        by_operation.sort_by(|a, b| a.operation.cmp(&b.operation));
+        RpcStatsSnapshot { by_operation }
+    }
+
+    pub fn reset(&self) {
+        self.ops.lock().clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn record_accumulates_count_and_time() {
+        let stats = RpcStatsCollector::new();
+        stats.record("SubmitJob", Duration::from_micros(100));
+        stats.record("SubmitJob", Duration::from_micros(300));
+
+        let snap = stats.snapshot();
+        assert_eq!(snap.by_operation.len(), 1);
+        let op = &snap.by_operation[0];
+        assert_eq!(op.operation, "SubmitJob");
+        assert_eq!(op.count, 2);
+        assert_eq!(op.total_time_us, 400);
+        assert_eq!(op.avg_time_us(), 200);
+    }
+
+    #[test]
+    fn reset_clears_accumulators() {
+        let stats = RpcStatsCollector::new();
+        stats.record("Ping", Duration::from_micros(10));
+        stats.reset();
+        assert!(stats.snapshot().by_operation.is_empty());
+    }
+}

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -19,6 +19,8 @@ use spur_proto::proto::*;
 
 use crate::cluster::ClusterManager;
 use crate::raft::RaftHandle;
+use crate::rpc_middleware::RpcStatsLayer;
+use crate::rpc_stats::RpcStatsCollector;
 
 const FORWARDED_HEADER: &str = "x-spur-forwarded";
 const LEADER_HEADER: &str = "x-spur-leader";
@@ -29,6 +31,7 @@ pub struct ControllerService {
     leader_proxy: LeaderProxy,
     /// Node ID → client API address (host:6817) for the x-spur-leader header.
     client_addrs: BTreeMap<u64, String>,
+    rpc_stats: Arc<RpcStatsCollector>,
 }
 
 struct LeaderProxy {
@@ -570,6 +573,37 @@ impl SlurmController for ControllerService {
         Ok(Response::new(crate::metrics_proto::node_metrics_to_proto(
             &snap,
         )))
+    }
+
+    async fn get_rpc_stats(&self, request: Request<()>) -> Result<Response<RpcStats>, Status> {
+        if self.check_leader(&request).is_err() {
+            {
+                let proxy = &self.leader_proxy;
+                let mut client = proxy.get_leader_client().await?;
+                let mut fwd = Request::new(());
+                *fwd.metadata_mut() = Self::forwarded_metadata();
+                return client.get_rpc_stats(fwd).await;
+            }
+        }
+
+        Ok(Response::new(crate::metrics_proto::rpc_stats_to_proto(
+            &self.rpc_stats.snapshot(),
+        )))
+    }
+
+    async fn reset_rpc_stats(&self, request: Request<()>) -> Result<Response<()>, Status> {
+        if self.check_leader(&request).is_err() {
+            {
+                let proxy = &self.leader_proxy;
+                let mut client = proxy.get_leader_client().await?;
+                let mut fwd = Request::new(());
+                *fwd.metadata_mut() = Self::forwarded_metadata();
+                return client.reset_rpc_stats(fwd).await;
+            }
+        }
+
+        self.rpc_stats.reset();
+        Ok(Response::new(()))
     }
 
     async fn register_agent(
@@ -1246,6 +1280,7 @@ pub async fn serve(
     addr: SocketAddr,
     cluster: Arc<ClusterManager>,
     raft_handle: Arc<RaftHandle>,
+    rpc_stats: Arc<RpcStatsCollector>,
 ) -> anyhow::Result<()> {
     let client_addrs: BTreeMap<u64, String> = raft_handle
         .peers
@@ -1265,11 +1300,15 @@ pub async fn serve(
     let service = ControllerService {
         cluster,
         client_addrs,
-        raft: raft_handle,
+        raft: raft_handle.clone(),
         leader_proxy,
+        rpc_stats: rpc_stats.clone(),
     };
 
+    let stats_layer = RpcStatsLayer::new(rpc_stats, raft_handle);
+
     tonic::transport::Server::builder()
+        .layer(stats_layer)
         .add_service(SlurmControllerServer::new(service))
         .serve(addr)
         .await?;

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -281,6 +281,10 @@ service SlurmController {
   rpc GetJobMetrics(google.protobuf.Empty) returns (JobMetrics);
   rpc GetNodeMetrics(google.protobuf.Empty) returns (NodeMetrics);
 
+  // Controller RPC handler statistics (since process start or last reset)
+  rpc GetRpcStats(google.protobuf.Empty) returns (RpcStats);
+  rpc ResetRpcStats(google.protobuf.Empty) returns (google.protobuf.Empty);
+
   // Agent registration
   rpc RegisterAgent(RegisterAgentRequest) returns (RegisterAgentResponse);
   rpc Heartbeat(HeartbeatRequest) returns (HeartbeatResponse);
@@ -485,6 +489,17 @@ message NodeMetrics {
   uint64 total_gpus = 7;
   uint64 alloc_gpus = 8;
   repeated NodeMetricsEntry per_node = 9;
+}
+
+message RpcOperationStats {
+  string operation = 1;
+  uint64 count = 2;
+  uint64 total_time_us = 3;
+  uint64 avg_time_us = 4;
+}
+
+message RpcStats {
+  repeated RpcOperationStats by_operation = 1;
 }
 
 message RegisterAgentRequest {


### PR DESCRIPTION
## Summary

- Add leader-side RPC handler statistics: per-operation call count, cumulative handler time (µs), and average time.
- Instrument all `SlurmController` gRPC methods automatically via a Tower middleware (timing includes Raft commit wait for mutation RPCs such as `SubmitJob`).
- Expose stats through `GetRpcStats` / `ResetRpcStats` gRPC, `GET /metrics/rpc` HTTP export, and an `sdiag` RPC statistics section with `--reset`.

## Motivation

Controller RPC handler timing is needed for throughput diagnosis (e.g. parallel `sbatch` benchmarks) and operator visibility into which APIs dominate controller load. Stats are accumulated in-memory on the leader since process start or last reset — no separate counter store.

## API changes

**Proto** (`proto/slurm.proto`):
- `GetRpcStats` → `RpcStats` (`RpcOperationStats`: operation, count, total_time_us, avg_time_us)
- `ResetRpcStats` → clears accumulators on the leader

**HTTP** (`:6822`, leader-gated):
- `GET /metrics/rpc` — `spur_rpc_stats`, `spur_rpc_stats_avg_time`, `spur_rpc_stats_total_time` labeled by `operation` (gRPC method name)

**CLI**:
- `sdiag` prints RPC statistics sorted by total time
- `sdiag --reset` calls `ResetRpcStats` before displaying

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` (`RUSTFLAGS="-D warnings"`)
- [x] `cargo test --locked`
- [x] `spur-metrics` rpc golden export tests
- [x] `spurctld` `metrics_proto` rpc ↔ HTTP gauge parity test