### PR TITLE
ci(nightly): skip scheduled runs on fork repositories

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   build:
     name: Build nightly
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     outputs:
       skip: ${{ steps.check.outputs.skip }}
@@ -170,6 +171,7 @@ jobs:
 
   trivy-nightly-scan:
     name: Trivy nightly rescan
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Fork repos inherit the nightly cron trigger, which fails (missing secrets, no Docker Hub access) and sends noisy failure emails to contributors.
- Gates the two root jobs (`build` and `trivy-nightly-scan`) on `github.event.repository.fork == false`. Downstream jobs (`verify`, `push-image`, `release`) cascade-skip via `needs`.
- `workflow_dispatch` still works on the main repo for manual triggers.

## Test plan

- [x] Verified `github.event.repository.fork` is the recommended pattern per [GitHub community docs](https://hugovk.dev/blog/2023/til-how-to-disable-cron-for-github-forks/)