### PR TITLE
feat(spur-metrics): add scheduler cycle and lifecycle statistics

### DIFF
--- a/crates/spur-cli/src/sdiag.rs
+++ b/crates/spur-cli/src/sdiag.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 use spur_core::job::JobState as CoreJobState;
 use spur_core::node::NodeState as CoreNodeState;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
-use spur_proto::proto::{JobMetrics, NodeMetrics, RpcOperationStats, RpcStats};
+use spur_proto::proto::{JobMetrics, NodeMetrics, RpcOperationStats, RpcStats, SchedStats};
 
 /// Display scheduler diagnostics and statistics.
 #[derive(Parser, Debug)]
@@ -16,7 +16,7 @@ pub struct SdiagArgs {
     #[arg(long)]
     pub noheader: bool,
 
-    /// Reset RPC statistics counters on the controller
+    /// Reset accumulated statistics counters on the controller
     #[arg(long)]
     pub reset: bool,
 
@@ -42,9 +42,9 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
 
     if args.reset {
         client
-            .reset_rpc_stats(())
+            .reset_diag_stats(())
             .await
-            .context("failed to reset RPC statistics")?;
+            .context("failed to reset diagnostic statistics")?;
     }
 
     let ping_resp = client.ping(()).await.context("failed to ping controller")?;
@@ -66,6 +66,12 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         .get_rpc_stats(())
         .await
         .context("failed to get RPC statistics")?
+        .into_inner();
+
+    let sched_stats = client
+        .get_sched_stats(())
+        .await
+        .context("failed to get scheduler statistics")?
         .into_inner();
 
     let server_time = ping
@@ -97,6 +103,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
 
     print_job_statistics(&job_metrics);
     print_node_statistics(&node_metrics);
+    print_scheduler_statistics(&sched_stats);
     print_rpc_statistics(&rpc_stats);
 
     Ok(())
@@ -208,6 +215,31 @@ fn print_node_statistics(metrics: &NodeMetrics) {
     );
     println!("  Total GPUs        : {}", metrics.total_gpus);
     println!("  Allocated GPUs    : {}", metrics.alloc_gpus);
+}
+
+fn scheduler_statistics_lines(stats: &SchedStats) -> Vec<String> {
+    vec![
+        String::new(),
+        "Scheduler Statistics:".to_string(),
+        format!("  Plugin              : {}", stats.plugin),
+        format!("  Cycles              : {}", stats.cycles),
+        format!("  Cycle last (us)     : {}", stats.cycle_last_time_us),
+        format!("  Cycle total (us)    : {}", stats.cycle_total_time_us),
+        format!("  Cycle avg (us)      : {}", stats.cycle_avg_time_us),
+        format!("  Schedule last (us)  : {}", stats.schedule_last_time_us),
+        format!("  Schedule total (us) : {}", stats.schedule_total_time_us),
+        format!("  Schedule avg (us)   : {}", stats.schedule_avg_time_us),
+        format!("  Jobs submitted      : {}", stats.jobs_submitted),
+        format!("  Jobs started        : {}", stats.jobs_started),
+        format!("  Jobs completed      : {}", stats.jobs_completed),
+        format!("  Jobs started (last) : {}", stats.jobs_started_last_cycle),
+    ]
+}
+
+fn print_scheduler_statistics(stats: &SchedStats) {
+    for line in scheduler_statistics_lines(stats) {
+        println!("{line}");
+    }
 }
 
 fn rpc_statistics_lines(stats: &RpcStats) -> Vec<String> {
@@ -322,6 +354,30 @@ mod tests {
 
         assert_eq!(finished, 3); // NODE_FAIL + 2 COMPLETED
         assert_eq!(active, 2); // RUNNING + SUSPENDED
+    }
+
+    #[test]
+    fn scheduler_statistics_lines_include_cycle_and_lifecycle_fields() {
+        let stats = SchedStats {
+            plugin: "backfill".into(),
+            cycles: 5,
+            cycle_total_time_us: 2500,
+            cycle_last_time_us: 600,
+            cycle_avg_time_us: 500,
+            schedule_total_time_us: 800,
+            schedule_last_time_us: 200,
+            schedule_avg_time_us: 160,
+            jobs_submitted: 10,
+            jobs_started: 8,
+            jobs_completed: 7,
+            jobs_started_last_cycle: 2,
+        };
+        let lines = scheduler_statistics_lines(&stats);
+        assert!(lines.iter().any(|l| l.contains("Plugin")));
+        assert!(lines.iter().any(|l| l.contains("Cycles")));
+        assert!(lines.iter().any(|l| l.contains("Cycle total (us)")));
+        assert!(lines.iter().any(|l| l.contains("Schedule total (us)")));
+        assert!(lines.iter().any(|l| l.contains("Jobs started (last) : 2")));
     }
 
     #[test]

--- a/crates/spur-cli/src/sdiag.rs
+++ b/crates/spur-cli/src/sdiag.rs
@@ -231,7 +231,7 @@ fn scheduler_statistics_lines(stats: &SchedStats) -> Vec<String> {
         format!("  Schedule avg (us)   : {}", stats.schedule_avg_time_us),
         format!("  Jobs submitted      : {}", stats.jobs_submitted),
         format!("  Jobs started        : {}", stats.jobs_started),
-        format!("  Jobs completed      : {}", stats.jobs_completed),
+        format!("  Jobs finalized      : {}", stats.jobs_finalized),
         format!("  Jobs started (last) : {}", stats.jobs_started_last_cycle),
     ]
 }
@@ -369,7 +369,7 @@ mod tests {
             schedule_avg_time_us: 160,
             jobs_submitted: 10,
             jobs_started: 8,
-            jobs_completed: 7,
+            jobs_finalized: 7,
             jobs_started_last_cycle: 2,
         };
         let lines = scheduler_statistics_lines(&stats);

--- a/crates/spur-metrics/src/export/mod.rs
+++ b/crates/spur-metrics/src/export/mod.rs
@@ -4,6 +4,7 @@
 //! prometheus-client registry encoding for spurctld metrics HTTP export.
 
 use prometheus_client::encoding::text::encode as encode_openmetrics;
+use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::gauge::Gauge;
 use prometheus_client::registry::Registry;
 use std::sync::atomic::AtomicU64;
@@ -22,6 +23,15 @@ pub(crate) fn register_gauge(registry: &mut Registry, name: &str, help: &str, va
     let gauge = Gauge::<u64, AtomicU64>::default();
     gauge.set(value);
     registry.register(name, help, gauge);
+}
+
+/// Register a scalar `u64` counter seeded from a snapshot value.
+pub(crate) fn register_counter(registry: &mut Registry, name: &str, help: &str, value: u64) {
+    let counter = Counter::<u64, AtomicU64>::default();
+    if value > 0 {
+        counter.inc_by(value);
+    }
+    registry.register(name, help, counter);
 }
 
 /// Build a registry, run `register`, and encode as OpenMetrics 1.0 text.

--- a/crates/spur-metrics/src/export/scheduler.rs
+++ b/crates/spur-metrics/src/export/scheduler.rs
@@ -38,9 +38,9 @@ pub fn register_scheduler(registry: &mut Registry, snap: &SchedStatsSnapshot) {
 
     register_gauge(
         registry,
-        "spur_scheduler_cycles",
-        "Scheduling cycles executed since reset",
-        snap.cycles,
+        "spur_scheduler_cycle_last_time_us",
+        "Most recent scheduling cycle wall time in microseconds",
+        snap.cycle_last_time_us,
     );
     register_gauge(
         registry,
@@ -50,21 +50,9 @@ pub fn register_scheduler(registry: &mut Registry, snap: &SchedStatsSnapshot) {
     );
     register_gauge(
         registry,
-        "spur_scheduler_cycle_last_time_us",
-        "Most recent scheduling cycle wall time in microseconds",
-        snap.cycle_last_time_us,
-    );
-    register_gauge(
-        registry,
-        "spur_scheduler_cycle_avg_time_us",
-        "Average scheduling cycle wall time in microseconds",
-        snap.cycle_avg_time_us(),
-    );
-    register_gauge(
-        registry,
-        "spur_scheduler_schedule_total_time_us",
-        "Cumulative Scheduler::schedule() time in microseconds",
-        snap.schedule_total_time_us,
+        "spur_scheduler_cycles_total",
+        "Scheduling cycles executed since reset",
+        snap.cycles,
     );
     register_gauge(
         registry,
@@ -74,33 +62,33 @@ pub fn register_scheduler(registry: &mut Registry, snap: &SchedStatsSnapshot) {
     );
     register_gauge(
         registry,
-        "spur_scheduler_schedule_avg_time_us",
-        "Average Scheduler::schedule() time in microseconds",
-        snap.schedule_avg_time_us(),
-    );
-    register_gauge(
-        registry,
-        "spur_scheduler_jobs_submitted",
-        "Jobs submitted since reset",
-        snap.jobs_submitted,
-    );
-    register_gauge(
-        registry,
-        "spur_scheduler_jobs_started",
-        "Jobs started since reset",
-        snap.jobs_started,
-    );
-    register_gauge(
-        registry,
-        "spur_scheduler_jobs_finalized",
-        "Jobs reaching a terminal state since reset",
-        snap.jobs_finalized,
+        "spur_scheduler_schedule_total_time_us",
+        "Cumulative Scheduler::schedule() time in microseconds",
+        snap.schedule_total_time_us,
     );
     register_gauge(
         registry,
         "spur_scheduler_jobs_started_last_cycle",
         "Jobs started in the most recent scheduling cycle",
         snap.jobs_started_last_cycle,
+    );
+    register_gauge(
+        registry,
+        "spur_scheduler_jobs_submitted_total",
+        "Jobs submitted since reset",
+        snap.jobs_submitted,
+    );
+    register_gauge(
+        registry,
+        "spur_scheduler_jobs_started_total",
+        "Jobs started since reset",
+        snap.jobs_started,
+    );
+    register_gauge(
+        registry,
+        "spur_scheduler_jobs_finalized_total",
+        "Jobs reaching a terminal state since reset",
+        snap.jobs_finalized,
     );
 }
 
@@ -132,10 +120,10 @@ mod tests {
     fn export_includes_scheduler_gauges() {
         let body = encode_scheduler_metrics(&sample_snapshot());
         assert!(body.contains("spur_scheduler_info{plugin=\"backfill\"} 1"));
-        assert!(body.contains("spur_scheduler_cycles 10"));
-        assert!(body.contains("spur_scheduler_cycle_avg_time_us 500"));
-        assert!(body.contains("spur_scheduler_schedule_avg_time_us 150"));
-        assert!(body.contains("spur_scheduler_jobs_submitted 42"));
+        assert!(body.contains("spur_scheduler_cycles_total 10"));
+        assert!(body.contains("spur_scheduler_cycle_total_time_us 5000"));
+        assert!(!body.contains("_avg_time_us"));
+        assert!(body.contains("spur_scheduler_jobs_submitted_total 42"));
         assert!(body.contains("spur_scheduler_jobs_started_last_cycle 3"));
         assert!(body.ends_with("# EOF\n"));
     }
@@ -147,7 +135,7 @@ mod tests {
             ..Default::default()
         };
         let body = encode_scheduler_metrics(&snap);
-        assert!(body.contains("spur_scheduler_cycles 0"));
+        assert!(body.contains("spur_scheduler_cycles_total 0"));
         assert!(body.ends_with("# EOF\n"));
     }
 }

--- a/crates/spur-metrics/src/export/scheduler.rs
+++ b/crates/spur-metrics/src/export/scheduler.rs
@@ -1,27 +1,153 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Scheduler gauge registration for `/metrics/scheduler` (Layer 1c).
+//! Scheduler gauge registration for `/metrics/scheduler`.
 
+use prometheus_client::encoding::EncodeLabelSet;
+use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::gauge::Gauge;
 use prometheus_client::registry::Registry;
+use std::sync::atomic::AtomicU64;
 
 use crate::export::encode_registered;
+use crate::export::register_gauge;
+use crate::scheduler::SchedStatsSnapshot;
 
-/// Register scheduler catalog gauges (stub until scheduler snapshot exists).
-pub fn register_scheduler(_registry: &mut Registry) {}
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct PluginLabel {
+    plugin: String,
+}
+
+fn set_plugin_info(registry: &mut Registry, snap: &SchedStatsSnapshot) {
+    let family = Family::<PluginLabel, Gauge<u64, AtomicU64>>::default();
+    family
+        .get_or_create(&PluginLabel {
+            plugin: snap.plugin.clone(),
+        })
+        .set(1);
+    registry.register(
+        "spur_scheduler_info",
+        "Active scheduler plugin (value is always 1)",
+        family,
+    );
+}
+
+/// Register scheduler gauges into `registry` from `snap`.
+pub fn register_scheduler(registry: &mut Registry, snap: &SchedStatsSnapshot) {
+    set_plugin_info(registry, snap);
+
+    register_gauge(
+        registry,
+        "spur_scheduler_cycles",
+        "Scheduling cycles executed since reset",
+        snap.cycles,
+    );
+    register_gauge(
+        registry,
+        "spur_scheduler_cycle_total_time_us",
+        "Cumulative scheduling cycle wall time in microseconds",
+        snap.cycle_total_time_us,
+    );
+    register_gauge(
+        registry,
+        "spur_scheduler_cycle_last_time_us",
+        "Most recent scheduling cycle wall time in microseconds",
+        snap.cycle_last_time_us,
+    );
+    register_gauge(
+        registry,
+        "spur_scheduler_cycle_avg_time_us",
+        "Average scheduling cycle wall time in microseconds",
+        snap.cycle_avg_time_us(),
+    );
+    register_gauge(
+        registry,
+        "spur_scheduler_schedule_total_time_us",
+        "Cumulative Scheduler::schedule() time in microseconds",
+        snap.schedule_total_time_us,
+    );
+    register_gauge(
+        registry,
+        "spur_scheduler_schedule_last_time_us",
+        "Most recent Scheduler::schedule() time in microseconds",
+        snap.schedule_last_time_us,
+    );
+    register_gauge(
+        registry,
+        "spur_scheduler_schedule_avg_time_us",
+        "Average Scheduler::schedule() time in microseconds",
+        snap.schedule_avg_time_us(),
+    );
+    register_gauge(
+        registry,
+        "spur_scheduler_jobs_submitted",
+        "Jobs submitted since reset",
+        snap.jobs_submitted,
+    );
+    register_gauge(
+        registry,
+        "spur_scheduler_jobs_started",
+        "Jobs started since reset",
+        snap.jobs_started,
+    );
+    register_gauge(
+        registry,
+        "spur_scheduler_jobs_completed",
+        "Jobs completed since reset",
+        snap.jobs_completed,
+    );
+    register_gauge(
+        registry,
+        "spur_scheduler_jobs_started_last_cycle",
+        "Jobs started in the most recent scheduling cycle",
+        snap.jobs_started_last_cycle,
+    );
+}
 
 /// Encode scheduler metrics for `/metrics/scheduler` as OpenMetrics 1.0 text.
-pub fn encode_scheduler_metrics() -> String {
-    encode_registered(register_scheduler)
+pub fn encode_scheduler_metrics(snap: &SchedStatsSnapshot) -> String {
+    encode_registered(|registry| register_scheduler(registry, snap))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn sample_snapshot() -> SchedStatsSnapshot {
+        SchedStatsSnapshot {
+            plugin: "backfill".into(),
+            cycles: 10,
+            cycle_total_time_us: 5000,
+            cycle_last_time_us: 600,
+            schedule_total_time_us: 1500,
+            schedule_last_time_us: 200,
+            jobs_submitted: 42,
+            jobs_started: 30,
+            jobs_completed: 28,
+            jobs_started_last_cycle: 3,
+        }
+    }
+
     #[test]
-    fn empty_scheduler_export_has_eof_only() {
-        let body = encode_scheduler_metrics();
-        assert_eq!(body, "# EOF\n");
+    fn export_includes_scheduler_gauges() {
+        let body = encode_scheduler_metrics(&sample_snapshot());
+        assert!(body.contains("spur_scheduler_info{plugin=\"backfill\"} 1"));
+        assert!(body.contains("spur_scheduler_cycles 10"));
+        assert!(body.contains("spur_scheduler_cycle_avg_time_us 500"));
+        assert!(body.contains("spur_scheduler_schedule_avg_time_us 150"));
+        assert!(body.contains("spur_scheduler_jobs_submitted 42"));
+        assert!(body.contains("spur_scheduler_jobs_started_last_cycle 3"));
+        assert!(body.ends_with("# EOF\n"));
+    }
+
+    #[test]
+    fn empty_snapshot_still_exports_plugin_info() {
+        let snap = SchedStatsSnapshot {
+            plugin: "backfill".into(),
+            ..Default::default()
+        };
+        let body = encode_scheduler_metrics(&snap);
+        assert!(body.contains("spur_scheduler_cycles 0"));
+        assert!(body.ends_with("# EOF\n"));
     }
 }

--- a/crates/spur-metrics/src/export/scheduler.rs
+++ b/crates/spur-metrics/src/export/scheduler.rs
@@ -92,9 +92,9 @@ pub fn register_scheduler(registry: &mut Registry, snap: &SchedStatsSnapshot) {
     );
     register_gauge(
         registry,
-        "spur_scheduler_jobs_completed",
-        "Jobs completed since reset",
-        snap.jobs_completed,
+        "spur_scheduler_jobs_finalized",
+        "Jobs reaching a terminal state since reset",
+        snap.jobs_finalized,
     );
     register_gauge(
         registry,
@@ -123,7 +123,7 @@ mod tests {
             schedule_last_time_us: 200,
             jobs_submitted: 42,
             jobs_started: 30,
-            jobs_completed: 28,
+            jobs_finalized: 28,
             jobs_started_last_cycle: 3,
         }
     }

--- a/crates/spur-metrics/src/export/scheduler.rs
+++ b/crates/spur-metrics/src/export/scheduler.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Scheduler gauge registration for `/metrics/scheduler`.
+//! Scheduler metric registration for `/metrics/scheduler`.
 
 use prometheus_client::encoding::EncodeLabelSet;
 use prometheus_client::metrics::family::Family;
@@ -10,7 +10,7 @@ use prometheus_client::registry::Registry;
 use std::sync::atomic::AtomicU64;
 
 use crate::export::encode_registered;
-use crate::export::register_gauge;
+use crate::export::{register_counter, register_gauge};
 use crate::scheduler::SchedStatsSnapshot;
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
@@ -32,7 +32,7 @@ fn set_plugin_info(registry: &mut Registry, snap: &SchedStatsSnapshot) {
     );
 }
 
-/// Register scheduler gauges into `registry` from `snap`.
+/// Register scheduler metrics into `registry` from `snap`.
 pub fn register_scheduler(registry: &mut Registry, snap: &SchedStatsSnapshot) {
     set_plugin_info(registry, snap);
 
@@ -48,9 +48,9 @@ pub fn register_scheduler(registry: &mut Registry, snap: &SchedStatsSnapshot) {
         "Cumulative scheduling cycle wall time in microseconds",
         snap.cycle_total_time_us,
     );
-    register_gauge(
+    register_counter(
         registry,
-        "spur_scheduler_cycles_total",
+        "spur_scheduler_cycles",
         "Scheduling cycles executed since reset",
         snap.cycles,
     );
@@ -72,21 +72,21 @@ pub fn register_scheduler(registry: &mut Registry, snap: &SchedStatsSnapshot) {
         "Jobs started in the most recent scheduling cycle",
         snap.jobs_started_last_cycle,
     );
-    register_gauge(
+    register_counter(
         registry,
-        "spur_scheduler_jobs_submitted_total",
+        "spur_scheduler_jobs_submitted",
         "Jobs submitted since reset",
         snap.jobs_submitted,
     );
-    register_gauge(
+    register_counter(
         registry,
-        "spur_scheduler_jobs_started_total",
+        "spur_scheduler_jobs_started",
         "Jobs started since reset",
         snap.jobs_started,
     );
-    register_gauge(
+    register_counter(
         registry,
-        "spur_scheduler_jobs_finalized_total",
+        "spur_scheduler_jobs_finalized",
         "Jobs reaching a terminal state since reset",
         snap.jobs_finalized,
     );
@@ -116,8 +116,18 @@ mod tests {
         }
     }
 
+    fn metric_type<'a>(body: &'a str, name: &str) -> &'a str {
+        let prefix = format!("# TYPE {name} ");
+        body.lines()
+            .find(|line| line.starts_with(&prefix))
+            .unwrap_or_else(|| panic!("missing TYPE line for {name}"))
+            .split_whitespace()
+            .nth(3)
+            .unwrap_or_else(|| panic!("malformed TYPE line for {name}"))
+    }
+
     #[test]
-    fn export_includes_scheduler_gauges() {
+    fn export_includes_scheduler_metrics() {
         let body = encode_scheduler_metrics(&sample_snapshot());
         assert!(body.contains("spur_scheduler_info{plugin=\"backfill\"} 1"));
         assert!(body.contains("spur_scheduler_cycles_total 10"));
@@ -125,6 +135,15 @@ mod tests {
         assert!(!body.contains("_avg_time_us"));
         assert!(body.contains("spur_scheduler_jobs_submitted_total 42"));
         assert!(body.contains("spur_scheduler_jobs_started_last_cycle 3"));
+        assert_eq!(metric_type(&body, "spur_scheduler_cycles"), "counter");
+        assert_eq!(
+            metric_type(&body, "spur_scheduler_jobs_submitted"),
+            "counter"
+        );
+        assert_eq!(
+            metric_type(&body, "spur_scheduler_cycle_last_time_us"),
+            "gauge"
+        );
         assert!(body.ends_with("# EOF\n"));
     }
 
@@ -136,6 +155,7 @@ mod tests {
         };
         let body = encode_scheduler_metrics(&snap);
         assert!(body.contains("spur_scheduler_cycles_total 0"));
+        assert_eq!(metric_type(&body, "spur_scheduler_cycles"), "counter");
         assert!(body.ends_with("# EOF\n"));
     }
 }

--- a/crates/spur-metrics/src/lib.rs
+++ b/crates/spur-metrics/src/lib.rs
@@ -7,6 +7,7 @@ pub mod export;
 pub mod job;
 pub mod node;
 pub mod rpc;
+pub mod scheduler;
 
 pub use export::jobs::{encode_job_metrics, job_state_metric_suffix};
 pub use export::nodes::encode_nodes_metrics;
@@ -16,3 +17,4 @@ pub use export::scheduler::encode_scheduler_metrics;
 pub use export::CONTENT_TYPE;
 pub use node::node_state_metric_suffix;
 pub use rpc::{RpcOperationSnapshot, RpcStatsSnapshot};
+pub use scheduler::SchedStatsSnapshot;

--- a/crates/spur-metrics/src/scheduler.rs
+++ b/crates/spur-metrics/src/scheduler.rs
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Snapshot of controller scheduler statistics since process start or last reset.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SchedStatsSnapshot {
+    pub plugin: String,
+    pub cycles: u64,
+    pub cycle_total_time_us: u64,
+    pub cycle_last_time_us: u64,
+    pub schedule_total_time_us: u64,
+    pub schedule_last_time_us: u64,
+    pub jobs_submitted: u64,
+    pub jobs_started: u64,
+    pub jobs_completed: u64,
+    pub jobs_started_last_cycle: u64,
+}
+
+impl SchedStatsSnapshot {
+    pub fn cycle_avg_time_us(&self) -> u64 {
+        self.cycle_total_time_us
+            .checked_div(self.cycles)
+            .unwrap_or(0)
+    }
+
+    pub fn schedule_avg_time_us(&self) -> u64 {
+        self.schedule_total_time_us
+            .checked_div(self.cycles)
+            .unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn avg_time_us_is_zero_when_cycles_zero() {
+        let snap = SchedStatsSnapshot {
+            cycle_total_time_us: 1000,
+            schedule_total_time_us: 500,
+            ..Default::default()
+        };
+        assert_eq!(snap.cycle_avg_time_us(), 0);
+        assert_eq!(snap.schedule_avg_time_us(), 0);
+    }
+
+    #[test]
+    fn avg_time_us_divides_total_by_cycles() {
+        let snap = SchedStatsSnapshot {
+            cycles: 4,
+            cycle_total_time_us: 4000,
+            schedule_total_time_us: 800,
+            ..Default::default()
+        };
+        assert_eq!(snap.cycle_avg_time_us(), 1000);
+        assert_eq!(snap.schedule_avg_time_us(), 200);
+    }
+}

--- a/crates/spur-metrics/src/scheduler.rs
+++ b/crates/spur-metrics/src/scheduler.rs
@@ -12,7 +12,7 @@ pub struct SchedStatsSnapshot {
     pub schedule_last_time_us: u64,
     pub jobs_submitted: u64,
     pub jobs_started: u64,
-    pub jobs_completed: u64,
+    pub jobs_finalized: u64,
     pub jobs_started_last_cycle: u64,
 }
 

--- a/crates/spur-metrics/tests/fixtures/scheduler.prom
+++ b/crates/spur-metrics/tests/fixtures/scheduler.prom
@@ -28,9 +28,9 @@ spur_scheduler_jobs_submitted 42
 # HELP spur_scheduler_jobs_started Jobs started since reset.
 # TYPE spur_scheduler_jobs_started gauge
 spur_scheduler_jobs_started 30
-# HELP spur_scheduler_jobs_completed Jobs completed since reset.
-# TYPE spur_scheduler_jobs_completed gauge
-spur_scheduler_jobs_completed 28
+# HELP spur_scheduler_jobs_finalized Jobs reaching a terminal state since reset.
+# TYPE spur_scheduler_jobs_finalized gauge
+spur_scheduler_jobs_finalized 28
 # HELP spur_scheduler_jobs_started_last_cycle Jobs started in the most recent scheduling cycle.
 # TYPE spur_scheduler_jobs_started_last_cycle gauge
 spur_scheduler_jobs_started_last_cycle 3

--- a/crates/spur-metrics/tests/fixtures/scheduler.prom
+++ b/crates/spur-metrics/tests/fixtures/scheduler.prom
@@ -1,0 +1,37 @@
+# HELP spur_scheduler_info Active scheduler plugin (value is always 1).
+# TYPE spur_scheduler_info gauge
+spur_scheduler_info{plugin="backfill"} 1
+# HELP spur_scheduler_cycles Scheduling cycles executed since reset.
+# TYPE spur_scheduler_cycles gauge
+spur_scheduler_cycles 10
+# HELP spur_scheduler_cycle_total_time_us Cumulative scheduling cycle wall time in microseconds.
+# TYPE spur_scheduler_cycle_total_time_us gauge
+spur_scheduler_cycle_total_time_us 5000
+# HELP spur_scheduler_cycle_last_time_us Most recent scheduling cycle wall time in microseconds.
+# TYPE spur_scheduler_cycle_last_time_us gauge
+spur_scheduler_cycle_last_time_us 600
+# HELP spur_scheduler_cycle_avg_time_us Average scheduling cycle wall time in microseconds.
+# TYPE spur_scheduler_cycle_avg_time_us gauge
+spur_scheduler_cycle_avg_time_us 500
+# HELP spur_scheduler_schedule_total_time_us Cumulative Scheduler::schedule() time in microseconds.
+# TYPE spur_scheduler_schedule_total_time_us gauge
+spur_scheduler_schedule_total_time_us 1500
+# HELP spur_scheduler_schedule_last_time_us Most recent Scheduler::schedule() time in microseconds.
+# TYPE spur_scheduler_schedule_last_time_us gauge
+spur_scheduler_schedule_last_time_us 200
+# HELP spur_scheduler_schedule_avg_time_us Average Scheduler::schedule() time in microseconds.
+# TYPE spur_scheduler_schedule_avg_time_us gauge
+spur_scheduler_schedule_avg_time_us 150
+# HELP spur_scheduler_jobs_submitted Jobs submitted since reset.
+# TYPE spur_scheduler_jobs_submitted gauge
+spur_scheduler_jobs_submitted 42
+# HELP spur_scheduler_jobs_started Jobs started since reset.
+# TYPE spur_scheduler_jobs_started gauge
+spur_scheduler_jobs_started 30
+# HELP spur_scheduler_jobs_completed Jobs completed since reset.
+# TYPE spur_scheduler_jobs_completed gauge
+spur_scheduler_jobs_completed 28
+# HELP spur_scheduler_jobs_started_last_cycle Jobs started in the most recent scheduling cycle.
+# TYPE spur_scheduler_jobs_started_last_cycle gauge
+spur_scheduler_jobs_started_last_cycle 3
+# EOF

--- a/crates/spur-metrics/tests/fixtures/scheduler.prom
+++ b/crates/spur-metrics/tests/fixtures/scheduler.prom
@@ -1,37 +1,31 @@
 # HELP spur_scheduler_info Active scheduler plugin (value is always 1).
 # TYPE spur_scheduler_info gauge
 spur_scheduler_info{plugin="backfill"} 1
-# HELP spur_scheduler_cycles Scheduling cycles executed since reset.
-# TYPE spur_scheduler_cycles gauge
-spur_scheduler_cycles 10
-# HELP spur_scheduler_cycle_total_time_us Cumulative scheduling cycle wall time in microseconds.
-# TYPE spur_scheduler_cycle_total_time_us gauge
-spur_scheduler_cycle_total_time_us 5000
 # HELP spur_scheduler_cycle_last_time_us Most recent scheduling cycle wall time in microseconds.
 # TYPE spur_scheduler_cycle_last_time_us gauge
 spur_scheduler_cycle_last_time_us 600
-# HELP spur_scheduler_cycle_avg_time_us Average scheduling cycle wall time in microseconds.
-# TYPE spur_scheduler_cycle_avg_time_us gauge
-spur_scheduler_cycle_avg_time_us 500
-# HELP spur_scheduler_schedule_total_time_us Cumulative Scheduler::schedule() time in microseconds.
-# TYPE spur_scheduler_schedule_total_time_us gauge
-spur_scheduler_schedule_total_time_us 1500
+# HELP spur_scheduler_cycle_total_time_us Cumulative scheduling cycle wall time in microseconds.
+# TYPE spur_scheduler_cycle_total_time_us gauge
+spur_scheduler_cycle_total_time_us 5000
+# HELP spur_scheduler_cycles_total Scheduling cycles executed since reset.
+# TYPE spur_scheduler_cycles_total gauge
+spur_scheduler_cycles_total 10
 # HELP spur_scheduler_schedule_last_time_us Most recent Scheduler::schedule() time in microseconds.
 # TYPE spur_scheduler_schedule_last_time_us gauge
 spur_scheduler_schedule_last_time_us 200
-# HELP spur_scheduler_schedule_avg_time_us Average Scheduler::schedule() time in microseconds.
-# TYPE spur_scheduler_schedule_avg_time_us gauge
-spur_scheduler_schedule_avg_time_us 150
-# HELP spur_scheduler_jobs_submitted Jobs submitted since reset.
-# TYPE spur_scheduler_jobs_submitted gauge
-spur_scheduler_jobs_submitted 42
-# HELP spur_scheduler_jobs_started Jobs started since reset.
-# TYPE spur_scheduler_jobs_started gauge
-spur_scheduler_jobs_started 30
-# HELP spur_scheduler_jobs_finalized Jobs reaching a terminal state since reset.
-# TYPE spur_scheduler_jobs_finalized gauge
-spur_scheduler_jobs_finalized 28
+# HELP spur_scheduler_schedule_total_time_us Cumulative Scheduler::schedule() time in microseconds.
+# TYPE spur_scheduler_schedule_total_time_us gauge
+spur_scheduler_schedule_total_time_us 1500
 # HELP spur_scheduler_jobs_started_last_cycle Jobs started in the most recent scheduling cycle.
 # TYPE spur_scheduler_jobs_started_last_cycle gauge
 spur_scheduler_jobs_started_last_cycle 3
+# HELP spur_scheduler_jobs_submitted_total Jobs submitted since reset.
+# TYPE spur_scheduler_jobs_submitted_total gauge
+spur_scheduler_jobs_submitted_total 42
+# HELP spur_scheduler_jobs_started_total Jobs started since reset.
+# TYPE spur_scheduler_jobs_started_total gauge
+spur_scheduler_jobs_started_total 30
+# HELP spur_scheduler_jobs_finalized_total Jobs reaching a terminal state since reset.
+# TYPE spur_scheduler_jobs_finalized_total gauge
+spur_scheduler_jobs_finalized_total 28
 # EOF

--- a/crates/spur-metrics/tests/fixtures/scheduler.prom
+++ b/crates/spur-metrics/tests/fixtures/scheduler.prom
@@ -7,8 +7,8 @@ spur_scheduler_cycle_last_time_us 600
 # HELP spur_scheduler_cycle_total_time_us Cumulative scheduling cycle wall time in microseconds.
 # TYPE spur_scheduler_cycle_total_time_us gauge
 spur_scheduler_cycle_total_time_us 5000
-# HELP spur_scheduler_cycles_total Scheduling cycles executed since reset.
-# TYPE spur_scheduler_cycles_total gauge
+# HELP spur_scheduler_cycles Scheduling cycles executed since reset.
+# TYPE spur_scheduler_cycles counter
 spur_scheduler_cycles_total 10
 # HELP spur_scheduler_schedule_last_time_us Most recent Scheduler::schedule() time in microseconds.
 # TYPE spur_scheduler_schedule_last_time_us gauge
@@ -19,13 +19,13 @@ spur_scheduler_schedule_total_time_us 1500
 # HELP spur_scheduler_jobs_started_last_cycle Jobs started in the most recent scheduling cycle.
 # TYPE spur_scheduler_jobs_started_last_cycle gauge
 spur_scheduler_jobs_started_last_cycle 3
-# HELP spur_scheduler_jobs_submitted_total Jobs submitted since reset.
-# TYPE spur_scheduler_jobs_submitted_total gauge
+# HELP spur_scheduler_jobs_submitted Jobs submitted since reset.
+# TYPE spur_scheduler_jobs_submitted counter
 spur_scheduler_jobs_submitted_total 42
-# HELP spur_scheduler_jobs_started_total Jobs started since reset.
-# TYPE spur_scheduler_jobs_started_total gauge
+# HELP spur_scheduler_jobs_started Jobs started since reset.
+# TYPE spur_scheduler_jobs_started counter
 spur_scheduler_jobs_started_total 30
-# HELP spur_scheduler_jobs_finalized_total Jobs reaching a terminal state since reset.
-# TYPE spur_scheduler_jobs_finalized_total gauge
+# HELP spur_scheduler_jobs_finalized Jobs reaching a terminal state since reset.
+# TYPE spur_scheduler_jobs_finalized counter
 spur_scheduler_jobs_finalized_total 28
 # EOF

--- a/crates/spur-metrics/tests/scheduler_export_golden.rs
+++ b/crates/spur-metrics/tests/scheduler_export_golden.rs
@@ -76,16 +76,13 @@ fn sample_snapshot() -> SchedStatsSnapshot {
 fn golden_scheduler_metrics() {
     let body = normalize_exposition(&encode_scheduler_metrics(&sample_snapshot()));
     let path = fixtures_dir().join("scheduler.prom");
+
+    if std::env::var_os("UPDATE_GOLDEN").is_some() {
+        std::fs::write(&path, &body).expect("write golden fixture");
+        return;
+    }
+
     let expected =
         std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
     assert_eq!(body, expected);
-}
-
-/// Regenerate `tests/fixtures/scheduler.prom` after intentional encoder changes:
-/// `cargo test -p spur-metrics --test scheduler_export_golden refresh_golden_fixtures -- --ignored --exact`
-#[test]
-#[ignore = "manual fixture refresh"]
-fn refresh_golden_fixtures() {
-    let body = normalize_exposition(&encode_scheduler_metrics(&sample_snapshot()));
-    std::fs::write(fixtures_dir().join("scheduler.prom"), body).expect("write golden fixture");
 }

--- a/crates/spur-metrics/tests/scheduler_export_golden.rs
+++ b/crates/spur-metrics/tests/scheduler_export_golden.rs
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Golden tests for scheduler metrics export.
+
+use spur_metrics::{encode_scheduler_metrics, SchedStatsSnapshot};
+use std::path::PathBuf;
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures")
+}
+
+fn normalize_exposition(body: &str) -> String {
+    let mut out = String::new();
+    let mut block: Vec<&str> = Vec::new();
+
+    fn flush(out: &mut String, block: &mut Vec<&str>) {
+        if block.is_empty() {
+            return;
+        }
+
+        let mut headers: Vec<&str> = Vec::new();
+        let mut samples: Vec<&str> = Vec::new();
+        for &line in block.iter() {
+            if line.starts_with("# HELP ") || line.starts_with("# TYPE ") {
+                headers.push(line);
+            } else if !line.is_empty() {
+                samples.push(line);
+            }
+        }
+        samples.sort_unstable();
+
+        for h in headers {
+            out.push_str(h);
+            out.push('\n');
+        }
+        for s in samples {
+            out.push_str(s);
+            out.push('\n');
+        }
+
+        block.clear();
+    }
+
+    for line in body.lines() {
+        if line.starts_with("# HELP ") {
+            flush(&mut out, &mut block);
+        }
+        if line == "# EOF" {
+            flush(&mut out, &mut block);
+            out.push_str("# EOF\n");
+            continue;
+        }
+        block.push(line);
+    }
+    flush(&mut out, &mut block);
+    out
+}
+
+fn sample_snapshot() -> SchedStatsSnapshot {
+    SchedStatsSnapshot {
+        plugin: "backfill".into(),
+        cycles: 10,
+        cycle_total_time_us: 5000,
+        cycle_last_time_us: 600,
+        schedule_total_time_us: 1500,
+        schedule_last_time_us: 200,
+        jobs_submitted: 42,
+        jobs_started: 30,
+        jobs_completed: 28,
+        jobs_started_last_cycle: 3,
+    }
+}
+
+#[test]
+fn golden_scheduler_metrics() {
+    let body = normalize_exposition(&encode_scheduler_metrics(&sample_snapshot()));
+    let path = fixtures_dir().join("scheduler.prom");
+    let expected =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    assert_eq!(body, expected);
+}
+
+/// Regenerate `tests/fixtures/scheduler.prom` after intentional encoder changes:
+/// `cargo test -p spur-metrics --test scheduler_export_golden refresh_golden_fixtures -- --ignored --exact`
+#[test]
+#[ignore = "manual fixture refresh"]
+fn refresh_golden_fixtures() {
+    let body = normalize_exposition(&encode_scheduler_metrics(&sample_snapshot()));
+    std::fs::write(fixtures_dir().join("scheduler.prom"), body).expect("write golden fixture");
+}

--- a/crates/spur-metrics/tests/scheduler_export_golden.rs
+++ b/crates/spur-metrics/tests/scheduler_export_golden.rs
@@ -67,7 +67,7 @@ fn sample_snapshot() -> SchedStatsSnapshot {
         schedule_last_time_us: 200,
         jobs_submitted: 42,
         jobs_started: 30,
-        jobs_completed: 28,
+        jobs_finalized: 28,
         jobs_started_last_cycle: 3,
     }
 }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -122,7 +122,6 @@ impl ClusterManager {
 
         let job_id = self.next_job_id.fetch_add(1, Ordering::SeqCst);
         let specs = expand_job_specs(spec, job_id)?;
-        let submitted = specs.len() as u64;
 
         for task_spec in specs {
             let task_id = if task_spec.array_job_id.is_some() {
@@ -134,12 +133,8 @@ impl ClusterManager {
                 job_id: task_id,
                 spec: Box::new(task_spec),
             })?;
-        }
-
-        if submitted > 0 {
-            // Array expansion is all-or-nothing: count only after every JobSubmit propose succeeds.
             if let Some(stats) = self.sched_stats.read().as_ref() {
-                stats.record_submitted(submitted);
+                stats.record_submitted(1);
             }
         }
 
@@ -606,7 +601,7 @@ impl ClusterManager {
 
     fn run_job_finalized_side_effects(&self, finalized: JobFinalized) {
         if let Some(stats) = self.sched_stats.read().as_ref() {
-            stats.record_completed();
+            stats.record_finalized();
         }
         self.run_epilog_slurmctld(finalized.job_id);
         self.notify_job_finished(finalized.job_id, finalized.state, finalized.exit_code);
@@ -3690,7 +3685,7 @@ mod tests {
 
         cm.complete_job(job_id, 0, JobState::Completed).unwrap();
         settle(&cm, job_id, JobState::Completed);
-        assert_eq!(stats.snapshot().jobs_completed, 1);
+        assert_eq!(stats.snapshot().jobs_finalized, 1);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -29,6 +29,7 @@ use crate::accounting::AccountingNotifier;
 use crate::fairshare_cache::FairshareCache;
 use crate::limits_cache::QosCache;
 use crate::raft::{ClientResponse, JobFinalized, SpurRaft, StateMachineApply};
+use crate::sched_stats::SchedStatsCollector;
 
 /// Result of recording a per-node completion report.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -69,6 +70,7 @@ pub struct ClusterManager {
     qos_cache: Arc<QosCache>,
     /// Wake signal for the scheduler loop.
     pub(crate) scheduler_notify: Arc<Notify>,
+    sched_stats: RwLock<Option<Arc<SchedStatsCollector>>>,
 }
 
 impl ClusterManager {
@@ -95,6 +97,7 @@ impl ClusterManager {
             fairshare_cache,
             qos_cache,
             scheduler_notify: Arc::new(Notify::new()),
+            sched_stats: RwLock::new(None),
         };
 
         info!("cluster manager initialized (state will be recovered via Raft)");
@@ -119,6 +122,7 @@ impl ClusterManager {
 
         let job_id = self.next_job_id.fetch_add(1, Ordering::SeqCst);
         let specs = expand_job_specs(spec, job_id)?;
+        let submitted = specs.len() as u64;
 
         for task_spec in specs {
             let task_id = if task_spec.array_job_id.is_some() {
@@ -130,6 +134,13 @@ impl ClusterManager {
                 job_id: task_id,
                 spec: Box::new(task_spec),
             })?;
+        }
+
+        if submitted > 0 {
+            // Array expansion is all-or-nothing: count only after every JobSubmit propose succeeds.
+            if let Some(stats) = self.sched_stats.read().as_ref() {
+                stats.record_submitted(submitted);
+            }
         }
 
         self.scheduler_notify.notify_one();
@@ -594,6 +605,9 @@ impl ClusterManager {
     }
 
     fn run_job_finalized_side_effects(&self, finalized: JobFinalized) {
+        if let Some(stats) = self.sched_stats.read().as_ref() {
+            stats.record_completed();
+        }
         self.run_epilog_slurmctld(finalized.job_id);
         self.notify_job_finished(finalized.job_id, finalized.state, finalized.exit_code);
     }
@@ -1980,6 +1994,27 @@ impl ClusterManager {
 
     pub fn set_accounting(&self, notifier: AccountingNotifier) {
         *self.accounting.write() = Some(notifier);
+    }
+
+    pub fn set_sched_stats(&self, stats: Arc<SchedStatsCollector>) {
+        *self.sched_stats.write() = Some(stats);
+    }
+
+    pub(crate) fn record_sched_cycle(
+        &self,
+        cycle_time_us: u64,
+        schedule_time_us: u64,
+        jobs_started: u64,
+    ) {
+        if let Some(stats) = self.sched_stats.read().as_ref() {
+            stats.record_cycle(cycle_time_us, schedule_time_us, jobs_started);
+        }
+    }
+
+    pub(crate) fn record_sched_job_started(&self) {
+        if let Some(stats) = self.sched_stats.read().as_ref() {
+            stats.record_started();
+        }
     }
 
     pub fn fairshare_cache(&self) -> &Arc<FairshareCache> {
@@ -3625,6 +3660,37 @@ mod tests {
 
         let node = cm.get_node("worker1").unwrap();
         assert_eq!(node.alloc_resources.cpus, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn sched_stats_track_submit_start_complete() {
+        use std::sync::Arc;
+
+        use crate::sched_stats::SchedStatsCollector;
+
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        let stats = Arc::new(SchedStatsCollector::new("backfill"));
+        cm.set_sched_stats(stats.clone());
+
+        register_node(&cm, "worker1", 8, 16000);
+        let job_id = submit_and_wait(&cm, basic_spec("stats-job"));
+        assert_eq!(stats.snapshot().jobs_submitted, 1);
+
+        let resources = scalar_alloc(2, 4000);
+        cm.start_job(
+            job_id,
+            vec!["worker1".into()],
+            resources.clone(),
+            per_node_for(&["worker1"], resources),
+        )
+        .unwrap();
+        cm.record_sched_job_started();
+        assert_eq!(stats.snapshot().jobs_started, 1);
+
+        cm.complete_job(job_id, 0, JobState::Completed).unwrap();
+        settle(&cm, job_id, JobState::Completed);
+        assert_eq!(stats.snapshot().jobs_completed, 1);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::atomic::{AtomicU32, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use chrono::{DateTime, Utc};
 use parking_lot::RwLock;
@@ -70,7 +70,7 @@ pub struct ClusterManager {
     qos_cache: Arc<QosCache>,
     /// Wake signal for the scheduler loop.
     pub(crate) scheduler_notify: Arc<Notify>,
-    sched_stats: RwLock<Option<Arc<SchedStatsCollector>>>,
+    sched_stats: OnceLock<Arc<SchedStatsCollector>>,
 }
 
 impl ClusterManager {
@@ -97,7 +97,7 @@ impl ClusterManager {
             fairshare_cache,
             qos_cache,
             scheduler_notify: Arc::new(Notify::new()),
-            sched_stats: RwLock::new(None),
+            sched_stats: OnceLock::new(),
         };
 
         info!("cluster manager initialized (state will be recovered via Raft)");
@@ -133,7 +133,7 @@ impl ClusterManager {
                 job_id: task_id,
                 spec: Box::new(task_spec),
             })?;
-            if let Some(stats) = self.sched_stats.read().as_ref() {
+            if let Some(stats) = self.sched_stats.get() {
                 stats.record_submitted(1);
             }
         }
@@ -600,7 +600,7 @@ impl ClusterManager {
     }
 
     fn run_job_finalized_side_effects(&self, finalized: JobFinalized) {
-        if let Some(stats) = self.sched_stats.read().as_ref() {
+        if let Some(stats) = self.sched_stats.get() {
             stats.record_finalized();
         }
         self.run_epilog_slurmctld(finalized.job_id);
@@ -1992,7 +1992,7 @@ impl ClusterManager {
     }
 
     pub fn set_sched_stats(&self, stats: Arc<SchedStatsCollector>) {
-        *self.sched_stats.write() = Some(stats);
+        let _ = self.sched_stats.set(stats);
     }
 
     pub(crate) fn record_sched_cycle(
@@ -2001,14 +2001,8 @@ impl ClusterManager {
         schedule_time_us: u64,
         jobs_started: u64,
     ) {
-        if let Some(stats) = self.sched_stats.read().as_ref() {
+        if let Some(stats) = self.sched_stats.get() {
             stats.record_cycle(cycle_time_us, schedule_time_us, jobs_started);
-        }
-    }
-
-    pub(crate) fn record_sched_job_started(&self) {
-        if let Some(stats) = self.sched_stats.read().as_ref() {
-            stats.record_started();
         }
     }
 
@@ -3680,7 +3674,7 @@ mod tests {
             per_node_for(&["worker1"], resources),
         )
         .unwrap();
-        cm.record_sched_job_started();
+        cm.record_sched_cycle(0, 0, 1);
         assert_eq!(stats.snapshot().jobs_started, 1);
 
         cm.complete_job(job_id, 0, JobState::Completed).unwrap();

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -12,6 +12,7 @@ mod raft_server;
 mod rest;
 mod rpc_middleware;
 mod rpc_stats;
+mod sched_stats;
 mod scheduler_loop;
 mod server;
 
@@ -23,6 +24,7 @@ use tracing::info;
 
 use cluster::ClusterManager;
 use rpc_stats::RpcStatsCollector;
+use sched_stats::SchedStatsCollector;
 
 #[derive(Parser)]
 #[command(name = "spurctld", about = "Spur controller daemon (spurctld)")]
@@ -140,6 +142,9 @@ async fn main() -> anyhow::Result<()> {
     let raft_handle = Arc::new(handle);
     cluster.set_raft(raft_handle.raft.clone());
 
+    let sched_stats = Arc::new(SchedStatsCollector::new(config.scheduler.plugin.clone()));
+    cluster.set_sched_stats(sched_stats.clone());
+
     // Connect to accounting daemon (best-effort -- scheduling works without it)
     match accounting::AccountingNotifier::connect(&config.accounting.host).await {
         Ok(notifier) => {
@@ -202,12 +207,14 @@ async fn main() -> anyhow::Result<()> {
         let metrics_cluster = cluster.clone();
         let metrics_raft = raft_handle.clone();
         let metrics_rpc_stats = rpc_stats.clone();
+        let metrics_sched_stats = sched_stats.clone();
         tokio::spawn(async move {
             if let Err(e) = metrics_server::serve(
                 metrics_addr,
                 metrics_cluster,
                 metrics_raft,
                 metrics_rpc_stats,
+                metrics_sched_stats,
             )
             .await
             {
@@ -230,7 +237,7 @@ async fn main() -> anyhow::Result<()> {
     // Start gRPC server
     let addr = listen_addr.parse()?;
     info!(%addr, "gRPC server listening");
-    server::serve(addr, cluster, raft_handle, rpc_stats).await?;
+    server::serve(addr, cluster, raft_handle, rpc_stats, sched_stats).await?;
 
     sched_handle.abort();
     Ok(())

--- a/crates/spurctld/src/metrics_proto.rs
+++ b/crates/spurctld/src/metrics_proto.rs
@@ -8,9 +8,10 @@ use spur_core::node::NodeState;
 use spur_metrics::job::JobMetricsSnapshot;
 use spur_metrics::node::NodeMetricsSnapshot;
 use spur_metrics::RpcStatsSnapshot;
+use spur_metrics::SchedStatsSnapshot;
 use spur_proto::proto::{
     JobMetrics, JobStateCount, NodeMetrics, NodeMetricsEntry, NodeStateCount, RpcOperationStats,
-    RpcStats,
+    RpcStats, SchedStats,
 };
 
 pub fn rpc_stats_to_proto(snap: &RpcStatsSnapshot) -> RpcStats {
@@ -26,6 +27,23 @@ pub fn rpc_stats_to_proto(snap: &RpcStatsSnapshot) -> RpcStats {
         .collect();
 
     RpcStats { by_operation }
+}
+
+pub fn sched_stats_to_proto(snap: &SchedStatsSnapshot) -> SchedStats {
+    SchedStats {
+        plugin: snap.plugin.clone(),
+        cycles: snap.cycles,
+        cycle_total_time_us: snap.cycle_total_time_us,
+        cycle_last_time_us: snap.cycle_last_time_us,
+        cycle_avg_time_us: snap.cycle_avg_time_us(),
+        schedule_total_time_us: snap.schedule_total_time_us,
+        schedule_last_time_us: snap.schedule_last_time_us,
+        schedule_avg_time_us: snap.schedule_avg_time_us(),
+        jobs_submitted: snap.jobs_submitted,
+        jobs_started: snap.jobs_started,
+        jobs_completed: snap.jobs_completed,
+        jobs_started_last_cycle: snap.jobs_started_last_cycle,
+    }
 }
 
 pub fn job_metrics_to_proto(snap: &JobMetricsSnapshot) -> JobMetrics {
@@ -93,9 +111,10 @@ mod tests {
     use spur_metrics::export::jobs::{encode_job_metrics, job_state_metric_suffix};
     use spur_metrics::export::nodes::encode_nodes_metrics;
     use spur_metrics::export::rpc::encode_rpc_metrics;
+    use spur_metrics::export::scheduler::encode_scheduler_metrics;
     use spur_metrics::job::JobMetricsSnapshot;
     use spur_metrics::node::NodeMetricsSnapshot;
-    use spur_metrics::{RpcOperationSnapshot, RpcStatsSnapshot};
+    use spur_metrics::{RpcOperationSnapshot, RpcStatsSnapshot, SchedStatsSnapshot};
 
     use super::*;
 
@@ -273,5 +292,41 @@ mod tests {
                 .unwrap();
             assert_eq!(total, op.total_time_us);
         }
+    }
+
+    #[test]
+    fn sched_proto_matches_http_gauges() {
+        let snap = SchedStatsSnapshot {
+            plugin: "backfill".into(),
+            cycles: 10,
+            cycle_total_time_us: 5000,
+            cycle_last_time_us: 600,
+            schedule_total_time_us: 1500,
+            schedule_last_time_us: 200,
+            jobs_submitted: 42,
+            jobs_started: 30,
+            jobs_completed: 28,
+            jobs_started_last_cycle: 3,
+        };
+        let proto = sched_stats_to_proto(&snap);
+        let body = encode_scheduler_metrics(&snap);
+
+        assert_eq!(proto.cycles, gauge_value(&body, "spur_scheduler_cycles"));
+        assert_eq!(
+            proto.cycle_avg_time_us,
+            gauge_value(&body, "spur_scheduler_cycle_avg_time_us")
+        );
+        assert_eq!(
+            proto.schedule_avg_time_us,
+            gauge_value(&body, "spur_scheduler_schedule_avg_time_us")
+        );
+        assert_eq!(
+            proto.jobs_submitted,
+            gauge_value(&body, "spur_scheduler_jobs_submitted")
+        );
+        assert_eq!(
+            proto.jobs_started_last_cycle,
+            gauge_value(&body, "spur_scheduler_jobs_started_last_cycle")
+        );
     }
 }

--- a/crates/spurctld/src/metrics_proto.rs
+++ b/crates/spurctld/src/metrics_proto.rs
@@ -311,22 +311,42 @@ mod tests {
         let proto = sched_stats_to_proto(&snap);
         let body = encode_scheduler_metrics(&snap);
 
-        assert_eq!(proto.cycles, gauge_value(&body, "spur_scheduler_cycles"));
         assert_eq!(
-            proto.cycle_avg_time_us,
-            gauge_value(&body, "spur_scheduler_cycle_avg_time_us")
-        );
-        assert_eq!(
-            proto.schedule_avg_time_us,
-            gauge_value(&body, "spur_scheduler_schedule_avg_time_us")
+            proto.cycles,
+            gauge_value(&body, "spur_scheduler_cycles_total")
         );
         assert_eq!(
             proto.jobs_submitted,
-            gauge_value(&body, "spur_scheduler_jobs_submitted")
+            gauge_value(&body, "spur_scheduler_jobs_submitted_total")
+        );
+        assert_eq!(
+            proto.jobs_started,
+            gauge_value(&body, "spur_scheduler_jobs_started_total")
+        );
+        assert_eq!(
+            proto.jobs_finalized,
+            gauge_value(&body, "spur_scheduler_jobs_finalized_total")
         );
         assert_eq!(
             proto.jobs_started_last_cycle,
             gauge_value(&body, "spur_scheduler_jobs_started_last_cycle")
         );
+        assert_eq!(
+            proto.cycle_last_time_us,
+            gauge_value(&body, "spur_scheduler_cycle_last_time_us")
+        );
+        assert_eq!(
+            proto.cycle_total_time_us,
+            gauge_value(&body, "spur_scheduler_cycle_total_time_us")
+        );
+        assert_eq!(
+            proto.schedule_last_time_us,
+            gauge_value(&body, "spur_scheduler_schedule_last_time_us")
+        );
+        assert_eq!(
+            proto.schedule_total_time_us,
+            gauge_value(&body, "spur_scheduler_schedule_total_time_us")
+        );
+        assert!(!body.contains("_avg_time_us"));
     }
 }

--- a/crates/spurctld/src/metrics_proto.rs
+++ b/crates/spurctld/src/metrics_proto.rs
@@ -41,7 +41,7 @@ pub fn sched_stats_to_proto(snap: &SchedStatsSnapshot) -> SchedStats {
         schedule_avg_time_us: snap.schedule_avg_time_us(),
         jobs_submitted: snap.jobs_submitted,
         jobs_started: snap.jobs_started,
-        jobs_completed: snap.jobs_completed,
+        jobs_finalized: snap.jobs_finalized,
         jobs_started_last_cycle: snap.jobs_started_last_cycle,
     }
 }
@@ -305,7 +305,7 @@ mod tests {
             schedule_last_time_us: 200,
             jobs_submitted: 42,
             jobs_started: 30,
-            jobs_completed: 28,
+            jobs_finalized: 28,
             jobs_started_last_cycle: 3,
         };
         let proto = sched_stats_to_proto(&snap);

--- a/crates/spurctld/src/metrics_server.rs
+++ b/crates/spurctld/src/metrics_server.rs
@@ -20,11 +20,13 @@ use tracing::info;
 use crate::cluster::ClusterManager;
 use crate::raft::RaftHandle;
 use crate::rpc_stats::RpcStatsCollector;
+use crate::sched_stats::SchedStatsCollector;
 
 struct MetricsState {
     cluster: Arc<ClusterManager>,
     raft: Arc<RaftHandle>,
     rpc_stats: Arc<RpcStatsCollector>,
+    sched_stats: Arc<SchedStatsCollector>,
 }
 
 /// Start the metrics HTTP server. Runs until the listener is closed.
@@ -33,11 +35,13 @@ pub async fn serve(
     cluster: Arc<ClusterManager>,
     raft: Arc<RaftHandle>,
     rpc_stats: Arc<RpcStatsCollector>,
+    sched_stats: Arc<SchedStatsCollector>,
 ) -> anyhow::Result<()> {
     let state = Arc::new(MetricsState {
         cluster,
         raft,
         rpc_stats,
+        sched_stats,
     });
 
     let app = Router::new()
@@ -89,7 +93,7 @@ async fn metrics_scheduler(State(state): State<Arc<MetricsState>>) -> Response {
     if !state.raft.is_leader() {
         return not_leader_response();
     }
-    metrics_response(encode_scheduler_metrics())
+    metrics_response(encode_scheduler_metrics(&state.sched_stats.snapshot()))
 }
 
 async fn metrics_jobs_users_accts(State(state): State<Arc<MetricsState>>) -> Response {
@@ -132,6 +136,7 @@ mod tests {
 
     use crate::cluster::ClusterManager;
     use crate::rpc_stats::RpcStatsCollector;
+    use crate::sched_stats::SchedStatsCollector;
 
     fn test_config() -> SlurmConfig {
         SlurmConfig {
@@ -194,6 +199,7 @@ mod tests {
             cluster: cm,
             raft: Arc::new(handle),
             rpc_stats: Arc::new(RpcStatsCollector::new()),
+            sched_stats: Arc::new(SchedStatsCollector::new("backfill")),
         });
         let app = Router::new()
             .route("/metrics/jobs", get(metrics_jobs))
@@ -360,8 +366,11 @@ mod tests {
             cluster: cm,
             raft: follower,
             rpc_stats: Arc::new(RpcStatsCollector::new()),
+            sched_stats: Arc::new(SchedStatsCollector::new("backfill")),
         });
-        let resp = metrics_rpc(State(state)).await;
+        let resp = metrics_rpc(State(state.clone())).await;
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let resp = metrics_scheduler(State(state)).await;
         assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 

--- a/crates/spurctld/src/rpc_middleware.rs
+++ b/crates/spurctld/src/rpc_middleware.rs
@@ -84,9 +84,7 @@ fn should_record_operation(operation: &str) -> bool {
     !matches!(
         operation,
         "GetRpcStats"
-            | "ResetRpcStats"
             | "GetSchedStats"
-            | "ResetSchedStats"
             | "ResetDiagStats"
             | "GetJobMetrics"
             | "GetNodeMetrics"
@@ -121,9 +119,7 @@ mod tests {
         assert!(should_record_operation("SubmitJob"));
         assert!(should_record_operation("GetJobs"));
         assert!(!should_record_operation("GetRpcStats"));
-        assert!(!should_record_operation("ResetRpcStats"));
         assert!(!should_record_operation("GetSchedStats"));
-        assert!(!should_record_operation("ResetSchedStats"));
         assert!(!should_record_operation("ResetDiagStats"));
         assert!(!should_record_operation("GetJobMetrics"));
         assert!(!should_record_operation("GetNodeMetrics"));

--- a/crates/spurctld/src/rpc_middleware.rs
+++ b/crates/spurctld/src/rpc_middleware.rs
@@ -83,7 +83,14 @@ where
 fn should_record_operation(operation: &str) -> bool {
     !matches!(
         operation,
-        "GetRpcStats" | "ResetRpcStats" | "GetJobMetrics" | "GetNodeMetrics" | "Ping"
+        "GetRpcStats"
+            | "ResetRpcStats"
+            | "GetSchedStats"
+            | "ResetSchedStats"
+            | "ResetDiagStats"
+            | "GetJobMetrics"
+            | "GetNodeMetrics"
+            | "Ping"
     )
 }
 
@@ -115,6 +122,9 @@ mod tests {
         assert!(should_record_operation("GetJobs"));
         assert!(!should_record_operation("GetRpcStats"));
         assert!(!should_record_operation("ResetRpcStats"));
+        assert!(!should_record_operation("GetSchedStats"));
+        assert!(!should_record_operation("ResetSchedStats"));
+        assert!(!should_record_operation("ResetDiagStats"));
         assert!(!should_record_operation("GetJobMetrics"));
         assert!(!should_record_operation("GetNodeMetrics"));
         assert!(!should_record_operation("Ping"));

--- a/crates/spurctld/src/sched_stats.rs
+++ b/crates/spurctld/src/sched_stats.rs
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! In-memory accumulator for scheduler cycle and lifecycle statistics.
+
+use parking_lot::Mutex;
+use spur_metrics::SchedStatsSnapshot;
+
+/// Leader-side scheduler statistics since process start or the last reset.
+#[derive(Debug)]
+pub struct SchedStatsCollector {
+    plugin: String,
+    inner: Mutex<SchedAccum>,
+}
+
+#[derive(Debug, Default)]
+struct SchedAccum {
+    cycles: u64,
+    cycle_total_time_us: u64,
+    cycle_last_time_us: u64,
+    schedule_total_time_us: u64,
+    schedule_last_time_us: u64,
+    jobs_submitted: u64,
+    jobs_started: u64,
+    jobs_completed: u64,
+    jobs_started_last_cycle: u64,
+}
+
+impl SchedStatsCollector {
+    pub fn new(plugin: impl Into<String>) -> Self {
+        Self {
+            plugin: plugin.into(),
+            inner: Mutex::new(SchedAccum::default()),
+        }
+    }
+
+    pub fn record_cycle(&self, cycle_time_us: u64, schedule_time_us: u64, jobs_started: u64) {
+        let mut accum = self.inner.lock();
+        accum.cycles += 1;
+        accum.cycle_total_time_us = accum.cycle_total_time_us.saturating_add(cycle_time_us);
+        accum.cycle_last_time_us = cycle_time_us;
+        accum.schedule_total_time_us = accum
+            .schedule_total_time_us
+            .saturating_add(schedule_time_us);
+        accum.schedule_last_time_us = schedule_time_us;
+        accum.jobs_started_last_cycle = jobs_started;
+    }
+
+    pub fn record_submitted(&self, count: u64) {
+        if count > 0 {
+            let mut accum = self.inner.lock();
+            accum.jobs_submitted = accum.jobs_submitted.saturating_add(count);
+        }
+    }
+
+    pub fn record_started(&self) {
+        self.inner.lock().jobs_started += 1;
+    }
+
+    pub fn record_completed(&self) {
+        self.inner.lock().jobs_completed += 1;
+    }
+
+    pub fn snapshot(&self) -> SchedStatsSnapshot {
+        let accum = self.inner.lock();
+        SchedStatsSnapshot {
+            plugin: self.plugin.clone(),
+            cycles: accum.cycles,
+            cycle_total_time_us: accum.cycle_total_time_us,
+            cycle_last_time_us: accum.cycle_last_time_us,
+            schedule_total_time_us: accum.schedule_total_time_us,
+            schedule_last_time_us: accum.schedule_last_time_us,
+            jobs_submitted: accum.jobs_submitted,
+            jobs_started: accum.jobs_started,
+            jobs_completed: accum.jobs_completed,
+            jobs_started_last_cycle: accum.jobs_started_last_cycle,
+        }
+    }
+
+    pub fn reset(&self) {
+        *self.inner.lock() = SchedAccum::default();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_cycle_accumulates_timing() {
+        let stats = SchedStatsCollector::new("backfill");
+        stats.record_cycle(1000, 200, 2);
+        stats.record_cycle(500, 100, 1);
+
+        let snap = stats.snapshot();
+        assert_eq!(snap.plugin, "backfill");
+        assert_eq!(snap.cycles, 2);
+        assert_eq!(snap.cycle_total_time_us, 1500);
+        assert_eq!(snap.cycle_last_time_us, 500);
+        assert_eq!(snap.cycle_avg_time_us(), 750);
+        assert_eq!(snap.schedule_total_time_us, 300);
+        assert_eq!(snap.schedule_last_time_us, 100);
+        assert_eq!(snap.schedule_avg_time_us(), 150);
+        assert_eq!(snap.jobs_started_last_cycle, 1);
+    }
+
+    #[test]
+    fn lifecycle_counters_accumulate() {
+        let stats = SchedStatsCollector::new("backfill");
+        stats.record_submitted(3);
+        stats.record_started();
+        stats.record_started();
+        stats.record_completed();
+
+        let snap = stats.snapshot();
+        assert_eq!(snap.jobs_submitted, 3);
+        assert_eq!(snap.jobs_started, 2);
+        assert_eq!(snap.jobs_completed, 1);
+    }
+
+    #[test]
+    fn reset_clears_accumulators() {
+        let stats = SchedStatsCollector::new("backfill");
+        stats.record_cycle(100, 50, 1);
+        stats.record_submitted(1);
+        stats.reset();
+        let snap = stats.snapshot();
+        assert_eq!(snap.cycles, 0);
+        assert_eq!(snap.jobs_submitted, 0);
+        assert_eq!(snap.plugin, "backfill");
+    }
+}

--- a/crates/spurctld/src/sched_stats.rs
+++ b/crates/spurctld/src/sched_stats.rs
@@ -3,40 +3,45 @@
 
 //! In-memory accumulator for scheduler cycle and lifecycle statistics.
 
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use parking_lot::Mutex;
 use spur_metrics::SchedStatsSnapshot;
 
-/// Leader-side scheduler statistics since process start or the last reset.
-#[derive(Debug)]
-pub struct SchedStatsCollector {
-    plugin: String,
-    inner: Mutex<SchedAccum>,
-}
-
 #[derive(Debug, Default)]
-struct SchedAccum {
+struct CycleAccum {
     cycles: u64,
     cycle_total_time_us: u64,
     cycle_last_time_us: u64,
     schedule_total_time_us: u64,
     schedule_last_time_us: u64,
-    jobs_submitted: u64,
-    jobs_started: u64,
-    jobs_finalized: u64,
     jobs_started_last_cycle: u64,
+}
+
+/// Leader-side scheduler statistics since process start or the last reset.
+#[derive(Debug)]
+pub struct SchedStatsCollector {
+    plugin: String,
+    cycle: Mutex<CycleAccum>,
+    jobs_submitted: AtomicU64,
+    jobs_started: AtomicU64,
+    jobs_finalized: AtomicU64,
 }
 
 impl SchedStatsCollector {
     pub fn new(plugin: impl Into<String>) -> Self {
         Self {
             plugin: plugin.into(),
-            inner: Mutex::new(SchedAccum::default()),
+            cycle: Mutex::new(CycleAccum::default()),
+            jobs_submitted: AtomicU64::new(0),
+            jobs_started: AtomicU64::new(0),
+            jobs_finalized: AtomicU64::new(0),
         }
     }
 
     pub fn record_cycle(&self, cycle_time_us: u64, schedule_time_us: u64, jobs_started: u64) {
-        let mut accum = self.inner.lock();
-        accum.cycles += 1;
+        let mut accum = self.cycle.lock();
+        accum.cycles = accum.cycles.saturating_add(1);
         accum.cycle_total_time_us = accum.cycle_total_time_us.saturating_add(cycle_time_us);
         accum.cycle_last_time_us = cycle_time_us;
         accum.schedule_total_time_us = accum
@@ -44,27 +49,24 @@ impl SchedStatsCollector {
             .saturating_add(schedule_time_us);
         accum.schedule_last_time_us = schedule_time_us;
         accum.jobs_started_last_cycle = jobs_started;
+        drop(accum);
+        if jobs_started > 0 {
+            self.jobs_started.fetch_add(jobs_started, Ordering::Relaxed);
+        }
     }
 
     pub fn record_submitted(&self, count: u64) {
         if count > 0 {
-            let mut accum = self.inner.lock();
-            accum.jobs_submitted = accum.jobs_submitted.saturating_add(count);
+            self.jobs_submitted.fetch_add(count, Ordering::Relaxed);
         }
     }
 
-    pub fn record_started(&self) {
-        let mut accum = self.inner.lock();
-        accum.jobs_started = accum.jobs_started.saturating_add(1);
-    }
-
     pub fn record_finalized(&self) {
-        let mut accum = self.inner.lock();
-        accum.jobs_finalized = accum.jobs_finalized.saturating_add(1);
+        self.jobs_finalized.fetch_add(1, Ordering::Relaxed);
     }
 
     pub fn snapshot(&self) -> SchedStatsSnapshot {
-        let accum = self.inner.lock();
+        let accum = self.cycle.lock();
         SchedStatsSnapshot {
             plugin: self.plugin.clone(),
             cycles: accum.cycles,
@@ -72,15 +74,18 @@ impl SchedStatsCollector {
             cycle_last_time_us: accum.cycle_last_time_us,
             schedule_total_time_us: accum.schedule_total_time_us,
             schedule_last_time_us: accum.schedule_last_time_us,
-            jobs_submitted: accum.jobs_submitted,
-            jobs_started: accum.jobs_started,
-            jobs_finalized: accum.jobs_finalized,
+            jobs_submitted: self.jobs_submitted.load(Ordering::Relaxed),
+            jobs_started: self.jobs_started.load(Ordering::Relaxed),
+            jobs_finalized: self.jobs_finalized.load(Ordering::Relaxed),
             jobs_started_last_cycle: accum.jobs_started_last_cycle,
         }
     }
 
     pub fn reset(&self) {
-        *self.inner.lock() = SchedAccum::default();
+        *self.cycle.lock() = CycleAccum::default();
+        self.jobs_submitted.store(0, Ordering::Relaxed);
+        self.jobs_started.store(0, Ordering::Relaxed);
+        self.jobs_finalized.store(0, Ordering::Relaxed);
     }
 }
 
@@ -89,7 +94,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn record_cycle_accumulates_timing() {
+    fn record_cycle_accumulates_timing_and_started_jobs() {
         let stats = SchedStatsCollector::new("backfill");
         stats.record_cycle(1000, 200, 2);
         stats.record_cycle(500, 100, 1);
@@ -103,6 +108,7 @@ mod tests {
         assert_eq!(snap.schedule_total_time_us, 300);
         assert_eq!(snap.schedule_last_time_us, 100);
         assert_eq!(snap.schedule_avg_time_us(), 150);
+        assert_eq!(snap.jobs_started, 3);
         assert_eq!(snap.jobs_started_last_cycle, 1);
     }
 
@@ -110,8 +116,7 @@ mod tests {
     fn lifecycle_counters_accumulate() {
         let stats = SchedStatsCollector::new("backfill");
         stats.record_submitted(3);
-        stats.record_started();
-        stats.record_started();
+        stats.record_cycle(0, 0, 2);
         stats.record_finalized();
 
         let snap = stats.snapshot();
@@ -129,6 +134,7 @@ mod tests {
         let snap = stats.snapshot();
         assert_eq!(snap.cycles, 0);
         assert_eq!(snap.jobs_submitted, 0);
+        assert_eq!(snap.jobs_started, 0);
         assert_eq!(snap.plugin, "backfill");
     }
 }

--- a/crates/spurctld/src/sched_stats.rs
+++ b/crates/spurctld/src/sched_stats.rs
@@ -22,7 +22,7 @@ struct SchedAccum {
     schedule_last_time_us: u64,
     jobs_submitted: u64,
     jobs_started: u64,
-    jobs_completed: u64,
+    jobs_finalized: u64,
     jobs_started_last_cycle: u64,
 }
 
@@ -54,11 +54,13 @@ impl SchedStatsCollector {
     }
 
     pub fn record_started(&self) {
-        self.inner.lock().jobs_started += 1;
+        let mut accum = self.inner.lock();
+        accum.jobs_started = accum.jobs_started.saturating_add(1);
     }
 
-    pub fn record_completed(&self) {
-        self.inner.lock().jobs_completed += 1;
+    pub fn record_finalized(&self) {
+        let mut accum = self.inner.lock();
+        accum.jobs_finalized = accum.jobs_finalized.saturating_add(1);
     }
 
     pub fn snapshot(&self) -> SchedStatsSnapshot {
@@ -72,7 +74,7 @@ impl SchedStatsCollector {
             schedule_last_time_us: accum.schedule_last_time_us,
             jobs_submitted: accum.jobs_submitted,
             jobs_started: accum.jobs_started,
-            jobs_completed: accum.jobs_completed,
+            jobs_finalized: accum.jobs_finalized,
             jobs_started_last_cycle: accum.jobs_started_last_cycle,
         }
     }
@@ -110,12 +112,12 @@ mod tests {
         stats.record_submitted(3);
         stats.record_started();
         stats.record_started();
-        stats.record_completed();
+        stats.record_finalized();
 
         let snap = stats.snapshot();
         assert_eq!(snap.jobs_submitted, 3);
         assert_eq!(snap.jobs_started, 2);
-        assert_eq!(snap.jobs_completed, 1);
+        assert_eq!(snap.jobs_finalized, 1);
     }
 
     #[test]

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::time::Instant;
 
 use chrono::Utc;
 use tracing::{debug, error, info, warn};
@@ -124,6 +125,8 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
             continue;
         }
 
+        let cycle_start = Instant::now();
+
         let cluster_state = ClusterState {
             nodes: &nodes,
             partitions: &partitions,
@@ -134,6 +137,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
         // Catch panics in the scheduler so that a single bad job doesn't kill
         // the entire scheduling loop (issue #56).
         let sched_ref = &mut scheduler;
+        let schedule_start = Instant::now();
         let assignments = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             sched_ref.schedule(&pending, &cluster_state)
         })) {
@@ -146,9 +150,14 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
                         .or_else(|| e.downcast_ref::<&str>().copied())
                         .unwrap_or("unknown")
                 );
+                let cycle_time_us = cycle_start.elapsed().as_micros().min(u64::MAX as u128) as u64;
+                let schedule_time_us =
+                    schedule_start.elapsed().as_micros().min(u64::MAX as u128) as u64;
+                cluster.record_sched_cycle(cycle_time_us, schedule_time_us, 0);
                 continue;
             }
         };
+        let schedule_time_us = schedule_start.elapsed().as_micros().min(u64::MAX as u128) as u64;
 
         // Preemption: if high-priority jobs couldn't be scheduled,
         // cancel lower-priority running jobs to free resources.
@@ -178,6 +187,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
             }
         }
 
+        let mut jobs_started_cycle = 0u64;
         for assignment in assignments {
             let job = match cluster.get_job(assignment.job_id) {
                 Some(j) => j,
@@ -234,6 +244,9 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
                     continue;
                 }
             }
+
+            cluster.record_sched_job_started();
+            jobs_started_cycle += 1;
 
             // Dispatch job to ALL assigned nodes
             let job_id = assignment.job_id;
@@ -343,6 +356,9 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
                 }
             });
         }
+
+        let cycle_time_us = cycle_start.elapsed().as_micros().min(u64::MAX as u128) as u64;
+        cluster.record_sched_cycle(cycle_time_us, schedule_time_us, jobs_started_cycle);
     }
 }
 

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -245,7 +245,6 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
                 }
             }
 
-            cluster.record_sched_job_started();
             jobs_started_cycle += 1;
 
             // Dispatch job to ALL assigned nodes

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -21,6 +21,7 @@ use crate::cluster::ClusterManager;
 use crate::raft::RaftHandle;
 use crate::rpc_middleware::RpcStatsLayer;
 use crate::rpc_stats::RpcStatsCollector;
+use crate::sched_stats::SchedStatsCollector;
 
 const FORWARDED_HEADER: &str = "x-spur-forwarded";
 const LEADER_HEADER: &str = "x-spur-leader";
@@ -32,6 +33,7 @@ pub struct ControllerService {
     /// Node ID → client API address (host:6817) for the x-spur-leader header.
     client_addrs: BTreeMap<u64, String>,
     rpc_stats: Arc<RpcStatsCollector>,
+    sched_stats: Arc<SchedStatsCollector>,
 }
 
 struct LeaderProxy {
@@ -603,6 +605,53 @@ impl SlurmController for ControllerService {
         }
 
         self.rpc_stats.reset();
+        Ok(Response::new(()))
+    }
+
+    async fn get_sched_stats(&self, request: Request<()>) -> Result<Response<SchedStats>, Status> {
+        if self.check_leader(&request).is_err() {
+            {
+                let proxy = &self.leader_proxy;
+                let mut client = proxy.get_leader_client().await?;
+                let mut fwd = Request::new(());
+                *fwd.metadata_mut() = Self::forwarded_metadata();
+                return client.get_sched_stats(fwd).await;
+            }
+        }
+
+        Ok(Response::new(crate::metrics_proto::sched_stats_to_proto(
+            &self.sched_stats.snapshot(),
+        )))
+    }
+
+    async fn reset_sched_stats(&self, request: Request<()>) -> Result<Response<()>, Status> {
+        if self.check_leader(&request).is_err() {
+            {
+                let proxy = &self.leader_proxy;
+                let mut client = proxy.get_leader_client().await?;
+                let mut fwd = Request::new(());
+                *fwd.metadata_mut() = Self::forwarded_metadata();
+                return client.reset_sched_stats(fwd).await;
+            }
+        }
+
+        self.sched_stats.reset();
+        Ok(Response::new(()))
+    }
+
+    async fn reset_diag_stats(&self, request: Request<()>) -> Result<Response<()>, Status> {
+        if self.check_leader(&request).is_err() {
+            {
+                let proxy = &self.leader_proxy;
+                let mut client = proxy.get_leader_client().await?;
+                let mut fwd = Request::new(());
+                *fwd.metadata_mut() = Self::forwarded_metadata();
+                return client.reset_diag_stats(fwd).await;
+            }
+        }
+
+        self.rpc_stats.reset();
+        self.sched_stats.reset();
         Ok(Response::new(()))
     }
 
@@ -1281,6 +1330,7 @@ pub async fn serve(
     cluster: Arc<ClusterManager>,
     raft_handle: Arc<RaftHandle>,
     rpc_stats: Arc<RpcStatsCollector>,
+    sched_stats: Arc<SchedStatsCollector>,
 ) -> anyhow::Result<()> {
     let client_addrs: BTreeMap<u64, String> = raft_handle
         .peers
@@ -1303,6 +1353,7 @@ pub async fn serve(
         raft: raft_handle.clone(),
         leader_proxy,
         rpc_stats: rpc_stats.clone(),
+        sched_stats: sched_stats.clone(),
     };
 
     let stats_layer = RpcStatsLayer::new(rpc_stats, raft_handle);

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -593,21 +593,6 @@ impl SlurmController for ControllerService {
         )))
     }
 
-    async fn reset_rpc_stats(&self, request: Request<()>) -> Result<Response<()>, Status> {
-        if self.check_leader(&request).is_err() {
-            {
-                let proxy = &self.leader_proxy;
-                let mut client = proxy.get_leader_client().await?;
-                let mut fwd = Request::new(());
-                *fwd.metadata_mut() = Self::forwarded_metadata();
-                return client.reset_rpc_stats(fwd).await;
-            }
-        }
-
-        self.rpc_stats.reset();
-        Ok(Response::new(()))
-    }
-
     async fn get_sched_stats(&self, request: Request<()>) -> Result<Response<SchedStats>, Status> {
         if self.check_leader(&request).is_err() {
             {
@@ -622,21 +607,6 @@ impl SlurmController for ControllerService {
         Ok(Response::new(crate::metrics_proto::sched_stats_to_proto(
             &self.sched_stats.snapshot(),
         )))
-    }
-
-    async fn reset_sched_stats(&self, request: Request<()>) -> Result<Response<()>, Status> {
-        if self.check_leader(&request).is_err() {
-            {
-                let proxy = &self.leader_proxy;
-                let mut client = proxy.get_leader_client().await?;
-                let mut fwd = Request::new(());
-                *fwd.metadata_mut() = Self::forwarded_metadata();
-                return client.reset_sched_stats(fwd).await;
-            }
-        }
-
-        self.sched_stats.reset();
-        Ok(Response::new(()))
     }
 
     async fn reset_diag_stats(&self, request: Request<()>) -> Result<Response<()>, Status> {

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -518,7 +518,7 @@ message SchedStats {
   uint64 schedule_avg_time_us = 8;
   uint64 jobs_submitted = 9;
   uint64 jobs_started = 10;
-  uint64 jobs_completed = 11;
+  uint64 jobs_finalized = 11;
   uint64 jobs_started_last_cycle = 12;
 }
 

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -285,6 +285,11 @@ service SlurmController {
   rpc GetRpcStats(google.protobuf.Empty) returns (RpcStats);
   rpc ResetRpcStats(google.protobuf.Empty) returns (google.protobuf.Empty);
 
+  // Scheduler cycle and lifecycle statistics (since process start or last reset)
+  rpc GetSchedStats(google.protobuf.Empty) returns (SchedStats);
+  rpc ResetSchedStats(google.protobuf.Empty) returns (google.protobuf.Empty);
+  rpc ResetDiagStats(google.protobuf.Empty) returns (google.protobuf.Empty);
+
   // Agent registration
   rpc RegisterAgent(RegisterAgentRequest) returns (RegisterAgentResponse);
   rpc Heartbeat(HeartbeatRequest) returns (HeartbeatResponse);
@@ -500,6 +505,21 @@ message RpcOperationStats {
 
 message RpcStats {
   repeated RpcOperationStats by_operation = 1;
+}
+
+message SchedStats {
+  string plugin = 1;
+  uint64 cycles = 2;
+  uint64 cycle_total_time_us = 3;
+  uint64 cycle_last_time_us = 4;
+  uint64 cycle_avg_time_us = 5;
+  uint64 schedule_total_time_us = 6;
+  uint64 schedule_last_time_us = 7;
+  uint64 schedule_avg_time_us = 8;
+  uint64 jobs_submitted = 9;
+  uint64 jobs_started = 10;
+  uint64 jobs_completed = 11;
+  uint64 jobs_started_last_cycle = 12;
 }
 
 message RegisterAgentRequest {

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -283,12 +283,10 @@ service SlurmController {
 
   // Controller RPC handler statistics (since process start or last reset)
   rpc GetRpcStats(google.protobuf.Empty) returns (RpcStats);
-  rpc ResetRpcStats(google.protobuf.Empty) returns (google.protobuf.Empty);
+  rpc ResetDiagStats(google.protobuf.Empty) returns (google.protobuf.Empty);
 
   // Scheduler cycle and lifecycle statistics (since process start or last reset)
   rpc GetSchedStats(google.protobuf.Empty) returns (SchedStats);
-  rpc ResetSchedStats(google.protobuf.Empty) returns (google.protobuf.Empty);
-  rpc ResetDiagStats(google.protobuf.Empty) returns (google.protobuf.Empty);
 
   // Agent registration
   rpc RegisterAgent(RegisterAgentRequest) returns (RegisterAgentResponse);


### PR DESCRIPTION
## Summary

- Add `SchedStatsCollector` as the single in-memory accumulator for scheduler metrics on the Raft leader: cycle wall time, `Scheduler::schedule()` time, and jobs submitted/started/completed since reset.
- Wire export through three read paths: `GET /metrics/scheduler`, `GetSchedStats` gRPC, and the `sdiag` scheduler block (matching the existing job/node/RPC metrics pattern).
- Add `ResetDiagStats` so `sdiag --reset` clears RPC and scheduler counters in one leader-side call.

## Approach

- **Cycle timing** is recorded in `scheduler_loop` when the leader runs a scheduling pass with pending work. Panic paths still record a cycle with zero starts.
- **Lifecycle counters** hook into `cluster`: submit after all array tasks propose, start after prolog succeeds, complete in `run_job_finalized_side_effects` so all terminal paths are counted.
- **HTTP encoding** lives in `spur-metrics`; spurctld holds the collector and converts snapshots for gRPC. Diagnostic RPCs are excluded from RPC timing middleware.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --exclude spur-ffi --all-targets --locked`
- [x] `cargo test --locked`
- [x] Golden fixture for `/metrics/scheduler` (`scheduler_export_golden`)
- [x] `metrics_proto` parity test (HTTP gauges vs gRPC `SchedStats`)
- [x] `sched_stats_track_submit_start_complete` cluster integration test
- [x] Follower 503 test for `/metrics/scheduler`