### PR TITLE
feat(spur-metrics): add partition, job and more metrics

### DIFF
--- a/crates/spur-cli/src/sdiag.rs
+++ b/crates/spur-cli/src/sdiag.rs
@@ -233,6 +233,8 @@ fn scheduler_statistics_lines(stats: &SchedStats) -> Vec<String> {
         format!("  Jobs started        : {}", stats.jobs_started),
         format!("  Jobs finalized      : {}", stats.jobs_finalized),
         format!("  Jobs started (last) : {}", stats.jobs_started_last_cycle),
+        format!("  Exit end of queue   : {}", stats.exit_end),
+        format!("  Exit max depth      : {}", stats.exit_max_depth),
     ]
 }
 
@@ -371,6 +373,8 @@ mod tests {
             jobs_started: 8,
             jobs_finalized: 7,
             jobs_started_last_cycle: 2,
+            exit_end: 4,
+            exit_max_depth: 1,
         };
         let lines = scheduler_statistics_lines(&stats);
         assert!(lines.iter().any(|l| l.contains("Plugin")));
@@ -378,6 +382,8 @@ mod tests {
         assert!(lines.iter().any(|l| l.contains("Cycle total (us)")));
         assert!(lines.iter().any(|l| l.contains("Schedule total (us)")));
         assert!(lines.iter().any(|l| l.contains("Jobs started (last) : 2")));
+        assert!(lines.iter().any(|l| l.contains("Exit end of queue   : 4")));
+        assert!(lines.iter().any(|l| l.contains("Exit max depth      : 1")));
     }
 
     #[test]

--- a/crates/spur-metrics/src/export/jobs.rs
+++ b/crates/spur-metrics/src/export/jobs.rs
@@ -45,6 +45,12 @@ pub fn register_jobs(registry: &mut Registry, snap: &JobMetricsSnapshot) {
 
     register_gauge(
         registry,
+        "spur_jobs_hold",
+        "Number of jobs in Pending state with a hold set",
+        snap.held_pending,
+    );
+    register_gauge(
+        registry,
         "spur_jobs_cpus_alloc",
         "Total CPUs allocated to jobs in Running or Completing state",
         snap.running_cpus,
@@ -117,6 +123,7 @@ mod tests {
         assert!(body.contains("# HELP spur_jobs "));
         assert!(body.contains("spur_jobs 4\n"));
         assert!(body.contains("spur_jobs_pending 2\n"));
+        assert!(body.contains("spur_jobs_hold 1\n"));
         assert!(body.contains("spur_jobs_running 1\n"));
         assert!(body.contains("spur_jobs_completed 1\n"));
         assert!(body.contains("spur_jobs_cpus_alloc 4\n"));

--- a/crates/spur-metrics/src/export/jobs_users_accts.rs
+++ b/crates/spur-metrics/src/export/jobs_users_accts.rs
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-user and per-account job gauge registration for `/metrics/jobs-users-accts`.
+//!
+//! Opt-in (`metrics.high_cardinality`): each user/account is its own time series.
+
+use prometheus_client::encoding::EncodeLabelSet;
+use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::gauge::Gauge;
+use prometheus_client::registry::Registry;
+use spur_core::job::JobState;
+use std::sync::atomic::AtomicU64;
+
+use crate::export::encode_registered;
+use crate::export::jobs::job_state_metric_suffix;
+use crate::job::JobMetricsSnapshot;
+use crate::user_acct::UserAcctMetricsSnapshot;
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct UserLabel {
+    username: String,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct AccountLabel {
+    account: String,
+}
+
+type LabeledGauge<L> = Family<L, Gauge<u64, AtomicU64>>;
+
+fn register_entity_gauges<L, F>(
+    registry: &mut Registry,
+    prefix: &str,
+    entities: &[(String, JobMetricsSnapshot)],
+    label_for: F,
+) where
+    L: Clone + std::hash::Hash + Eq + EncodeLabelSet + 'static + std::fmt::Debug + Send + Sync,
+    F: Fn(&str) -> L,
+{
+    let total = LabeledGauge::<L>::default();
+    let cpus_alloc = LabeledGauge::<L>::default();
+    let memory_alloc_bytes = LabeledGauge::<L>::default();
+    let gpus_alloc = LabeledGauge::<L>::default();
+    let mut state_families: Vec<(JobState, LabeledGauge<L>)> = JobState::ALL
+        .iter()
+        .map(|&s| (s, Family::default()))
+        .collect();
+
+    for (name, snap) in entities {
+        let label = label_for(name);
+        total.get_or_create(&label).set(snap.total);
+        cpus_alloc.get_or_create(&label).set(snap.running_cpus);
+        memory_alloc_bytes
+            .get_or_create(&label)
+            .set(snap.running_memory_bytes);
+        gpus_alloc.get_or_create(&label).set(snap.running_gpus);
+        for (state, family) in &state_families {
+            family.get_or_create(&label).set(snap.count_state(*state));
+        }
+    }
+
+    registry.register(format!("spur_{prefix}_jobs"), "Total number of jobs", total);
+    registry.register(
+        format!("spur_{prefix}_jobs_cpus_alloc"),
+        "Total CPUs allocated to jobs in Running or Completing state",
+        cpus_alloc,
+    );
+    registry.register(
+        format!("spur_{prefix}_jobs_memory_alloc_bytes"),
+        "Total memory in bytes allocated to jobs in Running or Completing state",
+        memory_alloc_bytes,
+    );
+    registry.register(
+        format!("spur_{prefix}_jobs_gpus_alloc"),
+        "Total GPUs allocated to jobs in Running or Completing state",
+        gpus_alloc,
+    );
+    for (state, family) in state_families.drain(..) {
+        let name = format!("spur_{prefix}_jobs_{}", job_state_metric_suffix(state));
+        let help = format!("Number of jobs in {} state", state.display());
+        registry.register(name, help, family);
+    }
+}
+
+/// Register per-user and per-account job gauges into `registry` from `snap`.
+pub fn register_jobs_users_accts(registry: &mut Registry, snap: &UserAcctMetricsSnapshot) {
+    register_entity_gauges(registry, "user", &snap.by_user, |username| UserLabel {
+        username: username.to_string(),
+    });
+    register_entity_gauges(registry, "account", &snap.by_account, |account| {
+        AccountLabel {
+            account: account.to_string(),
+        }
+    });
+}
+
+/// Encode per-user/per-account job metrics as OpenMetrics 1.0 text.
+pub fn encode_jobs_users_accts_metrics(snap: &UserAcctMetricsSnapshot) -> String {
+    encode_registered(|registry| register_jobs_users_accts(registry, snap))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spur_core::job::{Job, JobSpec};
+
+    #[test]
+    fn empty_snapshot_has_eof_only() {
+        let body = encode_jobs_users_accts_metrics(&UserAcctMetricsSnapshot::default());
+        assert_eq!(body, "# EOF\n");
+    }
+
+    #[test]
+    fn export_contains_per_user_and_per_account_families() {
+        let spec = JobSpec {
+            user: "alice".into(),
+            account: Some("teamA".into()),
+            ..Default::default()
+        };
+        let mut job = Job::new(1, spec);
+        job.state = JobState::Running;
+
+        let snap = UserAcctMetricsSnapshot::collect([&job]);
+        let body = encode_jobs_users_accts_metrics(&snap);
+
+        assert!(body.contains("spur_user_jobs{username=\"alice\"} 1\n"));
+        assert!(body.contains("spur_user_jobs_running{username=\"alice\"} 1\n"));
+        assert!(body.contains("spur_account_jobs{account=\"teamA\"} 1\n"));
+        assert!(body.contains("spur_account_jobs_running{account=\"teamA\"} 1\n"));
+    }
+}

--- a/crates/spur-metrics/src/export/mod.rs
+++ b/crates/spur-metrics/src/export/mod.rs
@@ -13,6 +13,7 @@ use std::sync::atomic::AtomicU64;
 pub const CONTENT_TYPE: &str = "application/openmetrics-text; version=1.0.0; charset=utf-8";
 
 pub mod jobs;
+pub mod jobs_users_accts;
 pub mod nodes;
 pub mod partitions;
 pub mod rpc;

--- a/crates/spur-metrics/src/export/partitions.rs
+++ b/crates/spur-metrics/src/export/partitions.rs
@@ -24,14 +24,10 @@ struct PartitionLabel {
 
 fn family_gauge(
     family: &Family<PartitionLabel, Gauge<u64, AtomicU64>>,
-    partition: &str,
+    label: &PartitionLabel,
     value: u64,
 ) {
-    family
-        .get_or_create(&PartitionLabel {
-            partition: partition.to_string(),
-        })
-        .set(value);
+    family.get_or_create(label).set(value);
 }
 
 /// Register partition gauges into `registry` from `snap`.
@@ -65,17 +61,20 @@ pub fn register_partitions(registry: &mut Registry, snap: &PartitionMetricsSnaps
     }
 
     for p in &snap.per_partition {
-        family_gauge(&jobs, &p.name, p.jobs_total);
-        family_gauge(&cpus, &p.name, p.cpus);
-        family_gauge(&cpus_alloc, &p.name, p.cpus_alloc);
-        family_gauge(&nodes, &p.name, p.nodes_total);
-        family_gauge(&memory_bytes, &p.name, p.memory_bytes);
-        family_gauge(&memory_alloc_bytes, &p.name, p.memory_alloc_bytes);
+        let label = PartitionLabel {
+            partition: p.name.clone(),
+        };
+        family_gauge(&jobs, &label, p.jobs_total);
+        family_gauge(&cpus, &label, p.cpus);
+        family_gauge(&cpus_alloc, &label, p.cpus_alloc);
+        family_gauge(&nodes, &label, p.nodes_total);
+        family_gauge(&memory_bytes, &label, p.memory_bytes);
+        family_gauge(&memory_alloc_bytes, &label, p.memory_alloc_bytes);
         for (state, family) in &job_state_families {
-            family_gauge(family, &p.name, p.count_job_state(*state));
+            family_gauge(family, &label, p.count_job_state(*state));
         }
         for (state, family) in &node_state_families {
-            family_gauge(family, &p.name, p.count_node_state(*state));
+            family_gauge(family, &label, p.count_node_state(*state));
         }
     }
 

--- a/crates/spur-metrics/src/export/partitions.rs
+++ b/crates/spur-metrics/src/export/partitions.rs
@@ -3,25 +3,176 @@
 
 //! Partition gauge registration for `/metrics/partitions` (Layer 1d).
 
+use prometheus_client::encoding::EncodeLabelSet;
+use prometheus_client::metrics::family::Family;
+use prometheus_client::metrics::gauge::Gauge;
 use prometheus_client::registry::Registry;
+use spur_core::job::JobState;
+use spur_core::node::NodeState;
+use std::sync::atomic::AtomicU64;
 
 use crate::export::encode_registered;
+use crate::export::jobs::job_state_metric_suffix;
+use crate::export::register_gauge;
+use crate::node::node_state_metric_suffix;
+use crate::partition::PartitionMetricsSnapshot;
 
-/// Register partition catalog gauges (stub until `PartitionMetricsSnapshot` exists).
-pub fn register_partitions(_registry: &mut Registry) {}
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct PartitionLabel {
+    partition: String,
+}
+
+fn family_gauge(
+    family: &Family<PartitionLabel, Gauge<u64, AtomicU64>>,
+    partition: &str,
+    value: u64,
+) {
+    family
+        .get_or_create(&PartitionLabel {
+            partition: partition.to_string(),
+        })
+        .set(value);
+}
+
+/// Register partition gauges into `registry` from `snap`.
+pub fn register_partitions(registry: &mut Registry, snap: &PartitionMetricsSnapshot) {
+    register_gauge(
+        registry,
+        "spur_partitions",
+        "Total number of partitions",
+        snap.total,
+    );
+
+    let jobs = Family::<PartitionLabel, Gauge<u64, AtomicU64>>::default();
+    let cpus = Family::<PartitionLabel, Gauge<u64, AtomicU64>>::default();
+    let cpus_alloc = Family::<PartitionLabel, Gauge<u64, AtomicU64>>::default();
+    let nodes = Family::<PartitionLabel, Gauge<u64, AtomicU64>>::default();
+    let memory_bytes = Family::<PartitionLabel, Gauge<u64, AtomicU64>>::default();
+    let memory_alloc_bytes = Family::<PartitionLabel, Gauge<u64, AtomicU64>>::default();
+    let mut job_state_families = Vec::new();
+    for &state in &JobState::ALL {
+        job_state_families.push((
+            state,
+            Family::<PartitionLabel, Gauge<u64, AtomicU64>>::default(),
+        ));
+    }
+    let mut node_state_families = Vec::new();
+    for &state in &NodeState::ALL {
+        node_state_families.push((
+            state,
+            Family::<PartitionLabel, Gauge<u64, AtomicU64>>::default(),
+        ));
+    }
+
+    for p in &snap.per_partition {
+        family_gauge(&jobs, &p.name, p.jobs_total);
+        family_gauge(&cpus, &p.name, p.cpus);
+        family_gauge(&cpus_alloc, &p.name, p.cpus_alloc);
+        family_gauge(&nodes, &p.name, p.nodes_total);
+        family_gauge(&memory_bytes, &p.name, p.memory_bytes);
+        family_gauge(&memory_alloc_bytes, &p.name, p.memory_alloc_bytes);
+        for (state, family) in &job_state_families {
+            family_gauge(family, &p.name, p.count_job_state(*state));
+        }
+        for (state, family) in &node_state_families {
+            family_gauge(family, &p.name, p.count_node_state(*state));
+        }
+    }
+
+    registry.register(
+        "spur_partition_jobs",
+        "Jobs on the specified partition",
+        jobs,
+    );
+    registry.register(
+        "spur_partition_cpus",
+        "Total CPUs on the specified partition",
+        cpus,
+    );
+    registry.register(
+        "spur_partition_cpus_alloc",
+        "Allocated CPUs on the specified partition",
+        cpus_alloc,
+    );
+    registry.register(
+        "spur_partition_nodes",
+        "Nodes on the specified partition",
+        nodes,
+    );
+    registry.register(
+        "spur_partition_memory_bytes",
+        "Total memory in bytes on the specified partition",
+        memory_bytes,
+    );
+    registry.register(
+        "spur_partition_memory_alloc_bytes",
+        "Allocated memory in bytes on the specified partition",
+        memory_alloc_bytes,
+    );
+    for (state, family) in job_state_families {
+        let name = format!("spur_partition_jobs_{}", job_state_metric_suffix(state));
+        let help = format!(
+            "Jobs in {} state on the specified partition",
+            state.display()
+        );
+        registry.register(name, help, family);
+    }
+    for (state, family) in node_state_families {
+        let name = format!("spur_partition_nodes_{}", node_state_metric_suffix(state));
+        let help = format!(
+            "Nodes in {} state on the specified partition",
+            state.display()
+        );
+        registry.register(name, help, family);
+    }
+}
 
 /// Encode partition metrics for `/metrics/partitions` as OpenMetrics 1.0 text.
-pub fn encode_partitions_metrics() -> String {
-    encode_registered(register_partitions)
+pub fn encode_partitions_metrics(snap: &PartitionMetricsSnapshot) -> String {
+    encode_registered(|registry| register_partitions(registry, snap))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use spur_core::job::{Job, JobSpec};
+    use spur_core::node::Node;
+    use spur_core::resource::ResourceSet;
 
     #[test]
     fn empty_partitions_export_has_eof_only() {
-        let body = encode_partitions_metrics();
-        assert_eq!(body, "# EOF\n");
+        let body = encode_partitions_metrics(&PartitionMetricsSnapshot::default());
+        assert!(body.contains("spur_partitions 0\n"));
+        assert!(body.ends_with("# EOF\n"));
+    }
+
+    #[test]
+    fn export_contains_per_partition_families() {
+        let spec = JobSpec {
+            partition: Some("default".into()),
+            ..Default::default()
+        };
+        let mut job = Job::new(1, spec);
+        job.state = JobState::Running;
+
+        let mut node = Node::new(
+            "n1".into(),
+            ResourceSet {
+                cpus: 8,
+                memory_mb: 16384,
+                gpus: Vec::new(),
+                generic: Default::default(),
+            },
+        );
+        node.partitions = vec!["default".into()];
+
+        let snap = PartitionMetricsSnapshot::collect(["default"], [&job], [&node]);
+        let body = encode_partitions_metrics(&snap);
+
+        assert!(body.contains("spur_partitions 1\n"));
+        assert!(body.contains("spur_partition_jobs{partition=\"default\"} 1\n"));
+        assert!(body.contains("spur_partition_jobs_running{partition=\"default\"} 1\n"));
+        assert!(body.contains("spur_partition_nodes{partition=\"default\"} 1\n"));
+        assert!(body.contains("spur_partition_cpus{partition=\"default\"} 8\n"));
     }
 }

--- a/crates/spur-metrics/src/export/scheduler.rs
+++ b/crates/spur-metrics/src/export/scheduler.rs
@@ -90,6 +90,18 @@ pub fn register_scheduler(registry: &mut Registry, snap: &SchedStatsSnapshot) {
         "Jobs reaching a terminal state since reset",
         snap.jobs_finalized,
     );
+    register_counter(
+        registry,
+        "spur_scheduler_exit_end",
+        "Cycles that considered every pending job",
+        snap.exit_end,
+    );
+    register_counter(
+        registry,
+        "spur_scheduler_exit_max_depth",
+        "Cycles that stopped early at scheduler.max_jobs_per_cycle",
+        snap.exit_max_depth,
+    );
 }
 
 /// Encode scheduler metrics for `/metrics/scheduler` as OpenMetrics 1.0 text.
@@ -113,6 +125,8 @@ mod tests {
             jobs_started: 30,
             jobs_finalized: 28,
             jobs_started_last_cycle: 3,
+            exit_end: 8,
+            exit_max_depth: 2,
         }
     }
 
@@ -135,6 +149,8 @@ mod tests {
         assert!(!body.contains("_avg_time_us"));
         assert!(body.contains("spur_scheduler_jobs_submitted_total 42"));
         assert!(body.contains("spur_scheduler_jobs_started_last_cycle 3"));
+        assert!(body.contains("spur_scheduler_exit_end_total 8"));
+        assert!(body.contains("spur_scheduler_exit_max_depth_total 2"));
         assert_eq!(metric_type(&body, "spur_scheduler_cycles"), "counter");
         assert_eq!(
             metric_type(&body, "spur_scheduler_jobs_submitted"),

--- a/crates/spur-metrics/src/lib.rs
+++ b/crates/spur-metrics/src/lib.rs
@@ -6,15 +6,20 @@
 pub mod export;
 pub mod job;
 pub mod node;
+pub mod partition;
 pub mod rpc;
 pub mod scheduler;
+pub mod user_acct;
 
 pub use export::jobs::{encode_job_metrics, job_state_metric_suffix};
+pub use export::jobs_users_accts::encode_jobs_users_accts_metrics;
 pub use export::nodes::encode_nodes_metrics;
 pub use export::partitions::encode_partitions_metrics;
 pub use export::rpc::encode_rpc_metrics;
 pub use export::scheduler::encode_scheduler_metrics;
 pub use export::CONTENT_TYPE;
 pub use node::node_state_metric_suffix;
+pub use partition::PartitionMetricsSnapshot;
 pub use rpc::{RpcOperationSnapshot, RpcStatsSnapshot};
 pub use scheduler::SchedStatsSnapshot;
+pub use user_acct::UserAcctMetricsSnapshot;

--- a/crates/spur-metrics/src/partition.rs
+++ b/crates/spur-metrics/src/partition.rs
@@ -40,13 +40,18 @@ impl PartitionMetricsSnapshot {
     /// membership, not the raw hostlist pattern in partition config).
     pub fn collect<'a>(
         partition_names: impl IntoIterator<Item = &'a str>,
-        jobs: impl IntoIterator<Item = &'a Job> + Clone,
-        nodes: impl IntoIterator<Item = &'a Node> + Clone,
+        jobs: impl IntoIterator<Item = &'a Job>,
+        nodes: impl IntoIterator<Item = &'a Node>,
     ) -> Self {
-        let mut per_partition = Vec::new();
-
-        for name in partition_names {
-            let mut m = PerPartitionMetrics {
+        let names: Vec<&'a str> = partition_names.into_iter().collect();
+        let index_of: std::collections::HashMap<&'a str, usize> = names
+            .iter()
+            .enumerate()
+            .map(|(i, &name)| (name, i))
+            .collect();
+        let mut per_partition: Vec<PerPartitionMetrics> = names
+            .iter()
+            .map(|name| PerPartitionMetrics {
                 name: name.to_string(),
                 jobs_total: 0,
                 jobs_by_state: [0; JOB_STATE_COUNT],
@@ -56,20 +61,29 @@ impl PartitionMetricsSnapshot {
                 cpus_alloc: 0,
                 memory_bytes: 0,
                 memory_alloc_bytes: 0,
+            })
+            .collect();
+
+        for job in jobs {
+            let Some(&i) = job
+                .spec
+                .partition
+                .as_deref()
+                .and_then(|name| index_of.get(name))
+            else {
+                continue;
             };
+            let m = &mut per_partition[i];
+            m.jobs_total += 1;
+            m.jobs_by_state[job_state_index(job.state)] += 1;
+        }
 
-            for job in jobs.clone() {
-                if job.spec.partition.as_deref() != Some(name) {
+        for node in nodes {
+            for partition in &node.partitions {
+                let Some(&i) = index_of.get(partition.as_str()) else {
                     continue;
-                }
-                m.jobs_total += 1;
-                m.jobs_by_state[job_state_index(job.state)] += 1;
-            }
-
-            for node in nodes.clone() {
-                if !node.partitions.iter().any(|p| p == name) {
-                    continue;
-                }
+                };
+                let m = &mut per_partition[i];
                 m.nodes_total += 1;
                 m.nodes_by_state[node_state_index(node.state)] += 1;
                 m.cpus += u64::from(node.total_resources.cpus);
@@ -77,8 +91,6 @@ impl PartitionMetricsSnapshot {
                 m.memory_bytes += memory_mb_to_bytes(node.total_resources.memory_mb);
                 m.memory_alloc_bytes += memory_mb_to_bytes(node.alloc_resources.memory_mb);
             }
-
-            per_partition.push(m);
         }
 
         per_partition.sort_by(|a, b| a.name.cmp(&b.name));

--- a/crates/spur-metrics/src/partition.rs
+++ b/crates/spur-metrics/src/partition.rs
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use spur_core::job::{Job, JobState};
+use spur_core::node::{Node, NodeState};
+
+use crate::job::{job_state_index, JOB_STATE_COUNT};
+use crate::node::{node_state_index, NODE_STATE_COUNT};
+
+/// Aggregated metrics for a single partition, keyed by name for labeled export.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PerPartitionMetrics {
+    pub name: String,
+    pub jobs_total: u64,
+    pub jobs_by_state: [u64; JOB_STATE_COUNT],
+    pub nodes_total: u64,
+    pub nodes_by_state: [u64; NODE_STATE_COUNT],
+    pub cpus: u64,
+    pub cpus_alloc: u64,
+    pub memory_bytes: u64,
+    pub memory_alloc_bytes: u64,
+}
+
+/// Aggregated partition metrics derived from the controller's job and node maps.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PartitionMetricsSnapshot {
+    pub total: u64,
+    pub per_partition: Vec<PerPartitionMetrics>,
+}
+
+fn memory_mb_to_bytes(mb: u64) -> u64 {
+    mb.saturating_mul(1024 * 1024)
+}
+
+impl PartitionMetricsSnapshot {
+    /// Rebuild metrics by scanning jobs and nodes against the named partitions.
+    ///
+    /// A job belongs to the partition named by `job.spec.partition`; a node
+    /// belongs to every partition listed in `node.partitions` (already-resolved
+    /// membership, not the raw hostlist pattern in partition config).
+    pub fn collect<'a>(
+        partition_names: impl IntoIterator<Item = &'a str>,
+        jobs: impl IntoIterator<Item = &'a Job> + Clone,
+        nodes: impl IntoIterator<Item = &'a Node> + Clone,
+    ) -> Self {
+        let mut per_partition = Vec::new();
+
+        for name in partition_names {
+            let mut m = PerPartitionMetrics {
+                name: name.to_string(),
+                jobs_total: 0,
+                jobs_by_state: [0; JOB_STATE_COUNT],
+                nodes_total: 0,
+                nodes_by_state: [0; NODE_STATE_COUNT],
+                cpus: 0,
+                cpus_alloc: 0,
+                memory_bytes: 0,
+                memory_alloc_bytes: 0,
+            };
+
+            for job in jobs.clone() {
+                if job.spec.partition.as_deref() != Some(name) {
+                    continue;
+                }
+                m.jobs_total += 1;
+                m.jobs_by_state[job_state_index(job.state)] += 1;
+            }
+
+            for node in nodes.clone() {
+                if !node.partitions.iter().any(|p| p == name) {
+                    continue;
+                }
+                m.nodes_total += 1;
+                m.nodes_by_state[node_state_index(node.state)] += 1;
+                m.cpus += u64::from(node.total_resources.cpus);
+                m.cpus_alloc += u64::from(node.alloc_resources.cpus);
+                m.memory_bytes += memory_mb_to_bytes(node.total_resources.memory_mb);
+                m.memory_alloc_bytes += memory_mb_to_bytes(node.alloc_resources.memory_mb);
+            }
+
+            per_partition.push(m);
+        }
+
+        per_partition.sort_by(|a, b| a.name.cmp(&b.name));
+        Self {
+            total: per_partition.len() as u64,
+            per_partition,
+        }
+    }
+}
+
+impl PerPartitionMetrics {
+    /// Count for a single job state.
+    pub fn count_job_state(&self, state: JobState) -> u64 {
+        self.jobs_by_state[job_state_index(state)]
+    }
+
+    /// Count for a single node state.
+    pub fn count_node_state(&self, state: NodeState) -> u64 {
+        self.nodes_by_state[node_state_index(state)]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spur_core::job::JobSpec;
+    use spur_core::resource::{ResourceAllocations, ResourceSet};
+
+    fn job_in(id: u32, partition: &str, state: JobState) -> Job {
+        let spec = JobSpec {
+            partition: Some(partition.into()),
+            ..Default::default()
+        };
+        let mut job = Job::new(id, spec);
+        job.state = state;
+        job
+    }
+
+    fn node_in(name: &str, partitions: &[&str], cpus: u32, memory_mb: u64) -> Node {
+        let mut node = Node::new(
+            name.into(),
+            ResourceSet {
+                cpus,
+                memory_mb,
+                gpus: Vec::new(),
+                generic: Default::default(),
+            },
+        );
+        node.partitions = partitions.iter().map(|p| p.to_string()).collect();
+        node.alloc_resources = ResourceAllocations::with_scalar(0, 0);
+        node
+    }
+
+    #[test]
+    fn empty_partitions() {
+        let snap = PartitionMetricsSnapshot::collect([], [].iter(), [].iter());
+        assert_eq!(snap, PartitionMetricsSnapshot::default());
+    }
+
+    #[test]
+    fn scopes_jobs_and_nodes_by_partition() {
+        let jobs = [
+            job_in(1, "default", JobState::Pending),
+            job_in(2, "default", JobState::Running),
+            job_in(3, "gpu", JobState::Running),
+        ];
+        let nodes = [
+            node_in("n1", &["default"], 8, 16384),
+            node_in("n2", &["default", "gpu"], 4, 8192),
+        ];
+
+        let snap = PartitionMetricsSnapshot::collect(["default", "gpu"], jobs.iter(), nodes.iter());
+        assert_eq!(snap.total, 2);
+
+        let default = &snap.per_partition[0];
+        assert_eq!(default.name, "default");
+        assert_eq!(default.jobs_total, 2);
+        assert_eq!(default.count_job_state(JobState::Pending), 1);
+        assert_eq!(default.count_job_state(JobState::Running), 1);
+        assert_eq!(default.nodes_total, 2);
+        assert_eq!(default.cpus, 12);
+
+        let gpu = &snap.per_partition[1];
+        assert_eq!(gpu.name, "gpu");
+        assert_eq!(gpu.jobs_total, 1);
+        assert_eq!(gpu.nodes_total, 1);
+        assert_eq!(gpu.cpus, 4);
+    }
+}

--- a/crates/spur-metrics/src/partition.rs
+++ b/crates/spur-metrics/src/partition.rs
@@ -156,6 +156,7 @@ mod tests {
             job_in(1, "default", JobState::Pending),
             job_in(2, "default", JobState::Running),
             job_in(3, "gpu", JobState::Running),
+            job_in(4, "nonexistent", JobState::Pending),
         ];
         let nodes = [
             node_in("n1", &["default"], 8, 16384),
@@ -167,6 +168,7 @@ mod tests {
 
         let default = &snap.per_partition[0];
         assert_eq!(default.name, "default");
+        // job 4's partition isn't in the known list — jobs_total (2) excludes it.
         assert_eq!(default.jobs_total, 2);
         assert_eq!(default.count_job_state(JobState::Pending), 1);
         assert_eq!(default.count_job_state(JobState::Running), 1);

--- a/crates/spur-metrics/src/scheduler.rs
+++ b/crates/spur-metrics/src/scheduler.rs
@@ -14,6 +14,11 @@ pub struct SchedStatsSnapshot {
     pub jobs_started: u64,
     pub jobs_finalized: u64,
     pub jobs_started_last_cycle: u64,
+    /// Cycles that considered every pending job (not depth-limited).
+    pub exit_end: u64,
+    /// Cycles that stopped early because more jobs were pending than
+    /// `scheduler.max_jobs_per_cycle` allows considering in one pass.
+    pub exit_max_depth: u64,
 }
 
 impl SchedStatsSnapshot {

--- a/crates/spur-metrics/src/user_acct.rs
+++ b/crates/spur-metrics/src/user_acct.rs
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+
+use spur_core::job::Job;
+
+use crate::job::JobMetricsSnapshot;
+
+/// Per-user and per-account job metrics, opt-in via `metrics.high_cardinality`
+/// since each distinct user/account becomes its own time series.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct UserAcctMetricsSnapshot {
+    pub by_user: Vec<(String, JobMetricsSnapshot)>,
+    pub by_account: Vec<(String, JobMetricsSnapshot)>,
+}
+
+impl UserAcctMetricsSnapshot {
+    /// Group jobs by `spec.user` and by `spec.account` (jobs without an
+    /// account are excluded from the account breakdown, not double-counted
+    /// under an empty key).
+    pub fn collect<'a>(jobs: impl IntoIterator<Item = &'a Job> + Clone) -> Self {
+        let mut by_user: BTreeMap<&str, Vec<&Job>> = BTreeMap::new();
+        let mut by_account: BTreeMap<&str, Vec<&Job>> = BTreeMap::new();
+
+        for job in jobs.clone() {
+            by_user.entry(&job.spec.user).or_default().push(job);
+            if let Some(account) = job.spec.account.as_deref().filter(|a| !a.is_empty()) {
+                by_account.entry(account).or_default().push(job);
+            }
+        }
+
+        Self {
+            by_user: by_user
+                .into_iter()
+                .map(|(user, jobs)| (user.to_string(), JobMetricsSnapshot::collect(jobs)))
+                .collect(),
+            by_account: by_account
+                .into_iter()
+                .map(|(account, jobs)| (account.to_string(), JobMetricsSnapshot::collect(jobs)))
+                .collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spur_core::job::{JobSpec, JobState};
+
+    fn job_for(id: u32, user: &str, account: Option<&str>, state: JobState) -> Job {
+        let spec = JobSpec {
+            user: user.into(),
+            account: account.map(String::from),
+            ..Default::default()
+        };
+        let mut job = Job::new(id, spec);
+        job.state = state;
+        job
+    }
+
+    #[test]
+    fn groups_by_user_and_account() {
+        let jobs = [
+            job_for(1, "alice", Some("teamA"), JobState::Running),
+            job_for(2, "alice", Some("teamA"), JobState::Pending),
+            job_for(3, "bob", None, JobState::Running),
+        ];
+        let snap = UserAcctMetricsSnapshot::collect(jobs.iter());
+
+        assert_eq!(snap.by_user.len(), 2);
+        let alice = &snap.by_user.iter().find(|(u, _)| u == "alice").unwrap().1;
+        assert_eq!(alice.total, 2);
+        assert_eq!(alice.count_state(JobState::Running), 1);
+        assert_eq!(alice.count_state(JobState::Pending), 1);
+
+        assert_eq!(snap.by_account.len(), 1);
+        let team_a = &snap.by_account[0];
+        assert_eq!(team_a.0, "teamA");
+        assert_eq!(team_a.1.total, 2);
+    }
+
+    #[test]
+    fn jobs_without_account_excluded_from_account_breakdown() {
+        let jobs = [job_for(1, "bob", None, JobState::Running)];
+        let snap = UserAcctMetricsSnapshot::collect(jobs.iter());
+        assert_eq!(snap.by_user.len(), 1);
+        assert!(snap.by_account.is_empty());
+    }
+
+    #[test]
+    fn empty_jobs() {
+        let snap = UserAcctMetricsSnapshot::collect([]);
+        assert_eq!(snap, UserAcctMetricsSnapshot::default());
+    }
+}

--- a/crates/spur-metrics/tests/fixtures/jobs.prom
+++ b/crates/spur-metrics/tests/fixtures/jobs.prom
@@ -37,6 +37,9 @@ spur_jobs_deadline 0
 # HELP spur_jobs_out_of_memory Number of jobs in OUT_OF_MEMORY state.
 # TYPE spur_jobs_out_of_memory gauge
 spur_jobs_out_of_memory 0
+# HELP spur_jobs_hold Number of jobs in Pending state with a hold set.
+# TYPE spur_jobs_hold gauge
+spur_jobs_hold 1
 # HELP spur_jobs_cpus_alloc Total CPUs allocated to jobs in Running or Completing state.
 # TYPE spur_jobs_cpus_alloc gauge
 spur_jobs_cpus_alloc 4

--- a/crates/spur-metrics/tests/fixtures/scheduler.prom
+++ b/crates/spur-metrics/tests/fixtures/scheduler.prom
@@ -28,4 +28,10 @@ spur_scheduler_jobs_started_total 30
 # HELP spur_scheduler_jobs_finalized Jobs reaching a terminal state since reset.
 # TYPE spur_scheduler_jobs_finalized counter
 spur_scheduler_jobs_finalized_total 28
+# HELP spur_scheduler_exit_end Cycles that considered every pending job.
+# TYPE spur_scheduler_exit_end counter
+spur_scheduler_exit_end_total 8
+# HELP spur_scheduler_exit_max_depth Cycles that stopped early at scheduler.max_jobs_per_cycle.
+# TYPE spur_scheduler_exit_max_depth counter
+spur_scheduler_exit_max_depth_total 2
 # EOF

--- a/crates/spur-metrics/tests/scheduler_export_golden.rs
+++ b/crates/spur-metrics/tests/scheduler_export_golden.rs
@@ -69,6 +69,8 @@ fn sample_snapshot() -> SchedStatsSnapshot {
         jobs_started: 30,
         jobs_finalized: 28,
         jobs_started_last_cycle: 3,
+        exit_end: 8,
+        exit_max_depth: 2,
     }
 }
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -260,11 +260,19 @@ impl ClusterManager {
 
     /// Aggregated per-partition metrics from the current job, node, and partition maps.
     pub fn partition_metrics(&self) -> PartitionMetricsSnapshot {
-        let partitions = self.partitions.read();
-        let names: Vec<&str> = partitions.iter().map(|p| p.name.as_str()).collect();
+        let names: Vec<String> = self
+            .partitions
+            .read()
+            .iter()
+            .map(|p| p.name.clone())
+            .collect();
         let jobs = self.jobs.read();
         let nodes = self.nodes.read();
-        PartitionMetricsSnapshot::collect(names, jobs.values(), nodes.values())
+        PartitionMetricsSnapshot::collect(
+            names.iter().map(|s| s.as_str()),
+            jobs.values(),
+            nodes.values(),
+        )
     }
 
     /// Aggregated per-user and per-account job metrics from the current job map.

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -24,6 +24,8 @@ use spur_core::step::{JobStep, StepState, STEP_BATCH, STEP_RESERVED_MIN};
 use spur_core::wal::WalOperation;
 use spur_metrics::job::JobMetricsSnapshot;
 use spur_metrics::node::NodeMetricsSnapshot;
+use spur_metrics::partition::PartitionMetricsSnapshot;
+use spur_metrics::user_acct::UserAcctMetricsSnapshot;
 
 use crate::accounting::AccountingNotifier;
 use crate::fairshare_cache::FairshareCache;
@@ -254,6 +256,21 @@ impl ClusterManager {
     pub fn node_metrics(&self) -> NodeMetricsSnapshot {
         let nodes = self.nodes.read();
         NodeMetricsSnapshot::collect(nodes.values())
+    }
+
+    /// Aggregated per-partition metrics from the current job, node, and partition maps.
+    pub fn partition_metrics(&self) -> PartitionMetricsSnapshot {
+        let partitions = self.partitions.read();
+        let names: Vec<&str> = partitions.iter().map(|p| p.name.as_str()).collect();
+        let jobs = self.jobs.read();
+        let nodes = self.nodes.read();
+        PartitionMetricsSnapshot::collect(names, jobs.values(), nodes.values())
+    }
+
+    /// Aggregated per-user and per-account job metrics from the current job map.
+    pub fn user_acct_metrics(&self) -> UserAcctMetricsSnapshot {
+        let jobs = self.jobs.read();
+        UserAcctMetricsSnapshot::collect(jobs.values())
     }
 
     /// Get jobs matching filters.

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2104,9 +2104,15 @@ impl ClusterManager {
         cycle_time_us: u64,
         schedule_time_us: u64,
         jobs_started: u64,
+        hit_depth_limit: bool,
     ) {
         if let Some(stats) = self.sched_stats.get() {
-            stats.record_cycle(cycle_time_us, schedule_time_us, jobs_started);
+            stats.record_cycle(
+                cycle_time_us,
+                schedule_time_us,
+                jobs_started,
+                hit_depth_limit,
+            );
         }
     }
 
@@ -3904,7 +3910,7 @@ mod tests {
             per_node_for(&["worker1"], resources),
         )
         .unwrap();
-        cm.record_sched_cycle(0, 0, 1);
+        cm.record_sched_cycle(0, 0, 1, false);
         assert_eq!(stats.snapshot().jobs_started, 1);
 
         cm.complete_job(job_id, 0, JobState::Completed).unwrap();

--- a/crates/spurctld/src/metrics_proto.rs
+++ b/crates/spurctld/src/metrics_proto.rs
@@ -43,6 +43,8 @@ pub fn sched_stats_to_proto(snap: &SchedStatsSnapshot) -> SchedStats {
         jobs_started: snap.jobs_started,
         jobs_finalized: snap.jobs_finalized,
         jobs_started_last_cycle: snap.jobs_started_last_cycle,
+        exit_end: snap.exit_end,
+        exit_max_depth: snap.exit_max_depth,
     }
 }
 
@@ -307,6 +309,8 @@ mod tests {
             jobs_started: 30,
             jobs_finalized: 28,
             jobs_started_last_cycle: 3,
+            exit_end: 8,
+            exit_max_depth: 2,
         };
         let proto = sched_stats_to_proto(&snap);
         let body = encode_scheduler_metrics(&snap);
@@ -346,6 +350,14 @@ mod tests {
         assert_eq!(
             proto.schedule_total_time_us,
             gauge_value(&body, "spur_scheduler_schedule_total_time_us")
+        );
+        assert_eq!(
+            proto.exit_end,
+            gauge_value(&body, "spur_scheduler_exit_end_total")
+        );
+        assert_eq!(
+            proto.exit_max_depth,
+            gauge_value(&body, "spur_scheduler_exit_max_depth_total")
         );
         assert!(!body.contains("_avg_time_us"));
     }

--- a/crates/spurctld/src/metrics_server.rs
+++ b/crates/spurctld/src/metrics_server.rs
@@ -12,8 +12,8 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::Router;
 use spur_metrics::{
-    encode_job_metrics, encode_nodes_metrics, encode_partitions_metrics, encode_rpc_metrics,
-    encode_scheduler_metrics, CONTENT_TYPE,
+    encode_job_metrics, encode_jobs_users_accts_metrics, encode_nodes_metrics,
+    encode_partitions_metrics, encode_rpc_metrics, encode_scheduler_metrics, CONTENT_TYPE,
 };
 use tracing::info;
 
@@ -79,7 +79,9 @@ async fn metrics_partitions(State(state): State<Arc<MetricsState>>) -> Response 
     if !state.raft.is_leader() {
         return not_leader_response();
     }
-    metrics_response(encode_partitions_metrics())
+    metrics_response(encode_partitions_metrics(
+        &state.cluster.partition_metrics(),
+    ))
 }
 
 async fn metrics_rpc(State(state): State<Arc<MetricsState>>) -> Response {
@@ -107,11 +109,9 @@ async fn metrics_jobs_users_accts(State(state): State<Arc<MetricsState>>) -> Res
     if !state.raft.is_leader() {
         return not_leader_response();
     }
-    (
-        StatusCode::NOT_FOUND,
-        "jobs-users-accts metrics deferred to a follow-up PR",
-    )
-        .into_response()
+    metrics_response(encode_jobs_users_accts_metrics(
+        &state.cluster.user_acct_metrics(),
+    ))
 }
 
 fn not_leader_response() -> Response {
@@ -386,5 +386,34 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn metrics_jobs_users_accts_returns_ok_when_enabled() {
+        let dir = TempDir::new().unwrap();
+        let mut config = test_config();
+        config.metrics.high_cardinality = true;
+        let cm = Arc::new(ClusterManager::new(config, dir.path()).unwrap());
+        let handle = crate::raft::start_raft(1, &["[::1]:0".into()], dir.path(), cm.clone())
+            .await
+            .unwrap();
+        handle
+            .raft
+            .wait(Some(Duration::from_secs(5)))
+            .metrics(|m| m.current_leader == Some(1), "leader elected")
+            .await
+            .expect("single-node raft did not self-elect within 5s");
+        let state = Arc::new(MetricsState {
+            cluster: cm,
+            raft: Arc::new(handle),
+            rpc_stats: Arc::new(RpcStatsCollector::new()),
+            sched_stats: Arc::new(SchedStatsCollector::new("backfill")),
+        });
+        let resp = metrics_jobs_users_accts(State(state)).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            CONTENT_TYPE
+        );
     }
 }

--- a/crates/spurctld/src/sched_stats.rs
+++ b/crates/spurctld/src/sched_stats.rs
@@ -26,6 +26,8 @@ pub struct SchedStatsCollector {
     jobs_submitted: AtomicU64,
     jobs_started: AtomicU64,
     jobs_finalized: AtomicU64,
+    exit_end: AtomicU64,
+    exit_max_depth: AtomicU64,
 }
 
 impl SchedStatsCollector {
@@ -36,10 +38,20 @@ impl SchedStatsCollector {
             jobs_submitted: AtomicU64::new(0),
             jobs_started: AtomicU64::new(0),
             jobs_finalized: AtomicU64::new(0),
+            exit_end: AtomicU64::new(0),
+            exit_max_depth: AtomicU64::new(0),
         }
     }
 
-    pub fn record_cycle(&self, cycle_time_us: u64, schedule_time_us: u64, jobs_started: u64) {
+    /// Record one scheduling cycle. `hit_depth_limit` is true when more jobs
+    /// were pending than `scheduler.max_jobs_per_cycle` allowed considering.
+    pub fn record_cycle(
+        &self,
+        cycle_time_us: u64,
+        schedule_time_us: u64,
+        jobs_started: u64,
+        hit_depth_limit: bool,
+    ) {
         let mut accum = self.cycle.lock();
         accum.cycles = accum.cycles.saturating_add(1);
         accum.cycle_total_time_us = accum.cycle_total_time_us.saturating_add(cycle_time_us);
@@ -52,6 +64,11 @@ impl SchedStatsCollector {
         drop(accum);
         if jobs_started > 0 {
             self.jobs_started.fetch_add(jobs_started, Ordering::Relaxed);
+        }
+        if hit_depth_limit {
+            self.exit_max_depth.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.exit_end.fetch_add(1, Ordering::Relaxed);
         }
     }
 
@@ -78,6 +95,8 @@ impl SchedStatsCollector {
             jobs_started: self.jobs_started.load(Ordering::Relaxed),
             jobs_finalized: self.jobs_finalized.load(Ordering::Relaxed),
             jobs_started_last_cycle: accum.jobs_started_last_cycle,
+            exit_end: self.exit_end.load(Ordering::Relaxed),
+            exit_max_depth: self.exit_max_depth.load(Ordering::Relaxed),
         }
     }
 
@@ -86,6 +105,8 @@ impl SchedStatsCollector {
         self.jobs_submitted.store(0, Ordering::Relaxed);
         self.jobs_started.store(0, Ordering::Relaxed);
         self.jobs_finalized.store(0, Ordering::Relaxed);
+        self.exit_end.store(0, Ordering::Relaxed);
+        self.exit_max_depth.store(0, Ordering::Relaxed);
     }
 }
 
@@ -96,8 +117,8 @@ mod tests {
     #[test]
     fn record_cycle_accumulates_timing_and_started_jobs() {
         let stats = SchedStatsCollector::new("backfill");
-        stats.record_cycle(1000, 200, 2);
-        stats.record_cycle(500, 100, 1);
+        stats.record_cycle(1000, 200, 2, false);
+        stats.record_cycle(500, 100, 1, false);
 
         let snap = stats.snapshot();
         assert_eq!(snap.plugin, "backfill");
@@ -116,7 +137,7 @@ mod tests {
     fn lifecycle_counters_accumulate() {
         let stats = SchedStatsCollector::new("backfill");
         stats.record_submitted(3);
-        stats.record_cycle(0, 0, 2);
+        stats.record_cycle(0, 0, 2, false);
         stats.record_finalized();
 
         let snap = stats.snapshot();
@@ -126,15 +147,29 @@ mod tests {
     }
 
     #[test]
+    fn exit_reason_counters_split_by_depth_limit() {
+        let stats = SchedStatsCollector::new("backfill");
+        stats.record_cycle(100, 50, 1, false);
+        stats.record_cycle(100, 50, 1, true);
+        stats.record_cycle(100, 50, 1, true);
+
+        let snap = stats.snapshot();
+        assert_eq!(snap.exit_end, 1);
+        assert_eq!(snap.exit_max_depth, 2);
+    }
+
+    #[test]
     fn reset_clears_accumulators() {
         let stats = SchedStatsCollector::new("backfill");
-        stats.record_cycle(100, 50, 1);
+        stats.record_cycle(100, 50, 1, true);
         stats.record_submitted(1);
         stats.reset();
         let snap = stats.snapshot();
         assert_eq!(snap.cycles, 0);
         assert_eq!(snap.jobs_submitted, 0);
         assert_eq!(snap.jobs_started, 0);
+        assert_eq!(snap.exit_end, 0);
+        assert_eq!(snap.exit_max_depth, 0);
         assert_eq!(snap.plugin, "backfill");
     }
 }

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -115,6 +115,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
         if pending.is_empty() {
             continue;
         }
+        let hit_depth_limit = pending.len() > max_jobs;
 
         let nodes = cluster.get_nodes();
         let partitions = cluster.get_partitions();
@@ -153,7 +154,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
                 let cycle_time_us = cycle_start.elapsed().as_micros().min(u64::MAX as u128) as u64;
                 let schedule_time_us =
                     schedule_start.elapsed().as_micros().min(u64::MAX as u128) as u64;
-                cluster.record_sched_cycle(cycle_time_us, schedule_time_us, 0);
+                cluster.record_sched_cycle(cycle_time_us, schedule_time_us, 0, hit_depth_limit);
                 continue;
             }
         };
@@ -357,7 +358,12 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
         }
 
         let cycle_time_us = cycle_start.elapsed().as_micros().min(u64::MAX as u128) as u64;
-        cluster.record_sched_cycle(cycle_time_us, schedule_time_us, jobs_started_cycle);
+        cluster.record_sched_cycle(
+            cycle_time_us,
+            schedule_time_us,
+            jobs_started_cycle,
+            hit_depth_limit,
+        );
     }
 }
 

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -549,6 +549,8 @@ message SchedStats {
   uint64 jobs_started = 10;
   uint64 jobs_finalized = 11;
   uint64 jobs_started_last_cycle = 12;
+  uint64 exit_end = 13;
+  uint64 exit_max_depth = 14;
 }
 
 message RegisterAgentRequest {


### PR DESCRIPTION
## Summary

Closes #393.

Slurm 25.11 ships a native OpenMetrics endpoint (`MetricsType=metrics/openmetrics`) with the same `/metrics/{jobs,nodes,partitions,scheduler,jobs-users-accts}` shape Spur already exposes on port 6822. Comparing the two live (2-node Spur cluster on this branch vs. a 2-node Slurm 25.11.6 cluster with its native plugin enabled) surfaced several gaps, closed here:

- **`spur_jobs_hold`** — held jobs were folded into `spur_jobs_pending` with no way to distinguish them. The data (`JobMetricsSnapshot::held_pending`) already existed, it just wasn't wired into the encoder.
- **`/metrics/partitions`** — was a stub that always returned empty output (a test literally asserted this). Now mirrors the `/metrics/jobs` and `/metrics/nodes` field sets (job/node state counts, cpu/memory totals), scoped per partition via each node's already-resolved partition membership and each job's `spec.partition`.
- **`/metrics/jobs-users-accts`** — returned a hardcoded placeholder string even with `metrics.high_cardinality` enabled. Now groups the same per-state job counts by submitting user and by account; jobs without an account are excluded from the account breakdown rather than counted under an empty key.
- **Scheduler exit-reason counters** — Slurm reports 6 reasons a scheduling cycle ended (end-of-queue, hit-depth-limit, hit-job-start-limit, blocked-on-licenses, hit-rpc-limit, timeout) plus 6 more for backfill. Spur's scheduler is a single bounded pass over pending jobs with no time budget, RPC-count cutoff, or license-blocking cycle exit, so only two reasons are real: it considered every pending job, or stopped early because more jobs were pending than `scheduler.max_jobs_per_cycle` allows in one pass. Added `spur_scheduler_exit_end`/`spur_scheduler_exit_max_depth` for exactly those two — adding counters for the other four would misrepresent behavior the scheduler doesn't have. Threaded through the existing `GetSchedStats` RPC into `sdiag`'s scheduler block alongside the fields PR #359 already surfaces there.

## Not addressed (scoped out, not silently dropped)

Slurm's native node metrics also report `resv` (under reservation), `maint` (maintenance-flagged), and `noresp` (not-responding, distinct from `down`) node states. Spur's `Node`/`NodeState` model has no equivalent concepts today — adding them would mean new state-tracking, not a metrics wiring fix, so it's out of scope here. Filed as a follow-up: #395.

Also filed from the same investigation, unrelated to this PR's scope: #396 (`sacct --format` syntax + wrong accounting user), #397 (`sreport cluster utilization` not implemented).

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` — zero warnings
- [x] `cargo test --locked` — all tests pass, no external services needed
- [x] Live-verified on a 2-node Spur cluster (this branch) against a 2-node Slurm 25.11.6 cluster with `MetricsType=metrics/openmetrics` enabled, confirming every new/changed metric returns a real **non-zero** value under the condition that should produce it (not just present with a zero placeholder):

  | Metric | Condition | Live value |
  |---|---|---|
  | `spur_jobs_hold` | `spur submit --hold` | `1` |
  | `spur_partition_jobs_running{partition="default"}` | job actively running | `1` |
  | `spur_user_jobs_running{username="root"}` | job actively running | `1` |
  | `spur_partition_jobs`, `spur_partition_cpus`, `spur_partition_nodes` | steady state | `5`, `34`, `2` |
  | `spur_user_jobs{username=...}` (both `root` and `vm`) | multiple submitters | non-zero for each |
  | `spur_scheduler_exit_end` | normal cycle | `3`+ |
  | `spur_scheduler_exit_max_depth` | `scheduler.max_jobs_per_cycle=1` + 3 concurrently pending jobs | `2` |

  `sdiag`'s scheduler block matches the metrics endpoint's counts throughout.
