### PR TITLE
fix(deploy): resolve releases without the GitHub API in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -114,9 +114,14 @@ fi
 # --- Resolve version ---
 if [ "$VERSION" = "latest" ]; then
     log "Fetching latest release..."
-    VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-        | grep '"tag_name"' | head -1 | cut -d'"' -f4) \
-        || err "No releases found. Create one with: gh release create v0.1.0"
+    # Use the Atom feed: /releases/latest ignores pre-releases (all our
+    # releases are pre-releases) and the unauthenticated API is rate-limited
+    # per IP. Feed is newest-first; take the first non-nightly tag.
+    VERSION=$(curl -fsSL "https://github.com/${REPO}/releases.atom" \
+        | grep -oE 'releases/tag/[^"]+' | sed 's#releases/tag/##' \
+        | grep -v '^nightly$' | head -1) \
+        || err "Could not resolve latest release from https://github.com/${REPO}/releases"
+    [ -n "$VERSION" ] || err "No releases found at https://github.com/${REPO}/releases"
 fi
 log "Installing Spur ${VERSION}"
 
@@ -125,10 +130,12 @@ TMPDIR=$(mktemp -d)
 trap 'rm -rf "${TMPDIR}"' EXIT
 
 if [ "$VERSION" = "nightly" ]; then
-    # Nightly tarballs include date+sha in the name — find the .tar.gz asset
-    TARBALL=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/tags/nightly" \
-        | grep '"name"' | grep '\.tar\.gz"' | grep -v sha256 | head -1 | cut -d'"' -f4) \
+    # Nightly tarball name carries date+sha; read it from expanded_assets
+    # rather than the rate-limited API.
+    TARBALL=$(curl -fsSL "https://github.com/${REPO}/releases/expanded_assets/nightly" \
+        | grep -oE 'spur-nightly-[^"]+-linux-amd64\.tar\.gz' | head -1) \
         || err "Could not find nightly release assets"
+    [ -n "$TARBALL" ] || err "Could not find nightly release assets"
 else
     TARBALL="spur-${VERSION}-linux-amd64.tar.gz"
 fi


### PR DESCRIPTION
## What

`curl ... install.sh | bash` failed with `No releases found`. Two causes:

1. The unauthenticated GitHub API is rate-limited to 60 req/hr per IP; shared egress IPs hit `403`, which surfaced as the misleading error.
2. `/releases/latest` ignores pre-releases, and every Spur release is a pre-release, so it returns `404` even when authenticated.

## Fix

Drop the GitHub API. Resolve the latest tag from the `releases.atom` feed (newest-first, first non-nightly tag) and the nightly asset from `expanded_assets`. Both are served by github.com with no rate limit and include pre-releases.

## Testing

Ran `install.sh` for both `latest` (resolves `v0.3.0`) and `nightly` from a previously rate-limited IP. Both download, verify checksum, and install cleanly.