### PR TITLE
fix(spurd): stage job scripts in /tmp to fix Permission denied for non-root users

### DIFF
--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -43,6 +43,8 @@ struct TrackedJob {
     cpus: u32,
     memory_mb: u64,
     nodelist: String,
+    /// Temp directory holding the staged job script; removed after job exits.
+    script_dir: std::path::PathBuf,
 }
 
 struct CompletedJob {
@@ -60,6 +62,7 @@ struct CompletedJob {
     cpus: u32,
     memory_mb: u64,
     nodelist: String,
+    script_dir: std::path::PathBuf,
 }
 
 pub struct AgentService {
@@ -184,6 +187,7 @@ impl AgentService {
                                 cpus: tracked.cpus,
                                 memory_mb: tracked.memory_mb,
                                 nodelist: tracked.nodelist.clone(),
+                                script_dir: tracked.script_dir.clone(),
                             });
                         }
                         Ok(None) => {}
@@ -196,6 +200,7 @@ impl AgentService {
                 for c in &completed {
                     jobs.remove(&c.job_id);
                     crate::container::cleanup_rootfs(c.job_id, &c.rootfs_mode);
+                    executor::cleanup_script_dir(&c.script_dir);
                     if let Some(ref cgroup) = c.cgroup {
                         crate::executor::cleanup_cgroup(cgroup);
                     }
@@ -662,8 +667,14 @@ impl SlurmAgent for AgentService {
         // wrapper shell). GPU devices are partitioned across tasks via
         // ROCR_VISIBLE_DEVICES / CUDA_VISIBLE_DEVICES overrides in each fork.
         let launch_script = if tasks_per_node > 1 {
-            // Write the user script to disk first so the wrapper can reference it
-            let user_script_path = format!("{}/.spur_user_{}.sh", work_dir, job_id);
+            // Dir may already exist (container path above); create_dir_all is safe — root-owned.
+            let staging_dir = std::env::temp_dir().join(format!(".spur_job_{}", job_id));
+            std::fs::create_dir_all(&staging_dir)
+                .map_err(|e| Status::internal(format!("failed to create staging dir: {}", e)))?;
+            let user_script_path = staging_dir
+                .join(format!(".spur_user_{}.sh", job_id))
+                .to_string_lossy()
+                .into_owned();
             std::fs::write(&user_script_path, &launch_script)
                 .map_err(|e| Status::internal(format!("failed to write user script: {}", e)))?;
             #[cfg(unix)]
@@ -801,6 +812,7 @@ impl SlurmAgent for AgentService {
                         cpus: launch_cfg.cpus,
                         memory_mb: launch_cfg.memory_mb,
                         nodelist: launch_cfg.nodelist,
+                        script_dir: result.script_dir,
                     },
                 );
                 Ok(Response::new(LaunchJobResponse {
@@ -1520,6 +1532,7 @@ impl TrackedJob {
             cpus: 1,
             memory_mb: 0,
             nodelist: String::new(),
+            script_dir: std::path::PathBuf::new(),
         }
     }
 }
@@ -1878,6 +1891,7 @@ mod tests {
             cpus: 1,
             memory_mb: 0,
             nodelist: String::new(),
+            script_dir: std::path::PathBuf::new(),
         };
         svc.insert_test_job(job_id, tracked).await;
 

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -78,6 +78,8 @@ pub struct LaunchResult {
     pub job: RunningJob,
     pub stdout_path: String,
     pub stderr_path: String,
+    /// Root-owned temp dir holding staged job scripts; caller removes via [`cleanup_script_dir`].
+    pub script_dir: PathBuf,
 }
 
 /// A running job process — either a tokio-managed child or a raw-forked container.
@@ -289,19 +291,9 @@ async fn spawn_job_process(
     };
     let script = script.as_str();
 
-    // Write script to temp file
-    let script_path = PathBuf::from(work_dir).join(format!(".spur_job_{}.sh", job_id));
-    tokio::fs::write(&script_path, script)
-        .await
-        .context("failed to write job script")?;
-
-    // Make executable
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o755);
-        std::fs::set_permissions(&script_path, perms)?;
-    }
+    // Stage to /tmp: work_dir may be /root (700) or NFS root_squash, both unreadable
+    // by the non-root executing user. /tmp sticky bit prevents TOCTOU substitution.
+    let (script_dir, script_path) = stage_script(job_id, script)?;
 
     // Resolve stdout/stderr paths
     let stdout_resolved = resolve_output_path(stdout_path, job_id, work_dir);
@@ -377,6 +369,7 @@ async fn spawn_job_process(
             job,
             stdout_path: stdout_resolved,
             stderr_path: stderr_resolved,
+            script_dir,
         });
     }
 
@@ -385,7 +378,7 @@ async fn spawn_job_process(
     // Issue #99: If root, wrap job with namespace isolation.
     let use_namespaces = nix::unistd::geteuid().is_root();
     let (launch_cmd, launch_args) = if use_namespaces {
-        let wrapper_path = PathBuf::from(work_dir).join(format!(".spur_ns_{}.sh", job_id));
+        let wrapper_path = script_dir.join(format!(".spur_ns_{}.sh", job_id));
         let visible_devices = cfg
             .host_device_plan
             .as_ref()
@@ -535,6 +528,7 @@ async fn spawn_job_process(
         job: RunningJob::Managed { child, cgroup_path },
         stdout_path: stdout_resolved,
         stderr_path: stderr_resolved,
+        script_dir,
     })
 }
 
@@ -1014,9 +1008,57 @@ fn wrap_with_burst_buffer(script: &str, bb: &str) -> String {
     wrapper
 }
 
+/// Stage a job script into a root-owned temp dir under `/tmp`.
+/// Returns `(dir_path, script_path)`; caller removes via [`cleanup_script_dir`].
+pub fn stage_script(job_id: JobId, script: &str) -> anyhow::Result<(PathBuf, PathBuf)> {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = std::env::temp_dir().join(format!(".spur_job_{}", job_id));
+    // O_EXCL: fail if an attacker pre-created the path. AlreadyExists is allowed
+    // only when agent_server legitimately pre-created it (container/multi-task).
+    std::fs::create_dir(&dir)
+        .or_else(|e| {
+            if e.kind() == std::io::ErrorKind::AlreadyExists {
+                Ok(())
+            } else {
+                Err(e)
+            }
+        })
+        .context("failed to create script staging dir")?;
+    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755))?;
+    let script_path = dir.join("script.sh");
+    std::fs::write(&script_path, script).context("failed to write job script")?;
+    std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))?;
+    Ok((dir, script_path))
+}
+
+/// Remove the temp directory created by [`stage_script`]. Best-effort: logs a
+/// warning on failure so cleanup never obscures job exit status.
+pub fn cleanup_script_dir(dir: &Path) {
+    if let Err(e) = std::fs::remove_dir_all(dir) {
+        warn!(path = %dir.display(), error = %e, "failed to clean up script staging dir");
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn stage_script_not_under_restricted_work_dir() {
+        use std::os::unix::fs::PermissionsExt;
+        let job_id: JobId = 99991;
+        let (dir, script_path) = stage_script(job_id, "#!/bin/bash\necho hi\n")
+            .expect("stage_script should succeed");
+        let tmp = std::env::temp_dir();
+        assert!(script_path.starts_with(&tmp), "script should be under /tmp, got {}", script_path.display());
+        let dir_mode = std::fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(dir_mode, 0o755);
+        let file_mode = std::fs::metadata(&script_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(file_mode, 0o755);
+        cleanup_script_dir(&dir);
+        assert!(!dir.exists());
+    }
+
 
     #[test]
     fn decode_wait_status_splits_exit_and_signal() {


### PR DESCRIPTION
## What

Non-root batch jobs failed immediately with:

```
/bin/bash: /root/.spur_job_<jobid>.sh: Permission denied
```

`spurd` runs as root and staged the job script in `{work_dir}/`, then launched the job as the submitting user. When `work_dir` was `/root` (mode 700) or an NFS mount with `root_squash`, the non-root user could not read the script.

## Approach

Stage all job scripts (main, namespace wrapper, container inner script, multi-task user script) in `/tmp/.spur_job_{id}/` — a root-owned directory with mode `0o755`. The job process's working directory (`work_dir`) is unchanged.

Key details:
- **TOCTOU**: first dir creation uses `create_dir` (O_EXCL) — fails atomically if an attacker pre-created the path.
- **Cleanup**: `script_dir` is tracked on `TrackedJob` and removed after every exit path, including graceful cancel (SIGTERM) and force-kill (SIGKILL).
- **NFS**: scripts now live on local `/tmp`, so `root_squash` has no effect.

## Testing

- Unit test: verifies `stage_script` places scripts under `/tmp`, not under a restricted dir; checks mode `0o755` on both dir and file; verifies cleanup.
- Live tested on a running cluster: job ran as `uid=1000(vm)`, output correct, no Permission denied; `/tmp/.spur_job_*` dirs cleaned up after job completion.

Fixes #364