### PR TITLE
docs(AGENTS-md): warn against #N references in PR/issue descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,8 @@ PR descriptions should be concise and readable — not line-by-line changelogs. 
 
 When filing issues, focus on the problem: what happened, what was expected, and how to reproduce. Do not prescribe a fix — that biases the person or agent addressing it.
 
+Do not use `#N` to reference numbered points within a PR or issue description — GitHub interprets `#1`, `#2`, etc. as links to other issues/PRs. Use `[N]` instead (e.g. "as noted in [1] above").
+
 A pre-commit hook is available in `.githooks/` (activate with `git config core.hooksPath .githooks`). It enforces formatting and SPDX license headers.
 
 Validate your changes before submitting:


### PR DESCRIPTION
GitHub interprets `#N` as a cross-reference to issue/PR N. When the intent is to reference a numbered point within the same PR or issue description (e.g. "see point `#1` above"), this silently creates a wrong link.

Adds a note to the Git Workflow section of AGENTS.md recommending `[N]` instead.