### PR TITLE
feat(spur-cli): add -w/--nodelist and -x/--exclude to srun and salloc

### DIFF
--- a/crates/spur-cli/src/salloc.rs
+++ b/crates/spur-cli/src/salloc.rs
@@ -56,6 +56,14 @@ pub struct SallocArgs {
     #[arg(short = 'C', long)]
     pub constraint: Option<String>,
 
+    /// Node list
+    #[arg(short = 'w', long)]
+    pub nodelist: Option<String>,
+
+    /// Exclude nodes
+    #[arg(short = 'x', long)]
+    pub exclude: Option<String>,
+
     /// Target a named reservation
     #[arg(long)]
     pub reservation: Option<String>,
@@ -103,6 +111,8 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let controller = args.controller.clone();
     let exclusive = args.exclusive;
     let constraint = args.constraint;
+    let nodelist = args.nodelist;
+    let exclude = args.exclude;
     let reservation = args.reservation;
     let partition = args.partition;
     let account = args.account;
@@ -130,6 +140,8 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         time_limit,
         exclusive,
         constraint: constraint.unwrap_or_default(),
+        nodelist: nodelist.unwrap_or_default(),
+        exclude: exclude.unwrap_or_default(),
         reservation: reservation.unwrap_or_default(),
         interactive: true,
         environment: HashMap::new(),
@@ -272,5 +284,27 @@ fn parse_memory_mb(s: &str) -> Result<u64> {
         Ok(mb.parse().context("invalid memory value")?)
     } else {
         Ok(s.parse().context("invalid memory value")?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_nodelist_and_exclude_short() {
+        let args = SallocArgs::try_parse_from(["salloc", "-w", "node001,node002", "-x", "node003"])
+            .expect("parse failed");
+        assert_eq!(args.nodelist.as_deref(), Some("node001,node002"));
+        assert_eq!(args.exclude.as_deref(), Some("node003"));
+    }
+
+    #[test]
+    fn parses_nodelist_and_exclude_long() {
+        let args =
+            SallocArgs::try_parse_from(["salloc", "--nodelist", "node001", "--exclude", "node002"])
+                .expect("parse failed");
+        assert_eq!(args.nodelist.as_deref(), Some("node001"));
+        assert_eq!(args.exclude.as_deref(), Some("node002"));
     }
 }

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -77,6 +77,14 @@ pub struct SrunArgs {
     #[arg(short = 'C', long)]
     pub constraint: Option<String>,
 
+    /// Node list
+    #[arg(short = 'w', long)]
+    pub nodelist: Option<String>,
+
+    /// Exclude nodes
+    #[arg(short = 'x', long)]
+    pub exclude: Option<String>,
+
     /// Target a named reservation
     #[arg(long)]
     pub reservation: Option<String>,
@@ -239,6 +247,8 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         environment,
         time_limit,
         constraint: args.constraint.unwrap_or_default(),
+        nodelist: args.nodelist.unwrap_or_default(),
+        exclude: args.exclude.unwrap_or_default(),
         reservation: args.reservation.unwrap_or_default(),
         mpi: args.mpi,
         container_image: args.container_image.unwrap_or_default(),
@@ -628,5 +638,40 @@ fn srun_hook_context(script_context: &str, work_dir: &str) -> spur_core::hooks::
         gpu_devices: Vec::new(),
         cpus: 1,
         memory_mb: 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_nodelist_and_exclude_short() {
+        let args = SrunArgs::try_parse_from([
+            "srun",
+            "-w",
+            "node001,node002",
+            "-x",
+            "node003",
+            "hostname",
+        ])
+        .expect("parse failed");
+        assert_eq!(args.nodelist.as_deref(), Some("node001,node002"));
+        assert_eq!(args.exclude.as_deref(), Some("node003"));
+    }
+
+    #[test]
+    fn parses_nodelist_and_exclude_long() {
+        let args = SrunArgs::try_parse_from([
+            "srun",
+            "--nodelist",
+            "node001",
+            "--exclude",
+            "node002",
+            "hostname",
+        ])
+        .expect("parse failed");
+        assert_eq!(args.nodelist.as_deref(), Some("node001"));
+        assert_eq!(args.exclude.as_deref(), Some("node002"));
     }
 }

--- a/crates/spur-sched/src/backfill.rs
+++ b/crates/spur-sched/src/backfill.rs
@@ -1,10 +1,10 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use chrono::{Duration, Utc};
-use tracing::debug;
+use tracing::{debug, warn};
 
 use spur_core::job::{Job, JobId};
 use spur_core::node::Node;
@@ -56,32 +56,30 @@ impl BackfillScheduler {
         let required = job_resource_request(job);
 
         // Parse nodelist / exclude constraints once, outside the per-node loop.
-        let nodelist: Option<Vec<&str>> = job
+        let nodelist: Option<HashSet<String>> = job
             .spec
             .nodelist
             .as_deref()
             .filter(|s| !s.is_empty())
-            .map(|s| s.split(',').map(str::trim).collect());
+            .map(|s| HashSet::from_iter(expand_hostlist_or_split(s)));
 
-        let exclude: Vec<&str> = job
+        let exclude: HashSet<String> = job
             .spec
             .exclude
             .as_deref()
-            .map(|s| s.split(',').map(str::trim).collect())
+            .map(|s| HashSet::from_iter(expand_hostlist_or_split(s)))
             .unwrap_or_default();
 
         nodes
             .iter()
             .enumerate()
             .filter(|(_, node)| {
-                // Honour --nodelist: node must be in the explicit allow-list.
                 if let Some(ref allowed) = nodelist {
-                    if !allowed.contains(&node.name.as_str()) {
+                    if !allowed.contains(&node.name) {
                         return false;
                     }
                 }
-                // Honour --exclude: node must not be in the deny-list.
-                if exclude.contains(&node.name.as_str()) {
+                if exclude.contains(&node.name) {
                     return false;
                 }
                 // Check partition membership (comma-separated OR matching)
@@ -369,7 +367,23 @@ impl Scheduler for BackfillScheduler {
     }
 }
 
-/// Extract the per-node resource request from a job spec.
+/// Expand a hostlist pattern (e.g. `node[001-003]`) into individual names.
+/// Falls back to a plain comma-split if the pattern is malformed, so
+/// existing behavior is preserved for simple comma-separated lists.
+fn expand_hostlist_or_split(pattern: &str) -> Vec<String> {
+    match spur_core::hostlist::expand(pattern) {
+        Ok(names) => names,
+        Err(e) => {
+            warn!(
+                pattern,
+                error = %e,
+                "hostlist expansion failed, falling back to comma-split"
+            );
+            pattern.split(',').map(|s| s.trim().to_string()).collect()
+        }
+    }
+}
+
 pub fn job_resource_request(job: &Job) -> ResourceSet {
     let cpus = if job.spec.tasks_per_node.is_some() {
         job.spec.tasks_per_node.unwrap_or(1) * job.spec.cpus_per_task
@@ -840,6 +854,67 @@ mod tests {
 
         let assignments = sched.schedule(&pending, &cluster);
         assert_eq!(assignments.len(), 0);
+    }
+
+    #[test]
+    fn test_nodelist_hostlist_range() {
+        let mut sched = BackfillScheduler::new(100);
+        let nodes = make_nodes(4);
+        let partitions = vec![Partition {
+            name: "default".into(),
+            ..Default::default()
+        }];
+
+        let pending = vec![make_job_with_nodelist(1, 2, Some("node[001-002]"), None)];
+        let cluster = ClusterState {
+            nodes: &nodes,
+            partitions: &partitions,
+            reservations: &[],
+            topology: None,
+        };
+
+        let assignments = sched.schedule(&pending, &cluster);
+        assert_eq!(assignments.len(), 1);
+        assert_eq!(assignments[0].nodes.len(), 2);
+        assert!(assignments[0].nodes.contains(&"node001".to_string()));
+        assert!(assignments[0].nodes.contains(&"node002".to_string()));
+    }
+
+    #[test]
+    fn test_exclude_hostlist_range() {
+        let mut sched = BackfillScheduler::new(100);
+        let nodes = make_nodes(4);
+        let partitions = vec![Partition {
+            name: "default".into(),
+            ..Default::default()
+        }];
+
+        let pending = vec![make_job_with_nodelist(1, 2, None, Some("node[001-002]"))];
+        let cluster = ClusterState {
+            nodes: &nodes,
+            partitions: &partitions,
+            reservations: &[],
+            topology: None,
+        };
+
+        let assignments = sched.schedule(&pending, &cluster);
+        assert_eq!(assignments.len(), 1);
+        assert_eq!(assignments[0].nodes.len(), 2);
+        assert!(!assignments[0].nodes.contains(&"node001".to_string()));
+        assert!(!assignments[0].nodes.contains(&"node002".to_string()));
+        assert!(assignments[0].nodes.contains(&"node003".to_string()));
+        assert!(assignments[0].nodes.contains(&"node004".to_string()));
+    }
+
+    #[test]
+    fn test_malformed_hostlist_falls_back_to_comma_split() {
+        // Reversed range is invalid; fallback returns the literal as a single token.
+        let result = expand_hostlist_or_split("node[003-001]");
+        assert_eq!(result, vec!["node[003-001]"]);
+
+        // Plain comma-separated list is not a hostlist pattern; fallback splits correctly.
+        let result = expand_hostlist_or_split("a,b,c");
+        assert_eq!(result, vec!["a", "b", "c"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `-w/--nodelist` and `-x/--exclude` flags to `srun` and `salloc`, matching `sbatch`. The proto fields (`JobSpec.nodelist`, `JobSpec.exclude`) and backfill scheduler filter already existed; this wires the CLI.
- Expand hostlist range patterns (e.g. `node[001-003]`) in the scheduler's nodelist/exclude filter using the existing `spur_core::hostlist::expand()` parser. Previously, ranges were treated as literal strings and never matched. This benefits `sbatch`, `srun`, and `salloc`.

## Test plan

- [x] Parse tests for `-w`/`-x` short and `--nodelist`/`--exclude` long forms in both `srun` and `salloc`
- [x] Backfill scheduler tests for hostlist range patterns in `--nodelist` and `--exclude`
- [x] `cargo clippy` clean, `cargo test` green
- [x] Bare-metal cluster (spur-node1/2/3): `srun -w spur-node2 hostname` pins to node2, `srun -x spur-node[1-2] hostname` runs on node3, `sbatch -w 'spur-node[1-2]'` schedules (was PENDING before)

Closes #375