### PR TITLE
fix(spur-cli): sacct format syntax, accounting field staleness, and missing job names

### DIFF
--- a/crates/spur-cli/src/format_engine.rs
+++ b/crates/spur-cli/src/format_engine.rs
@@ -111,6 +111,38 @@ pub fn parse_format(fmt: &str, header_map: &dyn Fn(char) -> &'static str) -> Vec
     fields
 }
 
+/// Parse sacct/sreport-style comma-separated field names (e.g.
+/// `JobID,JobName%-20,Elapsed`), unlike squeue/sinfo's `%`-specifier syntax.
+pub fn parse_named_format(
+    fmt: &str,
+    name_to_spec: &dyn Fn(&str) -> Option<char>,
+    header_map: &dyn Fn(char) -> &'static str,
+) -> Vec<FormatField> {
+    let mut fields = Vec::new();
+    for item in fmt.split(',') {
+        let item = item.trim();
+        if item.is_empty() {
+            continue;
+        }
+        let (name, width) = match item.split_once('%') {
+            Some((n, w)) => (n.trim(), w.trim().parse::<i32>().unwrap_or(0)),
+            None => (item, 0),
+        };
+        let Some(spec) = name_to_spec(name) else {
+            continue;
+        };
+        let abs_width = width.unsigned_abs() as usize;
+        fields.push(FormatField {
+            spec,
+            width: abs_width,
+            right_align: width >= 0,
+            truncate: if abs_width > 0 { Some(abs_width) } else { None },
+            header: header_map(spec).to_string(),
+        });
+    }
+    fields
+}
+
 /// Format a single row using parsed fields and a value resolver.
 pub fn format_row(fields: &[FormatField], resolver: &dyn Fn(char) -> String) -> String {
     let mut parts = Vec::new();
@@ -277,5 +309,63 @@ mod tests {
         assert!(header.contains("JOBID"));
         assert!(header.contains("PARTITION"));
         assert!(header.contains("NAME"));
+    }
+
+    fn test_name_to_spec(name: &str) -> Option<char> {
+        match name.to_lowercase().as_str() {
+            "jobid" => Some('i'),
+            "partition" => Some('P'),
+            "jobname" => Some('j'),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn parse_named_format_comma_separated_names() {
+        let fields = parse_named_format(
+            "JobID,Partition,JobName",
+            &test_name_to_spec,
+            &squeue_header,
+        );
+        assert_eq!(fields.len(), 3);
+        assert_eq!(fields[0].spec, 'i');
+        assert_eq!(fields[1].spec, 'P');
+        assert_eq!(fields[2].spec, 'j');
+        assert_eq!(fields[0].width, 0);
+    }
+
+    #[test]
+    fn parse_named_format_applies_percent_width() {
+        let fields = parse_named_format("JobName%20", &test_name_to_spec, &squeue_header);
+        assert_eq!(fields[0].width, 20);
+        assert!(fields[0].right_align);
+        assert_eq!(fields[0].truncate, Some(20));
+    }
+
+    #[test]
+    fn parse_named_format_negative_width_left_aligns() {
+        let fields = parse_named_format("JobName%-20", &test_name_to_spec, &squeue_header);
+        assert_eq!(fields[0].width, 20);
+        assert!(!fields[0].right_align);
+    }
+
+    #[test]
+    fn parse_named_format_skips_unknown_field_names() {
+        let fields = parse_named_format(
+            "JobID,NotAField,Partition",
+            &test_name_to_spec,
+            &squeue_header,
+        );
+        assert_eq!(fields.len(), 2);
+        assert_eq!(fields[0].spec, 'i');
+        assert_eq!(fields[1].spec, 'P');
+    }
+
+    #[test]
+    fn parse_named_format_is_case_insensitive() {
+        let fields = parse_named_format("jobid,PARTITION", &test_name_to_spec, &squeue_header);
+        assert_eq!(fields.len(), 2);
+        assert_eq!(fields[0].spec, 'i');
+        assert_eq!(fields[1].spec, 'P');
     }
 }

--- a/crates/spur-cli/src/format_engine.rs
+++ b/crates/spur-cli/src/format_engine.rs
@@ -111,8 +111,7 @@ pub fn parse_format(fmt: &str, header_map: &dyn Fn(char) -> &'static str) -> Vec
     fields
 }
 
-/// Parse sacct/sreport-style comma-separated field names (e.g.
-/// `JobID,JobName%-20,Elapsed`), unlike squeue/sinfo's `%`-specifier syntax.
+/// Parse sacct/sreport-style comma-separated field names, unlike squeue/sinfo's `%`-specifiers.
 pub fn parse_named_format(
     fmt: &str,
     name_to_spec: &dyn Fn(&str) -> Option<char>,

--- a/crates/spur-cli/src/sacct.rs
+++ b/crates/spur-cli/src/sacct.rs
@@ -96,7 +96,6 @@ pub fn sacct_header(spec: char) -> &'static str {
     }
 }
 
-/// Maps a sacct `--format` field name to its internal spec char.
 fn sacct_field_spec(name: &str) -> Option<char> {
     match name.to_lowercase().as_str() {
         "jobid" => Some('i'),
@@ -392,7 +391,7 @@ mod tests {
     }
 
     #[test]
-    fn sacct_field_spec_is_case_insensitive_and_round_trips_header() {
+    fn sacct_field_spec_is_case_insensitive_and_rejects_unknown_names() {
         for name in ["JobID", "jobid", "JOBID"] {
             assert_eq!(sacct_field_spec(name), Some('i'));
         }

--- a/crates/spur-cli/src/sacct.rs
+++ b/crates/spur-cli/src/sacct.rs
@@ -96,6 +96,31 @@ pub fn sacct_header(spec: char) -> &'static str {
     }
 }
 
+/// Maps a sacct `--format` field name to its internal spec char.
+fn sacct_field_spec(name: &str) -> Option<char> {
+    match name.to_lowercase().as_str() {
+        "jobid" => Some('i'),
+        "jobname" => Some('j'),
+        "user" => Some('u'),
+        "account" => Some('a'),
+        "partition" => Some('P'),
+        "state" => Some('T'),
+        "elapsed" => Some('M'),
+        "nnodes" => Some('D'),
+        "exitcode" => Some('x'),
+        "derivedexitcode" => Some('X'),
+        "start" => Some('S'),
+        "end" => Some('E'),
+        "submit" => Some('V'),
+        "timelimit" => Some('l'),
+        "nodelist" => Some('n'),
+        "ncpus" => Some('C'),
+        "reqmem" => Some('R'),
+        "qos" => Some('Q'),
+        _ => None,
+    }
+}
+
 pub async fn main() -> Result<()> {
     main_with_args(std::env::args().collect()).await
 }
@@ -103,17 +128,16 @@ pub async fn main() -> Result<()> {
 pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let args = SacctArgs::try_parse_from(&args)?;
 
-    let fmt = if let Some(ref f) = args.format {
-        f.clone()
+    // -o/--format uses Slurm's comma-separated field-name syntax, not %-specifiers.
+    let fields = if let Some(ref f) = args.format {
+        format_engine::parse_named_format(f, &sacct_field_spec, &sacct_header)
     } else if args.long {
-        SACCT_LONG_FORMAT.to_string()
+        format_engine::parse_format(SACCT_LONG_FORMAT, &sacct_header)
     } else if args.brief {
-        SACCT_BRIEF_FORMAT.to_string()
+        format_engine::parse_format(SACCT_BRIEF_FORMAT, &sacct_header)
     } else {
-        SACCT_DEFAULT_FORMAT.to_string()
+        format_engine::parse_format(SACCT_DEFAULT_FORMAT, &sacct_header)
     };
-
-    let fields = format_engine::parse_format(&fmt, &sacct_header);
 
     // Parse state filter
     let states: Vec<i32> = args
@@ -361,5 +385,32 @@ mod tests {
         for (s, expected) in cases {
             assert_eq!(parse_acct_state(s), Some(expected as i32), "state {s}");
         }
+    }
+
+    #[test]
+    fn sacct_field_spec_is_case_insensitive_and_round_trips_header() {
+        for name in ["JobID", "jobid", "JOBID"] {
+            assert_eq!(sacct_field_spec(name), Some('i'));
+        }
+        assert_eq!(sacct_field_spec("NotAField"), None);
+    }
+
+    #[test]
+    fn custom_format_comma_separated_names_populate_requested_columns() {
+        // Real Slurm's sacct --format syntax; used to produce blank columns.
+        let fields = format_engine::parse_named_format(
+            "JobID,JobName,Partition,State",
+            &sacct_field_spec,
+            &sacct_header,
+        );
+        assert_eq!(fields.len(), 4);
+        let mut j = job(0, 0, 0);
+        j.name = "train".into();
+        j.partition = "gpu".into();
+        j.job_id = 42;
+        let row = format_engine::format_row(&fields, &|spec| resolve_sacct_field(&j, spec));
+        assert!(row.contains("42"));
+        assert!(row.contains("train"));
+        assert!(row.contains("gpu"));
     }
 }

--- a/crates/spur-cli/src/sacct.rs
+++ b/crates/spur-cli/src/sacct.rs
@@ -130,7 +130,11 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
 
     // -o/--format uses Slurm's comma-separated field-name syntax, not %-specifiers.
     let fields = if let Some(ref f) = args.format {
-        format_engine::parse_named_format(f, &sacct_field_spec, &sacct_header)
+        let fields = format_engine::parse_named_format(f, &sacct_field_spec, &sacct_header);
+        if fields.is_empty() {
+            anyhow::bail!("sacct: no recognized fields in --format='{f}'");
+        }
+        fields
     } else if args.long {
         format_engine::parse_format(SACCT_LONG_FORMAT, &sacct_header)
     } else if args.brief {
@@ -412,5 +416,17 @@ mod tests {
         assert!(row.contains("42"));
         assert!(row.contains("train"));
         assert!(row.contains("gpu"));
+    }
+
+    #[tokio::test]
+    async fn format_with_no_recognized_fields_fails_fast() {
+        // Errors before ever connecting, so no server/network is needed here.
+        let err = main_with_args(vec![
+            "sacct".into(),
+            "--format=NotAField,AlsoNotAField".into(),
+        ])
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("no recognized fields"));
     }
 }

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -134,21 +134,25 @@ pub async fn record_job_start(
     start_time: DateTime<Utc>,
     reservation: &str,
 ) -> anyhow::Result<()> {
+    // job_id reuse after a Raft wipe means a conflict is a new, unrelated job.
     sqlx::query(
         r#"
         INSERT INTO jobs (job_id, user_name, account, partition_name, num_nodes, num_tasks, cpus_per_task, memory_mb, start_time, state, reservation)
         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'RUNNING', $10)
         ON CONFLICT (job_id) DO UPDATE SET
-            user_name = $2,
-            account = $3,
-            partition_name = $4,
-            num_nodes = $5,
-            num_tasks = $6,
-            cpus_per_task = $7,
-            memory_mb = $8,
-            start_time = $9,
-            state = 'RUNNING',
-            reservation = $10
+            user_name = EXCLUDED.user_name,
+            account = EXCLUDED.account,
+            partition_name = EXCLUDED.partition_name,
+            num_nodes = EXCLUDED.num_nodes,
+            num_tasks = EXCLUDED.num_tasks,
+            cpus_per_task = EXCLUDED.cpus_per_task,
+            memory_mb = EXCLUDED.memory_mb,
+            start_time = EXCLUDED.start_time,
+            state = EXCLUDED.state,
+            exit_code = 0,
+            exit_signal = 0,
+            derived_exit_code = 0,
+            end_time = NULL
         "#,
     )
     .bind(job_id)
@@ -809,6 +813,38 @@ mod job_history_tests {
         assert_eq!(limited[0].job_id, id2);
 
         delete_jobs(&pool, &ids).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL and PostgreSQL"]
+    async fn record_job_start_overwrites_reused_job_id() -> anyhow::Result<()> {
+        let pool = test_pool().await?;
+        let id = test_job_id(3);
+        delete_jobs(&pool, &[id]).await.ok();
+
+        let t1 = Utc::now() - Duration::hours(2);
+        record_job_start(&pool, id, "root", "acct-old", "debug", 2, 4, 2, 8192, t1).await?;
+        record_job_end(&pool, id, "FAILED", 137, t1 + Duration::minutes(5), 9, 137).await?;
+
+        let t2 = Utc::now() - Duration::hours(1);
+        record_job_start(&pool, id, "vm", "acct-new", "gpu", 1, 1, 1, 1024, t2).await?;
+
+        let history = get_job_history(&pool, None, None, None, None, &[], 100)
+            .await?
+            .into_iter()
+            .find(|r| r.job_id == id)
+            .expect("reused job_id should still be queryable");
+        assert_eq!(history.user_name, "vm");
+        assert_eq!(history.account, "acct-new");
+        assert_eq!(history.partition, "gpu");
+        assert_eq!(history.state, "RUNNING");
+        assert_eq!(history.exit_code, 0);
+        assert_eq!(history.exit_signal, 0);
+        assert_eq!(history.derived_exit_code, 0);
+        assert!(history.end_time.is_none());
+
+        delete_jobs(&pool, &[id]).await?;
         Ok(())
     }
 

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -201,10 +201,7 @@ pub async fn record_job_end(
     exit_signal: i32,
     derived_exit_code: i32,
 ) -> anyhow::Result<()> {
-    // RETURNING folds the read into the same upsert statement, so a job_id
-    // reused by a concurrent record_job_start can't slip stale field values
-    // into the usage row computed below. ON CONFLICT still tolerates end
-    // arriving before start (see the start_time null-check in update_usage).
+    // RETURNING closes the record_job_start job_id-reuse race by reading in the same statement.
     let row = sqlx::query(
         r#"
         INSERT INTO jobs (job_id, user_name, state, exit_code, end_time, exit_signal, derived_exit_code)

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -177,14 +177,16 @@ pub async fn record_job_start(
 
     // If end_time is already set, the end notification arrived first and skipped
     // usage computation (start_time was NULL at that point). Compute it now.
-    let end_time: Option<DateTime<Utc>> =
-        sqlx::query_scalar("SELECT end_time FROM jobs WHERE job_id = $1")
-            .bind(job_id)
-            .fetch_one(pool)
-            .await?;
+    let row = sqlx::query(
+        "SELECT user_name, account, start_time, num_tasks, cpus_per_task, end_time FROM jobs WHERE job_id = $1",
+    )
+    .bind(job_id)
+    .fetch_one(pool)
+    .await?;
 
+    let end_time: Option<DateTime<Utc>> = row.get("end_time");
     if let Some(end_time) = end_time {
-        update_usage(pool, job_id, end_time).await?;
+        update_usage(pool, row, end_time).await?;
     }
 
     Ok(())

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -132,14 +132,15 @@ pub async fn record_job_start(
     num_tasks: i32,
     cpus_per_task: i32,
     memory_mb: i64,
+    submit_time: DateTime<Utc>,
     start_time: DateTime<Utc>,
     reservation: &str,
 ) -> anyhow::Result<()> {
     // job_id reuse after a Raft wipe means a conflict is a new, unrelated job.
     sqlx::query(
         r#"
-        INSERT INTO jobs (job_id, name, user_name, account, partition_name, num_nodes, num_tasks, cpus_per_task, memory_mb, start_time, state, reservation)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'RUNNING', $11)
+        INSERT INTO jobs (job_id, name, user_name, account, partition_name, num_nodes, num_tasks, cpus_per_task, memory_mb, submit_time, start_time, state, reservation)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 'RUNNING', $12)
         ON CONFLICT (job_id) DO UPDATE SET
             name = EXCLUDED.name,
             user_name = EXCLUDED.user_name,
@@ -149,6 +150,7 @@ pub async fn record_job_start(
             num_tasks = EXCLUDED.num_tasks,
             cpus_per_task = EXCLUDED.cpus_per_task,
             memory_mb = EXCLUDED.memory_mb,
+            submit_time = EXCLUDED.submit_time,
             start_time = EXCLUDED.start_time,
             state = EXCLUDED.state,
             exit_code = 0,
@@ -166,6 +168,7 @@ pub async fn record_job_start(
     .bind(num_tasks)
     .bind(cpus_per_task)
     .bind(memory_mb)
+    .bind(submit_time)
     .bind(start_time)
     .bind(reservation)
     .execute(pool)
@@ -730,6 +733,7 @@ mod job_history_tests {
             1,
             0,
             t1,
+            t1,
             "",
         )
         .await?;
@@ -747,6 +751,7 @@ mod job_history_tests {
             1,
             0,
             t1,
+            t1,
             "",
         )
         .await?;
@@ -763,6 +768,7 @@ mod job_history_tests {
             1,
             1,
             0,
+            t2,
             t2,
             "",
         )
@@ -829,16 +835,27 @@ mod job_history_tests {
         let id = test_job_id(3);
         delete_jobs(&pool, &[id]).await.ok();
 
-        let t1 = Utc::now() - Duration::hours(2);
+        let submit1 = Utc::now() - Duration::hours(3);
+        let start1 = Utc::now() - Duration::hours(2);
         record_job_start(
-            &pool, id, "old-job", "root", "acct-old", "debug", 2, 4, 2, 8192, t1, "",
+            &pool, id, "old-job", "root", "acct-old", "debug", 2, 4, 2, 8192, submit1, start1, "",
         )
         .await?;
-        record_job_end(&pool, id, "FAILED", 137, t1 + Duration::minutes(5), 9, 137).await?;
+        record_job_end(
+            &pool,
+            id,
+            "FAILED",
+            137,
+            start1 + Duration::minutes(5),
+            9,
+            137,
+        )
+        .await?;
 
-        let t2 = Utc::now() - Duration::hours(1);
+        let submit2 = Utc::now() - Duration::minutes(90);
+        let start2 = Utc::now() - Duration::hours(1);
         record_job_start(
-            &pool, id, "new-job", "vm", "acct-new", "gpu", 1, 1, 1, 1024, t2, "",
+            &pool, id, "new-job", "vm", "acct-new", "gpu", 1, 1, 1, 1024, submit2, start2, "",
         )
         .await?;
 
@@ -856,6 +873,11 @@ mod job_history_tests {
         assert_eq!(history.exit_signal, 0);
         assert_eq!(history.derived_exit_code, 0);
         assert!(history.end_time.is_none());
+        assert_eq!(
+            history.submit_time.timestamp(),
+            submit2.timestamp(),
+            "submit_time must not carry over from the previous job"
+        );
 
         delete_jobs(&pool, &[id]).await?;
         Ok(())

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -124,6 +124,7 @@ ALTER TABLE jobs ADD COLUMN IF NOT EXISTS reservation TEXT NOT NULL DEFAULT '';
 pub async fn record_job_start(
     pool: &PgPool,
     job_id: i32,
+    name: &str,
     user: &str,
     account: &str,
     partition: &str,
@@ -137,9 +138,10 @@ pub async fn record_job_start(
     // job_id reuse after a Raft wipe means a conflict is a new, unrelated job.
     sqlx::query(
         r#"
-        INSERT INTO jobs (job_id, user_name, account, partition_name, num_nodes, num_tasks, cpus_per_task, memory_mb, start_time, state, reservation)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'RUNNING', $10)
+        INSERT INTO jobs (job_id, name, user_name, account, partition_name, num_nodes, num_tasks, cpus_per_task, memory_mb, start_time, state, reservation)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'RUNNING', $11)
         ON CONFLICT (job_id) DO UPDATE SET
+            name = EXCLUDED.name,
             user_name = EXCLUDED.user_name,
             account = EXCLUDED.account,
             partition_name = EXCLUDED.partition_name,
@@ -156,6 +158,7 @@ pub async fn record_job_start(
         "#,
     )
     .bind(job_id)
+    .bind(name)
     .bind(user)
     .bind(account)
     .bind(partition)
@@ -718,6 +721,7 @@ mod job_history_tests {
         record_job_start(
             &pool,
             id0,
+            "job-a",
             &user_a,
             &account_one,
             "debug",
@@ -734,6 +738,7 @@ mod job_history_tests {
         record_job_start(
             &pool,
             id1,
+            "job-b",
             &user_b,
             &account_one,
             "debug",
@@ -750,6 +755,7 @@ mod job_history_tests {
         record_job_start(
             &pool,
             id2,
+            "job-c",
             &user_a,
             &account_two,
             "debug",
@@ -824,17 +830,24 @@ mod job_history_tests {
         delete_jobs(&pool, &[id]).await.ok();
 
         let t1 = Utc::now() - Duration::hours(2);
-        record_job_start(&pool, id, "root", "acct-old", "debug", 2, 4, 2, 8192, t1).await?;
+        record_job_start(
+            &pool, id, "old-job", "root", "acct-old", "debug", 2, 4, 2, 8192, t1, "",
+        )
+        .await?;
         record_job_end(&pool, id, "FAILED", 137, t1 + Duration::minutes(5), 9, 137).await?;
 
         let t2 = Utc::now() - Duration::hours(1);
-        record_job_start(&pool, id, "vm", "acct-new", "gpu", 1, 1, 1, 1024, t2).await?;
+        record_job_start(
+            &pool, id, "new-job", "vm", "acct-new", "gpu", 1, 1, 1, 1024, t2, "",
+        )
+        .await?;
 
         let history = get_job_history(&pool, None, None, None, None, &[], 100)
             .await?
             .into_iter()
             .find(|r| r.job_id == id)
             .expect("reused job_id should still be queryable");
+        assert_eq!(history.name, "new-job");
         assert_eq!(history.user_name, "vm");
         assert_eq!(history.account, "acct-new");
         assert_eq!(history.partition, "gpu");

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use chrono::{DateTime, Utc};
+use sqlx::postgres::PgRow;
 use sqlx::{PgPool, QueryBuilder, Row};
 
 /// Run database migrations (create tables if they don't exist).
@@ -200,7 +201,11 @@ pub async fn record_job_end(
     exit_signal: i32,
     derived_exit_code: i32,
 ) -> anyhow::Result<()> {
-    sqlx::query(
+    // RETURNING folds the read into the same upsert statement, so a job_id
+    // reused by a concurrent record_job_start can't slip stale field values
+    // into the usage row computed below. ON CONFLICT still tolerates end
+    // arriving before start (see the start_time null-check in update_usage).
+    let row = sqlx::query(
         r#"
         INSERT INTO jobs (job_id, user_name, state, exit_code, end_time, exit_signal, derived_exit_code)
         VALUES ($1, '', $2, $3, $4, $5, $6)
@@ -210,6 +215,7 @@ pub async fn record_job_end(
             end_time = $4,
             exit_signal = $5,
             derived_exit_code = $6
+        RETURNING user_name, account, start_time, num_tasks, cpus_per_task
         "#,
     )
     .bind(job_id)
@@ -218,27 +224,16 @@ pub async fn record_job_end(
     .bind(end_time)
     .bind(exit_signal)
     .bind(derived_exit_code)
-    .execute(pool)
+    .fetch_one(pool)
     .await?;
 
-    update_usage(pool, job_id, end_time).await?;
+    update_usage(pool, row, end_time).await?;
 
     Ok(())
 }
 
-/// Update usage accounting for a completed job.
-async fn update_usage(pool: &PgPool, job_id: i32, end_time: DateTime<Utc>) -> anyhow::Result<()> {
-    let row = sqlx::query(
-        "SELECT user_name, account, start_time, num_tasks, cpus_per_task FROM jobs WHERE job_id = $1",
-    )
-    .bind(job_id)
-    .fetch_optional(pool)
-    .await?;
-
-    let Some(row) = row else {
-        return Ok(());
-    };
-
+/// Update usage accounting for a completed job, from the row `record_job_end` just wrote.
+async fn update_usage(pool: &PgPool, row: PgRow, end_time: DateTime<Utc>) -> anyhow::Result<()> {
     let user: String = row.get("user_name");
     let account: String = row.get("account");
     let start_time: Option<DateTime<Utc>> = row.get("start_time");

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -46,6 +46,7 @@ impl SlurmAccounting for AccountingService {
         db::record_job_start(
             &self.pool,
             req.job_id as i32,
+            &req.name,
             &req.user,
             &req.account,
             &req.partition,

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -36,6 +36,10 @@ impl SlurmAccounting for AccountingService {
             .start_time
             .map(|t| DateTime::from_timestamp(t.seconds, t.nanos as u32).unwrap_or_default())
             .unwrap_or_else(Utc::now);
+        let submit_time = req
+            .submit_time
+            .map(|t| DateTime::from_timestamp(t.seconds, t.nanos as u32).unwrap_or_default())
+            .unwrap_or(start_time);
 
         let (memory_mb, cpus) = req
             .resources
@@ -54,6 +58,7 @@ impl SlurmAccounting for AccountingService {
             cpus,
             1,
             memory_mb,
+            submit_time,
             start_time,
             &req.reservation,
         )

--- a/crates/spurctld/src/accounting/notifier.rs
+++ b/crates/spurctld/src/accounting/notifier.rs
@@ -17,6 +17,7 @@ pub struct JobStartRecord {
     pub num_tasks: u32,
     pub cpus_per_task: u32,
     pub memory_mb: u64,
+    pub submit_time: DateTime<Utc>,
     pub start_time: DateTime<Utc>,
     pub reservation: Option<String>,
 }
@@ -41,6 +42,7 @@ impl AccountingNotifier {
         let num_tasks = record.num_tasks as i32;
         let cpus_per_task = record.cpus_per_task as i32;
         let memory_mb = record.memory_mb as i64;
+        let submit_time = record.submit_time;
         let start_time = record.start_time;
         let reservation = record.reservation.unwrap_or_default();
         tokio::spawn(async move {
@@ -55,6 +57,7 @@ impl AccountingNotifier {
                 num_tasks,
                 cpus_per_task,
                 memory_mb,
+                submit_time,
                 start_time,
                 &reservation,
             )

--- a/crates/spurctld/src/accounting/notifier.rs
+++ b/crates/spurctld/src/accounting/notifier.rs
@@ -9,6 +9,7 @@ use spur_core::job::{JobId, JobState};
 
 pub struct JobStartRecord {
     pub job_id: JobId,
+    pub name: String,
     pub user: String,
     pub account: String,
     pub partition: String,
@@ -32,6 +33,7 @@ impl AccountingNotifier {
     pub fn notify_job_start(&self, record: JobStartRecord) {
         let pool = self.pool.clone();
         let job_id = record.job_id;
+        let name = record.name;
         let user = record.user;
         let account = record.account;
         let partition = record.partition;
@@ -45,6 +47,7 @@ impl AccountingNotifier {
             if let Err(e) = super::db::record_job_start(
                 &pool,
                 job_id as i32,
+                &name,
                 &user,
                 &account,
                 &partition,

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -578,6 +578,7 @@ impl ClusterManager {
         if let Some(ref notifier) = *self.accounting.read() {
             notifier.notify_job_start(JobStartRecord {
                 job_id,
+                name: spec_for_notify.name.clone(),
                 user: spec_for_notify.user.clone(),
                 account: spec_for_notify.account.clone().unwrap_or_default(),
                 partition: spec_for_notify.partition.clone().unwrap_or_default(),

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -516,6 +516,7 @@ impl ClusterManager {
         // Validate job exists and can transition
         let old_state;
         let spec_for_notify;
+        let submit_time_for_notify;
         {
             let jobs = self.jobs.read();
             let job = jobs
@@ -523,6 +524,7 @@ impl ClusterManager {
                 .ok_or_else(|| anyhow::anyhow!("job {} not found", job_id))?;
             old_state = job.state;
             spec_for_notify = job.spec.clone();
+            submit_time_for_notify = job.submit_time;
             if job.state != JobState::Pending {
                 anyhow::bail!("job {} cannot start from state {:?}", job_id, job.state);
             }
@@ -586,6 +588,7 @@ impl ClusterManager {
                 num_tasks: spec_for_notify.num_tasks,
                 cpus_per_task: spec_for_notify.cpus_per_task,
                 memory_mb: resources.memory_mb,
+                submit_time: submit_time_for_notify,
                 start_time: Utc::now(),
                 reservation: spec_for_notify.reservation.clone(),
             });

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -706,6 +706,7 @@ message RecordJobStartRequest {
   google.protobuf.Timestamp start_time = 6;
   string reservation = 7;
   string name = 8;
+  google.protobuf.Timestamp submit_time = 9;
 }
 
 message RecordJobEndRequest {

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -705,6 +705,7 @@ message RecordJobStartRequest {
   ResourceAllocations resources = 5;
   google.protobuf.Timestamp start_time = 6;
   string reservation = 7;
+  string name = 8;
 }
 
 message RecordJobEndRequest {

--- a/tests/native_host/e2e/test_accounting.py
+++ b/tests/native_host/e2e/test_accounting.py
@@ -23,7 +23,7 @@ class TestSacctExitReporting:
         sig_id = parse_job_id(c.sbatch(["-J", "acct-sig", "-N", "1", sig]))
         assert sig_id is not None
         wait_job(c, sig_id, timeout=60)
-        row = wait_sacct_row(c, sig_id, "%i %x")
+        row = wait_sacct_row(c, sig_id, "JobID,ExitCode")
         # ExitCode renders code:signal; the signal half is the parity fix.
         assert row.split()[1].endswith(":9"), f"expected signal half :9, got {row!r}"
 
@@ -39,7 +39,7 @@ class TestSacctExitReporting:
         m_id = parse_job_id(c.sbatch(["-J", "acct-multi", "-N", "1", multi]))
         assert m_id is not None
         wait_job(c, m_id, timeout=90)
-        row = wait_sacct_row(c, m_id, "%i %x %X")
+        row = wait_sacct_row(c, m_id, "JobID,ExitCode,DerivedExitCode")
         fields = row.split()
         assert fields[1] == "3:0", f"expected ExitCode 3:0, got {fields!r}"
         assert fields[2] == "7:0", f"expected DerivedExitCode 7:0, got {fields!r}"


### PR DESCRIPTION
## Summary

Closes #396.

Three bugs found and fixed during live testing on a 2-node Spur cluster, all in the accounting/`sacct` path:

- **`sacct -o`/`--format` used the wrong syntax model.** It fed any user-supplied value through the same `%`-specifier parser squeue/sinfo use, but real Slurm's `sacct --format` takes comma-separated field names instead (`JobID,JobName,State`, optionally suffixed with `%width`). Passing that syntax silently produced blank columns with no error. Added `parse_named_format` to `format_engine` (reusable by other accounting-style commands) and a name→spec map for sacct's fields. Default/long/brief presets are unchanged.

- **Accounting fields went stale when a `job_id` was reused.** The issue originally described this as "wrong submitting user," but that specific repro turned out to be a testing artifact (a stale binary shadowing the real one via `PATH`). Digging into *why* it happened anyway surfaced a real bug: `record_job_start`'s `ON CONFLICT (job_id) DO UPDATE` only refreshed `start_time`/`state`, leaving `user_name`, `account`, `partition_name`, and resource fields — plus terminal fields like `exit_code`/`end_time` — from whatever job previously held that ID. `job_id` reuse happens whenever a Raft state wipe resets the ID counter (documented, expected deploy-playbook behavior), so a brand-new, unrelated job could silently inherit a stale identity and terminal state in `sacct` output. Fixed by overwriting every field a fresh job should own on conflict.

- **Job names were never recorded to accounting at all**, found while verifying the format-string fix. `spur show job <id>` correctly reports the live job name from Raft state, but `sacct` always showed it blank — `record_job_start`'s `INSERT` never included the `name` column in the first place. Threaded `job.spec.name` through a new `RecordJobStartRequest.name` proto field into the same fixed `record_job_start` query.

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` — zero warnings
- [x] `cargo test --locked` — all tests pass, no external services needed
- [x] Real-PostgreSQL regression tests (`#[ignore]`d, run manually against a live database) verify the job-id-reuse fix overwrites every stale field, including `name`
- [x] Live-verified on a 2-node Spur cluster:
  - `sacct --format=JobID,JobName,Partition,State` populates every requested column, including with `%width` suffixes
  - `sacct --format=JobID,JobName,State` shows the name a job was submitted with (`--job-name=my-real-job` → `JobName=my-real-job`)
  - Default/long/brief presets unchanged