### PR TITLE
chore(deps): bump anyhow to 1.0.103 for RUSTSEC-2026-0190

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arraydeque"


### PR DESCRIPTION
## Summary

`cargo deny check` fails on `anyhow 1.0.102`, flagged by RUSTSEC-2026-0190 (unsound). Bumps `anyhow` to `1.0.103`, which is the patched release.

The advisory covers UB under Stacked Borrows: affected versions violate borrow rules when context is added to an error via `Error::context` and `Error::downcast_mut` is later called on the returned error. Fixed upstream in `6e8c000`.

Only `Cargo.lock` changes; the `^1` constraint in `Cargo.toml` already permits `1.0.103`.

Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0190

## Test plan

- [x] `cargo build` (full workspace, clean)
- [x] `cargo deny check` passes (advisories no longer fails)