### PR TITLE
fix(spurctld): honor node filters and match Slurm pending reasons

### DIFF
--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -260,8 +260,8 @@ impl PendingReason {
             Self::Priority => "Priority",
             Self::Resources => "Resources",
             Self::PartitionDown => "PartitionDown",
-            Self::PartitionNodeLimit => "PartNodeLimit",
-            Self::PartitionTimeLimit => "PartTimeLimit",
+            Self::PartitionNodeLimit => "PartitionNodeLimit",
+            Self::PartitionTimeLimit => "PartitionTimeLimit",
             Self::Dependency => "Dependency",
             Self::NodeDown => "NodeDown",
             Self::Held => "JobHeldUser",
@@ -1097,6 +1097,20 @@ mod tests {
         done.transition(JobState::Running).unwrap();
         done.transition(JobState::Completed).unwrap();
         assert!(done.transition(JobState::Deadline).is_err());
+    }
+
+    #[test]
+    fn partition_limit_reasons_match_slurm_strings() {
+        // squeue displays these verbatim; verified byte-exact against
+        // slurm 25.11.6 (`(PartitionNodeLimit)`), so they must not abbreviate.
+        assert_eq!(
+            PendingReason::PartitionNodeLimit.display(),
+            "PartitionNodeLimit"
+        );
+        assert_eq!(
+            PendingReason::PartitionTimeLimit.display(),
+            "PartitionTimeLimit"
+        );
     }
 
     #[test]

--- a/crates/spur-sched/src/backfill.rs
+++ b/crates/spur-sched/src/backfill.rs
@@ -1,16 +1,17 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use chrono::{Duration, Utc};
-use tracing::{debug, warn};
+use tracing::debug;
 
 use spur_core::job::{Job, JobId};
 use spur_core::node::Node;
 use spur_core::reservation::Reservation;
 use spur_core::resource::{build_exclusive_allocation, build_node_allocation, ResourceSet};
 
+use crate::node_match::NodePlacement;
 use crate::timeline::NodeTimeline;
 use crate::traits::{Assignment, ClusterState, Scheduler};
 
@@ -52,107 +53,25 @@ impl BackfillScheduler {
         nodes: &[Node],
         reservations: &[Reservation],
     ) -> Vec<usize> {
-        let partition_name = job.spec.partition.as_deref();
         let required = job_resource_request(job);
-
-        // Parse nodelist / exclude constraints once, outside the per-node loop.
-        let nodelist: Option<HashSet<String>> = job
-            .spec
-            .nodelist
-            .as_deref()
-            .filter(|s| !s.is_empty())
-            .map(|s| HashSet::from_iter(expand_hostlist_or_split(s)));
-
-        let exclude: HashSet<String> = job
-            .spec
-            .exclude
-            .as_deref()
-            .map(|s| HashSet::from_iter(expand_hostlist_or_split(s)))
-            .unwrap_or_default();
+        let placement = NodePlacement::new(job);
+        let now = Utc::now();
 
         nodes
             .iter()
             .enumerate()
             .filter(|(_, node)| {
-                if let Some(ref allowed) = nodelist {
-                    if !allowed.contains(&node.name) {
-                        return false;
-                    }
-                }
-                if exclude.contains(&node.name) {
+                if !placement.matches(node, reservations, now) {
                     return false;
                 }
-                // Check partition membership (comma-separated OR matching)
-                if let Some(pname) = partition_name {
-                    let requested: Vec<&str> = pname.split(',').map(str::trim).collect();
-                    if !requested
-                        .iter()
-                        .any(|rp| node.partitions.iter().any(|np| np == rp))
-                    {
-                        return false;
-                    }
-                }
-                // Check node is schedulable
-                if !node.is_schedulable() {
-                    return false;
-                }
-                // Exclusive job needs an idle node (no current allocations)
-                if job.spec.exclusive
-                    && (node.alloc_resources.cpus > 0 || node.alloc_resources.has_devices())
-                {
-                    return false;
-                }
-                // Skip nodes fully consumed by an exclusive job
+                // Skip nodes fully consumed by an exclusive job.
                 if node.alloc_resources.cpus >= node.total_resources.cpus
                     && node.total_resources.cpus > 0
                 {
                     return false;
                 }
-                // Check --constraint: all requested features must be present on the node
-                if let Some(ref constraint) = job.spec.constraint {
-                    let required_features: Vec<&str> = constraint
-                        .split(',')
-                        .map(str::trim)
-                        .filter(|s| !s.is_empty())
-                        .collect();
-                    if !required_features
-                        .iter()
-                        .all(|f| node.features.contains(&f.to_string()))
-                    {
-                        return false;
-                    }
-                }
-                // Reservation enforcement
-                let now = Utc::now();
-                let job_reservation = job.spec.reservation.as_deref().filter(|s| !s.is_empty());
-
-                let active_reservations: Vec<&Reservation> = reservations
-                    .iter()
-                    .filter(|r| r.is_active(now) && r.covers_node(&node.name))
-                    .collect();
-
-                if let Some(res_name) = job_reservation {
-                    // Job targets a reservation -- only allow nodes in that reservation
-                    if !active_reservations.iter().any(|r| r.name == res_name) {
-                        return false;
-                    }
-                    // Check user/account is allowed
-                    let user = &job.spec.user;
-                    let account = job.spec.account.as_deref();
-                    if !active_reservations
-                        .iter()
-                        .any(|r| r.name == res_name && r.allows_user(user, account))
-                    {
-                        return false;
-                    }
-                } else {
-                    // Job does NOT target a reservation -- skip reserved nodes
-                    if !active_reservations.is_empty() {
-                        return false;
-                    }
-                }
-
-                // Check resource capacity (total, not current available)
+                // Capacity against total resources: the backfill timeline below
+                // decides *when* the node is free, not whether it ever fits.
                 node.total_resources.can_satisfy(&required)
             })
             .map(|(i, _)| i)
@@ -364,23 +283,6 @@ impl Scheduler for BackfillScheduler {
 
     fn name(&self) -> &str {
         "backfill"
-    }
-}
-
-/// Expand a hostlist pattern (e.g. `node[001-003]`) into individual names.
-/// Falls back to a plain comma-split if the pattern is malformed, so
-/// existing behavior is preserved for simple comma-separated lists.
-fn expand_hostlist_or_split(pattern: &str) -> Vec<String> {
-    match spur_core::hostlist::expand(pattern) {
-        Ok(names) => names,
-        Err(e) => {
-            warn!(
-                pattern,
-                error = %e,
-                "hostlist expansion failed, falling back to comma-split"
-            );
-            pattern.split(',').map(|s| s.trim().to_string()).collect()
-        }
     }
 }
 
@@ -904,17 +806,6 @@ mod tests {
         assert!(!assignments[0].nodes.contains(&"node002".to_string()));
         assert!(assignments[0].nodes.contains(&"node003".to_string()));
         assert!(assignments[0].nodes.contains(&"node004".to_string()));
-    }
-
-    #[test]
-    fn test_malformed_hostlist_falls_back_to_comma_split() {
-        // Reversed range is invalid; fallback returns the literal as a single token.
-        let result = expand_hostlist_or_split("node[003-001]");
-        assert_eq!(result, vec!["node[003-001]"]);
-
-        // Plain comma-separated list is not a hostlist pattern; fallback splits correctly.
-        let result = expand_hostlist_or_split("a,b,c");
-        assert_eq!(result, vec!["a", "b", "c"]);
     }
 
     #[test]

--- a/crates/spur-sched/src/lib.rs
+++ b/crates/spur-sched/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod backfill;
 pub mod cons_tres;
+pub mod node_match;
 pub mod priority;
 pub mod timeline;
 pub mod traits;

--- a/crates/spur-sched/src/node_match.rs
+++ b/crates/spur-sched/src/node_match.rs
@@ -1,19 +1,9 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Shared node-placement matching.
-//!
-//! The scheduler ([`crate::backfill::BackfillScheduler::find_suitable_nodes`])
-//! and the pending-reason classifier both need to answer "could this job ever
-//! be placed on this node, ignoring current free capacity?". Keeping that logic
-//! in one place stops the two paths from drifting — a drift that previously let
-//! a job pinned to an unusable `--nodelist` report `Priority` (waiting its turn)
-//! instead of `Resources`/`ReqNodeNotAvail` (never schedulable here).
-//!
-//! Resource-capacity is deliberately *not* checked here: the scheduler compares
-//! against a node's total resources on a reservation timeline, while the
-//! pending-reason path compares against currently-available resources. Callers
-//! apply their own capacity check on top of [`NodePlacement::matches`].
+//! Shared node-placement matching used by both the scheduler and the
+//! pending-reason classifier so the two cannot drift. Capacity is not checked
+//! here: callers apply their own (scheduler vs total, pending-reason vs free).
 
 use std::collections::HashSet;
 
@@ -112,14 +102,8 @@ impl<'a> NodePlacement<'a> {
             .all(|f| node.features.iter().any(|nf| nf == f))
     }
 
-    /// Load-independent placement identity: could the job EVER target this node,
-    /// regardless of the node's current state or free capacity? Covers
-    /// nodelist/exclude, partition, feature constraints, and reservation access.
-    ///
-    /// This is the set the pending-reason classifier reasons over: if fewer than
-    /// `num_nodes` nodes are eligible here, the job is unschedulable as written
-    /// (bad `--nodelist`, unmatchable `--constraint`, too many nodes) rather than
-    /// merely waiting for busy nodes to free up.
+    /// Load-independent placement identity (nodelist/exclude, partition,
+    /// features, reservation), ignoring node state and free capacity.
     pub fn eligible(&self, node: &Node, reservations: &[Reservation], now: DateTime<Utc>) -> bool {
         self.allows_name(&node.name)
             && self.in_partition(node)
@@ -127,10 +111,8 @@ impl<'a> NodePlacement<'a> {
             && self.reservation_ok(node, reservations, now)
     }
 
-    /// Whether this node is a valid placement target for the job right now,
-    /// ignoring only current free capacity (the timeline decides *when* a busy
-    /// node frees up). Adds runtime state to [`eligible`](Self::eligible):
-    /// schedulability and the exclusive-idle requirement.
+    /// [`eligible`](Self::eligible) plus runtime state (schedulable,
+    /// exclusive-idle), still ignoring free capacity.
     pub fn matches(&self, node: &Node, reservations: &[Reservation], now: DateTime<Utc>) -> bool {
         if !self.eligible(node, reservations, now) {
             return false;

--- a/crates/spur-sched/src/node_match.rs
+++ b/crates/spur-sched/src/node_match.rs
@@ -1,0 +1,318 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared node-placement matching.
+//!
+//! The scheduler ([`crate::backfill::BackfillScheduler::find_suitable_nodes`])
+//! and the pending-reason classifier both need to answer "could this job ever
+//! be placed on this node, ignoring current free capacity?". Keeping that logic
+//! in one place stops the two paths from drifting — a drift that previously let
+//! a job pinned to an unusable `--nodelist` report `Priority` (waiting its turn)
+//! instead of `Resources`/`ReqNodeNotAvail` (never schedulable here).
+//!
+//! Resource-capacity is deliberately *not* checked here: the scheduler compares
+//! against a node's total resources on a reservation timeline, while the
+//! pending-reason path compares against currently-available resources. Callers
+//! apply their own capacity check on top of [`NodePlacement::matches`].
+
+use std::collections::HashSet;
+
+use chrono::{DateTime, Utc};
+use tracing::warn;
+
+use spur_core::job::Job;
+use spur_core::node::Node;
+use spur_core::reservation::Reservation;
+
+/// Job placement constraints, parsed once and reused across all candidate nodes.
+pub struct NodePlacement<'a> {
+    job: &'a Job,
+    /// Explicit `--nodelist` allow-list (expanded from hostlist), if any.
+    nodelist: Option<HashSet<String>>,
+    /// `--exclude` deny-list (expanded from hostlist).
+    exclude: HashSet<String>,
+    /// Requested `--constraint` features (all must be present on a node).
+    required_features: Vec<&'a str>,
+    /// Partitions the job may run in (`--partition` OR-list).
+    partitions: Vec<&'a str>,
+}
+
+impl<'a> NodePlacement<'a> {
+    /// Parse a job's placement constraints once.
+    pub fn new(job: &'a Job) -> Self {
+        let nodelist = job
+            .spec
+            .nodelist
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .map(|s| HashSet::from_iter(expand_hostlist_or_split(s)));
+
+        let exclude = job
+            .spec
+            .exclude
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .map(|s| HashSet::from_iter(expand_hostlist_or_split(s)))
+            .unwrap_or_default();
+
+        let required_features = job
+            .spec
+            .constraint
+            .as_deref()
+            .map(|c| {
+                c.split(',')
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let partitions = job
+            .spec
+            .partition
+            .as_deref()
+            .map(|p| p.split(',').map(str::trim).collect())
+            .unwrap_or_default();
+
+        Self {
+            job,
+            nodelist,
+            exclude,
+            required_features,
+            partitions,
+        }
+    }
+
+    /// True if the job's `--nodelist`/`--exclude` permit this node by name.
+    /// Name-only check: no partition, feature, capacity, or state involved.
+    pub fn allows_name(&self, name: &str) -> bool {
+        if let Some(ref allowed) = self.nodelist {
+            if !allowed.contains(name) {
+                return false;
+            }
+        }
+        !self.exclude.contains(name)
+    }
+
+    /// True if the node is in one of the job's requested partitions (or the job
+    /// requested no partition).
+    pub fn in_partition(&self, node: &Node) -> bool {
+        if self.partitions.is_empty() {
+            return true;
+        }
+        self.partitions
+            .iter()
+            .any(|rp| node.partitions.iter().any(|np| np == rp))
+    }
+
+    /// True if the node carries every requested `--constraint` feature.
+    pub fn has_features(&self, node: &Node) -> bool {
+        self.required_features
+            .iter()
+            .all(|f| node.features.iter().any(|nf| nf == f))
+    }
+
+    /// Load-independent placement identity: could the job EVER target this node,
+    /// regardless of the node's current state or free capacity? Covers
+    /// nodelist/exclude, partition, feature constraints, and reservation access.
+    ///
+    /// This is the set the pending-reason classifier reasons over: if fewer than
+    /// `num_nodes` nodes are eligible here, the job is unschedulable as written
+    /// (bad `--nodelist`, unmatchable `--constraint`, too many nodes) rather than
+    /// merely waiting for busy nodes to free up.
+    pub fn eligible(&self, node: &Node, reservations: &[Reservation], now: DateTime<Utc>) -> bool {
+        self.allows_name(&node.name)
+            && self.in_partition(node)
+            && self.has_features(node)
+            && self.reservation_ok(node, reservations, now)
+    }
+
+    /// Whether this node is a valid placement target for the job right now,
+    /// ignoring only current free capacity (the timeline decides *when* a busy
+    /// node frees up). Adds runtime state to [`eligible`](Self::eligible):
+    /// schedulability and the exclusive-idle requirement.
+    pub fn matches(&self, node: &Node, reservations: &[Reservation], now: DateTime<Utc>) -> bool {
+        if !self.eligible(node, reservations, now) {
+            return false;
+        }
+        if !node.is_schedulable() {
+            return false;
+        }
+        // Exclusive jobs need an idle node.
+        if self.job.spec.exclusive
+            && (node.alloc_resources.cpus > 0 || node.alloc_resources.has_devices())
+        {
+            return false;
+        }
+        true
+    }
+
+    fn reservation_ok(
+        &self,
+        node: &Node,
+        reservations: &[Reservation],
+        now: DateTime<Utc>,
+    ) -> bool {
+        let job_reservation = self
+            .job
+            .spec
+            .reservation
+            .as_deref()
+            .filter(|s| !s.is_empty());
+
+        let active: Vec<&Reservation> = reservations
+            .iter()
+            .filter(|r| r.is_active(now) && r.covers_node(&node.name))
+            .collect();
+
+        match job_reservation {
+            Some(res_name) => {
+                let user = &self.job.spec.user;
+                let account = self.job.spec.account.as_deref();
+                active
+                    .iter()
+                    .any(|r| r.name == res_name && r.allows_user(user, account))
+            }
+            // Jobs without a reservation may not use reserved nodes.
+            None => active.is_empty(),
+        }
+    }
+}
+
+/// Expand a hostlist pattern (e.g. `node[001-003]`) into individual names.
+/// Falls back to a plain comma-split if the pattern is malformed, so existing
+/// behaviour is preserved for simple comma-separated lists.
+pub fn expand_hostlist_or_split(pattern: &str) -> Vec<String> {
+    match spur_core::hostlist::expand(pattern) {
+        Ok(names) => names,
+        Err(e) => {
+            warn!(
+                pattern,
+                error = %e,
+                "hostlist expansion failed, falling back to comma-split"
+            );
+            pattern.split(',').map(|s| s.trim().to_string()).collect()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+    use spur_core::job::JobSpec;
+    use spur_core::node::NodeState;
+    use spur_core::resource::ResourceSet;
+
+    fn node(name: &str) -> Node {
+        let mut n = Node::new(
+            name.into(),
+            ResourceSet {
+                cpus: 64,
+                memory_mb: 256_000,
+                ..Default::default()
+            },
+        );
+        n.state = NodeState::Idle;
+        n.partitions = vec!["default".into()];
+        n
+    }
+
+    fn job_with(spec: JobSpec) -> Job {
+        Job::new(1, spec)
+    }
+
+    fn base_spec() -> JobSpec {
+        JobSpec {
+            name: "j".into(),
+            partition: Some("default".into()),
+            user: "test".into(),
+            num_nodes: 1,
+            num_tasks: 1,
+            cpus_per_task: 1,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn malformed_hostlist_falls_back_to_comma_split() {
+        // Reversed range is invalid; fallback returns the literal as one token.
+        assert_eq!(
+            expand_hostlist_or_split("node[003-001]"),
+            vec!["node[003-001]"]
+        );
+        // Plain comma list is not a hostlist pattern; fallback splits it.
+        assert_eq!(expand_hostlist_or_split("a,b,c"), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn nodelist_expands_brackets() {
+        let job = job_with(JobSpec {
+            nodelist: Some("node[001-003]".into()),
+            ..base_spec()
+        });
+        let p = NodePlacement::new(&job);
+        assert!(p.allows_name("node001"));
+        assert!(p.allows_name("node003"));
+        assert!(!p.allows_name("node004"));
+    }
+
+    #[test]
+    fn exclude_expands_brackets() {
+        let job = job_with(JobSpec {
+            exclude: Some("node[001-002]".into()),
+            ..base_spec()
+        });
+        let p = NodePlacement::new(&job);
+        assert!(!p.allows_name("node001"));
+        assert!(!p.allows_name("node002"));
+        assert!(p.allows_name("node003"));
+    }
+
+    #[test]
+    fn matches_respects_nodelist() {
+        let job = job_with(JobSpec {
+            nodelist: Some("node001".into()),
+            ..base_spec()
+        });
+        let p = NodePlacement::new(&job);
+        let now = Utc::now();
+        assert!(p.matches(&node("node001"), &[], now));
+        assert!(!p.matches(&node("node002"), &[], now));
+    }
+
+    #[test]
+    fn matches_requires_all_features() {
+        let job = job_with(JobSpec {
+            constraint: Some("mi300x,nvlink".into()),
+            ..base_spec()
+        });
+        let p = NodePlacement::new(&job);
+        let now = Utc::now();
+
+        let mut both = node("n1");
+        both.features = vec!["mi300x".into(), "nvlink".into()];
+        assert!(p.matches(&both, &[], now));
+
+        let mut one = node("n2");
+        one.features = vec!["mi300x".into()];
+        assert!(!p.matches(&one, &[], now));
+    }
+
+    #[test]
+    fn matches_blocks_reserved_node_for_unreserved_job() {
+        let job = job_with(base_spec());
+        let p = NodePlacement::new(&job);
+        let now = Utc::now();
+        let res = Reservation {
+            name: "r1".into(),
+            start_time: now - Duration::hours(1),
+            end_time: now + Duration::hours(1),
+            nodes: vec!["node001".into()],
+            accounts: Vec::new(),
+            users: vec!["alice".into()],
+        };
+        assert!(!p.matches(&node("node001"), std::slice::from_ref(&res), now));
+        assert!(p.matches(&node("node002"), &[res], now));
+    }
+}

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1897,87 +1897,76 @@ impl ClusterManager {
                 continue;
             }
 
-            // Determine the correct reason
-            let partition_name = job.spec.partition.as_deref();
+            // Placement constraints (nodelist/exclude/partition/constraint/
+            // reservation/exclusive) come from the SAME matcher the scheduler
+            // uses, so the reason we report can't disagree with what backfill
+            // actually does.
+            let placement = spur_sched::node_match::NodePlacement::new(job);
+            let now = chrono::Utc::now();
 
-            // Check if any node is schedulable in the target partition
-            let nodes_in_partition: Vec<&spur_core::node::Node> = cluster_state
+            let needed = (job.spec.num_nodes as usize).max(1);
+
+            // Nodes the job could EVER target (load-independent identity:
+            // nodelist/exclude, partition, features, reservation). Node state
+            // and capacity are deliberately excluded here.
+            let eligible: Vec<&spur_core::node::Node> = cluster_state
                 .nodes
                 .iter()
-                .filter(|n| {
-                    if let Some(pname) = partition_name {
-                        n.partitions.iter().any(|p| p == pname)
-                    } else {
-                        true
-                    }
-                })
+                .filter(|n| placement.eligible(n, cluster_state.reservations, now))
                 .collect();
 
-            if nodes_in_partition.is_empty() {
-                // No nodes in partition at all
-                job_entry.pending_reason = PendingReason::Resources;
+            // Not enough nodes can ever satisfy the placement constraints — the
+            // job is unschedulable as written (bad --nodelist/-w, too many
+            // nodes requested, unmatchable --constraint), not merely waiting.
+            if eligible.len() < needed {
+                job_entry.pending_reason = if job.spec.constraint.is_some() && eligible.is_empty() {
+                    PendingReason::BadConstraints
+                } else if job.spec.nodelist.as_deref().is_some_and(|s| !s.is_empty()) {
+                    PendingReason::ReqNodeNotAvail
+                } else {
+                    PendingReason::Resources
+                };
                 continue;
             }
 
-            // is_up() (not is_available()) so a fully-`Allocated` busy cluster
-            // counts as up — that's a `Resources` wait, not `NodeDown`.
-            let all_down = nodes_in_partition.iter().all(|n| !n.state.is_up());
-
-            if all_down {
-                job_entry.pending_reason = PendingReason::NodeDown;
+            // Enough eligible nodes exist but none are up. is_up() (not
+            // is_available()) so a fully-`Allocated` busy cluster counts as up —
+            // a `Resources` wait, not down. A job pinned via --nodelist to
+            // down/drained nodes reports ReqNodeNotAvail (Slurm parity);
+            // otherwise the partition is genuinely NodeDown.
+            if eligible.iter().all(|n| !n.state.is_up()) {
+                job_entry.pending_reason =
+                    if job.spec.nodelist.as_deref().is_some_and(|s| !s.is_empty()) {
+                        PendingReason::ReqNodeNotAvail
+                    } else {
+                        PendingReason::NodeDown
+                    };
                 continue;
             }
 
-            // Nodes exist but may be fully allocated — check if any node
-            // can satisfy resource requirements with AVAILABLE resources.
-            //
-            // Issue #65 (reopen of #56): previous check used total_resources,
-            // which always returned true for idle nodes even when their
-            // available resources (total - alloc) were insufficient because
-            // other jobs consumed them. Must use available = total - alloc.
+            // Count nodes that are schedulable AND can satisfy the request with
+            // AVAILABLE resources (total - alloc), matching what backfill does.
+            // Fewer free than needed → waiting on Resources; otherwise the job
+            // is simply queued behind higher priority.
             let required = spur_sched::backfill::job_resource_request(job);
-            let has_capable_node = nodes_in_partition.iter().any(|n| {
-                if !n.is_schedulable() {
-                    return false;
-                }
-                // Skip nodes fully consumed by existing allocations
-                if n.alloc_resources.cpus >= n.total_resources.cpus && n.total_resources.cpus > 0 {
-                    return false;
-                }
-                // Exclusive job needs an idle node (no current allocations)
-                if job.spec.exclusive
-                    && (n.alloc_resources.cpus > 0 || n.alloc_resources.has_devices())
-                {
-                    return false;
-                }
-                // Constraint feature check
-                if let Some(ref constraint) = job.spec.constraint {
-                    let required_features: Vec<&str> = constraint
-                        .split(',')
-                        .map(str::trim)
-                        .filter(|s| !s.is_empty())
-                        .collect();
-                    if !required_features
-                        .iter()
-                        .all(|f| n.features.contains(&f.to_string()))
+            let free_now = eligible
+                .iter()
+                .filter(|n| placement.matches(n, cluster_state.reservations, now))
+                .filter(|n| {
+                    if n.alloc_resources.cpus >= n.total_resources.cpus
+                        && n.total_resources.cpus > 0
                     {
                         return false;
                     }
-                }
-                // Check AVAILABLE resources (total minus already allocated),
-                // not just total capacity. This matches what the backfill
-                // scheduler actually does when trying to place a job.
-                n.can_satisfy_request(&required)
-            });
+                    n.can_satisfy_request(&required)
+                })
+                .count();
 
-            if !has_capable_node {
-                // Resources insufficient or constraints prevent scheduling
-                job_entry.pending_reason = PendingReason::Resources;
+            job_entry.pending_reason = if free_now < needed {
+                PendingReason::Resources
             } else {
-                // Capable nodes exist but currently occupied — backfill will
-                // schedule this job once they free up (or higher-priority jobs run)
-                job_entry.pending_reason = PendingReason::Priority;
-            }
+                PendingReason::Priority
+            };
         }
     }
 
@@ -4719,6 +4708,95 @@ mod tests {
         assert_eq!(
             cm.get_job(job_id).unwrap().pending_reason,
             PendingReason::NodeDown
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn nodelist_that_cannot_match_reports_req_node_not_avail() {
+        // A job pinned to a node that isn't idle/usable must report
+        // ReqNodeNotAvail, not Priority (as if merely queued behind others).
+        use spur_core::node::NodeState;
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 4, 8000);
+        register_node(&cm, "n2", 4, 8000);
+
+        let mut spec = basic_spec("pinned");
+        spec.nodelist = Some("n1".into());
+        let job_id = submit_and_wait(&cm, spec);
+        let snapshot = cm.get_job(job_id).unwrap();
+
+        // n1 is drained (not schedulable); n2 is idle but excluded by nodelist.
+        let mut n1 = cm.get_node("n1").unwrap();
+        n1.state = NodeState::Drain;
+        let n2 = cm.get_node("n2").unwrap();
+        let nodes = vec![n1, n2];
+        let state = spur_sched::traits::ClusterState {
+            nodes: &nodes,
+            partitions: &[],
+            reservations: &[],
+            topology: None,
+        };
+        cm.update_pending_reasons(&[&snapshot], &state);
+        assert_eq!(
+            cm.get_job(job_id).unwrap().pending_reason,
+            PendingReason::ReqNodeNotAvail
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn more_nodes_than_exist_reports_resources_not_priority() {
+        // B-05: a job needing more nodes than the partition has must report
+        // Resources, not Priority — it can never be scheduled by waiting.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 4, 8000);
+        register_node(&cm, "n2", 4, 8000);
+
+        let mut spec = basic_spec("toobig");
+        spec.num_nodes = 3; // only 2 nodes exist
+        spec.num_tasks = 3;
+        let job_id = submit_and_wait(&cm, spec);
+        let snapshot = cm.get_job(job_id).unwrap();
+
+        let nodes = vec![cm.get_node("n1").unwrap(), cm.get_node("n2").unwrap()];
+        let state = spur_sched::traits::ClusterState {
+            nodes: &nodes,
+            partitions: &[],
+            reservations: &[],
+            topology: None,
+        };
+        cm.update_pending_reasons(&[&snapshot], &state);
+        assert_eq!(
+            cm.get_job(job_id).unwrap().pending_reason,
+            PendingReason::Resources
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn unmatchable_constraint_reports_bad_constraints() {
+        // A --constraint no node carries can never schedule -> BadConstraints.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 4, 8000);
+
+        let mut spec = basic_spec("feat");
+        spec.constraint = Some("mi300x".into());
+        let job_id = submit_and_wait(&cm, spec);
+        let snapshot = cm.get_job(job_id).unwrap();
+
+        // Node has no features.
+        let nodes = vec![cm.get_node("n1").unwrap()];
+        let state = spur_sched::traits::ClusterState {
+            nodes: &nodes,
+            partitions: &[],
+            reservations: &[],
+            topology: None,
+        };
+        cm.update_pending_reasons(&[&snapshot], &state);
+        assert_eq!(
+            cm.get_job(job_id).unwrap().pending_reason,
+            PendingReason::BadConstraints
         );
     }
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1897,29 +1897,30 @@ impl ClusterManager {
                 continue;
             }
 
-            // Placement constraints (nodelist/exclude/partition/constraint/
-            // reservation/exclusive) come from the SAME matcher the scheduler
-            // uses, so the reason we report can't disagree with what backfill
-            // actually does.
+            // Reuse the scheduler's matcher so the reason can't disagree with
+            // what backfill actually does.
             let placement = spur_sched::node_match::NodePlacement::new(job);
             let now = chrono::Utc::now();
 
             let needed = (job.spec.num_nodes as usize).max(1);
 
-            // Nodes the job could EVER target (load-independent identity:
-            // nodelist/exclude, partition, features, reservation). Node state
-            // and capacity are deliberately excluded here.
             let eligible: Vec<&spur_core::node::Node> = cluster_state
                 .nodes
                 .iter()
                 .filter(|n| placement.eligible(n, cluster_state.reservations, now))
                 .collect();
 
-            // Not enough nodes can ever satisfy the placement constraints — the
-            // job is unschedulable as written (bad --nodelist/-w, too many
-            // nodes requested, unmatchable --constraint), not merely waiting.
+            // Fewer eligible nodes than requested: unschedulable as written.
             if eligible.len() < needed {
-                job_entry.pending_reason = if job.spec.constraint.is_some() && eligible.is_empty() {
+                let partition_size = cluster_state
+                    .nodes
+                    .iter()
+                    .filter(|n| placement.in_partition(n))
+                    .count();
+
+                job_entry.pending_reason = if needed > partition_size {
+                    PendingReason::PartitionNodeLimit
+                } else if job.spec.constraint.is_some() && eligible.is_empty() {
                     PendingReason::BadConstraints
                 } else if job.spec.nodelist.as_deref().is_some_and(|s| !s.is_empty()) {
                     PendingReason::ReqNodeNotAvail
@@ -1929,11 +1930,9 @@ impl ClusterManager {
                 continue;
             }
 
-            // Enough eligible nodes exist but none are up. is_up() (not
-            // is_available()) so a fully-`Allocated` busy cluster counts as up —
-            // a `Resources` wait, not down. A job pinned via --nodelist to
-            // down/drained nodes reports ReqNodeNotAvail (Slurm parity);
-            // otherwise the partition is genuinely NodeDown.
+            // Eligible nodes exist but none are up. is_up() keeps a busy
+            // `Allocated` cluster out of NodeDown; a nodelist pin to down nodes
+            // is ReqNodeNotAvail (Slurm parity).
             if eligible.iter().all(|n| !n.state.is_up()) {
                 job_entry.pending_reason =
                     if job.spec.nodelist.as_deref().is_some_and(|s| !s.is_empty()) {
@@ -1944,10 +1943,8 @@ impl ClusterManager {
                 continue;
             }
 
-            // Count nodes that are schedulable AND can satisfy the request with
-            // AVAILABLE resources (total - alloc), matching what backfill does.
-            // Fewer free than needed → waiting on Resources; otherwise the job
-            // is simply queued behind higher priority.
+            // Fewer nodes free (schedulable, available resources) than needed →
+            // Resources; otherwise queued behind higher priority.
             let required = spur_sched::backfill::job_resource_request(job);
             let free_now = eligible
                 .iter()
@@ -4745,9 +4742,10 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn more_nodes_than_exist_reports_resources_not_priority() {
-        // B-05: a job needing more nodes than the partition has must report
-        // Resources, not Priority — it can never be scheduled by waiting.
+    async fn more_nodes_than_exist_reports_partition_node_limit() {
+        // B-05: a job needing more nodes than the partition physically has must
+        // report PartitionNodeLimit (Slurm parity, verified on slurm 25.11.6),
+        // not Priority — it can never be scheduled by waiting.
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         register_node(&cm, "n1", 4, 8000);
@@ -4769,7 +4767,7 @@ mod tests {
         cm.update_pending_reasons(&[&snapshot], &state);
         assert_eq!(
             cm.get_job(job_id).unwrap().pending_reason,
-            PendingReason::Resources
+            PendingReason::PartitionNodeLimit
         );
     }
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -438,9 +438,18 @@ impl SlurmController for ControllerService {
             }
         }
 
-        let _req = request.into_inner();
+        let req = request.into_inner();
         let nodes = self.cluster.get_nodes();
-        let mut proto_nodes: Vec<NodeInfo> = nodes.iter().map(node_to_proto).collect();
+
+        // Honour the request filters; without this, `scontrol show node X` and
+        // `sinfo -n X` return the whole cluster.
+        let mut proto_nodes: Vec<NodeInfo> = nodes
+            .iter()
+            .filter(|n| node_matches_filter(n, &req.nodelist, &req.partition))
+            .map(node_to_proto)
+            .filter(|n| req.states.is_empty() || req.states.contains(&n.state))
+            .collect();
+
         let reservations = self.cluster.get_reservations();
         annotate_nodes_with_reservations(&mut proto_nodes, &reservations, Utc::now());
         Ok(Response::new(GetNodesResponse { nodes: proto_nodes }))
@@ -1907,6 +1916,23 @@ pub(crate) fn datetime_to_proto(dt: chrono::DateTime<chrono::Utc>) -> prost_type
     }
 }
 
+/// Whether a node passes a GetNodes request's name/partition filters. An empty
+/// filter matches everything; `nodelist` accepts a Slurm hostlist pattern.
+fn node_matches_filter(node: &spur_core::node::Node, nodelist: &str, partition: &str) -> bool {
+    let nodelist = nodelist.trim();
+    if !nodelist.is_empty() {
+        let allowed = spur_sched::node_match::expand_hostlist_or_split(nodelist);
+        if !allowed.iter().any(|n| n == &node.name) {
+            return false;
+        }
+    }
+    let partition = partition.trim();
+    if !partition.is_empty() && !node.partitions.iter().any(|p| p == partition) {
+        return false;
+    }
+    true
+}
+
 fn annotate_nodes_with_reservations(
     nodes: &mut [NodeInfo],
     reservations: &[Reservation],
@@ -1970,6 +1996,49 @@ mod tests {
             accounts: Vec::new(),
             users: Vec::new(),
         }
+    }
+
+    fn core_node(name: &str, partition: &str) -> spur_core::node::Node {
+        let mut n =
+            spur_core::node::Node::new(name.into(), spur_core::resource::ResourceSet::default());
+        n.partitions = vec![partition.into()];
+        n
+    }
+
+    #[test]
+    fn test_node_filter_empty_matches_all() {
+        let n = core_node("gpu01", "batch");
+        assert!(node_matches_filter(&n, "", ""));
+        assert!(node_matches_filter(&n, "  ", "  "));
+    }
+
+    #[test]
+    fn test_node_filter_by_name() {
+        let n = core_node("gpu01", "batch");
+        assert!(node_matches_filter(&n, "gpu01", ""));
+        assert!(!node_matches_filter(&n, "gpu02", ""));
+    }
+
+    #[test]
+    fn test_node_filter_hostlist_bracket() {
+        let n = core_node("gpu03", "batch");
+        assert!(node_matches_filter(&n, "gpu[01-04]", ""));
+        assert!(!node_matches_filter(&n, "gpu[05-08]", ""));
+    }
+
+    #[test]
+    fn test_node_filter_by_partition() {
+        let n = core_node("gpu01", "batch");
+        assert!(node_matches_filter(&n, "", "batch"));
+        assert!(!node_matches_filter(&n, "", "debug"));
+    }
+
+    #[test]
+    fn test_node_filter_name_and_partition_both_apply() {
+        let n = core_node("gpu01", "batch");
+        // Right name, wrong partition -> excluded.
+        assert!(!node_matches_filter(&n, "gpu01", "debug"));
+        assert!(node_matches_filter(&n, "gpu01", "batch"));
     }
 
     #[test]

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -441,11 +441,18 @@ impl SlurmController for ControllerService {
         let req = request.into_inner();
         let nodes = self.cluster.get_nodes();
 
+        let nodelist = req.nodelist.trim();
+        let allowed_names: Option<HashSet<String>> = (!nodelist.is_empty()).then(|| {
+            spur_sched::node_match::expand_hostlist_or_split(nodelist)
+                .into_iter()
+                .collect()
+        });
+
         // Honour the request filters; without this, `scontrol show node X` and
         // `sinfo -n X` return the whole cluster.
         let mut proto_nodes: Vec<NodeInfo> = nodes
             .iter()
-            .filter(|n| node_matches_filter(n, &req.nodelist, &req.partition))
+            .filter(|n| node_matches_filter(n, allowed_names.as_ref(), &req.partition))
             .map(node_to_proto)
             .filter(|n| req.states.is_empty() || req.states.contains(&n.state))
             .collect();
@@ -1916,21 +1923,28 @@ pub(crate) fn datetime_to_proto(dt: chrono::DateTime<chrono::Utc>) -> prost_type
     }
 }
 
-/// Whether a node passes a GetNodes request's name/partition filters. An empty
-/// filter matches everything; `nodelist` accepts a Slurm hostlist pattern.
-fn node_matches_filter(node: &spur_core::node::Node, nodelist: &str, partition: &str) -> bool {
-    let nodelist = nodelist.trim();
-    if !nodelist.is_empty() {
-        let allowed = spur_sched::node_match::expand_hostlist_or_split(nodelist);
-        if !allowed.iter().any(|n| n == &node.name) {
+/// Whether a node passes a GetNodes request's name/partition filters. A `None`
+/// name set matches every name; an empty `partition` matches every partition.
+/// `allowed_names` is the caller-expanded Slurm hostlist. `partition` accepts a
+/// Slurm-style comma-separated list, matching if any token names a node partition.
+fn node_matches_filter(
+    node: &spur_core::node::Node,
+    allowed_names: Option<&HashSet<String>>,
+    partition: &str,
+) -> bool {
+    if let Some(allowed) = allowed_names {
+        if !allowed.contains(&node.name) {
             return false;
         }
     }
-    let partition = partition.trim();
-    if !partition.is_empty() && !node.partitions.iter().any(|p| p == partition) {
-        return false;
+    let mut tokens = partition
+        .split(',')
+        .map(str::trim)
+        .filter(|p| !p.is_empty());
+    if partition.trim().is_empty() {
+        return true;
     }
-    true
+    tokens.any(|req| node.partitions.iter().any(|p| p == req))
 }
 
 fn annotate_nodes_with_reservations(
@@ -2005,40 +2019,56 @@ mod tests {
         n
     }
 
+    fn names(pattern: &str) -> Option<HashSet<String>> {
+        let pattern = pattern.trim();
+        (!pattern.is_empty()).then(|| {
+            spur_sched::node_match::expand_hostlist_or_split(pattern)
+                .into_iter()
+                .collect()
+        })
+    }
+
     #[test]
     fn test_node_filter_empty_matches_all() {
         let n = core_node("gpu01", "batch");
-        assert!(node_matches_filter(&n, "", ""));
-        assert!(node_matches_filter(&n, "  ", "  "));
+        assert!(node_matches_filter(&n, names("").as_ref(), ""));
+        assert!(node_matches_filter(&n, names("  ").as_ref(), "  "));
     }
 
     #[test]
     fn test_node_filter_by_name() {
         let n = core_node("gpu01", "batch");
-        assert!(node_matches_filter(&n, "gpu01", ""));
-        assert!(!node_matches_filter(&n, "gpu02", ""));
+        assert!(node_matches_filter(&n, names("gpu01").as_ref(), ""));
+        assert!(!node_matches_filter(&n, names("gpu02").as_ref(), ""));
     }
 
     #[test]
     fn test_node_filter_hostlist_bracket() {
         let n = core_node("gpu03", "batch");
-        assert!(node_matches_filter(&n, "gpu[01-04]", ""));
-        assert!(!node_matches_filter(&n, "gpu[05-08]", ""));
+        assert!(node_matches_filter(&n, names("gpu[01-04]").as_ref(), ""));
+        assert!(!node_matches_filter(&n, names("gpu[05-08]").as_ref(), ""));
     }
 
     #[test]
     fn test_node_filter_by_partition() {
         let n = core_node("gpu01", "batch");
-        assert!(node_matches_filter(&n, "", "batch"));
-        assert!(!node_matches_filter(&n, "", "debug"));
+        assert!(node_matches_filter(&n, names("").as_ref(), "batch"));
+        assert!(!node_matches_filter(&n, names("").as_ref(), "debug"));
     }
 
     #[test]
     fn test_node_filter_name_and_partition_both_apply() {
         let n = core_node("gpu01", "batch");
         // Right name, wrong partition -> excluded.
-        assert!(!node_matches_filter(&n, "gpu01", "debug"));
-        assert!(node_matches_filter(&n, "gpu01", "batch"));
+        assert!(!node_matches_filter(&n, names("gpu01").as_ref(), "debug"));
+        assert!(node_matches_filter(&n, names("gpu01").as_ref(), "batch"));
+    }
+
+    #[test]
+    fn test_node_filter_partition_comma_list() {
+        let n = core_node("gpu01", "gpu");
+        assert!(node_matches_filter(&n, names("").as_ref(), "gpu,cpu"));
+        assert!(!node_matches_filter(&n, names("").as_ref(), "cpu,fpga"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Node-placement eligibility (nodelist/exclude/partition/constraint/reservation) lived only inside the backfill scheduler, so two other code paths disagreed with it. This closes three Slurm-parity gaps:

- **Pending reason ignored placement constraints.** `update_pending_reasons` reported `Priority` whenever *any* capable node existed — ignoring `--nodelist`/`--exclude`/`--constraint` and counting a single node with `.any()` instead of requiring `num_nodes` suitable nodes. Jobs pinned to unusable nodes, or requesting more nodes than exist, showed `(Priority)` forever.
- **`GetNodes` ignored request filters.** `scontrol show node X` and `sinfo -n X` returned the whole cluster because the handler dropped the `nodelist`/`partition`/`states` fields.
- **Display strings didn't match Slurm.** `PartNodeLimit`/`PartTimeLimit` → `PartitionNodeLimit`/`PartitionTimeLimit` (squeue shows these verbatim).

## Approach

Extracted the shared eligibility logic into `spur_sched::node_match::NodePlacement` so the scheduler and the pending-reason classifier can't drift. Split load-independent placement identity (`eligible`) from runtime availability (`matches`). Wired the `GetNodes` handler to filter by name/partition/state through a small testable helper.

Pending-reason mapping now matches Slurm 25.11.6:
- request > partition size → `PartitionNodeLimit`
- unmatchable `--constraint` → `BadConstraints`
- `--nodelist` to down/absent nodes → `ReqNodeNotAvail`
- otherwise insufficient free → `Resources`, else `Priority`

## Testing

- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` — clean
- `cargo test --locked` — all pass (new unit tests for each reason and for the node filter)
- **Verified live on a 2-node cluster against a Slurm 25.11.6 reference**: single-node `scontrol show node`/`sinfo -n` returns one node; too-many-nodes → `PartitionNodeLimit`; nodelist→drained-node → `ReqNodeNotAvail`; a normal job still schedules (no over-reporting) — all matching Slurm output exactly.


## Related issues

Closes #379 — `-w`/`-x` targeting unavailable nodes now reports `ReqNodeNotAvail` instead of `(Priority)`; the acceptance criteria there are verified (including live against Slurm).
