### PR TITLE
ci: mark sub-1.0.0 releases as pre-release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
       "package-name": "spur",
       "include-component-in-tag": false,
       "draft-pull-request": true,
+      "prerelease": true,
       "bump-minor-pre-major": true,
       "changelog-sections": [
         { "type": "feat", "section": "Features" },


### PR DESCRIPTION
## Summary
Follow-up to #387. Sets `prerelease: true` in `release-please-config.json` so pre-major (0.x) GitHub Releases are flagged as pre-release.

- Applies to versions below `1.0.0`; automatically publishes as full releases once `1.0.0` is reached, no config change needed.
- Does not change version numbers (default versioning strategy retained; this is only the GitHub Release pre-release flag, not the `prerelease` versioning strategy that would produce `-beta.N` suffixes).
