### PR TITLE
ci(pr-lint): reject changelog-visible types on infra scopes

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -27,6 +27,18 @@ jobs:
           fi
           echo "PASS: PR title is valid."
 
+      - name: Reject changelog-visible types on infra scopes
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if echo "$PR_TITLE" | grep -Eq "^(feat|fix|perf)\((ci|cd|build|release|infra|e2e|docs|test|tests|style|chore|revert)\)"; then
+            echo "FAIL: '$PR_TITLE' uses a changelog-visible type (feat/fix/perf) with a non-product scope."
+            echo "Non-user-facing changes should use the right type instead. Examples:"
+            echo "  'ci(e2e): fix flaky test' not 'fix(e2e): fix flaky test'"
+            echo "  'test: fix broken fixture' not 'fix(test): fix broken fixture'"
+            exit 1
+          fi
+
   license-headers:
     name: SPDX License Headers
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,8 @@ PRs are squash-merged, so the **PR title is the final commit message**. Use conv
 - **scope**: crate name (e.g. `spur-cli`, `spurctld`, `spur-core`). If no single crate applies, use a concise scope reflecting the area of change (e.g. `proto`, `deploy`, `config`).
 - **message**: imperative mood, lowercase, no trailing period.
 
+Only `feat`, `fix`, and `perf` appear in the release changelog. Non-user-facing work (CI, tooling, infra) must use `ci`, `build`, or `chore` so it stays out of release notes. CI enforces this: a PR titled `fix(ci): ...` will be rejected, use `ci: ...` instead.
+
 PR descriptions should be concise and readable — not line-by-line changelogs. Cover: what this fixes/adds, the approach taken, important design choices or trade-offs, planned follow-ups (if any), and how it was tested. Keep individual commits meaningful for reviewers.
 
 When filing issues, focus on the problem: what happened, what was expected, and how to reproduce. Do not prescribe a fix — that biases the person or agent addressing it.


### PR DESCRIPTION
## Summary

- Add a PR title lint step that rejects `feat`/`fix`/`perf` when paired with infra scopes (`ci`, `cd`, `build`, `release`, `infra`, `e2e`). This prevents non-user-facing changes from leaking into the release-please changelog.
- Document the changelog type-selection rule in `AGENTS.md`.

## Context

`release-please-config.json` only includes `feat`/`fix`/`perf` in the changelog, so pure `ci:` or `chore:` commits are already hidden. The problem is PR titles like `fix(ci): ...` or `feat(e2e): ...`, where the type is changelog-visible but the scope is infra. Contributors should use `ci:`, `build:`, or `chore:` for these instead.

The `deploy` scope is intentionally excluded from the blocklist since deploy changes are user-facing.

## Test plan

- [x] Tested the grep pattern against positive cases (`fix(ci)`, `feat(e2e)`, `perf(build)`) and negative cases (`ci(deploy)`, `fix(spurctld)`, `feat(spur-cli)`, `fix(deployment)`)