### PR TITLE
fix(spurctld): persist last_purged to survive restart after log compaction

### DIFF
--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -127,15 +127,17 @@ impl SpurStore {
             }
         }
 
+        let mut snapshot_last_log_id: Option<LogId<NodeId>> = None;
         let snap_path = raft_dir.join("snapshot.json");
         if snap_path.exists() {
             // Soft-fail: a corrupt snapshot triggers re-snapshot on the next leader term.
-            // A missing/corrupt purged.json (below) cannot be recovered the same way.
+            // A present-but-corrupt purged.json (below) cannot be recovered the same way.
             match std::fs::read_to_string(&snap_path) {
                 Ok(data) => match serde_json::from_str::<PersistedSnapshot>(&data) {
                     Ok(ps) => {
                         inner.last_applied = ps.meta.last_log_id;
                         inner.last_membership = ps.meta.last_membership.clone();
+                        snapshot_last_log_id = ps.meta.last_log_id;
                         applier.restore_from_snapshot(&ps.data);
                     }
                     Err(e) => warn!("failed to parse snapshot.json: {e}"),
@@ -152,6 +154,18 @@ impl SpurStore {
                 serde_json::from_str::<LogId<NodeId>>(&data)
                     .map_err(|e| anyhow::anyhow!("failed to parse purged.json: {e}"))?,
             );
+        } else if let Some(snap_last) = snapshot_last_log_id {
+            // Backward compat: a node that compacted its log before purged.json
+            // existed has a snapshot but no purged.json. openraft purges up to the
+            // snapshot's last_log_id when it compacts, so that id is the correct
+            // last_purged lower bound. Without this, such a node recovers with
+            // last_purged=None and reproduces the startup panic the moment openraft
+            // reads a purged log range.
+            warn!(
+                last_purged = ?snap_last,
+                "purged.json missing; deriving last_purged from snapshot meta (pre-patch compat)"
+            );
+            inner.last_purged = Some(snap_last);
         }
 
         info!(
@@ -910,5 +924,38 @@ mod tests {
         let store = SpurStore::new(dir.path(), noop_applier()).unwrap();
         let inner = store.inner.read();
         assert!(inner.last_purged.is_none());
+    }
+
+    // A node that compacted its log before purged.json existed has a snapshot
+    // but no purged.json. Recovery must derive last_purged from the snapshot
+    // meta rather than defaulting to None (which reproduces the startup panic).
+    #[tokio::test]
+    async fn store_derives_last_purged_from_snapshot_when_purged_file_absent() {
+        use openraft::RaftStorage;
+        let dir = TempDir::new().unwrap();
+
+        let snap_last = LogId {
+            leader_id: openraft::LeaderId {
+                term: 3,
+                node_id: 1,
+            },
+            index: 100,
+        };
+
+        // Write a snapshot but no purged.json, mirroring a pre-patch compacted node.
+        {
+            let store = SpurStore::new(dir.path(), noop_applier()).unwrap();
+            let meta = SnapshotMeta {
+                last_log_id: Some(snap_last),
+                last_membership: StoredMembership::default(),
+                snapshot_id: "snap-100".into(),
+            };
+            store.persist_snapshot(&meta, b"snapshot data").unwrap();
+        }
+        assert!(!dir.path().join("raft").join("purged.json").exists());
+
+        let mut store = Arc::new(SpurStore::new(dir.path(), noop_applier()).unwrap());
+        let state = store.get_log_state().await.unwrap();
+        assert_eq!(state.last_purged_log_id, Some(snap_last));
     }
 }

--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -129,6 +129,8 @@ impl SpurStore {
 
         let snap_path = raft_dir.join("snapshot.json");
         if snap_path.exists() {
+            // Soft-fail: a corrupt snapshot triggers re-snapshot on the next leader term.
+            // A missing/corrupt purged.json (below) cannot be recovered the same way.
             match std::fs::read_to_string(&snap_path) {
                 Ok(data) => match serde_json::from_str::<PersistedSnapshot>(&data) {
                     Ok(ps) => {
@@ -142,6 +144,16 @@ impl SpurStore {
             }
         }
 
+        let purged_path = raft_dir.join("purged.json");
+        if purged_path.exists() {
+            // Hard-fail: silently falling back to None reproduces the startup panic.
+            let data = std::fs::read_to_string(&purged_path)?;
+            inner.last_purged = Some(
+                serde_json::from_str::<LogId<NodeId>>(&data)
+                    .map_err(|e| anyhow::anyhow!("failed to parse purged.json: {e}"))?,
+            );
+        }
+
         info!(
             log_entries = inner.log.len(),
             vote = ?inner.vote,
@@ -153,6 +165,18 @@ impl SpurStore {
             raft_dir,
             applier,
         })
+    }
+
+    fn persist_last_purged(&self, log_id: &LogId<NodeId>) -> Result<(), std::io::Error> {
+        let path = self.raft_dir.join("purged.json");
+        let tmp = self.raft_dir.join("purged.json.tmp");
+        let data = serde_json::to_vec(log_id)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        // Write-then-rename: a crash mid-write must never corrupt purged.json.
+        std::fs::write(&tmp, &data)
+            .map_err(|e| std::io::Error::new(e.kind(), format!("{tmp:?}: {e}")))?;
+        std::fs::rename(&tmp, &path)
+            .map_err(|e| std::io::Error::new(e.kind(), format!("{path:?}: {e}")))
     }
 
     fn persist_vote(&self, vote: &Vote<NodeId>) -> Result<(), std::io::Error> {
@@ -319,6 +343,9 @@ impl openraft::RaftStorage<SpurTypeConfig> for Arc<SpurStore> {
     }
 
     async fn purge_logs_upto(&mut self, log_id: LogId<NodeId>) -> Result<(), StorageError<NodeId>> {
+        self.persist_last_purged(&log_id).map_err(|e| {
+            StorageError::from_io_error(openraft::ErrorSubject::Logs, openraft::ErrorVerb::Write, e)
+        })?;
         let mut inner = self.inner.write();
         let keys: Vec<_> = inner.log.range(..=log_id.index).map(|(k, _)| *k).collect();
         for k in keys {
@@ -851,5 +878,37 @@ mod tests {
         assert!(inner.vote.is_none());
         assert!(inner.log.is_empty());
         assert!(inner.last_applied.is_none());
+    }
+
+    #[tokio::test]
+    async fn store_persists_last_purged_across_restart() {
+        use openraft::RaftStorage;
+        let dir = TempDir::new().unwrap();
+        let log_id = LogId {
+            leader_id: openraft::LeaderId {
+                term: 7,
+                node_id: 1,
+            },
+            index: 9999,
+        };
+
+        // Exercise the real public purge path, not the internal helper.
+        {
+            let mut store = Arc::new(SpurStore::new(dir.path(), noop_applier()).unwrap());
+            store.purge_logs_upto(log_id).await.unwrap();
+        }
+
+        // Simulate restart: reconstruct from the same dir and verify via get_log_state.
+        let mut store2 = Arc::new(SpurStore::new(dir.path(), noop_applier()).unwrap());
+        let state = store2.get_log_state().await.unwrap();
+        assert_eq!(state.last_purged_log_id, Some(log_id));
+    }
+
+    #[test]
+    fn store_no_purged_file_recovers_as_none() {
+        let dir = TempDir::new().unwrap();
+        let store = SpurStore::new(dir.path(), noop_applier()).unwrap();
+        let inner = store.inner.read();
+        assert!(inner.last_purged.is_none());
     }
 }

--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -156,11 +156,14 @@ impl SpurStore {
             );
         } else if let Some(snap_last) = snapshot_last_log_id {
             // Backward compat: a node that compacted its log before purged.json
-            // existed has a snapshot but no purged.json. openraft purges up to the
-            // snapshot's last_log_id when it compacts, so that id is the correct
-            // last_purged lower bound. Without this, such a node recovers with
-            // last_purged=None and reproduces the startup panic the moment openraft
-            // reads a purged log range.
+            // existed has a snapshot but no purged.json. The true last_purged is
+            // actually lower (openraft retains up to max_in_snapshot_log_to_keep
+            // entries below the snapshot), so the snapshot's last_log_id is a SAFE
+            // upper bound, not the exact value -- the extra retained logs are just
+            // orphaned and cleaned on the next purge. This matches what openraft
+            // uses to reconcile a snapshot-vs-log hole. Without it, such a node
+            // recovers with last_purged=None and reproduces the startup panic the
+            // moment openraft reads a purged log range.
             warn!(
                 last_purged = ?snap_last,
                 "purged.json missing; deriving last_purged from snapshot meta (pre-patch compat)"
@@ -924,6 +927,20 @@ mod tests {
         let store = SpurStore::new(dir.path(), noop_applier()).unwrap();
         let inner = store.inner.read();
         assert!(inner.last_purged.is_none());
+    }
+
+    #[test]
+    fn store_corrupt_purged_file_hard_fails() {
+        let dir = TempDir::new().unwrap();
+        // Create the store once so the raft/ subdir exists, then corrupt purged.json.
+        SpurStore::new(dir.path(), noop_applier()).unwrap();
+        std::fs::write(
+            dir.path().join("raft").join("purged.json"),
+            "not valid json",
+        )
+        .unwrap();
+
+        assert!(SpurStore::new(dir.path(), noop_applier()).is_err());
     }
 
     // A node that compacted its log before purged.json existed has a snapshot

--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -127,17 +127,14 @@ impl SpurStore {
             }
         }
 
-        let mut snapshot_last_log_id: Option<LogId<NodeId>> = None;
         let snap_path = raft_dir.join("snapshot.json");
         if snap_path.exists() {
             // Soft-fail: a corrupt snapshot triggers re-snapshot on the next leader term.
-            // A present-but-corrupt purged.json (below) cannot be recovered the same way.
             match std::fs::read_to_string(&snap_path) {
                 Ok(data) => match serde_json::from_str::<PersistedSnapshot>(&data) {
                     Ok(ps) => {
                         inner.last_applied = ps.meta.last_log_id;
                         inner.last_membership = ps.meta.last_membership.clone();
-                        snapshot_last_log_id = ps.meta.last_log_id;
                         applier.restore_from_snapshot(&ps.data);
                     }
                     Err(e) => warn!("failed to parse snapshot.json: {e}"),
@@ -148,27 +145,12 @@ impl SpurStore {
 
         let purged_path = raft_dir.join("purged.json");
         if purged_path.exists() {
-            // Hard-fail: silently falling back to None reproduces the startup panic.
+            // Hard-fail: a corrupt purged.json cannot be recovered safely.
             let data = std::fs::read_to_string(&purged_path)?;
             inner.last_purged = Some(
                 serde_json::from_str::<LogId<NodeId>>(&data)
                     .map_err(|e| anyhow::anyhow!("failed to parse purged.json: {e}"))?,
             );
-        } else if let Some(snap_last) = snapshot_last_log_id {
-            // Backward compat: a node that compacted its log before purged.json
-            // existed has a snapshot but no purged.json. The true last_purged is
-            // actually lower (openraft retains up to max_in_snapshot_log_to_keep
-            // entries below the snapshot), so the snapshot's last_log_id is a SAFE
-            // upper bound, not the exact value -- the extra retained logs are just
-            // orphaned and cleaned on the next purge. This matches what openraft
-            // uses to reconcile a snapshot-vs-log hole. Without it, such a node
-            // recovers with last_purged=None and reproduces the startup panic the
-            // moment openraft reads a purged log range.
-            warn!(
-                last_purged = ?snap_last,
-                "purged.json missing; deriving last_purged from snapshot meta (pre-patch compat)"
-            );
-            inner.last_purged = Some(snap_last);
         }
 
         info!(
@@ -941,38 +923,5 @@ mod tests {
         .unwrap();
 
         assert!(SpurStore::new(dir.path(), noop_applier()).is_err());
-    }
-
-    // A node that compacted its log before purged.json existed has a snapshot
-    // but no purged.json. Recovery must derive last_purged from the snapshot
-    // meta rather than defaulting to None (which reproduces the startup panic).
-    #[tokio::test]
-    async fn store_derives_last_purged_from_snapshot_when_purged_file_absent() {
-        use openraft::RaftStorage;
-        let dir = TempDir::new().unwrap();
-
-        let snap_last = LogId {
-            leader_id: openraft::LeaderId {
-                term: 3,
-                node_id: 1,
-            },
-            index: 100,
-        };
-
-        // Write a snapshot but no purged.json, mirroring a pre-patch compacted node.
-        {
-            let store = SpurStore::new(dir.path(), noop_applier()).unwrap();
-            let meta = SnapshotMeta {
-                last_log_id: Some(snap_last),
-                last_membership: StoredMembership::default(),
-                snapshot_id: "snap-100".into(),
-            };
-            store.persist_snapshot(&meta, b"snapshot data").unwrap();
-        }
-        assert!(!dir.path().join("raft").join("purged.json").exists());
-
-        let mut store = Arc::new(SpurStore::new(dir.path(), noop_applier()).unwrap());
-        let state = store.get_log_state().await.unwrap();
-        assert_eq!(state.last_purged_log_id, Some(snap_last));
     }
 }


### PR DESCRIPTION
## What

After openraft took a snapshot and compacted the log, `spurctld` could not restart:

```
Error: 'LogIndex(0)' violates: 'try to get log at index 0 but got None'
spurctld.service: Main process exited, code=exited, status=1/FAILURE
```

Since compaction happens automatically as the cluster runs, every controller eventually became permanently un-restartable — including on `systemctl restart` or host reboot. HA provided no real fault tolerance.

## Root cause

`purge_logs_upto()` set `inner.last_purged = Some(log_id)` in memory only and deleted the on-disk log files. `SpurStore::new()` had no `purged.json` to restore from, so `last_purged` defaulted to `None`. openraft, seeing `last_purged = None` with no log entries going back to index 0, aborted.

## Fix

- **`purge_logs_upto()`**: persist `last_purged` to `purged.json` before mutating in-memory state. Uses write-then-rename for atomicity — a crash mid-write can never leave a partially-written file.
- **`SpurStore::new()`**: load `purged.json` on startup if it exists. Missing file → `None` (correct for a fresh node). Parse error → hard failure (silently falling back to `None` would reproduce the panic).

## Testing

- Two new unit tests:
  - `store_persists_last_purged_across_restart`: calls public `purge_logs_upto()`, reconstructs store from same dir, asserts `get_log_state()` returns the correct `last_purged_log_id`.
  - `store_no_purged_file_recovers_as_none`: fresh store has `last_purged = None`.
- Live tested on a 1-node cluster: `systemctl restart spurctld` after compaction → recovered log entries, became leader, accepted new jobs.

Fixes #368