### PR TITLE
feat(spur): node deregistration, drain, and job eviction

### DIFF
--- a/crates/spur-cli/src/node.rs
+++ b/crates/spur-cli/src/node.rs
@@ -41,6 +41,25 @@ pub enum NodeCommand {
         #[arg(required = true)]
         labels: Vec<String>,
     },
+    /// Drain a node: stop scheduling new jobs while existing jobs finish.
+    Drain {
+        /// Node name
+        node: String,
+        /// Reason for draining
+        #[arg(long)]
+        reason: Option<String>,
+    },
+    /// Remove a node from the cluster entirely.
+    Remove {
+        /// Node name
+        node: String,
+        /// Force removal even if jobs are running (jobs will be failed with NODE_FAIL)
+        #[arg(long)]
+        force: bool,
+        /// Reason for removal
+        #[arg(long)]
+        reason: Option<String>,
+    },
 }
 
 pub async fn main() -> Result<()> {
@@ -52,6 +71,12 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let controller = parsed.controller;
     match parsed.command {
         NodeCommand::Label { node, labels } => cmd_label(&controller, node, labels).await,
+        NodeCommand::Drain { node, reason } => cmd_drain(&controller, node, reason).await,
+        NodeCommand::Remove {
+            node,
+            force,
+            reason,
+        } => cmd_remove(&controller, node, force, reason).await,
     }
 }
 
@@ -99,6 +124,66 @@ async fn cmd_label(controller: &str, node: String, label_args: Vec<String>) -> R
         println!("  {node}: {k} removed");
     }
 
+    Ok(())
+}
+
+async fn cmd_drain(controller: &str, node: String, reason: Option<String>) -> Result<()> {
+    let mut client = SlurmControllerClient::connect(controller.to_string()).await?;
+    let resp = client
+        .drain_node(spur_proto::proto::DrainNodeRequest {
+            name: node.clone(),
+            reason: reason.clone().unwrap_or_default(),
+        })
+        .await?
+        .into_inner();
+
+    if resp.running_jobs > 0 {
+        println!(
+            "Node {node} set to draining ({} running job{} will finish first)",
+            resp.running_jobs,
+            if resp.running_jobs == 1 { "" } else { "s" }
+        );
+    } else {
+        println!("Node {node} set to drain");
+    }
+    if let Some(r) = reason {
+        println!("  reason: {r}");
+    }
+    Ok(())
+}
+
+async fn cmd_remove(
+    controller: &str,
+    node: String,
+    force: bool,
+    reason: Option<String>,
+) -> Result<()> {
+    let mut client = SlurmControllerClient::connect(controller.to_string()).await?;
+    let resp = client
+        .deregister_node(spur_proto::proto::DeregisterNodeRequest {
+            name: node.clone(),
+            force,
+            reason: reason.clone().unwrap_or_default(),
+        })
+        .await?
+        .into_inner();
+
+    if resp.evicted_jobs_count > 0 {
+        println!(
+            "Node {node} removed from cluster ({} job{} evicted)",
+            resp.evicted_jobs_count,
+            if resp.evicted_jobs_count == 1 {
+                ""
+            } else {
+                "s"
+            }
+        );
+    } else {
+        println!("Node {node} removed from cluster");
+    }
+    if let Some(r) = reason {
+        println!("  reason: {r}");
+    }
     Ok(())
 }
 

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -274,6 +274,11 @@ pub struct ControllerConfig {
     /// Listen address for Raft internal gRPC traffic (separate from client API).
     #[serde(default = "default_raft_listen_addr")]
     pub raft_listen_addr: String,
+
+    /// Seconds without a heartbeat before a node is marked Down.
+    /// Defaults to 90 when absent.
+    #[serde(default)]
+    pub heartbeat_timeout_secs: Option<u64>,
 }
 
 fn default_listen_addr() -> String {
@@ -307,6 +312,7 @@ impl Default for ControllerConfig {
             peers: Vec::new(),
             node_id: None,
             raft_listen_addr: "[::]:6821".into(),
+            heartbeat_timeout_secs: None,
         }
     }
 }
@@ -1132,5 +1138,35 @@ memory_mb = 1024000
         let parts = config.build_partitions();
         assert_eq!(parts[0].name, "gpu");
         assert_eq!(parts[0].max_time_minutes, Some(4320));
+    }
+
+    #[test]
+    fn controller_config_defaults_for_new_fields() {
+        let config = ControllerConfig::default();
+        assert_eq!(config.heartbeat_timeout_secs, None);
+    }
+
+    #[test]
+    fn controller_config_parses_heartbeat_timeout() {
+        let toml = r#"
+cluster_name = "test"
+
+[controller]
+heartbeat_timeout_secs = 120
+"#;
+        let config = SlurmConfig::load_from_str(toml).unwrap();
+        assert_eq!(config.controller.heartbeat_timeout_secs, Some(120));
+    }
+
+    #[test]
+    fn controller_config_absent_fields_are_none() {
+        let toml = r#"
+cluster_name = "test"
+
+[controller]
+listen_addr = "[::]:6817"
+"#;
+        let config = SlurmConfig::load_from_str(toml).unwrap();
+        assert_eq!(config.controller.heartbeat_timeout_secs, None);
     }
 }

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -749,6 +749,7 @@ impl Job {
             (JobState::Completing, JobState::Completed) => true,
             (JobState::Completing, JobState::Failed) => true,
             (JobState::Completing, JobState::Cancelled) => true,
+            (JobState::Completing, JobState::NodeFail) => true,
             (JobState::Completing, JobState::OutOfMemory) => true,
             (JobState::Suspended, JobState::Running) => true,
             (JobState::Suspended, JobState::Cancelled) => true,

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -105,6 +105,12 @@ pub enum WalOperation {
         remove: Vec<String>,
     },
 
+    // Node deregistration
+    NodeRemove {
+        name: String,
+        reason: Option<String>,
+    },
+
     // Admission token operations
     TokenCreate {
         token: AdmissionToken,
@@ -140,6 +146,45 @@ mod tests {
                 assert_eq!(node_name, "n0");
                 assert_eq!(exit_code, 0);
                 assert_eq!(signal, 9);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod deregistration_wal_tests {
+    use super::*;
+
+    #[test]
+    fn node_remove_round_trips() {
+        let op = WalOperation::NodeRemove {
+            name: "gpu01".into(),
+            reason: Some("decommission".into()),
+        };
+        let json = serde_json::to_string(&op).unwrap();
+        let back: WalOperation = serde_json::from_str(&json).unwrap();
+        match back {
+            WalOperation::NodeRemove { name, reason } => {
+                assert_eq!(name, "gpu01");
+                assert_eq!(reason.as_deref(), Some("decommission"));
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn node_remove_none_reason_round_trips() {
+        let op = WalOperation::NodeRemove {
+            name: "n0".into(),
+            reason: None,
+        };
+        let json = serde_json::to_string(&op).unwrap();
+        let back: WalOperation = serde_json::from_str(&json).unwrap();
+        match back {
+            WalOperation::NodeRemove { name, reason } => {
+                assert_eq!(name, "n0");
+                assert!(reason.is_none());
             }
             _ => panic!("wrong variant"),
         }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -334,9 +334,7 @@ impl ClusterManager {
             exit_code: -1,
             state: JobState::Deadline,
         })?;
-        if let Some(f) = resp.job_finalized {
-            self.run_job_finalized_side_effects(f);
-        }
+        self.run_all_finalized_side_effects(&resp);
 
         info!(job_id, "job deadline passed — transitioned to DEADLINE");
         Ok(())
@@ -362,9 +360,7 @@ impl ClusterManager {
             exit_code: -1,
             state: JobState::Cancelled,
         })?;
-        if let Some(f) = resp.job_finalized {
-            self.run_job_finalized_side_effects(f);
-        }
+        self.run_all_finalized_side_effects(&resp);
 
         info!(job_id, "job cancelled");
         Ok(())
@@ -536,8 +532,8 @@ impl ClusterManager {
             })
             .map_err(|source| NodeCompleteError::RaftPropose { source })?;
 
-        if let Some(f) = resp.job_finalized {
-            self.run_job_finalized_side_effects(f);
+        self.run_all_finalized_side_effects(&resp);
+        if let Some(f) = resp.jobs_finalized.first() {
             return Ok(NodeCompleteResult::AllDone {
                 state: f.state,
                 exit_code: f.exit_code,
@@ -577,9 +573,7 @@ impl ClusterManager {
             exit_code,
             state,
         })?;
-        if let Some(f) = resp.job_finalized {
-            self.run_job_finalized_side_effects(f);
-        }
+        self.run_all_finalized_side_effects(&resp);
 
         debug!(job_id, exit_code, "job completed");
         Ok(())
@@ -588,6 +582,12 @@ impl ClusterManager {
     fn run_job_finalized_side_effects(&self, finalized: JobFinalized) {
         self.run_epilog_slurmctld(finalized.job_id);
         self.notify_job_finished(finalized.job_id, finalized.state, finalized.exit_code);
+    }
+
+    fn run_all_finalized_side_effects(&self, resp: &ClientResponse) {
+        for f in &resp.jobs_finalized {
+            self.run_job_finalized_side_effects(*f);
+        }
     }
 
     fn run_epilog_slurmctld(&self, job_id: JobId) {
@@ -1063,16 +1063,18 @@ impl ClusterManager {
 
     /// Reconcile node liveness state with heartbeat data.
     /// Marks stale nodes Down and recovers nodes whose heartbeat has resumed.
-    pub fn check_node_health(&self, timeout_secs: u64) {
+    /// Returns finalized jobs from eviction so callers can send cancel RPCs.
+    pub fn check_node_health(&self, timeout_secs: u64) -> Vec<JobFinalized> {
         let actions = {
             let nodes = self.nodes.read();
             let refs: Vec<&Node> = nodes.values().collect();
             evaluate_node_health(&refs, Utc::now(), timeout_secs)
         };
-        self.apply_health_actions(actions);
+        self.apply_health_actions(actions)
     }
 
-    fn apply_health_actions(&self, actions: Vec<HealthAction>) {
+    fn apply_health_actions(&self, actions: Vec<HealthAction>) -> Vec<JobFinalized> {
+        let mut evicted = Vec::new();
         for action in actions {
             match action {
                 HealthAction::MarkDown {
@@ -1081,14 +1083,21 @@ impl ClusterManager {
                     admin_locked,
                 } => {
                     warn!(node = %name, "node marked DOWN (heartbeat timeout)");
-                    if let Err(e) = self.propose(WalOperation::NodeStateChange {
-                        name,
+                    match self.propose(WalOperation::NodeStateChange {
+                        name: name.clone(),
                         old_state,
                         new_state: NodeState::Down,
                         reason: Some("Not responding".into()),
                         admin_locked,
                     }) {
-                        warn!(error = %e, "failed to propose node DOWN");
+                        Ok(resp) => {
+                            self.run_all_finalized_side_effects(&resp);
+                            evicted.extend(resp.jobs_finalized);
+                        }
+                        Err(e) => {
+                            warn!(error = %e, "failed to propose node DOWN");
+                            continue;
+                        }
                     }
                 }
                 HealthAction::Recover { name, old_state } => {
@@ -1105,6 +1114,85 @@ impl ClusterManager {
                 }
             }
         }
+        evicted
+    }
+
+    /// Drain a node: stop scheduling new jobs on it. Running jobs finish naturally.
+    /// Returns (actual_state, running_job_count).
+    pub fn drain_node(
+        &self,
+        name: &str,
+        reason: Option<String>,
+    ) -> anyhow::Result<(NodeState, u32)> {
+        let (old_state, running_count) = {
+            let nodes = self.nodes.read();
+            let node = nodes
+                .get(name)
+                .ok_or_else(|| anyhow::anyhow!("node '{}' not found", name))?;
+            let jobs = self.jobs.read();
+            let count = jobs
+                .values()
+                .filter(|j| {
+                    matches!(
+                        j.state,
+                        JobState::Running | JobState::Completing | JobState::Suspended
+                    ) && j.allocated_nodes.iter().any(|n| n == name)
+                })
+                .count() as u32;
+            (node.state, count)
+        };
+        let target_state = if running_count > 0 {
+            NodeState::Draining
+        } else {
+            NodeState::Drain
+        };
+        self.propose(WalOperation::NodeStateChange {
+            name: name.to_string(),
+            old_state,
+            new_state: target_state,
+            reason,
+            admin_locked: true,
+        })?;
+        info!(node = %name, state = %target_state, "node drain requested");
+        Ok((target_state, running_count))
+    }
+
+    /// Remove a node from the cluster. If `force`, evict running jobs first.
+    /// Returns finalized jobs from eviction so callers can send cancel RPCs.
+    pub fn remove_node(
+        &self,
+        name: &str,
+        force: bool,
+        reason: Option<String>,
+    ) -> anyhow::Result<Vec<JobFinalized>> {
+        {
+            let nodes = self.nodes.read();
+            if !nodes.contains_key(name) {
+                anyhow::bail!("node '{}' not found", name);
+            }
+        }
+        if !force {
+            let jobs = self.jobs.read();
+            let has_running = jobs.values().any(|j| {
+                matches!(
+                    j.state,
+                    JobState::Running | JobState::Completing | JobState::Suspended
+                ) && j.allocated_nodes.iter().any(|n| n == name)
+            });
+            if has_running {
+                anyhow::bail!(
+                    "node '{}' has running jobs; use --force to evict them",
+                    name
+                );
+            }
+        }
+
+        let resp = self.propose(WalOperation::NodeRemove {
+            name: name.to_string(),
+            reason,
+        })?;
+        self.run_all_finalized_side_effects(&resp);
+        Ok(resp.jobs_finalized)
     }
 
     /// Create a job step.
@@ -1409,9 +1497,7 @@ impl ClusterManager {
                 state: JobState::Cancelled,
             }) {
                 Ok(resp) => {
-                    if let Some(f) = resp.job_finalized {
-                        self.run_job_finalized_side_effects(f);
-                    }
+                    self.run_all_finalized_side_effects(&resp);
                     info!(job_id = id, "job cancelled: dependency never satisfied");
                     cancelled.push(id);
                 }
@@ -1831,6 +1917,14 @@ impl ClusterManager {
         // job leaving the running set frees its licenses automatically.
     }
 
+    /// Finalize steps for all evicted jobs returned by remove_node / health check.
+    pub fn complete_evicted_steps(&self, evicted: &[JobFinalized]) {
+        let now = Utc::now();
+        for fin in evicted {
+            self.complete_job_steps(&fin.job_id, fin.exit_code, now);
+        }
+    }
+
     #[allow(clippy::result_large_err)]
     fn propose(&self, op: WalOperation) -> anyhow::Result<ClientResponse> {
         let raft = self
@@ -1843,6 +1937,90 @@ impl ClusterManager {
         })
         .map(|res| res.data)
         .map_err(|e| anyhow::anyhow!("raft propose failed: {}", e))
+    }
+
+    /// Evict a single job by ID: transition to NodeFail, then free its
+    /// allocations on every node it spans. Transition is validated first
+    /// so allocations are never freed for a job that can't be evicted.
+    fn evict_job(
+        job_id: JobId,
+        jobs: &mut HashMap<JobId, Job>,
+        nodes: &mut HashMap<String, Node>,
+        timestamp: chrono::DateTime<Utc>,
+    ) -> Option<JobFinalized> {
+        let job = jobs.get_mut(&job_id)?;
+
+        if let Some(since) = job.suspended_at.take() {
+            job.suspended_secs += (timestamp - since).num_seconds().max(0);
+        }
+        if let Err(e) = job.transition(JobState::NodeFail) {
+            warn!(job_id, error = %e, "evict: invalid transition to NodeFail");
+            return None;
+        }
+        job.exit_code = Some(-1);
+        job.end_time = Some(timestamp);
+        job.pending_reason = PendingReason::NodeDown;
+        job.node_completions.clear();
+
+        let alloc_nodes = job.allocated_nodes.clone();
+        if let Some(ref total) = job.allocated_resources {
+            let node_count = alloc_nodes.len().max(1) as u32;
+            for alloc_node in &alloc_nodes {
+                if let Some(node) = nodes.get_mut(alloc_node) {
+                    let slice = job
+                        .per_node_alloc
+                        .get(alloc_node)
+                        .cloned()
+                        .unwrap_or_else(|| {
+                            ResourceAllocations::with_scalar(
+                                total.cpus / node_count,
+                                total.memory_mb / node_count as u64,
+                            )
+                        });
+                    node.alloc_resources.subtract(&slice);
+                    node.update_state_from_alloc();
+                    if node.state == NodeState::Draining
+                        && node.alloc_resources.cpus == 0
+                        && !node.alloc_resources.has_devices()
+                    {
+                        node.state = NodeState::Drain;
+                    }
+                }
+            }
+        }
+
+        Some(JobFinalized {
+            job_id,
+            state: JobState::NodeFail,
+            exit_code: -1,
+        })
+    }
+
+    /// Fail all running/completing/suspended jobs on a node, releasing
+    /// allocations on **every** node each job spans.
+    fn evict_jobs_on_node(
+        node_name: &str,
+        jobs: &mut HashMap<JobId, Job>,
+        nodes: &mut HashMap<String, Node>,
+        timestamp: chrono::DateTime<Utc>,
+        response: &mut ClientResponse,
+    ) {
+        let affected: Vec<JobId> = jobs
+            .iter()
+            .filter(|(_, j)| {
+                matches!(
+                    j.state,
+                    JobState::Running | JobState::Completing | JobState::Suspended
+                ) && j.allocated_nodes.iter().any(|n| n == node_name)
+            })
+            .map(|(&id, _)| id)
+            .collect();
+
+        for jid in affected {
+            if let Some(fin) = Self::evict_job(jid, jobs, nodes, timestamp) {
+                response.jobs_finalized.push(fin);
+            }
+        }
     }
 
     /// Apply a WalOperation to in-memory state.
@@ -2063,11 +2241,11 @@ impl ClusterManager {
                     self.complete_job_steps(job_id, final_exit, timestamp);
                     self.next_job_id.store(next_id, Ordering::Relaxed);
                     return ClientResponse {
-                        job_finalized: Some(JobFinalized {
+                        jobs_finalized: vec![JobFinalized {
                             job_id: *job_id,
                             state: final_state,
                             exit_code: final_exit,
-                        }),
+                        }],
                     };
                 }
             }
@@ -2092,7 +2270,7 @@ impl ClusterManager {
                         return ClientResponse::default();
                     }
                     if state.is_terminal() {
-                        response.job_finalized = Some(JobFinalized {
+                        response.jobs_finalized.push(JobFinalized {
                             job_id: *job_id,
                             state: *state,
                             exit_code: *exit_code,
@@ -2272,6 +2450,9 @@ impl ClusterManager {
                     node.state_reason = reason.clone();
                     node.admin_locked = *admin_locked;
                 }
+                if *new_state == NodeState::Down {
+                    Self::evict_jobs_on_node(name, &mut jobs, &mut nodes, timestamp, &mut response);
+                }
             }
             WalOperation::NodeLabelsUpdate { name, set, remove } => {
                 if let Some(node) = nodes.get_mut(name) {
@@ -2307,6 +2488,24 @@ impl ClusterManager {
                         }
                     }
                 }
+            }
+            WalOperation::NodeRemove { name, reason } => {
+                Self::evict_jobs_on_node(name, &mut jobs, &mut nodes, timestamp, &mut response);
+                if let Some(node) = nodes.get(name) {
+                    if node.alloc_resources.cpus > 0 || node.alloc_resources.has_devices() {
+                        warn!(
+                            node = %name,
+                            reason = reason.as_deref().unwrap_or(""),
+                            "removing node with nonzero allocations"
+                        );
+                    }
+                }
+                nodes.remove(name);
+                info!(
+                    node = %name,
+                    reason = reason.as_deref().unwrap_or(""),
+                    "node removed from cluster"
+                );
             }
             WalOperation::TokenCreate { token } => {
                 self.tokens.write().insert(token.id.clone(), token.clone());
@@ -3662,7 +3861,7 @@ mod tests {
             exit_code: 0,
             signal: 0,
         });
-        assert!(r1.job_finalized.is_none());
+        assert!(r1.jobs_finalized.is_empty());
         assert_eq!(cm.get_job(1).unwrap().state, JobState::Completing);
 
         let r2 = cm.apply_operation(&WalOperation::JobNodeComplete {
@@ -3671,7 +3870,10 @@ mod tests {
             exit_code: 0,
             signal: 0,
         });
-        let f = r2.job_finalized.expect("last node should finalize");
+        let f = r2
+            .jobs_finalized
+            .first()
+            .expect("last node should finalize");
         assert_eq!(f.job_id, 1);
         assert_eq!(f.state, JobState::Completed);
         assert_eq!(f.exit_code, 0);
@@ -3706,7 +3908,10 @@ mod tests {
             exit_code: 0,
             state: JobState::Completed,
         });
-        let f = resp.job_finalized.expect("JobComplete should finalize");
+        let f = resp
+            .jobs_finalized
+            .first()
+            .expect("JobComplete should finalize");
         assert_eq!(f.job_id, 1);
         assert_eq!(f.state, JobState::Completed);
         assert_eq!(f.exit_code, 0);
@@ -3740,9 +3945,10 @@ mod tests {
             exit_code: 0,
             state: JobState::Completed,
         });
-        first
-            .job_finalized
-            .expect("first JobComplete should finalize");
+        assert!(
+            !first.jobs_finalized.is_empty(),
+            "first JobComplete should finalize"
+        );
         let node = cm.get_node("worker1").unwrap();
         assert_eq!(node.alloc_resources.cpus, 0);
         assert_eq!(node.alloc_resources.memory_mb, 0);
@@ -3752,7 +3958,7 @@ mod tests {
             exit_code: -1,
             state: JobState::Cancelled,
         });
-        assert!(second.job_finalized.is_none());
+        assert!(second.jobs_finalized.is_empty());
 
         let job = cm.get_job(1).unwrap();
         assert_eq!(job.state, JobState::Completed);
@@ -5844,5 +6050,371 @@ mod tests {
             result.is_ok(),
             "array job submission should trigger scheduler notification"
         );
+    }
+
+    // ---- Node deregistration tests ----
+
+    fn start_job_on(cm: &ClusterManager, id: JobId, node: &str) {
+        cm.apply_operation(&WalOperation::JobStateChange {
+            job_id: id,
+            old_state: JobState::Pending,
+            new_state: JobState::Running,
+        });
+        cm.apply_operation(&WalOperation::JobStart {
+            job_id: id,
+            nodes: vec![node.into()],
+            resources: scalar_alloc(1, 1000),
+            per_node_alloc: per_node_for(&[node], scalar_alloc(1, 1000)),
+        });
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn node_state_change_to_down_evicts_running_jobs() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        register_node(&cm, "n1", 4, 8000);
+        let id = submit_and_wait(&cm, basic_spec("evict-me"));
+        start_job_on(&cm, id, "n1");
+        assert_eq!(cm.get_job(id).unwrap().state, JobState::Running);
+
+        let resp = cm.apply_operation(&WalOperation::NodeStateChange {
+            name: "n1".into(),
+            old_state: NodeState::Allocated,
+            new_state: NodeState::Down,
+            reason: Some("heartbeat timeout".into()),
+            admin_locked: false,
+        });
+        assert_eq!(resp.jobs_finalized.len(), 1);
+        assert_eq!(resp.jobs_finalized[0].job_id, id);
+        assert_eq!(resp.jobs_finalized[0].state, JobState::NodeFail);
+
+        let job = cm.get_job(id).unwrap();
+        assert_eq!(job.state, JobState::NodeFail);
+        assert_eq!(job.exit_code, Some(-1));
+
+        let node = cm.get_node("n1").unwrap();
+        assert_eq!(node.state, NodeState::Down);
+        assert_eq!(node.alloc_resources.cpus, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn node_state_change_to_down_no_jobs_is_clean() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        register_node(&cm, "n1", 4, 8000);
+
+        let resp = cm.apply_operation(&WalOperation::NodeStateChange {
+            name: "n1".into(),
+            old_state: NodeState::Idle,
+            new_state: NodeState::Down,
+            reason: None,
+            admin_locked: false,
+        });
+        assert!(resp.jobs_finalized.is_empty());
+        assert_eq!(cm.get_node("n1").unwrap().state, NodeState::Down);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn node_remove_deletes_node() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        register_node(&cm, "n1", 4, 8000);
+        assert!(cm.get_node("n1").is_some());
+
+        cm.apply_operation(&WalOperation::NodeRemove {
+            name: "n1".into(),
+            reason: Some("decommission".into()),
+        });
+        assert!(cm.get_node("n1").is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn node_remove_evicts_and_deletes() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        register_node(&cm, "n1", 4, 8000);
+        let id = submit_and_wait(&cm, basic_spec("j"));
+        start_job_on(&cm, id, "n1");
+
+        let resp = cm.apply_operation(&WalOperation::NodeRemove {
+            name: "n1".into(),
+            reason: None,
+        });
+        assert_eq!(resp.jobs_finalized.len(), 1);
+        assert_eq!(resp.jobs_finalized[0].state, JobState::NodeFail);
+        assert_eq!(cm.get_job(id).unwrap().state, JobState::NodeFail);
+        assert!(cm.get_node("n1").is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn drain_node_sets_draining_with_running_jobs() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        register_node(&cm, "n1", 4, 8000);
+        let id = submit_and_wait(&cm, basic_spec("drain-job"));
+        start_job_on(&cm, id, "n1");
+
+        cm.drain_node("n1", Some("maintenance".into())).unwrap();
+        wait_for("n1 draining", || {
+            cm.get_node("n1")
+                .is_some_and(|n| n.state == NodeState::Draining)
+        });
+
+        let node = cm.get_node("n1").unwrap();
+        assert!(node.admin_locked);
+        assert_eq!(node.state_reason.as_deref(), Some("maintenance"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn drain_node_sets_drain_without_running_jobs() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        register_node(&cm, "n1", 4, 8000);
+
+        cm.drain_node("n1", None).unwrap();
+        wait_for("n1 drain", || {
+            cm.get_node("n1")
+                .is_some_and(|n| n.state == NodeState::Drain)
+        });
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn remove_node_rejects_running_without_force() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        register_node(&cm, "n1", 4, 8000);
+        let id = submit_and_wait(&cm, basic_spec("j"));
+        start_job_on(&cm, id, "n1");
+
+        let err = cm.remove_node("n1", false, None);
+        assert!(err.is_err());
+        assert!(cm.get_node("n1").is_some());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn remove_node_force_evicts_and_removes() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        register_node(&cm, "n1", 4, 8000);
+        let id = submit_and_wait(&cm, basic_spec("j"));
+        start_job_on(&cm, id, "n1");
+
+        cm.remove_node("n1", true, Some("bad node".into())).unwrap();
+        wait_for("n1 removed", || cm.get_node("n1").is_none());
+
+        assert_eq!(cm.get_job(id).unwrap().state, JobState::NodeFail);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn multinode_eviction_frees_all_nodes() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        register_node(&cm, "n1", 4, 8000);
+        register_node(&cm, "n2", 4, 8000);
+
+        let id = submit_and_wait(&cm, basic_spec("multi"));
+
+        let alloc = scalar_alloc(2, 2000);
+        let per_node = per_node_for(&["n1", "n2"], scalar_alloc(1, 1000));
+        cm.start_job(id, vec!["n1".into(), "n2".into()], alloc, per_node)
+            .unwrap();
+        settle(&cm, id, JobState::Running);
+
+        assert_eq!(cm.get_node("n1").unwrap().alloc_resources.cpus, 1);
+        assert_eq!(cm.get_node("n2").unwrap().alloc_resources.cpus, 1);
+
+        let evicted = cm
+            .remove_node("n1", true, Some("evict test".into()))
+            .unwrap();
+        wait_for("n1 removed", || cm.get_node("n1").is_none());
+
+        assert_eq!(evicted.len(), 1);
+        assert_eq!(evicted[0].job_id, id);
+        assert_eq!(cm.get_job(id).unwrap().state, JobState::NodeFail);
+
+        let n2 = cm.get_node("n2").unwrap();
+        assert_eq!(
+            n2.alloc_resources.cpus, 0,
+            "peer node n2 must have allocations freed"
+        );
+        assert_eq!(n2.alloc_resources.memory_mb, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn draining_to_drain_on_last_job_complete() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        register_node(&cm, "n1", 4, 8000);
+        let id = submit_and_wait(&cm, basic_spec("drain-job"));
+        start_job_on(&cm, id, "n1");
+
+        cm.drain_node("n1", None).unwrap();
+        wait_for("n1 draining", || {
+            cm.get_node("n1")
+                .is_some_and(|n| n.state == NodeState::Draining)
+        });
+
+        cm.apply_operation(&WalOperation::JobNodeComplete {
+            job_id: id,
+            node_name: "n1".into(),
+            exit_code: 0,
+            signal: 0,
+        });
+
+        let node = cm.get_node("n1").unwrap();
+        assert_eq!(node.state, NodeState::Drain);
+    }
+
+    // --- Direct evict_job unit tests ---
+
+    fn make_running_job(job_id: JobId, nodes: &[&str], cpus_per_node: u32) -> Job {
+        let mut spec = basic_spec("evict-test");
+        spec.cpus_per_task = cpus_per_node;
+        let mut job = Job::new(job_id, spec);
+        job.state = JobState::Running;
+        job.start_time = Some(Utc::now());
+        let node_list: Vec<String> = nodes.iter().map(|n| (*n).to_string()).collect();
+        let total_cpus = cpus_per_node * nodes.len() as u32;
+        job.allocated_nodes = node_list;
+        job.allocated_resources = Some(ResourceAllocations::with_scalar(total_cpus, 0));
+        job.per_node_alloc = nodes
+            .iter()
+            .map(|n| {
+                (
+                    (*n).to_string(),
+                    ResourceAllocations::with_scalar(cpus_per_node, 0),
+                )
+            })
+            .collect();
+        job
+    }
+
+    fn make_test_node(name: &str, total_cpus: u32, alloc_cpus: u32) -> Node {
+        let mut node = Node::new(
+            name.into(),
+            ResourceSet {
+                cpus: total_cpus,
+                ..Default::default()
+            },
+        );
+        node.state = if alloc_cpus > 0 {
+            NodeState::Allocated
+        } else {
+            NodeState::Idle
+        };
+        node.alloc_resources = ResourceAllocations::with_scalar(alloc_cpus, 0);
+        node
+    }
+
+    #[test]
+    fn evict_job_returns_none_for_missing_job() {
+        let mut jobs = HashMap::new();
+        let mut nodes = HashMap::new();
+        let result = ClusterManager::evict_job(999, &mut jobs, &mut nodes, Utc::now());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn evict_job_transitions_running_to_nodefail() {
+        let mut jobs = HashMap::new();
+        let mut nodes = HashMap::new();
+        jobs.insert(1, make_running_job(1, &["n1"], 2));
+        nodes.insert("n1".into(), make_test_node("n1", 4, 2));
+
+        let fin = ClusterManager::evict_job(1, &mut jobs, &mut nodes, Utc::now()).unwrap();
+        assert_eq!(fin.job_id, 1);
+        assert_eq!(fin.state, JobState::NodeFail);
+        assert_eq!(fin.exit_code, -1);
+
+        let job = &jobs[&1];
+        assert_eq!(job.state, JobState::NodeFail);
+        assert_eq!(job.exit_code, Some(-1));
+        assert!(job.end_time.is_some());
+        assert_eq!(job.pending_reason, PendingReason::NodeDown);
+    }
+
+    #[test]
+    fn evict_job_frees_allocations_on_all_nodes() {
+        let mut jobs = HashMap::new();
+        let mut nodes = HashMap::new();
+        jobs.insert(1, make_running_job(1, &["n1", "n2"], 2));
+        nodes.insert("n1".into(), make_test_node("n1", 4, 2));
+        nodes.insert("n2".into(), make_test_node("n2", 4, 2));
+
+        ClusterManager::evict_job(1, &mut jobs, &mut nodes, Utc::now());
+
+        assert_eq!(nodes["n1"].alloc_resources.cpus, 0);
+        assert_eq!(nodes["n2"].alloc_resources.cpus, 0);
+    }
+
+    #[test]
+    fn evict_job_returns_none_for_terminal_job() {
+        let mut jobs = HashMap::new();
+        let mut nodes = HashMap::new();
+        let mut job = make_running_job(1, &["n1"], 2);
+        job.state = JobState::Completed;
+        jobs.insert(1, job);
+        nodes.insert("n1".into(), make_test_node("n1", 4, 2));
+
+        let result = ClusterManager::evict_job(1, &mut jobs, &mut nodes, Utc::now());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn evict_job_finalizes_suspended_time() {
+        let mut jobs = HashMap::new();
+        let mut nodes = HashMap::new();
+        let suspended_at = Utc::now() - chrono::Duration::seconds(30);
+        let mut job = make_running_job(1, &["n1"], 2);
+        job.state = JobState::Suspended;
+        job.suspended_at = Some(suspended_at);
+        job.suspended_secs = 10;
+        jobs.insert(1, job);
+        nodes.insert("n1".into(), make_test_node("n1", 4, 2));
+
+        ClusterManager::evict_job(1, &mut jobs, &mut nodes, Utc::now());
+
+        let job = &jobs[&1];
+        assert!(job.suspended_at.is_none());
+        assert!(job.suspended_secs >= 40, "should accumulate ~30s more");
+    }
+
+    #[test]
+    fn evict_job_transitions_completing_to_nodefail() {
+        let mut jobs = HashMap::new();
+        let mut nodes = HashMap::new();
+        let mut job = make_running_job(1, &["n1"], 2);
+        job.state = JobState::Completing;
+        jobs.insert(1, job);
+        nodes.insert("n1".into(), make_test_node("n1", 4, 2));
+
+        let fin = ClusterManager::evict_job(1, &mut jobs, &mut nodes, Utc::now()).unwrap();
+        assert_eq!(fin.state, JobState::NodeFail);
+        assert_eq!(jobs[&1].state, JobState::NodeFail);
+        assert_eq!(nodes["n1"].alloc_resources.cpus, 0);
+    }
+
+    #[test]
+    fn evict_job_transitions_draining_node_to_drain() {
+        let mut jobs = HashMap::new();
+        let mut nodes = HashMap::new();
+        jobs.insert(1, make_running_job(1, &["n1"], 2));
+        let mut node = make_test_node("n1", 4, 2);
+        node.state = NodeState::Draining;
+        nodes.insert("n1".into(), node);
+
+        ClusterManager::evict_job(1, &mut jobs, &mut nodes, Utc::now());
+
+        assert_eq!(nodes["n1"].state, NodeState::Drain);
     }
 }

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -175,7 +175,8 @@ async fn main() -> anyhow::Result<()> {
         scheduler_loop::run(sched_cluster, sched_raft).await;
     });
 
-    // Start node health checker (90s timeout, only on leader).
+    // Start node health checker (only on leader).
+    let hb_timeout = config.controller.heartbeat_timeout_secs.unwrap_or(90);
     let health_cluster = cluster.clone();
     let health_raft = raft_handle.clone();
     tokio::spawn(async move {
@@ -185,7 +186,16 @@ async fn main() -> anyhow::Result<()> {
             if !health_raft.is_leader() {
                 continue;
             }
-            health_cluster.check_node_health(90);
+            let evicted = health_cluster.check_node_health(hb_timeout);
+            for fin in &evicted {
+                if let Some(job) = health_cluster.get_job(fin.job_id) {
+                    let c = health_cluster.clone();
+                    tokio::spawn(async move {
+                        crate::scheduler_loop::send_cancel_to_agents(&c, &job, 9).await;
+                    });
+                }
+            }
+            health_cluster.complete_evicted_steps(&evicted);
         }
     });
 

--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -46,7 +46,8 @@ pub struct JobFinalized {
 /// Response returned after a Raft write is committed.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ClientResponse {
-    pub job_finalized: Option<JobFinalized>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub jobs_finalized: Vec<JobFinalized>,
 }
 
 /// Trait for applying committed Raft entries to the cluster state.

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -529,6 +529,9 @@ impl SlurmController for ControllerService {
         } else {
             Some(req.reason)
         };
+        if self.cluster.get_node(&req.name).is_none() {
+            return Err(Status::not_found(format!("node {} not found", req.name)));
+        }
         let (actual_state, running_jobs) = self
             .cluster
             .drain_node(&req.name, reason)
@@ -563,6 +566,9 @@ impl SlurmController for ControllerService {
         } else {
             Some(req.reason)
         };
+        if self.cluster.get_node(&req.name).is_none() {
+            return Err(Status::not_found(format!("node {} not found", req.name)));
+        }
         let evicted = self
             .cluster
             .remove_node(&req.name, req.force, reason)
@@ -616,6 +622,9 @@ impl SlurmController for ControllerService {
             }
         }
 
+        if self.cluster.get_node(&req.hostname).is_none() {
+            return Ok(Response::new(()));
+        }
         let evicted = self
             .cluster
             .remove_node(

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -115,6 +115,17 @@ impl ControllerService {
         meta
     }
 
+    fn spawn_cancel_for_evicted(&self, evicted: &[crate::raft::JobFinalized]) {
+        for fin in evicted {
+            if let Some(job) = self.cluster.get_job(fin.job_id) {
+                let cluster = self.cluster.clone();
+                tokio::spawn(async move {
+                    crate::scheduler_loop::send_cancel_to_agents(&cluster, &job, 9).await;
+                });
+            }
+        }
+    }
+
     /// Validate an admission token if token mode is enabled.
     /// Returns the node_token JWT to include in the registration response,
     /// or an empty string if admission mode is open.
@@ -491,6 +502,130 @@ impl SlurmController for ControllerService {
                 .update_node_labels(&req.name, req.labels, &req.remove_labels)
                 .map_err(|e| Status::internal(e.to_string()))?;
         }
+        Ok(Response::new(()))
+    }
+
+    async fn drain_node(
+        &self,
+        request: Request<spur_proto::proto::DrainNodeRequest>,
+    ) -> Result<Response<spur_proto::proto::DrainNodeResponse>, Status> {
+        if let Err(status) = self.check_leader(&request) {
+            let proxy = &self.leader_proxy;
+            match proxy.get_leader_client().await {
+                Ok(mut client) => {
+                    let mut fwd = Request::new(request.into_inner());
+                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    return client.drain_node(fwd).await;
+                }
+                Err(e) => {
+                    warn!("failed to forward drain_node to leader: {e}");
+                    return Err(status);
+                }
+            }
+        }
+        let req = request.into_inner();
+        let reason = if req.reason.is_empty() {
+            None
+        } else {
+            Some(req.reason)
+        };
+        let (actual_state, running_jobs) = self
+            .cluster
+            .drain_node(&req.name, reason)
+            .map_err(|e| Status::internal(e.to_string()))?;
+        Ok(Response::new(spur_proto::proto::DrainNodeResponse {
+            actual_state: actual_state.to_string(),
+            running_jobs,
+        }))
+    }
+
+    async fn deregister_node(
+        &self,
+        request: Request<spur_proto::proto::DeregisterNodeRequest>,
+    ) -> Result<Response<spur_proto::proto::DeregisterNodeResponse>, Status> {
+        if let Err(status) = self.check_leader(&request) {
+            let proxy = &self.leader_proxy;
+            match proxy.get_leader_client().await {
+                Ok(mut client) => {
+                    let mut fwd = Request::new(request.into_inner());
+                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    return client.deregister_node(fwd).await;
+                }
+                Err(e) => {
+                    warn!("failed to forward deregister_node to leader: {e}");
+                    return Err(status);
+                }
+            }
+        }
+        let req = request.into_inner();
+        let reason = if req.reason.is_empty() {
+            None
+        } else {
+            Some(req.reason)
+        };
+        let evicted = self
+            .cluster
+            .remove_node(&req.name, req.force, reason)
+            .map_err(|e| Status::failed_precondition(e.to_string()))?;
+        self.spawn_cancel_for_evicted(&evicted);
+        self.cluster.complete_evicted_steps(&evicted);
+        Ok(Response::new(spur_proto::proto::DeregisterNodeResponse {
+            evicted_jobs_count: evicted.len() as u32,
+        }))
+    }
+
+    async fn deregister_agent(
+        &self,
+        request: Request<spur_proto::proto::DeregisterAgentRequest>,
+    ) -> Result<Response<()>, Status> {
+        if let Err(status) = self.check_leader(&request) {
+            let proxy = &self.leader_proxy;
+            match proxy.get_leader_client().await {
+                Ok(mut client) => {
+                    let mut fwd = Request::new(request.into_inner());
+                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    return client.deregister_agent(fwd).await;
+                }
+                Err(e) => {
+                    warn!("failed to forward deregister_agent to leader: {e}");
+                    return Err(status);
+                }
+            }
+        }
+        let req = request.into_inner();
+
+        if matches!(
+            self.cluster.config.admission.mode,
+            spur_core::config::AdmissionMode::Token
+        ) {
+            if req.node_token.is_empty() {
+                return Err(Status::unauthenticated("node token required"));
+            }
+            let jwt_key = self
+                .cluster
+                .config
+                .auth
+                .jwt_key
+                .as_deref()
+                .unwrap_or("spur-default-key");
+            let identity =
+                spur_core::admission::verify_node_token(&req.node_token, jwt_key.as_bytes())
+                    .map_err(|e| Status::unauthenticated(e.to_string()))?;
+            if identity.hostname != req.hostname {
+                return Err(Status::permission_denied("node token hostname mismatch"));
+            }
+        }
+
+        let evicted = self
+            .cluster
+            .remove_node(
+                &req.hostname,
+                true,
+                Some(req.reason.clone()).filter(|r| !r.is_empty()),
+            )
+            .map_err(|e| Status::internal(e.to_string()))?;
+        self.spawn_cancel_for_evicted(&evicted);
+        self.cluster.complete_evicted_steps(&evicted);
         Ok(Response::new(()))
     }
 

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -211,10 +211,29 @@ async fn main() -> anyhow::Result<()> {
     let addr = args.listen.parse()?;
     info!(%addr, "agent gRPC server listening");
 
-    tonic::transport::Server::builder()
+    let server_future = tonic::transport::Server::builder()
         .add_service(spur_proto::proto::slurm_agent_server::SlurmAgentServer::new(agent_service))
-        .serve(addr)
-        .await?;
+        .serve(addr);
+
+    let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+
+    tokio::select! {
+        result = server_future => { result?; }
+        _ = sigterm.recv() => {
+            info!("received SIGTERM, deregistering from controller");
+            let dereg_reporter = reporter.clone();
+            match tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                dereg_reporter.deregister("agent shutdown"),
+            )
+            .await
+            {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => warn!(error = %e, "deregistration failed"),
+                Err(_) => warn!("deregistration timed out"),
+            }
+        }
+    }
 
     Ok(())
 }

--- a/crates/spurd/src/reporter.rs
+++ b/crates/spurd/src/reporter.rs
@@ -80,6 +80,26 @@ impl NodeReporter {
         Ok(())
     }
 
+    /// Notify the controller that this agent is shutting down.
+    pub async fn deregister(&self, reason: &str) -> anyhow::Result<()> {
+        let current_token = self.node_token.read().unwrap().clone();
+        let mut client = SlurmControllerClient::connect(self.controller_addr.clone())
+            .await
+            .context("failed to connect to spurctld for deregistration")?;
+
+        client
+            .deregister_agent(spur_proto::proto::DeregisterAgentRequest {
+                hostname: self.hostname.clone(),
+                node_token: current_token,
+                reason: reason.to_string(),
+            })
+            .await
+            .context("deregistration RPC failed")?;
+
+        info!("deregistered from controller");
+        Ok(())
+    }
+
     /// Periodic heartbeat loop.
     pub async fn heartbeat_loop(&self) {
         let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(30));

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -266,6 +266,11 @@ service SlurmController {
   rpc GetNodes(GetNodesRequest) returns (GetNodesResponse);
   rpc GetNode(GetNodeRequest) returns (NodeInfo);
   rpc UpdateNode(UpdateNodeRequest) returns (google.protobuf.Empty);
+  rpc DrainNode(DrainNodeRequest) returns (DrainNodeResponse);
+  rpc DeregisterNode(DeregisterNodeRequest) returns (DeregisterNodeResponse);
+
+  // Agent deregistration (called by spurd on SIGTERM)
+  rpc DeregisterAgent(DeregisterAgentRequest) returns (google.protobuf.Empty);
 
   // Partition management
   rpc GetPartitions(GetPartitionsRequest) returns (GetPartitionsResponse);
@@ -427,6 +432,32 @@ message UpdateNodeRequest {
   optional string reason = 3;
   map<string, string> labels = 4;
   repeated string remove_labels = 5;
+}
+
+message DrainNodeRequest {
+  string name = 1;
+  string reason = 2;
+}
+
+message DrainNodeResponse {
+  string actual_state = 1;
+  uint32 running_jobs = 2;
+}
+
+message DeregisterNodeRequest {
+  string name = 1;
+  bool force = 2;
+  string reason = 3;
+}
+
+message DeregisterNodeResponse {
+  uint32 evicted_jobs_count = 1;
+}
+
+message DeregisterAgentRequest {
+  string hostname = 1;
+  string node_token = 2;
+  string reason = 3;
 }
 
 message GetPartitionsRequest {

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -240,8 +240,8 @@ class SpurCluster:
         self.agent_labels = agent_labels or {}
         if kill_stale:
             self._kill_controller()
-            self._kill_agents(use_sudo=False)
-            self._kill_agents(use_sudo=True)  # best-effort for rootful
+            self._kill_agents(use_sudo=False, broad=True)
+            self._kill_agents(use_sudo=True, broad=True)  # best-effort for rootful
         if self.accounting_enabled:
             self._start_accounting()
         self.start_controller(config_overrides, kill_stale=False)
@@ -804,9 +804,16 @@ mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
     def _kill_controller(self):
         self._pkill(self.nodes[0], f"{self.bin_dir}/spurctld")
 
-    def _kill_agents(self, use_sudo: bool = False):
+    def _kill_agents(self, use_sudo: bool = False, broad: bool = False):
         for node in self.nodes:
             self._pkill(node, f"{self.bin_dir}/spurd", use_sudo=use_sudo)
+            # Kill any process holding the agent port, even from a different
+            # bin_dir (e.g. a stale spurd left by a previous pytest session).
+            if broad:
+                prefix = self._sudo_prefix() if use_sudo else ""
+                node.exec_allow_fail(
+                    f"{prefix}fuser -k {AGENT_PORT}/tcp 2>/dev/null || true"
+                )
 
     def _spurd_start_cmd(self, node_index: int) -> str:
         node = self.nodes[node_index]

--- a/tests/native_host/e2e/conftest.py
+++ b/tests/native_host/e2e/conftest.py
@@ -131,12 +131,23 @@ def _provision_cluster(ssh_nodes, remote_bin_dir):
 
 
 @pytest.fixture
-def cluster(ssh_nodes, remote_bin_dir):
+def cluster_config_overrides():
+    """Override this fixture in tests/classes to customise the cluster config.
+
+    Return a dict that will be deep-merged into the default config before
+    spurctld starts.  The default (no overrides) returns None.
+    """
+    return None
+
+
+@pytest.fixture
+def cluster(ssh_nodes, remote_bin_dir, cluster_config_overrides):
     """
     Per-test fixture: a fully running Spur cluster with default config.
     Torn down (processes killed, dirs removed) after the test.
     """
-    spur_cluster = _deploy_cluster(ssh_nodes, remote_bin_dir)
+    spur_cluster = _deploy_cluster(ssh_nodes, remote_bin_dir,
+                                   config_overrides=cluster_config_overrides)
     yield spur_cluster
     spur_cluster.teardown()
 
@@ -157,7 +168,7 @@ def unstarted_cluster(ssh_nodes, remote_bin_dir):
 
 
 @pytest.fixture
-def multi_node_cluster(ssh_nodes, remote_bin_dir):
+def multi_node_cluster(ssh_nodes, remote_bin_dir, cluster_config_overrides):
     """
     Per-test fixture for multi-node tests.
     Skips if fewer than 2 nodes are configured.
@@ -168,7 +179,8 @@ def multi_node_cluster(ssh_nodes, remote_bin_dir):
             f"(got {len(ssh_nodes)})"
         )
 
-    spur_cluster = _deploy_cluster(ssh_nodes, remote_bin_dir)
+    spur_cluster = _deploy_cluster(ssh_nodes, remote_bin_dir,
+                                   config_overrides=cluster_config_overrides)
     yield spur_cluster
     spur_cluster.teardown()
 

--- a/tests/native_host/e2e/test_deregistration.py
+++ b/tests/native_host/e2e/test_deregistration.py
@@ -1,0 +1,214 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+E2E tests for node deregistration.
+
+Covers: graceful drain+remove, forced eviction, dead-node auto-cleanup,
+agent self-deregistration, and the bug fix for failing jobs on downed nodes.
+"""
+
+import time
+
+import pytest
+
+from cluster import parse_job_id, job_state, SpurCluster
+
+
+def _wait_job_terminal(cluster, job_id, timeout=120):
+    """Wait for a job to reach any terminal state including NODE_FAIL."""
+    terminal = {"CD", "F", "CA", "TO", "NF", "PR", "DL", "OOM"}
+    deadline = time.time() + timeout
+    last = ""
+    while time.time() < deadline:
+        sq = cluster.squeue_all()
+        state = job_state(sq, job_id)
+        if state in terminal:
+            return state
+        if state is not None:
+            last = state
+        time.sleep(2)
+    raise TimeoutError(
+        f"Job {job_id} did not reach terminal state within {timeout}s (last: {last})"
+    )
+
+
+def _wait_node_state(cluster, node_name, target_states, timeout=60):
+    """Poll sinfo until a node reaches one of the target states."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            out = cluster.sinfo()
+            for line in out.splitlines():
+                if node_name in line:
+                    for state in target_states:
+                        if state in line:
+                            return state
+        except Exception:
+            pass
+        time.sleep(2)
+    raise TimeoutError(
+        f"Node {node_name} did not reach {target_states} within {timeout}s"
+    )
+
+
+def _wait_node_gone(cluster, node_name, timeout=60):
+    """Poll sinfo until a node disappears."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            out = cluster.sinfo()
+            if node_name not in out:
+                return
+        except Exception:
+            pass
+        time.sleep(2)
+    raise TimeoutError(f"Node {node_name} still visible after {timeout}s")
+
+
+def _kill_agent(cluster, node_index):
+    """Kill the spurd process on a specific node (SIGKILL, no deregister)."""
+    node = cluster.nodes[node_index]
+    prefix = cluster._sudo_prefix() if cluster.agent_as_root else ""
+    node.exec_allow_fail(
+        f"{prefix}pkill -9 -f '{cluster.bin_dir}/spurd' 2>/dev/null || true"
+    )
+
+
+def _sigterm_agent(cluster, node_index):
+    """Send SIGTERM to spurd on a specific node (graceful deregister)."""
+    node = cluster.nodes[node_index]
+    prefix = cluster._sudo_prefix() if cluster.agent_as_root else ""
+    node.exec_allow_fail(
+        f"{prefix}pkill -TERM -f '{cluster.bin_dir}/spurd' 2>/dev/null || true"
+    )
+
+
+class TestDrainAndRemove:
+    """Test graceful drain + remove path."""
+
+    def test_drain_and_remove(self, multi_node_cluster):
+        cluster = multi_node_cluster
+        node0 = cluster.node_names[0]
+        node1 = cluster.node_names[1]
+
+        cluster.cli(["spur", "node", "drain", node0, "--reason", "maintenance"])
+        _wait_node_state(cluster, node0, ["drain"])
+
+        out = cluster.sinfo()
+        assert "drain" in out.lower()
+
+        script = cluster.write_file(
+            "drain_test.sh", "#!/bin/bash\nsleep 1\necho done\n"
+        )
+        sbatch_out = cluster.sbatch(["-N1", script])
+        job_id = parse_job_id(sbatch_out)
+        assert job_id is not None
+        state = _wait_job_terminal(cluster, job_id)
+        assert state == "CD", f"expected COMPLETED, got {state}"
+
+        cluster.cli(["spur", "node", "remove", node0])
+        _wait_node_gone(cluster, node0)
+
+
+class TestForcedEviction:
+    """Test forced node removal with running jobs."""
+
+    def test_force_remove_kills_jobs(self, multi_node_cluster):
+        cluster = multi_node_cluster
+        node0 = cluster.node_names[0]
+
+        script = cluster.write_file(
+            "long_sleep.sh", "#!/bin/bash\nsleep 600\n"
+        )
+        sbatch_out = cluster.sbatch(["-N1", f"--nodelist={node0}", script])
+        job_id = parse_job_id(sbatch_out)
+        assert job_id is not None
+
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            sq = cluster.squeue_all()
+            if job_state(sq, job_id) == "R":
+                break
+            time.sleep(1)
+        assert job_state(cluster.squeue_all(), job_id) == "R"
+
+        cluster.cli([
+            "spur", "node", "remove", node0, "--force",
+            "--reason", "eviction test",
+        ])
+
+        state = _wait_job_terminal(cluster, job_id)
+        assert state == "NF", f"expected NODE_FAIL, got {state}"
+        _wait_node_gone(cluster, node0)
+
+    def test_remove_blocked_by_running_jobs(self, multi_node_cluster):
+        cluster = multi_node_cluster
+        node0 = cluster.node_names[0]
+
+        script = cluster.write_file(
+            "block_sleep.sh", "#!/bin/bash\nsleep 600\n"
+        )
+        sbatch_out = cluster.sbatch(["-N1", f"--nodelist={node0}", script])
+        job_id = parse_job_id(sbatch_out)
+        assert job_id is not None
+
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            sq = cluster.squeue_all()
+            if job_state(sq, job_id) == "R":
+                break
+            time.sleep(1)
+
+        out = cluster.cli_allow_fail(["spur", "node", "remove", node0])
+        assert "running jobs" in out.lower() or "failed_precondition" in out.lower(), (
+            f"expected rejection, got: {out}"
+        )
+
+        assert node0 in cluster.sinfo()
+        cluster.scancel(str(job_id))
+
+
+class TestAgentSelfDeregistration:
+    """Test SIGTERM-based agent self-deregistration."""
+
+    def test_agent_sigterm_deregisters(self, multi_node_cluster):
+        cluster = multi_node_cluster
+        node1 = cluster.node_names[1]
+
+        _sigterm_agent(cluster, 1)
+        _wait_node_gone(cluster, node1, timeout=30)
+
+
+class TestDownNodeFailsJobs:
+    """Verify the bug fix: jobs on downed nodes transition to NODE_FAIL."""
+
+    HB_TIMEOUT = 10
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return {"controller": {"heartbeat_timeout_secs": self.HB_TIMEOUT}}
+
+    def test_down_node_fails_jobs(self, multi_node_cluster):
+        cluster = multi_node_cluster
+        node0 = cluster.node_names[0]
+
+        script = cluster.write_file(
+            "down_sleep.sh", "#!/bin/bash\nsleep 600\n"
+        )
+        sbatch_out = cluster.sbatch(["-N1", f"--nodelist={node0}", script])
+        job_id = parse_job_id(sbatch_out)
+        assert job_id is not None
+
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            sq = cluster.squeue_all()
+            if job_state(sq, job_id) == "R":
+                break
+            time.sleep(1)
+        assert job_state(cluster.squeue_all(), job_id) == "R"
+
+        _kill_agent(cluster, 0)
+
+        state = _wait_job_terminal(cluster, job_id, timeout=self.HB_TIMEOUT + 30)
+        assert state == "NF", f"expected NODE_FAIL, got {state}"


### PR DESCRIPTION
## Summary

- Add node drain (`spur node drain`) and remove (`spur node remove [--force]`) commands with DrainNode, DeregisterNode, and DeregisterAgent gRPC RPCs. Drain stops new scheduling while running jobs finish; remove deletes the node entirely, optionally force-evicting running jobs to NODE_FAIL.
- Implement atomic job eviction in the controller: validate the job state transition to NodeFail before freeing allocations on all allocated nodes (prevents double-deallocation). Eviction integrates into node health checks (heartbeat timeout → Down → evict), explicit node removal, and agent self-deregistration.
- Add SIGTERM handling to spurd so agents gracefully deregister from the controller on shutdown instead of waiting for heartbeat timeout.

## Approach

The core eviction logic lives in two helpers: `evict_job` (single job, transition + free allocations across all nodes) and `evict_jobs_on_node` (filter jobs by node, call `evict_job` per job). These are called from `apply_operation` for `NodeStateChange` (→ Down) and `NodeRemove` WAL operations, making eviction durable and replay-safe.

`ClientResponse.job_finalized` was changed from `Option` to `Vec<JobFinalized>` to support bulk eviction in a single Raft proposal. Server handlers spawn async cancel RPCs to agents for evicted jobs and finalize their steps.

The `Completing → NodeFail` job state transition was added to allow eviction of jobs that are partially completing when a node goes down.

Heartbeat timeout is now configurable via `controller.heartbeat_timeout_secs` in spur.conf (default 90s).

## Test plan

- [x] Unit tests for `evict_job` covering: missing job, terminal job, multi-node allocations, suspended time accounting, Completing jobs, Draining→Drain node transition
- [x] Unit tests for drain_node, remove_node, NodeRemove WAL, NodeStateChange→Down eviction
- [x] `cargo clippy` and `cargo test` pass
- [x] E2E test suite (`test_deregistration.py`) with 5 tests: drain+remove, forced eviction, remove blocked by running jobs, agent SIGTERM deregistration, heartbeat-timeout job failure
- [x] Manual testing on 3-node bare-metal cluster: drain idle/busy nodes, force remove with eviction count, SIGTERM deregistration, heartbeat timeout auto-eviction
- [x] Test infrastructure: added `cluster_config_overrides` fixture for per-test config customisation, fixed stale-process cleanup across pytest sessions