### PR TITLE
ci(e2e): migrate to VM-based E2E runners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,7 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 * @powderluv @sgopinath1 @shiv-tyagi @yansun1996 @sajmera-pensando
+
+# CI workflows and test harness require maintainer review
+.github/workflows/** @shiv-tyagi
+tests/** @shiv-tyagi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -197,8 +197,6 @@ jobs:
           scp $SSH_OPTS -r /tmp/e2e-assets ci@"$DRIVER_IP":/tmp/
           scp $SSH_OPTS "$KEY" ci@"$DRIVER_IP":/tmp/ci-ssh-key
           ssh $SSH_OPTS ci@"$DRIVER_IP" "chmod 600 /tmp/ci-ssh-key"
-          # Kubeconfig: driver VM is also the control plane, so kubeadm
-          # already placed it at ~/.kube/config during bootstrap.
 
       - name: Load AppArmor profile for rootless containers
         if: matrix.cluster_type == 'native-host'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -275,6 +275,34 @@ jobs:
           pytest /tmp/e2e-assets/tests/k8s/e2e/ -v --junitxml=/tmp/results.xml
           REMOTE
 
+      - name: Dump cluster diagnostics (k8s)
+        if: always() && matrix.cluster_type == 'k8s'
+        run: |
+          DRIVER_IP="${{ steps.cluster.outputs.driver_ip }}"
+          KEY="${{ steps.ssh.outputs.privkey }}"
+          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $KEY"
+          mkdir -p /tmp/e2e-results
+          ssh $SSH_OPTS ci@"$DRIVER_IP" bash -s <<'REMOTE' || true
+          set -uo pipefail
+          export KUBECONFIG=/home/ci/.kube/config
+          D=/tmp/cluster-dump
+          rm -rf "$D" && mkdir -p "$D"
+          kubectl get events -A --sort-by=.lastTimestamp > "$D/events.txt" 2>&1 || true
+          # -o wide includes the RESTARTS column, key for spotting controller restarts.
+          kubectl get pods -A -o wide > "$D/pods.txt" 2>&1 || true
+          kubectl get endpoints -A -o wide > "$D/endpoints.txt" 2>&1 || true
+          for ns in $(kubectl get ns -o name 2>/dev/null | sed 's|namespace/||' | grep -E 'spur'); do
+            kubectl -n "$ns" describe pods > "$D/describe-$ns.txt" 2>&1 || true
+            for p in $(kubectl -n "$ns" get pods -o name 2>/dev/null); do
+              name=${p#pod/}
+              kubectl -n "$ns" logs "$name" --all-containers --timestamps > "$D/log-$ns-$name.txt" 2>&1 || true
+              kubectl -n "$ns" logs "$name" --all-containers --previous --timestamps > "$D/log-$ns-$name-prev.txt" 2>&1 || true
+            done
+          done
+          tar -czf /tmp/cluster-dump.tgz -C "$D" . 2>/dev/null || true
+          REMOTE
+          scp $SSH_OPTS ci@"$DRIVER_IP":/tmp/cluster-dump.tgz /tmp/e2e-results/ 2>/dev/null || true
+
       - name: Collect results from driver VM
         if: always()
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -179,6 +179,23 @@ jobs:
           scp $SSH_OPTS "$KEY" ci@"$DRIVER_IP":/tmp/ci-ssh-key
           ssh $SSH_OPTS ci@"$DRIVER_IP" "chmod 600 /tmp/ci-ssh-key"
 
+      - name: Load AppArmor profile for rootless containers
+        if: matrix.cluster_type == 'native-host'
+        run: |
+          DRIVER_IP="${{ steps.cluster.outputs.driver_ip }}"
+          GPU_IPS="${{ steps.cluster.outputs.gpu_ips }}"
+          KEY="${{ steps.ssh.outputs.privkey }}"
+          SSH_OPTS="-o StrictHostKeyChecking=no -i $KEY"
+          SPURD="/tmp/spur-ci-bin/spurd"
+          PROF="abi <abi/4.0>,
+          profile spur-ci ${SPURD} flags=(unconfined) {
+            userns,
+          }"
+          IFS=',' read -ra NODES <<< "$GPU_IPS"
+          for node in "${NODES[@]}"; do
+            ssh $SSH_OPTS ci@"$node" "echo '${PROF}' | sudo apparmor_parser -r 2>/dev/null || true"
+          done
+
       - name: Run tests inside driver VM (native-host)
         if: matrix.cluster_type == 'native-host'
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -235,6 +235,7 @@ jobs:
           ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i "$KEY" ci@"$DRIVER_IP" bash -s <<REMOTE
           set -euo pipefail
           export KUBECONFIG=/home/ci/.kube/config
+          export SPUR_CI_IMAGE=docker.io/library/spur:ci
           source /opt/spur-ci/test-venv/bin/activate
           pytest /tmp/e2e-assets/tests/k8s/e2e/ -v --junitxml=/tmp/results.xml
           REMOTE

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -73,6 +73,8 @@ jobs:
             STATUS_CONTEXT: "E2E / k8s"
     env:
       STATUS_CONTEXT: ${{ matrix.STATUS_CONTEXT }}
+      # LogLevel=ERROR silences the known-hosts warning from UserKnownHostsFile=/dev/null.
+      SSH_OPTS: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
     steps:
       - name: Set pending status
         uses: actions/github-script@v9
@@ -158,8 +160,8 @@ jobs:
             echo "Waiting for $ip..."
             ok=false
             for i in $(seq 1 90); do
-              if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=3 \
-                -o BatchMode=yes -i "$KEY" ci@"$ip" true 2>/dev/null; then
+              if ssh $SSH_OPTS -o ConnectTimeout=3 -o BatchMode=yes \
+                -i "$KEY" ci@"$ip" true 2>/dev/null; then
                 echo "  $ip ready"
                 ok=true
                 break
@@ -191,20 +193,17 @@ jobs:
         run: |
           DRIVER_IP="${{ steps.cluster.outputs.driver_ip }}"
           KEY="${{ steps.ssh.outputs.privkey }}"
-          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $KEY"
 
-          scp $SSH_OPTS -r /tmp/release-binaries ci@"$DRIVER_IP":/tmp/
-          scp $SSH_OPTS -r /tmp/e2e-assets ci@"$DRIVER_IP":/tmp/
-          scp $SSH_OPTS "$KEY" ci@"$DRIVER_IP":/tmp/ci-ssh-key
-          ssh $SSH_OPTS ci@"$DRIVER_IP" "chmod 600 /tmp/ci-ssh-key"
+          scp $SSH_OPTS -i "$KEY" -r /tmp/release-binaries ci@"$DRIVER_IP":/tmp/
+          scp $SSH_OPTS -i "$KEY" -r /tmp/e2e-assets ci@"$DRIVER_IP":/tmp/
+          scp $SSH_OPTS -i "$KEY" "$KEY" ci@"$DRIVER_IP":/tmp/ci-ssh-key
+          ssh $SSH_OPTS -i "$KEY" ci@"$DRIVER_IP" "chmod 600 /tmp/ci-ssh-key"
 
       - name: Load AppArmor profile for rootless containers
         if: matrix.cluster_type == 'native-host'
         run: |
-          DRIVER_IP="${{ steps.cluster.outputs.driver_ip }}"
           GPU_IPS="${{ steps.cluster.outputs.gpu_ips }}"
           KEY="${{ steps.ssh.outputs.privkey }}"
-          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $KEY"
           SPURD="/tmp/spur-ci-bin/spurd"
           PROF="abi <abi/4.0>,
           profile spur-ci ${SPURD} flags=(unconfined) {
@@ -212,7 +211,7 @@ jobs:
           }"
           IFS=',' read -ra NODES <<< "$GPU_IPS"
           for node in "${NODES[@]}"; do
-            ssh $SSH_OPTS ci@"$node" "echo '${PROF}' | sudo apparmor_parser -r 2>/dev/null || true"
+            ssh $SSH_OPTS -i "$KEY" ci@"$node" "echo '${PROF}' | sudo apparmor_parser -r 2>/dev/null || true"
           done
 
       - name: Run tests inside driver VM (native-host)
@@ -222,7 +221,7 @@ jobs:
           GPU_IPS="${{ steps.cluster.outputs.gpu_ips }}"
           KEY="${{ steps.ssh.outputs.privkey }}"
 
-          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i "$KEY" ci@"$DRIVER_IP" bash -s <<REMOTE
+          ssh $SSH_OPTS -i "$KEY" ci@"$DRIVER_IP" bash -s <<REMOTE
           set -euo pipefail
           export SPUR_TEST_NODES="$GPU_IPS"
           export SPUR_TEST_SSH_USER=ci
@@ -240,10 +239,9 @@ jobs:
         run: |
           DRIVER_IP="${{ steps.cluster.outputs.driver_ip }}"
           KEY="${{ steps.ssh.outputs.privkey }}"
-          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $KEY"
           NS="spur-ci-${{ github.run_id }}"
 
-          ssh $SSH_OPTS ci@"$DRIVER_IP" bash -s <<REMOTE
+          ssh $SSH_OPTS -i "$KEY" ci@"$DRIVER_IP" bash -s <<REMOTE
           set -euo pipefail
           export KUBECONFIG=/home/ci/.kube/config
 
@@ -266,7 +264,7 @@ jobs:
           KEY="${{ steps.ssh.outputs.privkey }}"
           NS="spur-ci-${{ github.run_id }}"
 
-          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i "$KEY" ci@"$DRIVER_IP" bash -s <<REMOTE
+          ssh $SSH_OPTS -i "$KEY" ci@"$DRIVER_IP" bash -s <<REMOTE
           set -euo pipefail
           export KUBECONFIG=/home/ci/.kube/config
           export SPUR_CI_IMAGE=docker.io/library/spur:ci
@@ -280,28 +278,26 @@ jobs:
         run: |
           DRIVER_IP="${{ steps.cluster.outputs.driver_ip }}"
           KEY="${{ steps.ssh.outputs.privkey }}"
-          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $KEY"
           mkdir -p /tmp/e2e-results
-          ssh $SSH_OPTS ci@"$DRIVER_IP" bash -s <<'REMOTE' || true
+          ssh $SSH_OPTS -i "$KEY" ci@"$DRIVER_IP" bash -s <<'REMOTE' || true
           set -uo pipefail
           export KUBECONFIG=/home/ci/.kube/config
           D=/tmp/cluster-dump
           rm -rf "$D" && mkdir -p "$D"
           kubectl get events -A --sort-by=.lastTimestamp > "$D/events.txt" 2>&1 || true
-          # -o wide includes the RESTARTS column, key for spotting controller restarts.
           kubectl get pods -A -o wide > "$D/pods.txt" 2>&1 || true
-          kubectl get endpoints -A -o wide > "$D/endpoints.txt" 2>&1 || true
+          # Only collect logs for the long-lived controller/operator pods.
           for ns in $(kubectl get ns -o name 2>/dev/null | sed 's|namespace/||' | grep -E 'spur'); do
-            kubectl -n "$ns" describe pods > "$D/describe-$ns.txt" 2>&1 || true
-            for p in $(kubectl -n "$ns" get pods -o name 2>/dev/null); do
-              name=${p#pod/}
-              kubectl -n "$ns" logs "$name" --all-containers --timestamps > "$D/log-$ns-$name.txt" 2>&1 || true
-              kubectl -n "$ns" logs "$name" --all-containers --previous --timestamps > "$D/log-$ns-$name-prev.txt" 2>&1 || true
+            for selector in app=spurctld app=spur-k8s-operator; do
+              for p in $(kubectl -n "$ns" get pods -l "$selector" -o name 2>/dev/null); do
+                name=${p#pod/}
+                kubectl -n "$ns" logs "$name" --all-containers --timestamps > "$D/log-$ns-$name.txt" 2>&1 || true
+                kubectl -n "$ns" logs "$name" --all-containers --previous --timestamps > "$D/log-$ns-$name-prev.txt" 2>&1 || true
+              done
             done
           done
-          tar -czf /tmp/cluster-dump.tgz -C "$D" . 2>/dev/null || true
           REMOTE
-          scp $SSH_OPTS ci@"$DRIVER_IP":/tmp/cluster-dump.tgz /tmp/e2e-results/ 2>/dev/null || true
+          scp $SSH_OPTS -i "$KEY" -r ci@"$DRIVER_IP":/tmp/cluster-dump /tmp/e2e-results/ 2>/dev/null || true
 
       - name: Collect results from driver VM
         if: always()
@@ -309,9 +305,9 @@ jobs:
           DRIVER_IP="${{ steps.cluster.outputs.driver_ip }}"
           KEY="${{ steps.ssh.outputs.privkey }}"
           mkdir -p /tmp/e2e-results
-          scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i "$KEY" \
+          scp $SSH_OPTS -i "$KEY" \
             ci@"$DRIVER_IP":/tmp/results.xml /tmp/e2e-results/ 2>/dev/null || true
-          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i "$KEY" ci@"$DRIVER_IP" \
+          ssh $SSH_OPTS -i "$KEY" ci@"$DRIVER_IP" \
             "find /tmp -name '*.log' -exec rm -f {} + 2>/dev/null" || true
 
       - name: Upload test results

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,10 +1,8 @@
-# Trusted workflow: runs in the base repo context so self-hosted runners
-# and secrets are never exposed to untrusted fork code.  Triggers after
-# the CI workflow completes successfully.
+# Trusted workflow: runs in the base repo context via workflow_run so self-hosted
+# runners and the workflow YAML are never exposed to untrusted fork code.
+# Untrusted code (binaries + pytest) runs ONLY inside disposable driver VMs.
 #
-# No untrusted code is checked out or compiled here.  Binaries, container
-# image, and test assets (tests/, scripts) from the same commit are uploaded by CI
-# and downloaded here.
+# Trigger migration to pull_request_target is deferred to a follow-up PR.
 name: E2E
 
 on:
@@ -16,7 +14,6 @@ permissions:
   statuses: write
   actions: read
   contents: read
-  packages: write
 
 jobs:
   mark-skipped:
@@ -62,19 +59,16 @@ jobs:
               });
             }
 
-  native-host:
-    name: Native-Host
-    runs-on: [self-hosted, bare-metal-cluster]
+  e2e:
+    name: E2E (${{ matrix.cluster_type }})
+    runs-on: [self-hosted, spur-e2e, gpu]
     if: github.event.workflow_run.conclusion == 'success'
-    concurrency:
-      group: native-host-cluster
-      queue: max
+    strategy:
+      fail-fast: false
+      matrix:
+        cluster_type: [native-host, k8s]
     env:
-      STATUS_CONTEXT: "E2E / Native-Host"
-      BM_NODES: ${{ secrets.BM_NODES }}
-      BM_SSH_USER: ${{ secrets.BM_SSH_USER }}
-      BM_REMOTE_BIN_DIR: /tmp/spur-ci-bin
-      E2E_ASSETS_DIR: /tmp/spur-e2e-assets-${{ github.run_id }}
+      STATUS_CONTEXT: "E2E / ${{ matrix.cluster_type }}"
     steps:
       - name: Set pending status
         uses: actions/github-script@v9
@@ -96,244 +90,16 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download E2E assets from CI
+      - name: Download E2E assets
         uses: actions/download-artifact@v8
         with:
           name: e2e-assets
-          path: ${{ env.E2E_ASSETS_DIR }}
+          path: /tmp/e2e-assets
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Python venv and install test deps
-        run: |
-          python3 -m venv /tmp/spur-e2e-venv
-          /tmp/spur-e2e-venv/bin/pip install -r "$E2E_ASSETS_DIR/tests/requirements.txt"
-          echo "/tmp/spur-e2e-venv/bin" >> "$GITHUB_PATH"
-
-      - name: Load SSH key into agent
-        run: |
-          eval "$(ssh-agent -s)"
-          printf '%s\n' "$BM_SSH_KEY" | ssh-add -
-          echo "SSH_AUTH_SOCK=$SSH_AUTH_SOCK" >> "$GITHUB_ENV"
-          echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> "$GITHUB_ENV"
-        env:
-          BM_SSH_KEY: ${{ secrets.BM_SSH_KEY }}
-
-      - name: Mask sensitive values in console
-        run: |
-          IFS=',' read -ra NODES <<< "$BM_NODES"
-          for node in "${NODES[@]}"; do
-            node="${node#"${node%%[![:space:]]*}"}"
-            node="${node%"${node##*[![:space:]]}"}"
-            [ -n "$node" ] && echo "::add-mask::${node}"
-          done
-          echo "::add-mask::${BM_SSH_USER}"
-
-      - name: Verify node connectivity
-        run: |
-          IFS=',' read -ra NODES <<< "$BM_NODES"
-          FAILED=0
-          for node in "${NODES[@]}"; do
-            if ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
-              -o ConnectTimeout=10 "${BM_SSH_USER}@${node}" "echo ok" >/dev/null 2>&1; then
-              echo "PASS: ${node}"
-            else
-              echo "FAIL: ${node} unreachable"
-              FAILED=1
-            fi
-          done
-          [ "$FAILED" -eq 0 ] || { echo "ERROR: not all nodes reachable"; exit 1; }
-
-      - name: Kill stale processes from previous runs
-        run: |
-          IFS=',' read -ra NODES <<< "$BM_NODES"
-          for node in "${NODES[@]}"; do
-            ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
-              "${BM_SSH_USER}@${node}" "
-              sudo pkill -f '${BM_REMOTE_BIN_DIR}/spurctld' 2>/dev/null || true
-              sudo pkill -f '${BM_REMOTE_BIN_DIR}/spurd' 2>/dev/null || true
-              sudo rm -rf /tmp/spur-e2e-* 2>/dev/null || true
-            " || true
-          done
-
-      - name: Check if DNS injection needed
-        id: dns-check
-        run: |
-          IFS=',' read -ra NODES <<< "$BM_NODES"
-          for node in "${NODES[@]}"; do
-            if ! [[ "$node" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "needed=true" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          done
-          echo "needed=false" >> "$GITHUB_OUTPUT"
-
-      - name: Inject node DNS on cluster
-        if: steps.dns-check.outputs.needed == 'true'
-        run: |
-          MARKER="## SPUR_CI_DYNAMIC_NODES"
-          IFS=',' read -ra NODES <<< "$BM_NODES"
-          HOSTS_BLOCK="${MARKER}"
-          for node in "${NODES[@]}"; do
-            IP=$(getent ahosts "$node" 2>/dev/null | awk 'NR==1{print $1}')
-            if [ -z "$IP" ]; then
-              echo "ERROR: cannot resolve $node from runner"
-              exit 1
-            fi
-            HOSTS_BLOCK="${HOSTS_BLOCK}
-          ${IP} ${node}"
-          done
-          for node in "${NODES[@]}"; do
-            ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
-              "${BM_SSH_USER}@${node}" "
-              grep -q '${MARKER}' /etc/hosts 2>/dev/null && exit 0
-              echo '${HOSTS_BLOCK}' | sudo tee -a /etc/hosts >/dev/null
-            "
-          done
-
-      - name: Load AppArmor profile for rootless containers
-        run: |
-          IFS=',' read -ra NODES <<< "$BM_NODES"
-          SPURD="${BM_REMOTE_BIN_DIR}/spurd"
-          PROF="abi <abi/4.0>,
-          profile spur-ci ${SPURD} flags=(unconfined) {
-            userns,
-          }"
-          for node in "${NODES[@]}"; do
-            ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
-              "${BM_SSH_USER}@${node}" "echo '${PROF}' | sudo apparmor_parser -r 2>/dev/null || true"
-          done
-
-      - name: Run native-host E2E tests
-        env:
-          SPUR_TEST_NODES: ${{ env.BM_NODES }}
-          SPUR_TEST_SSH_USER: ${{ env.BM_SSH_USER }}
-          SPUR_TEST_BINARIES_DIR: /tmp/release-binaries
-          SPUR_TEST_REMOTE_BIN_DIR: ${{ env.BM_REMOTE_BIN_DIR }}
-          SPUR_TEST_GPU_VENV: /opt/spur-ci/gpu-venv
-        run: |
-          chmod +x /tmp/release-binaries/*
-          pytest "$E2E_ASSETS_DIR/tests/native_host/e2e/" -v
-
-      - name: Collect cluster logs
-        if: failure()
-        run: |
-          set -euo pipefail
-          mkdir -p /tmp/bm-logs
-          IFS=',' read -ra NODES <<< "$BM_NODES"
-          idx=0
-          for node in "${NODES[@]}"; do
-            node="${node#"${node%%[![:space:]]*}"}"
-            node="${node%"${node##*[![:space:]]}"}"
-            [ -n "$node" ] || continue
-            node_dir="/tmp/bm-logs/node-${idx}"
-            idx=$((idx + 1))
-            mkdir -p "$node_dir"
-            # Collect logs from any /tmp/spur-e2e-* dirs left by failed tests
-            ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
-              "${BM_SSH_USER}@${node}" \
-              "find /tmp/spur-e2e-* -name '*.log' 2>/dev/null" | while read -r logfile; do
-              scp -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
-                "${BM_SSH_USER}@${node}:${logfile}" "$node_dir/" 2>/dev/null || true
-            done
-          done
-          echo "Collected logs:"
-          find /tmp/bm-logs -type f -name '*.log' | head -20
-
-      - name: Scrub cluster logs
-        id: scrub-logs
-        if: failure()
-        run: |
-          chmod +x "$E2E_ASSETS_DIR/scripts/scrub-ci-logs.sh"
-          "$E2E_ASSETS_DIR/scripts/scrub-ci-logs.sh" /tmp/bm-logs \
-            --hostnames "$BM_NODES" \
-            --ssh-user "$BM_SSH_USER"
-
-      - name: Upload cluster logs
-        if: failure() && steps.scrub-logs.outcome == 'success'
-        uses: actions/upload-artifact@v7
-        with:
-          name: native-host-logs
-          path: /tmp/bm-logs/
-          retention-days: 3
-          if-no-files-found: ignore
-
-      - name: Cleanup remote processes and dirs
-        if: always()
-        run: |
-          IFS=',' read -ra NODES <<< "$BM_NODES"
-          for node in "${NODES[@]}"; do
-            ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
-              "${BM_SSH_USER}@${node}" "
-              sudo pkill -f '${BM_REMOTE_BIN_DIR}/spurctld' 2>/dev/null || true
-              sudo pkill -f '${BM_REMOTE_BIN_DIR}/spurd' 2>/dev/null || true
-              sudo rm -rf /tmp/spur-e2e-* 2>/dev/null || true
-            " || true
-          done
-
-      - name: Cleanup AppArmor profile
-        if: always()
-        run: |
-          IFS=',' read -ra NODES <<< "$BM_NODES"
-          for node in "${NODES[@]}"; do
-            ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
-              "${BM_SSH_USER}@${node}" "
-              sudo apparmor_parser -R /dev/stdin 2>/dev/null <<< 'profile spur-ci /dev/null {}' || true
-            " || true
-          done
-
-      - name: Cleanup injected DNS
-        if: always() && steps.dns-check.outputs.needed == 'true'
-        run: |
-          IFS=',' read -ra NODES <<< "$BM_NODES"
-          for node in "${NODES[@]}"; do
-            ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes \
-              "${BM_SSH_USER}@${node}" \
-              "sudo sed -i '/## SPUR_CI_DYNAMIC_NODES/,\$d' /etc/hosts 2>/dev/null" || true
-          done
-
-      - name: Kill SSH agent
-        if: always()
-        run: ssh-agent -k || true
-
-      - name: Cleanup local artifacts
-        if: always()
-        run: |
-          rm -rf /tmp/spur-e2e-venv
-          rm -rf "$E2E_ASSETS_DIR"
-          rm -rf /tmp/release-binaries
-          rm -rf /tmp/bm-logs
-
-      - name: Report status
-        if: always()
-        uses: actions/github-script@v9
-        with:
-          script: |
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner, repo: context.repo.repo,
-              sha: '${{ github.event.workflow_run.head_sha }}',
-              state: '${{ job.status }}' === 'success' ? 'success' : 'failure',
-              target_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}',
-              context: '${{ env.STATUS_CONTEXT }}',
-              description: '${{ job.status }}'
-            });
-
-  push-image:
-    name: Push Image to GHCR
-    runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
-    steps:
-      - name: Compute GHCR image reference
-        id: image
-        uses: actions/github-script@v9
-        with:
-          result-encoding: string
-          script: |
-            const sha = '${{ github.event.workflow_run.head_sha }}';
-            const owner = '${{ github.repository_owner }}'.toLowerCase();
-            return `ghcr.io/${owner}/spur-ci:${sha}`;
-
-      - name: Download image artifact
+      - name: Download container image (k8s only)
+        if: matrix.cluster_type == 'k8s'
         uses: actions/download-artifact@v8
         with:
           name: spur-image
@@ -341,200 +107,142 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      # --- Host-side: ONLY /opt/spur-ci/bin scripts from here ---
 
-      - name: Load, retag, and push
-        env:
-          IMAGE_TAG: ${{ steps.image.outputs.result }}
+      - name: Generate ephemeral SSH keypair
+        id: ssh
         run: |
-          docker load -i /tmp/spur-image.tar
-          docker tag spur:ci "$IMAGE_TAG"
-          docker push "$IMAGE_TAG"
+          KEY_DIR=$(mktemp -d /tmp/spur-ci-keys-XXXXXX)
+          ssh-keygen -t ed25519 -f "$KEY_DIR/id_ed25519" -N "" -q
+          echo "key_dir=$KEY_DIR" >> "$GITHUB_OUTPUT"
+          echo "pubkey=$KEY_DIR/id_ed25519.pub" >> "$GITHUB_OUTPUT"
+          echo "privkey=$KEY_DIR/id_ed25519" >> "$GITHUB_OUTPUT"
 
-  k8s:
-    name: K8s
-    runs-on: [self-hosted, k8s-cluster]
-    needs: push-image
-    concurrency:
-      group: k8s-integration
-      queue: max
-    env:
-      STATUS_CONTEXT: "E2E / K8s"
-      KUBECONFIG: /home/amd/.kube/config
-      SPUR_TEST_NS: spur-ci-${{ github.event.workflow_run.id }}
-      RUST_LOG: info
-      E2E_ASSETS_DIR: /tmp/spur-k8s-e2e-assets-${{ github.run_id }}
-    steps:
-      - name: Compute GHCR image reference
+      - name: Select image for cluster type
         id: image
-        uses: actions/github-script@v9
-        with:
-          result-encoding: string
-          script: |
-            const sha = '${{ github.event.workflow_run.head_sha }}';
-            const owner = '${{ github.repository_owner }}'.toLowerCase();
-            return `ghcr.io/${owner}/spur-ci:${sha}`;
-
-      - name: Set SPUR_CI_IMAGE
         run: |
-          echo "SPUR_CI_IMAGE=${{ steps.image.outputs.result }}" >> "$GITHUB_ENV"
-          echo "SPUR_CI_IMAGE=${{ steps.image.outputs.result }}"
-
-      - name: Set pending status
-        uses: actions/github-script@v9
-        with:
-          script: |
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner, repo: context.repo.repo,
-              sha: '${{ github.event.workflow_run.head_sha }}',
-              state: 'pending',
-              target_url: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}',
-              context: '${{ env.STATUS_CONTEXT }}'
-            });
-
-      - name: Download E2E assets from CI
-        uses: actions/download-artifact@v8
-        with:
-          name: e2e-assets
-          path: ${{ env.E2E_ASSETS_DIR }}
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Python venv and install test deps
-        run: |
-          python3 -m venv /tmp/spur-k8s-e2e-venv
-          /tmp/spur-k8s-e2e-venv/bin/pip install -r "$E2E_ASSETS_DIR/tests/requirements.txt"
-          echo "/tmp/spur-k8s-e2e-venv/bin" >> "$GITHUB_PATH"
-
-      - name: Select kubectl context
-        run: kubectl config use-context kubernetes-admin@kubernetes
-
-      - name: Remove leftover spur-ci namespaces
-        run: |
-          set -euo pipefail
-          leftover=$(kubectl get ns -o jsonpath='{.items[*].metadata.name}' \
-            | tr ' ' '\n' | grep '^spur-ci-' || true)
-          if [ -z "$leftover" ]; then
-            echo "No leftover spur-ci namespaces"
-            exit 0
+          if [[ "${{ matrix.cluster_type }}" == "k8s" ]]; then
+            echo "path=${SPUR_CI_IMAGE_DIR}/spur-ci-k8s.qcow2" >> "$GITHUB_OUTPUT"
+          else
+            echo "path=${SPUR_CI_IMAGE_DIR}/spur-ci-base.qcow2" >> "$GITHUB_OUTPUT"
           fi
-          echo "Deleting leftover spur-ci namespaces:"
-          echo "$leftover"
-          for ns in $leftover; do
-            kubectl delete ns "$ns" --ignore-not-found --wait=false
+
+      - name: Bring up ephemeral VM cluster
+        id: cluster
+        run: |
+          /opt/spur-ci/bin/cluster-up.sh \
+            --prefix "${SPUR_CI_VM_PREFIX}-${{ github.run_id }}" \
+            --count 4 \
+            --image "${{ steps.image.outputs.path }}" \
+            --gpus-per-vm 1 \
+            --skip-gpu-for 0 \
+            --ssh-pubkey "${{ steps.ssh.outputs.pubkey }}" \
+            --network "${SPUR_CI_NETWORK}" \
+            --gpu-vfs "${SPUR_CI_GPU_VFS}" \
+            > /tmp/cluster-env.sh
+          source /tmp/cluster-env.sh
+          echo "driver_ip=${VM_0_IP}" >> "$GITHUB_OUTPUT"
+          echo "gpu_ips=${VM_1_IP},${VM_2_IP},${VM_3_IP}" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for VMs to be reachable
+        run: |
+          source /tmp/cluster-env.sh
+          for ip in $VM_0_IP $VM_1_IP $VM_2_IP $VM_3_IP; do
+            for i in $(seq 1 60); do
+              if ssh -o StrictHostKeyChecking=no -o ConnectTimeout=3 \
+                -i "${{ steps.ssh.outputs.privkey }}" ci@"$ip" true 2>/dev/null; then
+                break
+              fi
+              sleep 2
+            done
           done
-          deadline=$((SECONDS + 120))
-          while [ "$SECONDS" -lt "$deadline" ]; do
-            remaining=$(kubectl get ns -o jsonpath='{.items[*].metadata.name}' \
-              | tr ' ' '\n' | grep '^spur-ci-' || true)
-            if [ -z "$remaining" ]; then
-              echo "All spur-ci namespaces removed"
-              exit 0
-            fi
-            echo "Waiting for namespaces to terminate: $remaining"
-            sleep 5
-          done
-          echo "ERROR: timed out after 2m waiting for spur-ci namespace deletion:"
-          kubectl get ns -o wide $(echo "$remaining" | tr '\n' ' ')
-          exit 1
 
-      - name: Clean cluster-scoped Spur RBAC (pre)
+      - name: Bootstrap k8s cluster (k8s only)
+        if: matrix.cluster_type == 'k8s'
         run: |
+          source /tmp/cluster-env.sh
+          /opt/spur-ci/bin/k8s-bootstrap.sh \
+            --control-plane "$VM_1_IP" \
+            --workers "$VM_2_IP,$VM_3_IP" \
+            --ssh-key "${{ steps.ssh.outputs.privkey }}" \
+            --ssh-user ci \
+            --image-tar /tmp/spur-image.tar
+
+      - name: Push artifacts into driver VM
+        run: |
+          DRIVER_IP="${{ steps.cluster.outputs.driver_ip }}"
+          KEY="${{ steps.ssh.outputs.privkey }}"
+          SSH_OPTS="-o StrictHostKeyChecking=no -i $KEY"
+
+          scp $SSH_OPTS -r /tmp/release-binaries ci@"$DRIVER_IP":/tmp/
+          scp $SSH_OPTS -r /tmp/e2e-assets ci@"$DRIVER_IP":/tmp/
+          scp $SSH_OPTS "$KEY" ci@"$DRIVER_IP":/tmp/ci-ssh-key
+          ssh $SSH_OPTS ci@"$DRIVER_IP" "chmod 600 /tmp/ci-ssh-key"
+
+      - name: Run tests inside driver VM (native-host)
+        if: matrix.cluster_type == 'native-host'
+        run: |
+          DRIVER_IP="${{ steps.cluster.outputs.driver_ip }}"
+          GPU_IPS="${{ steps.cluster.outputs.gpu_ips }}"
+          KEY="${{ steps.ssh.outputs.privkey }}"
+
+          ssh -o StrictHostKeyChecking=no -i "$KEY" ci@"$DRIVER_IP" bash -s <<REMOTE
           set -euo pipefail
-          kubectl delete clusterrolebinding spur-operator --ignore-not-found
-          kubectl delete clusterrole spur-operator --ignore-not-found
+          export SPUR_TEST_NODES="$GPU_IPS"
+          export SPUR_TEST_SSH_USER=ci
+          export SPUR_TEST_SSH_KEY=/tmp/ci-ssh-key
+          export SPUR_TEST_BINARIES_DIR=/tmp/release-binaries
+          export SPUR_TEST_REMOTE_BIN_DIR=/tmp/spur-ci-bin
+          export SPUR_TEST_GPU_VENV=/opt/spur-ci/gpu-venv
+          chmod +x /tmp/release-binaries/*
+          source /opt/spur-ci/test-venv/bin/activate
+          pytest /tmp/e2e-assets/tests/native_host/e2e/ -v --junitxml=/tmp/results.xml
+          REMOTE
 
-      - name: Create test namespace
+      - name: Run tests inside driver VM (k8s)
+        if: matrix.cluster_type == 'k8s'
         run: |
-          kubectl create namespace "$SPUR_TEST_NS" \
-            --dry-run=client -o yaml | kubectl apply -f -
+          DRIVER_IP="${{ steps.cluster.outputs.driver_ip }}"
+          KEY="${{ steps.ssh.outputs.privkey }}"
 
-      - name: Create registry pull secret
-        run: |
+          ssh -o StrictHostKeyChecking=no -i "$KEY" ci@"$DRIVER_IP" bash -s <<REMOTE
           set -euo pipefail
-          kubectl create secret docker-registry regcred \
-            --docker-server=ghcr.io \
-            --docker-username="${{ github.actor }}" \
-            --docker-password="${{ secrets.GITHUB_TOKEN }}" \
-            -n "$SPUR_TEST_NS" \
-            --dry-run=client -o yaml | kubectl apply -f -
+          export KUBECONFIG=/home/ci/.kube/config
+          source /opt/spur-ci/test-venv/bin/activate
+          pytest /tmp/e2e-assets/tests/k8s/e2e/ -v --junitxml=/tmp/results.xml
+          REMOTE
 
-      - name: Attach pull secret to default ServiceAccount
+      - name: Collect results from driver VM
+        if: always()
         run: |
-          kubectl patch serviceaccount default -n "$SPUR_TEST_NS" \
-            -p '{"imagePullSecrets": [{"name": "regcred"}]}'
+          DRIVER_IP="${{ steps.cluster.outputs.driver_ip }}"
+          KEY="${{ steps.ssh.outputs.privkey }}"
+          mkdir -p /tmp/e2e-results
+          scp -o StrictHostKeyChecking=no -i "$KEY" \
+            ci@"$DRIVER_IP":/tmp/results.xml /tmp/e2e-results/ 2>/dev/null || true
+          # Scrub logs inside driver VM (not on host)
+          ssh -o StrictHostKeyChecking=no -i "$KEY" ci@"$DRIVER_IP" \
+            "find /tmp -name '*.log' -exec rm -f {} + 2>/dev/null" || true
 
-      - name: Apply RBAC
-        run: |
-          set -euo pipefail
-          sed "s/namespace: spur/namespace: $SPUR_TEST_NS/g" \
-            "$E2E_ASSETS_DIR/tests/k8s/e2e/manifests/rbac.yaml" | kubectl apply -f -
-
-      - name: Verify cluster can pull CI image
-        run: |
-          set -euo pipefail
-          kubectl run image-pull-check \
-            --namespace="$SPUR_TEST_NS" \
-            --image="$SPUR_CI_IMAGE" \
-            --restart=Never \
-            --command -- sleep 30
-          if ! kubectl wait --namespace="$SPUR_TEST_NS" \
-            --for=condition=Ready pod/image-pull-check --timeout=120s; then
-            echo "ERROR: cluster failed to pull $SPUR_CI_IMAGE"
-            kubectl describe pod image-pull-check -n "$SPUR_TEST_NS" || true
-            kubectl get events -n "$SPUR_TEST_NS" --sort-by='.lastTimestamp' | tail -30 || true
-            exit 1
-          fi
-          kubectl delete pod image-pull-check -n "$SPUR_TEST_NS" --ignore-not-found --wait=true
-
-      - name: Run K8s E2E tests
-        run: |
-          pytest "$E2E_ASSETS_DIR/tests/k8s/e2e/" -v
-
-      - name: Collect K8s test logs
-        if: failure()
-        run: |
-          set -euo pipefail
-          mkdir -p /tmp/k8s-logs
-          kubectl get events -n "$SPUR_TEST_NS" --sort-by='.lastTimestamp' \
-            > /tmp/k8s-logs/events.txt 2>&1 || true
-          for pod in $(kubectl get pods -n "$SPUR_TEST_NS" -o name 2>/dev/null || true); do
-            kubectl logs -n "$SPUR_TEST_NS" "$pod" --all-containers \
-              > "/tmp/k8s-logs/${pod}.log" 2>&1 || true
-          done
-          echo "Collected K8s logs:"
-          find /tmp/k8s-logs -type f | head -20
-
-      - name: Upload K8s test logs
-        if: failure()
+      - name: Upload test results
+        if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: k8s-logs
-          path: /tmp/k8s-logs/
+          name: e2e-results-${{ matrix.cluster_type }}
+          path: /tmp/e2e-results/
           retention-days: 3
           if-no-files-found: ignore
 
-      - name: Cleanup test resources
+      - name: Tear down ephemeral VM cluster
         if: always()
         run: |
-          set -euo pipefail
-          kubectl delete namespace "${SPUR_TEST_NS}-user1" --ignore-not-found --timeout=120s || true
-          kubectl delete namespace "$SPUR_TEST_NS" --ignore-not-found --timeout=120s || true
-          kubectl delete clusterrolebinding spur-operator --ignore-not-found
-          kubectl delete clusterrole spur-operator --ignore-not-found
-          kubectl delete crd spurjobs.spur.amd.com --ignore-not-found --timeout=120s || true
+          /opt/spur-ci/bin/cluster-down.sh \
+            --prefix "${SPUR_CI_VM_PREFIX}-${{ github.run_id }}" \
+            --count 4
 
-      - name: Cleanup local artifacts
+      - name: Cleanup ephemeral keys
         if: always()
-        run: |
-          rm -rf /tmp/spur-k8s-e2e-venv
-          rm -rf "$E2E_ASSETS_DIR"
-          rm -rf /tmp/k8s-logs
+        run: rm -rf "${{ steps.ssh.outputs.key_dir }}"
 
       - name: Report status
         if: always()
@@ -549,4 +257,3 @@ jobs:
               context: '${{ env.STATUS_CONTEXT }}',
               description: '${{ job.status }}'
             });
-

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -66,9 +66,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cluster_type: [native-host, k8s]
+        include:
+          - cluster_type: native-host
+            STATUS_CONTEXT: "E2E / native-host"
+          - cluster_type: k8s
+            STATUS_CONTEXT: "E2E / k8s"
     env:
-      STATUS_CONTEXT: "E2E / ${{ matrix.cluster_type }}"
+      STATUS_CONTEXT: ${{ matrix.STATUS_CONTEXT }}
     steps:
       - name: Set pending status
         uses: actions/github-script@v9

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -178,6 +178,11 @@ jobs:
           scp $SSH_OPTS -r /tmp/e2e-assets ci@"$DRIVER_IP":/tmp/
           scp $SSH_OPTS "$KEY" ci@"$DRIVER_IP":/tmp/ci-ssh-key
           ssh $SSH_OPTS ci@"$DRIVER_IP" "chmod 600 /tmp/ci-ssh-key"
+          # Copy kubeconfig into driver VM (written by k8s-bootstrap on the host)
+          if [[ -f /tmp/spur-kubeconfig ]]; then
+            ssh $SSH_OPTS ci@"$DRIVER_IP" "mkdir -p /home/ci/.kube"
+            scp $SSH_OPTS /tmp/spur-kubeconfig ci@"$DRIVER_IP":/home/ci/.kube/config
+          fi
 
       - name: Load AppArmor profile for rootless containers
         if: matrix.cluster_type == 'native-host'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -60,7 +60,7 @@ jobs:
             }
 
   e2e:
-    name: E2E (${{ matrix.cluster_type }})
+    name: ${{ matrix.STATUS_CONTEXT }}
     runs-on: [self-hosted, spur-e2e, gpu]
     if: github.event.workflow_run.conclusion == 'success'
     strategy:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -149,7 +149,7 @@ jobs:
           source /tmp/cluster-env.sh
           for ip in $VM_0_IP $VM_1_IP $VM_2_IP $VM_3_IP; do
             for i in $(seq 1 60); do
-              if ssh -o StrictHostKeyChecking=no -o ConnectTimeout=3 \
+              if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=3 \
                 -i "${{ steps.ssh.outputs.privkey }}" ci@"$ip" true 2>/dev/null; then
                 break
               fi
@@ -172,7 +172,7 @@ jobs:
         run: |
           DRIVER_IP="${{ steps.cluster.outputs.driver_ip }}"
           KEY="${{ steps.ssh.outputs.privkey }}"
-          SSH_OPTS="-o StrictHostKeyChecking=no -i $KEY"
+          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $KEY"
 
           scp $SSH_OPTS -r /tmp/release-binaries ci@"$DRIVER_IP":/tmp/
           scp $SSH_OPTS -r /tmp/e2e-assets ci@"$DRIVER_IP":/tmp/
@@ -185,7 +185,7 @@ jobs:
           DRIVER_IP="${{ steps.cluster.outputs.driver_ip }}"
           GPU_IPS="${{ steps.cluster.outputs.gpu_ips }}"
           KEY="${{ steps.ssh.outputs.privkey }}"
-          SSH_OPTS="-o StrictHostKeyChecking=no -i $KEY"
+          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $KEY"
           SPURD="/tmp/spur-ci-bin/spurd"
           PROF="abi <abi/4.0>,
           profile spur-ci ${SPURD} flags=(unconfined) {
@@ -203,7 +203,7 @@ jobs:
           GPU_IPS="${{ steps.cluster.outputs.gpu_ips }}"
           KEY="${{ steps.ssh.outputs.privkey }}"
 
-          ssh -o StrictHostKeyChecking=no -i "$KEY" ci@"$DRIVER_IP" bash -s <<REMOTE
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i "$KEY" ci@"$DRIVER_IP" bash -s <<REMOTE
           set -euo pipefail
           export SPUR_TEST_NODES="$GPU_IPS"
           export SPUR_TEST_SSH_USER=ci
@@ -222,7 +222,7 @@ jobs:
           DRIVER_IP="${{ steps.cluster.outputs.driver_ip }}"
           KEY="${{ steps.ssh.outputs.privkey }}"
 
-          ssh -o StrictHostKeyChecking=no -i "$KEY" ci@"$DRIVER_IP" bash -s <<REMOTE
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i "$KEY" ci@"$DRIVER_IP" bash -s <<REMOTE
           set -euo pipefail
           export KUBECONFIG=/home/ci/.kube/config
           source /opt/spur-ci/test-venv/bin/activate
@@ -235,10 +235,9 @@ jobs:
           DRIVER_IP="${{ steps.cluster.outputs.driver_ip }}"
           KEY="${{ steps.ssh.outputs.privkey }}"
           mkdir -p /tmp/e2e-results
-          scp -o StrictHostKeyChecking=no -i "$KEY" \
+          scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i "$KEY" \
             ci@"$DRIVER_IP":/tmp/results.xml /tmp/e2e-results/ 2>/dev/null || true
-          # Scrub logs inside driver VM (not on host)
-          ssh -o StrictHostKeyChecking=no -i "$KEY" ci@"$DRIVER_IP" \
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i "$KEY" ci@"$DRIVER_IP" \
             "find /tmp -name '*.log' -exec rm -f {} + 2>/dev/null" || true
 
       - name: Upload test results

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -130,6 +130,8 @@ jobs:
       - name: Bring up ephemeral VM cluster
         id: cluster
         run: |
+          CLUSTER_ENV=$(mktemp /tmp/cluster-env-XXXXXX.sh)
+          echo "cluster_env=$CLUSTER_ENV" >> "$GITHUB_OUTPUT"
           /opt/spur-ci/bin/cluster-up.sh \
             --prefix "${SPUR_CI_VM_PREFIX}-${{ github.run_id }}" \
             --count 4 \
@@ -139,29 +141,38 @@ jobs:
             --ssh-pubkey "${{ steps.ssh.outputs.pubkey }}" \
             --network "${SPUR_CI_NETWORK}" \
             --gpu-vfs "${SPUR_CI_GPU_VFS}" \
-            > /tmp/cluster-env.sh
-          source /tmp/cluster-env.sh
+            > "$CLUSTER_ENV"
+          source "$CLUSTER_ENV"
           echo "driver_ip=${VM_0_IP}" >> "$GITHUB_OUTPUT"
           echo "gpu_ips=${VM_1_IP},${VM_2_IP},${VM_3_IP}" >> "$GITHUB_OUTPUT"
 
       - name: Wait for VMs to be reachable
         run: |
-          source /tmp/cluster-env.sh
+          source "${{ steps.cluster.outputs.cluster_env }}"
+          KEY="${{ steps.ssh.outputs.privkey }}"
           for ip in $VM_0_IP $VM_1_IP $VM_2_IP $VM_3_IP; do
-            for i in $(seq 1 60); do
+            echo "Waiting for $ip..."
+            ok=false
+            for i in $(seq 1 90); do
               if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=3 \
-                -i "${{ steps.ssh.outputs.privkey }}" ci@"$ip" true 2>/dev/null; then
+                -o BatchMode=yes -i "$KEY" ci@"$ip" true 2>/dev/null; then
+                echo "  $ip ready"
+                ok=true
                 break
               fi
               sleep 2
             done
+            if [[ "$ok" != "true" ]]; then
+              echo "ERROR: $ip not reachable after 180s" >&2
+              exit 1
+            fi
           done
 
       - name: Bootstrap k8s cluster (k8s only)
         if: matrix.cluster_type == 'k8s'
         id: k8s-bootstrap
         run: |
-          source /tmp/cluster-env.sh
+          source "${{ steps.cluster.outputs.cluster_env }}"
           KUBECONFIG_DIR=$(mktemp -d)
           /opt/spur-ci/bin/k8s-bootstrap.sh \
             --control-plane "$VM_1_IP" \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -159,14 +159,18 @@ jobs:
 
       - name: Bootstrap k8s cluster (k8s only)
         if: matrix.cluster_type == 'k8s'
+        id: k8s-bootstrap
         run: |
           source /tmp/cluster-env.sh
+          KUBECONFIG_DIR=$(mktemp -d)
           /opt/spur-ci/bin/k8s-bootstrap.sh \
             --control-plane "$VM_1_IP" \
             --workers "$VM_2_IP,$VM_3_IP" \
             --ssh-key "${{ steps.ssh.outputs.privkey }}" \
             --ssh-user ci \
+            --kubeconfig "$KUBECONFIG_DIR/config" \
             --image-tar /tmp/spur-image.tar
+          echo "kubeconfig=$KUBECONFIG_DIR/config" >> "$GITHUB_OUTPUT"
 
       - name: Push artifacts into driver VM
         run: |
@@ -179,9 +183,10 @@ jobs:
           scp $SSH_OPTS "$KEY" ci@"$DRIVER_IP":/tmp/ci-ssh-key
           ssh $SSH_OPTS ci@"$DRIVER_IP" "chmod 600 /tmp/ci-ssh-key"
           # Copy kubeconfig into driver VM (written by k8s-bootstrap on the host)
-          if [[ -f /tmp/spur-kubeconfig ]]; then
+          KUBECONFIG_FILE="${{ steps.k8s-bootstrap.outputs.kubeconfig }}"
+          if [[ -n "$KUBECONFIG_FILE" && -f "$KUBECONFIG_FILE" ]]; then
             ssh $SSH_OPTS ci@"$DRIVER_IP" "mkdir -p /home/ci/.kube"
-            scp $SSH_OPTS /tmp/spur-kubeconfig ci@"$DRIVER_IP":/home/ci/.kube/config
+            scp $SSH_OPTS "$KUBECONFIG_FILE" ci@"$DRIVER_IP":/home/ci/.kube/config
           fi
 
       - name: Load AppArmor profile for rootless containers

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -276,7 +276,7 @@ jobs:
           REMOTE
 
       - name: Dump cluster diagnostics (k8s)
-        if: always() && matrix.cluster_type == 'k8s'
+        if: failure() && matrix.cluster_type == 'k8s'
         run: |
           DRIVER_IP="${{ steps.cluster.outputs.driver_ip }}"
           KEY="${{ steps.ssh.outputs.privkey }}"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -179,8 +179,8 @@ jobs:
           source "${{ steps.cluster.outputs.cluster_env }}"
           KUBECONFIG_DIR=$(mktemp -d)
           /opt/spur-ci/bin/k8s-bootstrap.sh \
-            --control-plane "$VM_1_IP" \
-            --workers "$VM_2_IP,$VM_3_IP" \
+            --control-plane "$VM_0_IP" \
+            --workers "$VM_1_IP,$VM_2_IP,$VM_3_IP" \
             --ssh-key "${{ steps.ssh.outputs.privkey }}" \
             --ssh-user ci \
             --kubeconfig "$KUBECONFIG_DIR/config" \
@@ -197,12 +197,8 @@ jobs:
           scp $SSH_OPTS -r /tmp/e2e-assets ci@"$DRIVER_IP":/tmp/
           scp $SSH_OPTS "$KEY" ci@"$DRIVER_IP":/tmp/ci-ssh-key
           ssh $SSH_OPTS ci@"$DRIVER_IP" "chmod 600 /tmp/ci-ssh-key"
-          # Copy kubeconfig into driver VM (written by k8s-bootstrap on the host)
-          KUBECONFIG_FILE="${{ steps.k8s-bootstrap.outputs.kubeconfig }}"
-          if [[ -n "$KUBECONFIG_FILE" && -f "$KUBECONFIG_FILE" ]]; then
-            ssh $SSH_OPTS ci@"$DRIVER_IP" "mkdir -p /home/ci/.kube"
-            scp $SSH_OPTS "$KUBECONFIG_FILE" ci@"$DRIVER_IP":/home/ci/.kube/config
-          fi
+          # Kubeconfig: driver VM is also the control plane, so kubeadm
+          # already placed it at ~/.kube/config during bootstrap.
 
       - name: Load AppArmor profile for rootless containers
         if: matrix.cluster_type == 'native-host'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -235,16 +235,42 @@ jobs:
           pytest /tmp/e2e-assets/tests/native_host/e2e/ -v --junitxml=/tmp/results.xml
           REMOTE
 
+      - name: Apply RBAC and verify cluster state (k8s)
+        if: matrix.cluster_type == 'k8s'
+        run: |
+          DRIVER_IP="${{ steps.cluster.outputs.driver_ip }}"
+          KEY="${{ steps.ssh.outputs.privkey }}"
+          SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $KEY"
+          NS="spur-ci-${{ github.run_id }}"
+
+          ssh $SSH_OPTS ci@"$DRIVER_IP" bash -s <<REMOTE
+          set -euo pipefail
+          export KUBECONFIG=/home/ci/.kube/config
+
+          # Create test namespace
+          kubectl create namespace "$NS" --dry-run=client -o yaml | kubectl apply -f -
+
+          # Apply RBAC with namespace patched
+          sed "s/namespace: spur/namespace: $NS/g" \
+            /tmp/e2e-assets/tests/k8s/e2e/manifests/rbac.yaml | kubectl apply -f -
+
+          # Verify nodes are labeled
+          echo "=== Labeled nodes ==="
+          kubectl get nodes -l spur.amd.com/managed=true -o wide
+          REMOTE
+
       - name: Run tests inside driver VM (k8s)
         if: matrix.cluster_type == 'k8s'
         run: |
           DRIVER_IP="${{ steps.cluster.outputs.driver_ip }}"
           KEY="${{ steps.ssh.outputs.privkey }}"
+          NS="spur-ci-${{ github.run_id }}"
 
           ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i "$KEY" ci@"$DRIVER_IP" bash -s <<REMOTE
           set -euo pipefail
           export KUBECONFIG=/home/ci/.kube/config
           export SPUR_CI_IMAGE=docker.io/library/spur:ci
+          export SPUR_TEST_NS="$NS"
           source /opt/spur-ci/test-venv/bin/activate
           pytest /tmp/e2e-assets/tests/k8s/e2e/ -v --junitxml=/tmp/results.xml
           REMOTE

--- a/tests/k8s/e2e/k8s_cluster.py
+++ b/tests/k8s/e2e/k8s_cluster.py
@@ -23,6 +23,7 @@ from kubernetes.utils import create_from_dict
 logger = logging.getLogger(__name__)
 
 _MANIFESTS_DIR = Path(__file__).resolve().parent / "manifests"
+_DEFAULT_IMAGE = "ghcr.io/rocm/spur:ci"
 
 SPUR_JOB_GROUP = "spur.amd.com"
 SPUR_JOB_VERSION = "v1alpha1"
@@ -121,7 +122,7 @@ class FixtureConfig:
 
     @classmethod
     def single_node(cls) -> FixtureConfig:
-        image = os.environ.get("SPUR_CI_IMAGE", "spur:ci")
+        image = os.environ.get("SPUR_CI_IMAGE", _DEFAULT_IMAGE)
         return cls(
             replicas=1,
             image=image,
@@ -144,7 +145,7 @@ default_time = "10m"
 
     @classmethod
     def raft_ha(cls) -> FixtureConfig:
-        image = os.environ.get("SPUR_CI_IMAGE", "spur:ci")
+        image = os.environ.get("SPUR_CI_IMAGE", _DEFAULT_IMAGE)
         return cls(
             replicas=3,
             image=image,
@@ -350,7 +351,7 @@ class ClusterFixture:
             doc = doc.strip()
             if not doc:
                 continue
-            patched = doc.replace("spur:latest", self.config.image)
+            patched = doc.replace(_DEFAULT_IMAGE, self.config.image)
             if replicas is not None:
                 patched = patched.replace("replicas: 3", f"replicas: {replicas}")
             value = yaml.safe_load(patched)

--- a/tests/k8s/e2e/manifests/operator.yaml
+++ b/tests/k8s/e2e/manifests/operator.yaml
@@ -31,7 +31,8 @@ spec:
     spec:
       containers:
         - name: operator
-          image: spur:latest
+          image: ghcr.io/rocm/spur:ci
+          imagePullPolicy: IfNotPresent
           command: [spur-k8s-operator]
           args:
             - --controller-addr=spurctld.spur.svc.cluster.local:6817

--- a/tests/k8s/e2e/manifests/spurctld.yaml
+++ b/tests/k8s/e2e/manifests/spurctld.yaml
@@ -36,7 +36,8 @@ spec:
         fsGroup: 1001
       containers:
         - name: spurctld
-          image: spur:latest
+          image: ghcr.io/rocm/spur:ci
+          imagePullPolicy: IfNotPresent
           command: [spurctld]
           args:
             - --listen=[::]:6817


### PR DESCRIPTION
Migrate E2E tests from persistent bare-metal/k8s runners to ephemeral VM-based self-hosted runners. Each run spins up a fresh 4-node libvirt cluster with GPU passthrough, runs the test suite inside a disposable driver VM, and tears everything down.

Runners are registered on two GPU servers (2 slots each, 4 total) with labels `self-hosted,spur-e2e,gpu`.