### PR TITLE
fix(spurctld): make preemption terminate and requeue jobs correctly

### DIFF
--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -742,6 +742,17 @@ impl NodeCompleteError {
     }
 }
 
+/// Result of applying a transition through the tolerant apply path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransitionOutcome {
+    /// The state changed from its previous value to the requested one.
+    Applied,
+    /// The requested state equalled the current state; nothing changed.
+    /// Expected on WAL replay / HA follower catch-up where an entry may be
+    /// re-applied after it has already taken effect.
+    NoOp,
+}
+
 impl Job {
     /// Attempt a state transition, enforcing the state machine.
     pub fn transition(&mut self, to: JobState) -> Result<(), JobTransitionError> {
@@ -799,6 +810,23 @@ impl Job {
                 to,
             })
         }
+    }
+
+    /// Transition tolerant of already-applied entries, for the WAL apply path.
+    ///
+    /// A request to move to the state the job is already in is a `NoOp` rather
+    /// than an error: replaying a committed log or catching up an HA follower
+    /// legitimately re-applies entries, and those must not surface as invalid
+    /// transitions. Genuine illegal moves (e.g. Completed -> Running) still
+    /// error. Live command paths use the strict `transition()` instead.
+    pub fn apply_transition(
+        &mut self,
+        to: JobState,
+    ) -> Result<TransitionOutcome, JobTransitionError> {
+        if self.state == to {
+            return Ok(TransitionOutcome::NoOp);
+        }
+        self.transition(to).map(|()| TransitionOutcome::Applied)
     }
 }
 
@@ -1058,6 +1086,51 @@ mod tests {
     fn test_invalid_transition() {
         let mut job = make_job();
         assert!(job.transition(JobState::Completed).is_err());
+    }
+
+    #[test]
+    fn apply_transition_idempotent_terminal_is_noop() {
+        // WAL replay / HA follower catch-up re-applies committed entries. A
+        // completed job re-completing must be a silent NoOp, not an error.
+        let mut job = make_job();
+        job.transition(JobState::Running).unwrap();
+        job.transition(JobState::Completed).unwrap();
+
+        let outcome = job
+            .apply_transition(JobState::Completed)
+            .expect("re-applying the current terminal state must not error");
+        assert_eq!(outcome, TransitionOutcome::NoOp);
+        assert_eq!(job.state, JobState::Completed);
+    }
+
+    #[test]
+    fn apply_transition_reports_applied_for_real_move() {
+        let mut job = make_job();
+        let outcome = job
+            .apply_transition(JobState::Running)
+            .expect("Pending -> Running is legal");
+        assert_eq!(outcome, TransitionOutcome::Applied);
+        assert_eq!(job.state, JobState::Running);
+    }
+
+    #[test]
+    fn apply_transition_still_rejects_illegal_move() {
+        // Idempotency tolerance must not weaken the state machine: a genuinely
+        // illegal move (Completed -> Running) still errors on the apply path.
+        let mut job = make_job();
+        job.transition(JobState::Running).unwrap();
+        job.transition(JobState::Completed).unwrap();
+        assert!(job.apply_transition(JobState::Running).is_err());
+        assert_eq!(job.state, JobState::Completed);
+    }
+
+    #[test]
+    fn apply_transition_noop_on_non_terminal_repeat() {
+        let mut job = make_job();
+        job.transition(JobState::Running).unwrap();
+        let outcome = job.apply_transition(JobState::Running).unwrap();
+        assert_eq!(outcome, TransitionOutcome::NoOp);
+        assert_eq!(job.state, JobState::Running);
     }
 
     #[test]

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -88,6 +88,12 @@ impl JobState {
         matches!(self, Self::Running | Self::Completing | Self::Suspended)
     }
 
+    /// End of a run: `is_terminal()` plus `Preempted` (which may still requeue).
+    /// Distinct from `is_terminal()`, whose semantics must not shift.
+    pub fn is_finalized(&self) -> bool {
+        self.is_terminal() || matches!(self, Self::Preempted)
+    }
+
     /// Per-node completion state implied by one exit code.
     pub fn completion_state_for_exit_code(exit_code: i32) -> Self {
         if exit_code == 0 {
@@ -812,13 +818,9 @@ impl Job {
         }
     }
 
-    /// Transition tolerant of already-applied entries, for the WAL apply path.
-    ///
-    /// A request to move to the state the job is already in is a `NoOp` rather
-    /// than an error: replaying a committed log or catching up an HA follower
-    /// legitimately re-applies entries, and those must not surface as invalid
-    /// transitions. Genuine illegal moves (e.g. Completed -> Running) still
-    /// error. Live command paths use the strict `transition()` instead.
+    /// WAL-apply transition: a move to the current state is a `NoOp` (replay /
+    /// follower catch-up), illegal moves still error. Live paths use
+    /// `transition()`.
     pub fn apply_transition(
         &mut self,
         to: JobState,
@@ -1122,6 +1124,21 @@ mod tests {
         job.transition(JobState::Completed).unwrap();
         assert!(job.apply_transition(JobState::Running).is_err());
         assert_eq!(job.state, JobState::Completed);
+    }
+
+    #[test]
+    fn is_finalized_covers_terminal_and_preempted_but_not_active() {
+        // Distinct from is_terminal(): Preempted is finalized (end of run) but
+        // NOT terminal (it may be requeued to Pending).
+        assert!(JobState::Preempted.is_finalized());
+        assert!(!JobState::Preempted.is_terminal());
+        assert!(JobState::Completed.is_finalized());
+        assert!(JobState::Cancelled.is_finalized());
+        // Active / schedulable states are not finalized.
+        assert!(!JobState::Running.is_finalized());
+        assert!(!JobState::Completing.is_finalized());
+        assert!(!JobState::Suspended.is_finalized());
+        assert!(!JobState::Pending.is_finalized());
     }
 
     #[test]

--- a/crates/spur-core/src/partition.rs
+++ b/crates/spur-core/src/partition.rs
@@ -73,6 +73,22 @@ pub enum PreemptMode {
     Suspend,
 }
 
+impl PreemptMode {
+    /// Ranking used to pick a single mode when a job spans multiple partitions
+    /// (comma-separated OR list). Higher = more disruptive to the preempted
+    /// job. A job occupying a node in a partition that permits a harder
+    /// preemption can be preempted that hard, so the most aggressive matched
+    /// mode wins — maximizing the scheduler's ability to free resources.
+    pub fn aggressiveness(self) -> u8 {
+        match self {
+            Self::Off => 0,
+            Self::Suspend => 1,
+            Self::Requeue => 2,
+            Self::Cancel => 3,
+        }
+    }
+}
+
 impl Default for Partition {
     fn default() -> Self {
         Self {
@@ -95,5 +111,17 @@ impl Default for Partition {
             preempt_mode: PreemptMode::Off,
             priority_tier: 1,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preempt_mode_aggressiveness_orders_cancel_over_requeue_over_suspend_over_off() {
+        assert!(PreemptMode::Cancel.aggressiveness() > PreemptMode::Requeue.aggressiveness());
+        assert!(PreemptMode::Requeue.aggressiveness() > PreemptMode::Suspend.aggressiveness());
+        assert!(PreemptMode::Suspend.aggressiveness() > PreemptMode::Off.aggressiveness());
     }
 }

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -58,6 +58,13 @@ pub enum WalOperation {
         old_priority: u32,
         new_priority: u32,
     },
+    /// Requeue a preempted job to Pending with an eligibility hold until
+    /// `begin_time` (leader-stamped once, applied verbatim for deterministic replay).
+    JobRequeueHold {
+        job_id: JobId,
+        /// Absolute instant before which the requeued job stays ineligible.
+        begin_time: chrono::DateTime<chrono::Utc>,
+    },
     JobSuspend {
         job_id: JobId,
         /// Controller-stamped instant of suspension (for replay-deterministic accounting).
@@ -194,6 +201,27 @@ mod deregistration_wal_tests {
 #[cfg(test)]
 mod suspend_wal_tests {
     use super::*;
+
+    #[test]
+    fn requeue_hold_op_round_trips() {
+        let begin_time = chrono::Utc::now();
+        let op = WalOperation::JobRequeueHold {
+            job_id: 42,
+            begin_time,
+        };
+        let json = serde_json::to_string(&op).unwrap();
+        let back: WalOperation = serde_json::from_str(&json).unwrap();
+        match back {
+            WalOperation::JobRequeueHold {
+                job_id,
+                begin_time: b,
+            } => {
+                assert_eq!(job_id, 42);
+                assert_eq!(b, begin_time);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
 
     #[test]
     fn suspend_resume_ops_round_trip() {

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -58,11 +58,16 @@ pub enum WalOperation {
         old_priority: u32,
         new_priority: u32,
     },
-    /// Requeue a preempted job to Pending with an eligibility hold until
-    /// `begin_time` (leader-stamped once, applied verbatim for deterministic replay).
-    JobRequeueHold {
+    /// Preempt a running job and requeue it in one atomic step: free its node
+    /// allocation, end the prior run for accounting (as PREEMPTED), return it to
+    /// Pending, and hold it ineligible until `begin_time` so the scheduler can't
+    /// re-dispatch it into its own in-flight kill. A single committed entry
+    /// leaves the job Pending-with-hold and nodes freed, so a leadership change
+    /// or restart mid-sequence cannot strand it in PREEMPTED. `begin_time` is
+    /// the leader-computed absolute instant (already max'd against any user
+    /// `--begin`); followers apply it verbatim and re-apply is a NoOp.
+    JobPreemptRequeue {
         job_id: JobId,
-        /// Absolute instant before which the requeued job stays ineligible.
         begin_time: chrono::DateTime<chrono::Utc>,
     },
     JobSuspend {
@@ -203,16 +208,16 @@ mod suspend_wal_tests {
     use super::*;
 
     #[test]
-    fn requeue_hold_op_round_trips() {
+    fn preempt_requeue_op_round_trips() {
         let begin_time = chrono::Utc::now();
-        let op = WalOperation::JobRequeueHold {
+        let op = WalOperation::JobPreemptRequeue {
             job_id: 42,
             begin_time,
         };
         let json = serde_json::to_string(&op).unwrap();
         let back: WalOperation = serde_json::from_str(&json).unwrap();
         match back {
-            WalOperation::JobRequeueHold {
+            WalOperation::JobPreemptRequeue {
                 job_id,
                 begin_time: b,
             } => {

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -605,14 +605,9 @@ impl ClusterManager {
         Ok(())
     }
 
-    /// Preempt a running job according to its partition's PreemptMode.
-    ///
-    /// Performs the controller-side state change and, for requeue mode, returns
-    /// the job to Pending so it is rescheduled once resources free up. The
-    /// caller is responsible for dispatching the matching signal to node agents
-    /// (kill for cancel/requeue, SIGSTOP for suspend); the returned
-    /// `PreemptOutcome` says which. `Off` is rejected so the caller never
-    /// preempts a job whose partition forbids it.
+    /// Preempt a running job per its partition's PreemptMode. Does the
+    /// controller-side state change; the caller dispatches the signal named by
+    /// the returned `PreemptOutcome`. `Off` is rejected.
     pub fn preempt_job(&self, job_id: JobId, mode: PreemptMode) -> anyhow::Result<PreemptOutcome> {
         {
             let jobs = self.jobs.read();
@@ -637,26 +632,14 @@ impl ClusterManager {
                 Ok(PreemptOutcome::Killed)
             }
             PreemptMode::Requeue => {
-                // Complete as Preempted first: this deallocates nodes, returns
-                // licenses, fires accounting, and — for --requeue jobs — already
-                // routes back to Pending via notify_job_finished/maybe_requeue.
                 self.complete_job(job_id, -1, JobState::Preempted)?;
-                // Requeue preempt mode returns the job to the queue regardless of
-                // the job's own --requeue flag, so force Pending if it stranded
-                // in the terminal Preempted state.
-                let needs_requeue = self
-                    .jobs
-                    .read()
-                    .get(&job_id)
-                    .is_some_and(|j| j.state == JobState::Preempted);
-                if needs_requeue {
-                    self.propose(WalOperation::JobStateChange {
-                        job_id,
-                        old_state: JobState::Preempted,
-                        new_state: JobState::Pending,
-                    })?;
-                }
-                info!(job_id, "job preempted (requeue)");
+                // Return to Pending with a short eligibility hold, else the
+                // scheduler re-dispatches the job into its own in-flight cancel.
+                // Stamped once on the leader, applied verbatim on followers.
+                let hold_secs = (self.config.scheduler.interval_secs as i64 * 2 + 3).max(5);
+                let begin_time = Utc::now() + chrono::Duration::seconds(hold_secs);
+                self.propose(WalOperation::JobRequeueHold { job_id, begin_time })?;
+                info!(job_id, hold_secs, "job preempted (requeue)");
                 Ok(PreemptOutcome::Killed)
             }
         }
@@ -745,10 +728,8 @@ impl ClusterManager {
             );
         }
 
-        let should_requeue = matches!(
-            state,
-            JobState::Timeout | JobState::Preempted | JobState::NodeFail
-        );
+        // Preempted excluded: preempt_job owns its requeue (with hold).
+        let should_requeue = matches!(state, JobState::Timeout | JobState::NodeFail);
         if should_requeue {
             if let Err(e) = self.maybe_requeue(job_id) {
                 warn!(job_id, error = %e, "failed to requeue job");
@@ -1817,9 +1798,12 @@ impl ClusterManager {
 
             jobs.values()
                 .filter(|job| {
+                    let begin_held = job.pending_reason == PendingReason::BeginTime
+                        && job.spec.begin_time.is_some_and(|b| now < b);
                     job.state == JobState::Pending
                         && job.pending_reason != PendingReason::Held
                         && job.pending_reason != PendingReason::DeadLine
+                        && !begin_held
                 })
                 .filter_map(|job| {
                     // Same drop order as pending_jobs(): Part -> Dep -> QoS ->
@@ -1841,13 +1825,17 @@ impl ClusterManager {
         }
 
         let mut jobs = self.jobs.write();
+        let now = Utc::now();
         for (id, reason) in blocked {
             if let Some(j) = jobs.get_mut(&id) {
                 // Re-check under the write lock: the read snapshot was released,
                 // so the job may have started or been held/deadlined since.
+                let begin_held = j.pending_reason == PendingReason::BeginTime
+                    && j.spec.begin_time.is_some_and(|b| now < b);
                 if j.state == JobState::Pending
                     && j.pending_reason != PendingReason::Held
                     && j.pending_reason != PendingReason::DeadLine
+                    && !begin_held
                 {
                     j.pending_reason = reason;
                 }
@@ -1962,6 +1950,13 @@ impl ClusterManager {
             // tick; clobbering with Resources/NodeDown would mislead any
             // observer that polls in between.
             if job_entry.pending_reason == PendingReason::DeadLine {
+                continue;
+            }
+            // Keep an active BeginTime hold (e.g. requeue-by-preemption) until
+            // it lapses, then fall through to the real wait reason.
+            if job_entry.pending_reason == PendingReason::BeginTime
+                && job_entry.spec.begin_time.is_some_and(|b| Utc::now() < b)
+            {
                 continue;
             }
 
@@ -2219,6 +2214,17 @@ impl ClusterManager {
         .map_err(|e| anyhow::anyhow!("raft propose failed: {}", e))
     }
 
+    /// Clear a job's run-state so it is schedulable again after requeue.
+    fn reset_job_for_requeue(job: &mut Job) {
+        job.requeue_count += 1;
+        job.start_time = None;
+        job.exit_code = None;
+        job.allocated_nodes.clear();
+        job.allocated_resources = None;
+        job.per_node_alloc.clear();
+        job.pending_reason = PendingReason::None;
+    }
+
     /// Evict a single job by ID: transition to NodeFail, then free its
     /// allocations on every node it spans. Transition is validated first
     /// so allocations are never freed for a job that can't be evicted.
@@ -2343,17 +2349,26 @@ impl ClusterManager {
                             TransitionOutcome::NoOp
                         }
                     };
-                    // Requeue: reset allocation fields when returning to Pending.
-                    // Gated on a real transition so a replayed (already-Pending)
-                    // entry doesn't double-count requeue_count or re-wipe fields.
+                    // Gated on a real transition so a replay doesn't re-wipe
+                    // fields or double-count requeue_count.
                     if outcome == TransitionOutcome::Applied && *new_state == JobState::Pending {
-                        job.requeue_count += 1;
-                        job.start_time = None;
-                        job.exit_code = None;
-                        job.allocated_nodes.clear();
-                        job.allocated_resources = None;
-                        job.per_node_alloc.clear();
-                        job.pending_reason = PendingReason::None;
+                        Self::reset_job_for_requeue(job);
+                    }
+                }
+            }
+            WalOperation::JobRequeueHold { job_id, begin_time } => {
+                if let Some(job) = jobs.get_mut(job_id) {
+                    match job.apply_transition(JobState::Pending) {
+                        Ok(TransitionOutcome::Applied) => {
+                            Self::reset_job_for_requeue(job);
+                            // Ineligible until begin_time (Slurm parity: BeginTime).
+                            job.spec.begin_time = Some(*begin_time);
+                            job.pending_reason = PendingReason::BeginTime;
+                        }
+                        Ok(TransitionOutcome::NoOp) => {}
+                        Err(e) => {
+                            warn!(job_id = *job_id, error = %e, "invalid requeue-hold transition in WAL apply")
+                        }
                     }
                 }
             }
@@ -2424,7 +2439,9 @@ impl ClusterManager {
                     let Some(job) = jobs.get_mut(job_id) else {
                         return ClientResponse::default();
                     };
-                    if job.state.is_terminal() {
+                    // A completion for a non-active job is stale/replayed; skip
+                    // it rather than forcing an illegal finalize transition.
+                    if !job.state.is_active() {
                         return ClientResponse::default();
                     }
 
@@ -2547,7 +2564,9 @@ impl ClusterManager {
                 let allocated_resources;
                 let already_deallocated;
                 if let Some(job) = jobs.get_mut(job_id) {
-                    if job.state.is_terminal() {
+                    // is_finalized (incl. Preempted): a stale/replayed complete
+                    // is a silent no-op, not a rejected-transition warning.
+                    if job.state.is_finalized() {
                         return ClientResponse::default();
                     }
                     if let Err(e) = job.transition(*state) {
@@ -4721,6 +4740,83 @@ mod tests {
         assert_eq!(job.state, JobState::Pending);
         assert!(job.allocated_nodes.is_empty());
         assert_eq!(cm.node_metrics().alloc_cpus, 0, "nodes must be freed");
+
+        // The requeue must carry a future begin_time hold so the scheduler
+        // cannot re-dispatch the job into its own in-flight preemption cancel,
+        // and it must display BeginTime (Slurm parity).
+        let begin = job
+            .spec
+            .begin_time
+            .expect("requeue must set a begin_time hold");
+        assert!(begin > Utc::now(), "begin_time hold must be in the future");
+        assert_eq!(job.pending_reason, PendingReason::BeginTime);
+
+        // While the hold is active the job is excluded from scheduling.
+        assert!(
+            !cm.pending_jobs().iter().any(|j| j.job_id == job_id),
+            "held job must not be eligible for dispatch"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn preempt_requeue_hold_reason_survives_pending_reason_passes() {
+        // The BeginTime hold reason must not be clobbered by the pending-reason
+        // maintenance passes while the hold is still active.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let job_id = run_job_on(&cm, "hold-reason", "worker1");
+        cm.preempt_job(job_id, PreemptMode::Requeue).unwrap();
+        settle(&cm, job_id, JobState::Pending);
+        assert_eq!(
+            cm.get_job(job_id).unwrap().pending_reason,
+            PendingReason::BeginTime
+        );
+
+        cm.tag_blocked_pending_reasons();
+        assert_eq!(
+            cm.get_job(job_id).unwrap().pending_reason,
+            PendingReason::BeginTime,
+            "tag_blocked_pending_reasons must not clobber an active BeginTime hold"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn preempt_requeue_hold_expires_and_job_reschedules() {
+        // Once the hold lapses the job must become eligible and actually run
+        // again — the hold must not permanently strand it.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let job_id = run_job_on(&cm, "hold-expiry", "worker1");
+        cm.preempt_job(job_id, PreemptMode::Requeue).unwrap();
+        settle(&cm, job_id, JobState::Pending);
+
+        // Simulate the hold having elapsed by moving begin_time into the past,
+        // exactly as the wall clock would after the hold window.
+        {
+            let mut jobs = cm.jobs.write();
+            let job = jobs.get_mut(&job_id).unwrap();
+            job.spec.begin_time = Some(Utc::now() - chrono::Duration::seconds(1));
+        }
+
+        assert!(
+            cm.pending_jobs().iter().any(|j| j.job_id == job_id),
+            "job must be eligible again once the hold lapses"
+        );
+
+        // And it can be started again (not stranded).
+        let resources = scalar_alloc(2, 4000);
+        cm.start_job(
+            job_id,
+            vec!["worker1".into()],
+            resources.clone(),
+            per_node_for(&["worker1"], resources),
+        )
+        .unwrap();
+        settle(&cm, job_id, JobState::Running);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -4866,6 +4962,118 @@ mod tests {
             1,
             "replayed requeue must not double-count"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn apply_requeue_hold_is_replay_deterministic() {
+        // JobRequeueHold carries an absolute begin_time; followers/replay apply
+        // that exact instant and a re-applied entry is a NoOp (no double-count,
+        // no drifting timestamp).
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("hold-replay")),
+        });
+        cm.apply_operation(&WalOperation::JobStateChange {
+            job_id: 1,
+            old_state: JobState::Pending,
+            new_state: JobState::Running,
+        });
+        cm.apply_operation(&WalOperation::JobComplete {
+            job_id: 1,
+            exit_code: -1,
+            state: JobState::Preempted,
+        });
+
+        let begin_time = Utc::now() + chrono::Duration::seconds(5);
+        cm.apply_operation(&WalOperation::JobRequeueHold {
+            job_id: 1,
+            begin_time,
+        });
+        let job = cm.get_job(1).unwrap();
+        assert_eq!(job.state, JobState::Pending);
+        assert_eq!(job.spec.begin_time, Some(begin_time));
+        assert_eq!(job.pending_reason, PendingReason::BeginTime);
+        assert_eq!(job.requeue_count, 1);
+
+        // Replay the identical entry: exact same begin_time, no double-count.
+        cm.apply_operation(&WalOperation::JobRequeueHold {
+            job_id: 1,
+            begin_time,
+        });
+        let job = cm.get_job(1).unwrap();
+        assert_eq!(
+            job.spec.begin_time,
+            Some(begin_time),
+            "instant must not drift"
+        );
+        assert_eq!(
+            job.requeue_count, 1,
+            "replayed requeue-hold must not double-count"
+        );
+    }
+
+    /// Drive a job to RUNNING on `node` then finalize it as PREEMPTED via the
+    /// apply path, returning its id. Mirrors the pre-fix WAL state that stranded
+    /// jobs in PREEMPTED.
+    fn preempted_job_on(cm: &ClusterManager, name: &str, node: &str) -> JobId {
+        let job_id = run_job_on(cm, name, node);
+        cm.apply_operation(&WalOperation::JobComplete {
+            job_id,
+            exit_code: -1,
+            state: JobState::Preempted,
+        });
+        assert_eq!(cm.get_job(job_id).unwrap().state, JobState::Preempted);
+        job_id
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn apply_node_complete_on_preempted_job_is_noop() {
+        // A late/replayed node-completion for an already-PREEMPTED job must not
+        // force an illegal PREEMPTED -> COMPLETED finalize: no state change, no
+        // JobFinalized side-effect.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let job_id = preempted_job_on(&cm, "late-nodecomplete", "worker1");
+
+        let resp = cm.apply_operation(&WalOperation::JobNodeComplete {
+            job_id,
+            node_name: "worker1".into(),
+            exit_code: 0,
+            signal: 0,
+        });
+        assert!(
+            resp.jobs_finalized.is_empty(),
+            "stale node-complete must not re-finalize"
+        );
+        assert_eq!(cm.get_job(job_id).unwrap().state, JobState::Preempted);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn apply_job_complete_on_preempted_job_is_noop() {
+        // Replaying a terminal JobComplete over an already-PREEMPTED job is a
+        // silent no-op (this is the WAL-replay case for jobs 75/177).
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let job_id = preempted_job_on(&cm, "replay-complete", "worker1");
+
+        let resp = cm.apply_operation(&WalOperation::JobComplete {
+            job_id,
+            exit_code: 0,
+            state: JobState::Completed,
+        });
+        assert!(
+            resp.jobs_finalized.is_empty(),
+            "replayed complete over PREEMPTED must not re-finalize"
+        );
+        assert_eq!(cm.get_job(job_id).unwrap().state, JobState::Preempted);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -632,13 +632,28 @@ impl ClusterManager {
                 Ok(PreemptOutcome::Killed)
             }
             PreemptMode::Requeue => {
-                self.complete_job(job_id, -1, JobState::Preempted)?;
-                // Return to Pending with a short eligibility hold, else the
-                // scheduler re-dispatches the job into its own in-flight cancel.
-                // Stamped once on the leader, applied verbatim on followers.
+                // Single atomic op: free nodes, end the run for accounting, and
+                // return to Pending with an eligibility hold. A two-proposal
+                // sequence could strand the job in PREEMPTED if the second
+                // proposal failed after the first committed (leadership change /
+                // restart), which nothing scans for or recovers.
+                //
+                // Requeue-by-preemption intentionally ignores spec.requeue and
+                // the maybe_requeue MAX_REQUEUE cap: Slurm always requeues a
+                // preempted job regardless of its --requeue flag. This is a
+                // deliberate divergence from the ordinary requeue path.
                 let hold_secs = (self.config.scheduler.interval_secs as i64 * 2 + 3).max(5);
-                let begin_time = Utc::now() + chrono::Duration::seconds(hold_secs);
-                self.propose(WalOperation::JobRequeueHold { job_id, begin_time })?;
+                let hold = Utc::now() + chrono::Duration::seconds(hold_secs);
+                // Honor a later user --begin: compute the max on the leader so
+                // followers apply one verbatim instant (no per-replica clock).
+                let begin_time = self
+                    .jobs
+                    .read()
+                    .get(&job_id)
+                    .and_then(|j| j.spec.begin_time)
+                    .map_or(hold, |user_begin| user_begin.max(hold));
+                let resp = self.propose(WalOperation::JobPreemptRequeue { job_id, begin_time })?;
+                self.run_all_finalized_side_effects(&resp);
                 info!(job_id, hold_secs, "job preempted (requeue)");
                 Ok(PreemptOutcome::Killed)
             }
@@ -2356,21 +2371,79 @@ impl ClusterManager {
                     }
                 }
             }
-            WalOperation::JobRequeueHold { job_id, begin_time } => {
-                if let Some(job) = jobs.get_mut(job_id) {
-                    match job.apply_transition(JobState::Pending) {
-                        Ok(TransitionOutcome::Applied) => {
-                            Self::reset_job_for_requeue(job);
-                            // Ineligible until begin_time (Slurm parity: BeginTime).
-                            job.spec.begin_time = Some(*begin_time);
-                            job.pending_reason = PendingReason::BeginTime;
-                        }
-                        Ok(TransitionOutcome::NoOp) => {}
-                        Err(e) => {
-                            warn!(job_id = *job_id, error = %e, "invalid requeue-hold transition in WAL apply")
+            WalOperation::JobPreemptRequeue { job_id, begin_time } => {
+                // Only a running job is preempted; on replay the job is already
+                // Pending, so this is a NoOp (no re-dealloc, no double requeue).
+                let freed_nodes;
+                let allocated_resources;
+                let per_node_map;
+                {
+                    let Some(job) = jobs.get_mut(job_id) else {
+                        return ClientResponse::default();
+                    };
+                    if job.state != JobState::Running {
+                        return ClientResponse::default();
+                    }
+                    // Route through Preempted so the state machine and accounting
+                    // see a finished run, then requeue to Pending — one atomic
+                    // apply; the intermediate Preempted never escapes the lock.
+                    if let Err(e) = job.transition(JobState::Preempted) {
+                        warn!(job_id = *job_id, error = %e, "invalid preempt transition in WAL apply");
+                        return ClientResponse::default();
+                    }
+                    job.exit_code = Some(-1);
+                    job.end_time = Some(timestamp);
+                    if let Some(since) = job.suspended_at.take() {
+                        job.suspended_secs += (timestamp - since).num_seconds().max(0);
+                    }
+                    freed_nodes = job.allocated_nodes.clone();
+                    allocated_resources = job.allocated_resources.clone();
+                    per_node_map = job.per_node_alloc.clone();
+                    job.node_completions.clear();
+
+                    if let Err(e) = job.transition(JobState::Pending) {
+                        warn!(job_id = *job_id, error = %e, "invalid requeue transition in WAL apply");
+                        return ClientResponse::default();
+                    }
+                    Self::reset_job_for_requeue(job);
+                    job.spec.begin_time = Some(*begin_time);
+                    job.pending_reason = PendingReason::BeginTime;
+                }
+                if let Some(ref total) = allocated_resources {
+                    let node_count = freed_nodes.len().max(1) as u32;
+                    for name in &freed_nodes {
+                        if let Some(node) = nodes.get_mut(name) {
+                            let slice = per_node_map.get(name).cloned().unwrap_or_else(|| {
+                                warn!(job_id = *job_id, node = %name, "per_node_alloc missing at preempt deallocation, using scalar fallback");
+                                ResourceAllocations::with_scalar(
+                                    total.cpus / node_count,
+                                    total.memory_mb / node_count as u64,
+                                )
+                            });
+                            node.alloc_resources.subtract(&slice);
+                            node.update_state_from_alloc();
+                            if node.state == NodeState::Draining
+                                && node.alloc_resources.cpus == 0
+                                && !node.alloc_resources.has_devices()
+                            {
+                                node.state = NodeState::Drain;
+                            }
                         }
                     }
                 }
+                drop(jobs);
+                drop(nodes);
+                // Complete steps and fire accounting for the terminated run as
+                // PREEMPTED, even though the job itself is now Pending-with-hold.
+                self.complete_job_steps(job_id, -1, timestamp);
+                self.next_job_id.store(next_id, Ordering::Relaxed);
+                return ClientResponse {
+                    jobs_finalized: vec![JobFinalized {
+                        job_id: *job_id,
+                        state: JobState::Preempted,
+                        exit_code: -1,
+                    }],
+                };
             }
             WalOperation::JobSuspend { job_id, at } => {
                 if let Some(job) = jobs.get_mut(job_id) {
@@ -4759,6 +4832,38 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn preempt_requeue_preserves_later_user_begin() {
+        // A user --begin further out than the preemption hold must win: the
+        // requeue must not shorten the user's constraint.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let user_begin = Utc::now() + chrono::Duration::hours(1);
+        let mut spec = basic_spec("user-begin");
+        spec.begin_time = Some(user_begin);
+        let job_id = submit_and_wait(&cm, spec);
+        let resources = scalar_alloc(2, 4000);
+        cm.start_job(
+            job_id,
+            vec!["worker1".into()],
+            resources.clone(),
+            per_node_for(&["worker1"], resources),
+        )
+        .unwrap();
+        settle(&cm, job_id, JobState::Running);
+
+        cm.preempt_job(job_id, PreemptMode::Requeue).unwrap();
+        settle(&cm, job_id, JobState::Pending);
+
+        assert_eq!(
+            cm.get_job(job_id).unwrap().spec.begin_time,
+            Some(user_begin),
+            "user --begin beyond the hold must be preserved"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn preempt_requeue_hold_reason_survives_pending_reason_passes() {
         // The BeginTime hold reason must not be clobbered by the pending-reason
         // maintenance passes while the hold is still active.
@@ -4965,45 +5070,59 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn apply_requeue_hold_is_replay_deterministic() {
-        // JobRequeueHold carries an absolute begin_time; followers/replay apply
-        // that exact instant and a re-applied entry is a NoOp (no double-count,
-        // no drifting timestamp).
+    async fn apply_preempt_requeue_is_atomic_and_replay_deterministic() {
+        // A single JobPreemptRequeue op takes a RUNNING job to Pending-with-hold
+        // AND frees its nodes AND finalizes the prior run as PREEMPTED for
+        // accounting — no intermediate state. Replay applies the exact begin_time
+        // and is a NoOp (no double-count, no drift, no re-dealloc).
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         register_node(&cm, "worker1", 8, 16000);
 
         cm.apply_operation(&WalOperation::JobSubmit {
             job_id: 1,
-            spec: Box::new(basic_spec("hold-replay")),
+            spec: Box::new(basic_spec("preempt-replay")),
         });
         cm.apply_operation(&WalOperation::JobStateChange {
             job_id: 1,
             old_state: JobState::Pending,
             new_state: JobState::Running,
         });
-        cm.apply_operation(&WalOperation::JobComplete {
+        let alloc = scalar_alloc(2, 4000);
+        cm.apply_operation(&WalOperation::JobStart {
             job_id: 1,
-            exit_code: -1,
-            state: JobState::Preempted,
+            nodes: vec!["worker1".into()],
+            resources: alloc.clone(),
+            per_node_alloc: per_node_for(&["worker1"], alloc),
         });
+        assert_eq!(cm.get_node("worker1").unwrap().alloc_resources.cpus, 2);
 
         let begin_time = Utc::now() + chrono::Duration::seconds(5);
-        cm.apply_operation(&WalOperation::JobRequeueHold {
+        let resp = cm.apply_operation(&WalOperation::JobPreemptRequeue {
             job_id: 1,
             begin_time,
         });
+        // One op finalizes the prior run as PREEMPTED (drives accounting) ...
+        assert_eq!(resp.jobs_finalized.len(), 1);
+        assert_eq!(resp.jobs_finalized[0].state, JobState::Preempted);
+        // ... and the job is Pending-with-hold with nodes freed.
         let job = cm.get_job(1).unwrap();
         assert_eq!(job.state, JobState::Pending);
         assert_eq!(job.spec.begin_time, Some(begin_time));
         assert_eq!(job.pending_reason, PendingReason::BeginTime);
         assert_eq!(job.requeue_count, 1);
+        assert!(job.allocated_nodes.is_empty());
+        assert_eq!(cm.get_node("worker1").unwrap().alloc_resources.cpus, 0);
 
-        // Replay the identical entry: exact same begin_time, no double-count.
-        cm.apply_operation(&WalOperation::JobRequeueHold {
+        // Replay the identical entry: job is already Pending -> NoOp.
+        let replay = cm.apply_operation(&WalOperation::JobPreemptRequeue {
             job_id: 1,
             begin_time,
         });
+        assert!(
+            replay.jobs_finalized.is_empty(),
+            "replayed preempt-requeue must not re-finalize"
+        );
         let job = cm.get_job(1).unwrap();
         assert_eq!(
             job.spec.begin_time,
@@ -5012,8 +5131,9 @@ mod tests {
         );
         assert_eq!(
             job.requeue_count, 1,
-            "replayed requeue-hold must not double-count"
+            "replayed preempt-requeue must not double-count"
         );
+        assert_eq!(cm.get_node("worker1").unwrap().alloc_resources.cpus, 0);
     }
 
     /// Drive a job to RUNNING on `node` then finalize it as PREEMPTED via the

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -14,9 +14,11 @@ use tracing::{debug, info, warn};
 use spur_core::accounting::{Qos, TresRecord, TresType};
 use spur_core::burst_buffer::BbStageState;
 use spur_core::config::SlurmConfig;
-use spur_core::job::{Job, JobId, JobSpec, JobState, NodeCompleteError, PendingReason};
+use spur_core::job::{
+    Job, JobId, JobSpec, JobState, NodeCompleteError, PendingReason, TransitionOutcome,
+};
 use spur_core::node::{Node, NodeEvent, NodeSource, NodeState};
-use spur_core::partition::Partition;
+use spur_core::partition::{Partition, PreemptMode};
 use spur_core::qos::{check_qos_limits, QosCheckResult};
 use spur_core::reservation::Reservation;
 use spur_core::resource::{ResourceAllocations, ResourceSet};
@@ -40,6 +42,15 @@ pub enum NodeCompleteResult {
     AllDone { state: JobState, exit_code: i32 },
     /// Job was already in a terminal state (duplicate or race with cancel/timeout).
     AlreadyTerminal,
+}
+
+/// What the caller must dispatch to node agents after `preempt_job`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreemptOutcome {
+    /// Kill the job's processes on every allocated node (cancel or requeue mode).
+    Killed,
+    /// Stop (SIGSTOP) the job's processes; allocation is retained (suspend mode).
+    Suspended,
 }
 
 /// Central cluster state manager.
@@ -592,6 +603,63 @@ impl ClusterManager {
 
         debug!(job_id, exit_code, "job completed");
         Ok(())
+    }
+
+    /// Preempt a running job according to its partition's PreemptMode.
+    ///
+    /// Performs the controller-side state change and, for requeue mode, returns
+    /// the job to Pending so it is rescheduled once resources free up. The
+    /// caller is responsible for dispatching the matching signal to node agents
+    /// (kill for cancel/requeue, SIGSTOP for suspend); the returned
+    /// `PreemptOutcome` says which. `Off` is rejected so the caller never
+    /// preempts a job whose partition forbids it.
+    pub fn preempt_job(&self, job_id: JobId, mode: PreemptMode) -> anyhow::Result<PreemptOutcome> {
+        {
+            let jobs = self.jobs.read();
+            let job = jobs
+                .get(&job_id)
+                .ok_or_else(|| anyhow::anyhow!("job {} not found", job_id))?;
+            if job.state != JobState::Running {
+                anyhow::bail!("job {} is not running (state {:?})", job_id, job.state);
+            }
+        }
+
+        match mode {
+            PreemptMode::Off => anyhow::bail!("preemption disabled for job {}", job_id),
+            PreemptMode::Suspend => {
+                self.suspend_job(job_id, "")?;
+                info!(job_id, "job preempted (suspend)");
+                Ok(PreemptOutcome::Suspended)
+            }
+            PreemptMode::Cancel => {
+                self.complete_job(job_id, -1, JobState::Cancelled)?;
+                info!(job_id, "job preempted (cancel)");
+                Ok(PreemptOutcome::Killed)
+            }
+            PreemptMode::Requeue => {
+                // Complete as Preempted first: this deallocates nodes, returns
+                // licenses, fires accounting, and — for --requeue jobs — already
+                // routes back to Pending via notify_job_finished/maybe_requeue.
+                self.complete_job(job_id, -1, JobState::Preempted)?;
+                // Requeue preempt mode returns the job to the queue regardless of
+                // the job's own --requeue flag, so force Pending if it stranded
+                // in the terminal Preempted state.
+                let needs_requeue = self
+                    .jobs
+                    .read()
+                    .get(&job_id)
+                    .is_some_and(|j| j.state == JobState::Preempted);
+                if needs_requeue {
+                    self.propose(WalOperation::JobStateChange {
+                        job_id,
+                        old_state: JobState::Preempted,
+                        new_state: JobState::Pending,
+                    })?;
+                }
+                info!(job_id, "job preempted (requeue)");
+                Ok(PreemptOutcome::Killed)
+            }
+        }
     }
 
     fn run_job_finalized_side_effects(&self, finalized: JobFinalized) {
@@ -2268,11 +2336,17 @@ impl ClusterManager {
                 job_id, new_state, ..
             } => {
                 if let Some(job) = jobs.get_mut(job_id) {
-                    if let Err(e) = job.transition(*new_state) {
-                        warn!(job_id = *job_id, error = %e, "invalid state transition in WAL apply");
-                    }
-                    // Requeue: reset allocation fields when returning to Pending
-                    if *new_state == JobState::Pending {
+                    let outcome = match job.apply_transition(*new_state) {
+                        Ok(outcome) => outcome,
+                        Err(e) => {
+                            warn!(job_id = *job_id, error = %e, "invalid state transition in WAL apply");
+                            TransitionOutcome::NoOp
+                        }
+                    };
+                    // Requeue: reset allocation fields when returning to Pending.
+                    // Gated on a real transition so a replayed (already-Pending)
+                    // entry doesn't double-count requeue_count or re-wipe fields.
+                    if outcome == TransitionOutcome::Applied && *new_state == JobState::Pending {
                         job.requeue_count += 1;
                         job.start_time = None;
                         job.exit_code = None;
@@ -2285,21 +2359,24 @@ impl ClusterManager {
             }
             WalOperation::JobSuspend { job_id, at } => {
                 if let Some(job) = jobs.get_mut(job_id) {
-                    if let Err(e) = job.transition(JobState::Suspended) {
-                        warn!(job_id = *job_id, error = %e, "invalid suspend transition in WAL apply");
-                    } else {
-                        job.suspended_at = Some(*at);
+                    match job.apply_transition(JobState::Suspended) {
+                        Ok(TransitionOutcome::Applied) => job.suspended_at = Some(*at),
+                        Ok(TransitionOutcome::NoOp) => {}
+                        Err(e) => {
+                            warn!(job_id = *job_id, error = %e, "invalid suspend transition in WAL apply")
+                        }
                     }
                 }
             }
             WalOperation::JobResume { job_id, at } => {
                 if let Some(job) = jobs.get_mut(job_id) {
-                    match job.transition(JobState::Running) {
-                        Ok(()) => {
+                    match job.apply_transition(JobState::Running) {
+                        Ok(TransitionOutcome::Applied) => {
                             if let Some(since) = job.suspended_at.take() {
                                 job.suspended_secs += (*at - since).num_seconds().max(0);
                             }
                         }
+                        Ok(TransitionOutcome::NoOp) => {}
                         Err(e) => {
                             warn!(job_id = *job_id, error = %e, "invalid resume transition in WAL apply")
                         }
@@ -4608,6 +4685,187 @@ mod tests {
 
         let job = cm.get_job(job_id).unwrap();
         assert_eq!(job.state, JobState::Cancelled);
+    }
+
+    /// Drive a fresh job all the way to RUNNING on `node`, returning its id.
+    fn run_job_on(cm: &ClusterManager, name: &str, node: &str) -> JobId {
+        let job_id = submit_and_wait(cm, basic_spec(name));
+        let resources = scalar_alloc(2, 4000);
+        cm.start_job(
+            job_id,
+            vec![node.into()],
+            resources.clone(),
+            per_node_for(&[node], resources),
+        )
+        .unwrap();
+        settle(cm, job_id, JobState::Running);
+        job_id
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn preempt_job_requeue_returns_job_to_pending_and_frees_nodes() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        // --requeue not set on the spec: requeue preempt mode must still
+        // return the job to the queue rather than stranding it in PREEMPTED.
+        let job_id = run_job_on(&cm, "preempt-requeue", "worker1");
+        assert_eq!(cm.node_metrics().alloc_cpus, 2);
+
+        let outcome = cm.preempt_job(job_id, PreemptMode::Requeue).unwrap();
+        assert_eq!(outcome, PreemptOutcome::Killed);
+        settle(&cm, job_id, JobState::Pending);
+
+        let job = cm.get_job(job_id).unwrap();
+        assert_eq!(job.state, JobState::Pending);
+        assert!(job.allocated_nodes.is_empty());
+        assert_eq!(cm.node_metrics().alloc_cpus, 0, "nodes must be freed");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn preempt_job_cancel_terminates_and_frees_nodes() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let job_id = run_job_on(&cm, "preempt-cancel", "worker1");
+        let outcome = cm.preempt_job(job_id, PreemptMode::Cancel).unwrap();
+        assert_eq!(outcome, PreemptOutcome::Killed);
+        settle(&cm, job_id, JobState::Cancelled);
+
+        let job = cm.get_job(job_id).unwrap();
+        assert_eq!(job.state, JobState::Cancelled);
+        assert_eq!(cm.node_metrics().alloc_cpus, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn preempt_job_suspend_retains_allocation() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let job_id = run_job_on(&cm, "preempt-suspend", "worker1");
+        let outcome = cm.preempt_job(job_id, PreemptMode::Suspend).unwrap();
+        assert_eq!(outcome, PreemptOutcome::Suspended);
+        settle(&cm, job_id, JobState::Suspended);
+
+        // Suspend retains the allocation (the process is only SIGSTOP'd).
+        assert_eq!(cm.node_metrics().alloc_cpus, 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn preempt_job_off_mode_is_rejected() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let job_id = run_job_on(&cm, "preempt-off", "worker1");
+        assert!(cm.preempt_job(job_id, PreemptMode::Off).is_err());
+        // Job keeps running; nothing was preempted.
+        assert_eq!(cm.get_job(job_id).unwrap().state, JobState::Running);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn preempt_job_rejects_non_running() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        let job_id = submit_and_wait(&cm, basic_spec("still-pending"));
+        assert!(cm.preempt_job(job_id, PreemptMode::Requeue).is_err());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn apply_job_state_change_idempotent_on_replay() {
+        // WAL replay re-applies committed entries. A terminal job whose
+        // completion entry is replayed must stay terminal without erroring or
+        // re-running finalize side effects.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("replay")),
+        });
+        cm.apply_operation(&WalOperation::JobStateChange {
+            job_id: 1,
+            old_state: JobState::Pending,
+            new_state: JobState::Running,
+        });
+
+        // Re-applying the same running transition is a NoOp, not an error.
+        cm.apply_operation(&WalOperation::JobStateChange {
+            job_id: 1,
+            old_state: JobState::Pending,
+            new_state: JobState::Running,
+        });
+        assert_eq!(cm.get_job(1).unwrap().state, JobState::Running);
+
+        let alloc = scalar_alloc(2, 4000);
+        cm.apply_operation(&WalOperation::JobStart {
+            job_id: 1,
+            nodes: vec!["worker1".into()],
+            resources: alloc.clone(),
+            per_node_alloc: per_node_for(&["worker1"], alloc),
+        });
+        cm.apply_operation(&WalOperation::JobComplete {
+            job_id: 1,
+            exit_code: 0,
+            state: JobState::Completed,
+        });
+
+        // Replaying the terminal complete: still Completed, resources still freed.
+        let replayed = cm.apply_operation(&WalOperation::JobComplete {
+            job_id: 1,
+            exit_code: 0,
+            state: JobState::Completed,
+        });
+        assert!(replayed.jobs_finalized.is_empty());
+        assert_eq!(cm.get_job(1).unwrap().state, JobState::Completed);
+        assert_eq!(cm.get_node("worker1").unwrap().alloc_resources.cpus, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn apply_requeue_state_change_not_double_counted_on_replay() {
+        // A replayed Preempted->Pending entry must not double-increment
+        // requeue_count or re-wipe allocation fields.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("requeue-replay")),
+        });
+        cm.apply_operation(&WalOperation::JobStateChange {
+            job_id: 1,
+            old_state: JobState::Pending,
+            new_state: JobState::Running,
+        });
+        cm.apply_operation(&WalOperation::JobComplete {
+            job_id: 1,
+            exit_code: -1,
+            state: JobState::Preempted,
+        });
+        cm.apply_operation(&WalOperation::JobStateChange {
+            job_id: 1,
+            old_state: JobState::Preempted,
+            new_state: JobState::Pending,
+        });
+        assert_eq!(cm.get_job(1).unwrap().requeue_count, 1);
+
+        // Replay the same requeue transition (job already Pending): NoOp.
+        cm.apply_operation(&WalOperation::JobStateChange {
+            job_id: 1,
+            old_state: JobState::Preempted,
+            new_state: JobState::Pending,
+        });
+        assert_eq!(
+            cm.get_job(1).unwrap().requeue_count,
+            1,
+            "replayed requeue must not double-count"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -424,11 +424,8 @@ fn job_preempt_mode(
         .unwrap_or(PreemptMode::Off)
 }
 
-/// Try to preempt lower-priority running jobs to make room for higher-priority
-/// pending jobs. Honors the running job's partition PreemptMode: cancel and
-/// requeue kill the process on every node (requeue also returns the job to
-/// Pending); suspend stops it in place. Jobs whose partition has PreemptMode
-/// Off are never preempted.
+/// Preempt lower-priority running jobs per their partition PreemptMode
+/// (Off jobs are never preempted).
 async fn try_preempt(
     cluster: &Arc<ClusterManager>,
     partitions: &[spur_core::partition::Partition],
@@ -465,9 +462,7 @@ async fn try_preempt(
             );
             match cluster.preempt_job(candidate.job_id, mode) {
                 Ok(PreemptOutcome::Killed) => {
-                    // Signal 0 = graceful cancel (SIGTERM, then SIGKILL after a
-                    // grace period), giving the preempted job a chance to
-                    // checkpoint — matches Slurm's default preemption grace.
+                    // Signal 0 = graceful cancel (SIGTERM then SIGKILL).
                     send_cancel_to_agents(cluster, candidate, 0).await;
                 }
                 Ok(PreemptOutcome::Suspended) => {

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -409,6 +409,10 @@ pub(crate) fn compute_job_allocation(
 }
 
 /// Resolve the effective PreemptMode for a job from its partition config.
+///
+/// `job.spec.partition` is a comma-separated OR list (same convention as the
+/// backfill scheduler's node matching), so a job may span several partitions.
+/// The most aggressive mode among the matched partitions wins.
 fn job_preempt_mode(
     job: &spur_core::job::Job,
     partitions: &[spur_core::partition::Partition],
@@ -417,10 +421,12 @@ fn job_preempt_mode(
     let Some(name) = job.spec.partition.as_deref().filter(|p| !p.is_empty()) else {
         return PreemptMode::Off;
     };
-    partitions
-        .iter()
-        .find(|p| p.name == name)
+    name.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .filter_map(|req| partitions.iter().find(|p| p.name == req))
         .map(|p| p.preempt_mode)
+        .max_by_key(|m| m.aggressiveness())
         .unwrap_or(PreemptMode::Off)
 }
 
@@ -1339,5 +1345,75 @@ mod tests {
         let alloc = compute_job_allocation(&job, &nodes, &per_node);
 
         assert_eq!(alloc.cpus, 64);
+    }
+
+    fn partition_with_mode(
+        name: &str,
+        mode: spur_core::partition::PreemptMode,
+    ) -> spur_core::partition::Partition {
+        spur_core::partition::Partition {
+            name: name.into(),
+            preempt_mode: mode,
+            ..Default::default()
+        }
+    }
+
+    fn job_in_partitions(partition: &str) -> Job {
+        job_with_spec(JobSpec {
+            partition: Some(partition.into()),
+            ..Default::default()
+        })
+    }
+
+    #[test]
+    fn job_preempt_mode_single_partition() {
+        use spur_core::partition::PreemptMode;
+        let parts = vec![partition_with_mode("gpu", PreemptMode::Requeue)];
+        assert_eq!(
+            job_preempt_mode(&job_in_partitions("gpu"), &parts),
+            PreemptMode::Requeue
+        );
+    }
+
+    #[test]
+    fn job_preempt_mode_unset_or_unknown_is_off() {
+        use spur_core::partition::PreemptMode;
+        let parts = vec![partition_with_mode("gpu", PreemptMode::Cancel)];
+        assert_eq!(
+            job_preempt_mode(&job_with_spec(JobSpec::default()), &parts),
+            PreemptMode::Off
+        );
+        assert_eq!(
+            job_preempt_mode(&job_in_partitions("nope"), &parts),
+            PreemptMode::Off
+        );
+    }
+
+    #[test]
+    fn job_preempt_mode_multi_partition_picks_most_aggressive() {
+        use spur_core::partition::PreemptMode;
+        // A job spanning gpu,cpu must resolve a mode (was Off before the fix,
+        // making multi-partition jobs unpreemptable). Cancel > Requeue.
+        let parts = vec![
+            partition_with_mode("gpu", PreemptMode::Requeue),
+            partition_with_mode("cpu", PreemptMode::Cancel),
+        ];
+        assert_eq!(
+            job_preempt_mode(&job_in_partitions("gpu, cpu"), &parts),
+            PreemptMode::Cancel
+        );
+    }
+
+    #[test]
+    fn job_preempt_mode_multi_partition_off_when_none_configured() {
+        use spur_core::partition::PreemptMode;
+        let parts = vec![
+            partition_with_mode("gpu", PreemptMode::Off),
+            partition_with_mode("cpu", PreemptMode::Off),
+        ];
+        assert_eq!(
+            job_preempt_mode(&job_in_partitions("gpu,cpu"), &parts),
+            PreemptMode::Off
+        );
     }
 }

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -173,7 +173,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
                 // "no suitable nodes at all".
                 cluster.update_pending_reasons(&unscheduled, &cluster_state);
 
-                try_preempt(&cluster, &unscheduled);
+                try_preempt(&cluster, &partitions, &unscheduled).await;
 
                 // Federation: forward still-unschedulable jobs to peer clusters.
                 if !cluster.config.federation.clusters.is_empty() {
@@ -408,9 +408,35 @@ pub(crate) fn compute_job_allocation(
     }
 }
 
-/// Try to preempt lower-priority running jobs to make room for higher-priority pending jobs.
-fn try_preempt(cluster: &Arc<ClusterManager>, unscheduled: &[&spur_core::job::Job]) {
+/// Resolve the effective PreemptMode for a job from its partition config.
+fn job_preempt_mode(
+    job: &spur_core::job::Job,
+    partitions: &[spur_core::partition::Partition],
+) -> spur_core::partition::PreemptMode {
+    use spur_core::partition::PreemptMode;
+    let Some(name) = job.spec.partition.as_deref().filter(|p| !p.is_empty()) else {
+        return PreemptMode::Off;
+    };
+    partitions
+        .iter()
+        .find(|p| p.name == name)
+        .map(|p| p.preempt_mode)
+        .unwrap_or(PreemptMode::Off)
+}
+
+/// Try to preempt lower-priority running jobs to make room for higher-priority
+/// pending jobs. Honors the running job's partition PreemptMode: cancel and
+/// requeue kill the process on every node (requeue also returns the job to
+/// Pending); suspend stops it in place. Jobs whose partition has PreemptMode
+/// Off are never preempted.
+async fn try_preempt(
+    cluster: &Arc<ClusterManager>,
+    partitions: &[spur_core::partition::Partition],
+    unscheduled: &[&spur_core::job::Job],
+) {
+    use crate::cluster::PreemptOutcome;
     use spur_core::job::JobState;
+    use spur_core::partition::PreemptMode;
 
     // Get running jobs sorted by priority (lowest first = best preemption candidates)
     let mut running: Vec<spur_core::job::Job> = cluster
@@ -422,24 +448,41 @@ fn try_preempt(cluster: &Arc<ClusterManager>, unscheduled: &[&spur_core::job::Jo
     for pending in unscheduled {
         // Only preempt if pending job has significantly higher priority
         for candidate in &running {
-            if candidate.priority < pending.priority / 2 {
-                // Preempt: cancel the lower-priority job
-                info!(
-                    preempted_job = candidate.job_id,
-                    preempted_priority = candidate.priority,
-                    pending_job = pending.job_id,
-                    pending_priority = pending.priority,
-                    "preempting lower-priority job"
-                );
-                if let Err(e) = cluster.complete_job(candidate.job_id, -1, JobState::Preempted) {
+            if candidate.priority >= pending.priority / 2 {
+                continue;
+            }
+            let mode = job_preempt_mode(candidate, partitions);
+            if mode == PreemptMode::Off {
+                continue;
+            }
+            info!(
+                preempted_job = candidate.job_id,
+                preempted_priority = candidate.priority,
+                pending_job = pending.job_id,
+                pending_priority = pending.priority,
+                mode = ?mode,
+                "preempting lower-priority job"
+            );
+            match cluster.preempt_job(candidate.job_id, mode) {
+                Ok(PreemptOutcome::Killed) => {
+                    // Signal 0 = graceful cancel (SIGTERM, then SIGKILL after a
+                    // grace period), giving the preempted job a chance to
+                    // checkpoint — matches Slurm's default preemption grace.
+                    send_cancel_to_agents(cluster, candidate, 0).await;
+                }
+                Ok(PreemptOutcome::Suspended) => {
+                    send_suspend_to_agents(cluster, candidate, false).await;
+                }
+                Err(e) => {
                     warn!(
                         job_id = candidate.job_id,
                         error = %e,
                         "failed to preempt job"
                     );
+                    continue;
                 }
-                break; // One preemption per cycle, re-evaluate next cycle
             }
+            break; // One preemption per cycle, re-evaluate next cycle
         }
     }
 }


### PR DESCRIPTION
## Summary

Preemption marked a job `PREEMPTED` in the controller queue but never signaled the agent, and WAL replay rejected already-applied transitions. This closes the preemption-lifecycle parity gaps:

- **Preempted jobs stranded.** `try_preempt` set state to `Preempted` but didn't kill the process or requeue: `squeue` showed `PR` while the process kept running and accounting still saw `RUNNING`. Now preemption honors the partition `PreemptMode` (cancel/requeue/suspend), dispatches the matching signal to agents, and — for requeue — returns the job to `Pending`.
- **Re-dispatch race.** Requeueing straight to `Pending` let the scheduler re-dispatch the job on the next cycle, where the in-flight preemption cancel then killed the fresh run (`FAILED`/`RaisedSignal`). Fixed with a short `begin_time` eligibility hold (new `JobRequeueHold` WAL op), so the job sits in `Pending (BeginTime)` until the cancel settles — matching Slurm's requeue-by-preemption behavior.
- **Invalid-transition log spam.** WAL replay / late agent reports for an already-finalized job hit the strict state machine (`PREEMPTED -> COMPLETED`) and logged errors. Added a replay-tolerant `apply_transition` (NoOp on `from == to`) and guarded the completion paths on already-finalized jobs, without weakening the live state machine.

## Approach

- `Job::apply_transition` returns `Applied`/`NoOp`; WAL apply uses it so replay/HA-follower catch-up is silent while live commands stay strict.
- `ClusterManager::preempt_job(mode)` performs the controller-side change; the scheduler dispatches the signal named by the returned `PreemptOutcome`. `Off` is rejected.
- The requeue hold instant is stamped once on the leader and applied verbatim on followers, keeping replay deterministic.
- New `JobState::is_finalized()` (`is_terminal()` + `Preempted`) gates the completion apply paths; `is_terminal()` semantics are left untouched.

## Testing

- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` — clean
- `cargo test --locked` — 1506 pass (new tests: requeue-hold set/expiry/reason-survival, WAL round-trip + replay determinism, stale-completion no-ops)
- **Verified live on a 2-node cluster against a Slurm 25.11.6 reference configured with `partition_prio` + `PreemptMode=REQUEUE`**: a low-priority job preempted by a high-priority one goes to `PENDING (BeginTime)` with its process killed, the high job runs, `squeue`/state agree, and startup WAL replay of historical preempted jobs produces zero invalid-transition warnings — matching Slurm.


## Related issues

Implements the core of #284 — partition-`PreemptMode`-driven Cancel/Requeue/Suspend/Off preemption (Requeue and Suspend previously defined but non-functional). Two items from #284 are intentionally left for follow-up and #284 should stay open to track them:
- the `priority / 2` selection heuristic is unchanged (strict-priority comparison not yet adopted)
- `PreemptExemptTime` grace period is not implemented
