### PR TITLE
fix(spurctld): enforce job ownership on cancel, suspend, and resume

### DIFF
--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -179,7 +179,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
                 .cancel_job(spur_proto::proto::CancelJobRequest {
                     job_id,
                     signal: 0,
-                    user: String::new(),
+                    user: whoami::username().unwrap_or_else(|_| "unknown".into()),
                 })
                 .await
                 .context("requeue failed")?;
@@ -194,7 +194,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             client
                 .suspend_job(spur_proto::proto::SuspendJobRequest {
                     job_id,
-                    user: String::new(),
+                    user: whoami::username().unwrap_or_else(|_| "unknown".into()),
                 })
                 .await
                 .context("suspend failed")?;
@@ -209,7 +209,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             client
                 .resume_job(spur_proto::proto::ResumeJobRequest {
                     job_id,
-                    user: String::new(),
+                    user: whoami::username().unwrap_or_else(|_| "unknown".into()),
                 })
                 .await
                 .context("resume failed")?;

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -451,7 +451,8 @@ impl ClusterManager {
         .into())
     }
 
-    /// Cancel a job. The requesting `user` must be the job owner or root.
+    /// Cancel a job. The requesting `user` must be the job owner, root, or
+    /// empty (trusted internal/daemon calls).
     pub fn cancel_job(&self, job_id: JobId, user: &str) -> anyhow::Result<()> {
         {
             let jobs = self.jobs.read();
@@ -479,6 +480,7 @@ impl ClusterManager {
     }
 
     /// Suspend a running job: validate state, record through Raft. Allocation is retained.
+    /// The requesting `user` must be the job owner, root, or empty (trusted internal calls).
     pub fn suspend_job(&self, job_id: JobId, user: &str) -> anyhow::Result<()> {
         {
             let jobs = self.jobs.read();
@@ -499,6 +501,7 @@ impl ClusterManager {
     }
 
     /// Resume a suspended job: validate state, record through Raft, fold suspended time.
+    /// The requesting `user` must be the job owner, root, or empty (trusted internal calls).
     pub fn resume_job(&self, job_id: JobId, user: &str) -> anyhow::Result<()> {
         {
             let jobs = self.jobs.read();
@@ -7585,6 +7588,110 @@ mod tests {
         cm.cancel_job(job_id, "").unwrap();
         settle(&cm, job_id, JobState::Cancelled);
         assert_eq!(cm.get_job(job_id).unwrap().state, JobState::Cancelled);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn suspend_job_wrong_user_rejected() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+        let id = submit_and_wait(&cm, basic_spec("sus-auth"));
+        let res = scalar_alloc(2, 4000);
+        cm.start_job(
+            id,
+            vec!["n1".into()],
+            res.clone(),
+            per_node_for(&["n1"], res),
+        )
+        .unwrap();
+        settle(&cm, id, JobState::Running);
+
+        let result = cm.suspend_job(id, "other_user");
+        assert!(
+            result.is_err(),
+            "non-owner must not suspend another user's job"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("cannot") && err_msg.contains("suspend"),
+            "error should mention the denied action: {err_msg}"
+        );
+        assert_eq!(cm.get_job(id).unwrap().state, JobState::Running);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn suspend_job_root_allowed() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+        let id = submit_and_wait(&cm, basic_spec("sus-root"));
+        let res = scalar_alloc(2, 4000);
+        cm.start_job(
+            id,
+            vec!["n1".into()],
+            res.clone(),
+            per_node_for(&["n1"], res),
+        )
+        .unwrap();
+        settle(&cm, id, JobState::Running);
+
+        cm.suspend_job(id, "root").unwrap();
+        settle(&cm, id, JobState::Suspended);
+        assert_eq!(cm.get_job(id).unwrap().state, JobState::Suspended);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn resume_job_wrong_user_rejected() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+        let id = submit_and_wait(&cm, basic_spec("res-auth"));
+        let res = scalar_alloc(2, 4000);
+        cm.start_job(
+            id,
+            vec!["n1".into()],
+            res.clone(),
+            per_node_for(&["n1"], res),
+        )
+        .unwrap();
+        settle(&cm, id, JobState::Running);
+        cm.suspend_job(id, "testuser").unwrap();
+        settle(&cm, id, JobState::Suspended);
+
+        let result = cm.resume_job(id, "other_user");
+        assert!(
+            result.is_err(),
+            "non-owner must not resume another user's job"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("cannot") && err_msg.contains("resume"),
+            "error should mention the denied action: {err_msg}"
+        );
+        assert_eq!(cm.get_job(id).unwrap().state, JobState::Suspended);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn resume_job_root_allowed() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+        let id = submit_and_wait(&cm, basic_spec("res-root"));
+        let res = scalar_alloc(2, 4000);
+        cm.start_job(
+            id,
+            vec!["n1".into()],
+            res.clone(),
+            per_node_for(&["n1"], res),
+        )
+        .unwrap();
+        settle(&cm, id, JobState::Running);
+        cm.suspend_job(id, "testuser").unwrap();
+        settle(&cm, id, JobState::Suspended);
+
+        cm.resume_job(id, "root").unwrap();
+        settle(&cm, id, JobState::Running);
+        assert_eq!(cm.get_job(id).unwrap().state, JobState::Running);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -12,6 +12,7 @@ use tokio::sync::Notify;
 use tracing::{debug, info, warn};
 
 use spur_core::accounting::{Qos, TresRecord, TresType};
+use spur_core::auth::AuthError;
 use spur_core::burst_buffer::BbStageState;
 use spur_core::config::SlurmConfig;
 use spur_core::job::{
@@ -436,8 +437,22 @@ impl ClusterManager {
         Ok(())
     }
 
-    /// Cancel a job.
-    pub fn cancel_job(&self, job_id: JobId, _user: &str) -> anyhow::Result<()> {
+    /// Check that `user` is allowed to perform `action` on a job owned by `owner`.
+    /// Empty user (internal/daemon calls) and root are always allowed.
+    fn check_job_owner(user: &str, owner: &str, action: &str) -> anyhow::Result<()> {
+        if user.is_empty() || user == "root" || user == owner {
+            return Ok(());
+        }
+        Err(AuthError::NotJobOwner {
+            user: user.into(),
+            owner: owner.into(),
+            action: action.into(),
+        }
+        .into())
+    }
+
+    /// Cancel a job. The requesting `user` must be the job owner or root.
+    pub fn cancel_job(&self, job_id: JobId, user: &str) -> anyhow::Result<()> {
         {
             let jobs = self.jobs.read();
             let job = jobs
@@ -446,6 +461,7 @@ impl ClusterManager {
             if job.state.is_terminal() {
                 anyhow::bail!("job {} is already {:?}", job_id, job.state);
             }
+            Self::check_job_owner(user, &job.spec.user, "cancel")?;
         }
 
         // Use JobComplete (not JobStateChange) so that resource deallocation
@@ -463,7 +479,7 @@ impl ClusterManager {
     }
 
     /// Suspend a running job: validate state, record through Raft. Allocation is retained.
-    pub fn suspend_job(&self, job_id: JobId, _user: &str) -> anyhow::Result<()> {
+    pub fn suspend_job(&self, job_id: JobId, user: &str) -> anyhow::Result<()> {
         {
             let jobs = self.jobs.read();
             let job = jobs
@@ -472,6 +488,7 @@ impl ClusterManager {
             if job.state != JobState::Running {
                 anyhow::bail!("job {} is not running (state {:?})", job_id, job.state);
             }
+            Self::check_job_owner(user, &job.spec.user, "suspend")?;
         }
         self.propose(WalOperation::JobSuspend {
             job_id,
@@ -482,7 +499,7 @@ impl ClusterManager {
     }
 
     /// Resume a suspended job: validate state, record through Raft, fold suspended time.
-    pub fn resume_job(&self, job_id: JobId, _user: &str) -> anyhow::Result<()> {
+    pub fn resume_job(&self, job_id: JobId, user: &str) -> anyhow::Result<()> {
         {
             let jobs = self.jobs.read();
             let job = jobs
@@ -491,6 +508,7 @@ impl ClusterManager {
             if job.state != JobState::Suspended {
                 anyhow::bail!("job {} is not suspended (state {:?})", job_id, job.state);
             }
+            Self::check_job_owner(user, &job.spec.user, "resume")?;
         }
         self.propose(WalOperation::JobResume {
             job_id,
@@ -4365,10 +4383,10 @@ mod tests {
         )
         .unwrap();
         settle(&cm, id, JobState::Running);
-        cm.suspend_job(id, "u").unwrap();
+        cm.suspend_job(id, "testuser").unwrap();
         settle(&cm, id, JobState::Suspended);
         // Second suspend on an already-suspended job is rejected (not Running).
-        assert!(cm.suspend_job(id, "u").is_err());
+        assert!(cm.suspend_job(id, "testuser").is_err());
         assert_eq!(cm.get_job(id).unwrap().state, JobState::Suspended);
     }
 
@@ -4387,12 +4405,12 @@ mod tests {
         )
         .unwrap();
         settle(&cm, id, JobState::Running);
-        cm.suspend_job(id, "u").unwrap();
+        cm.suspend_job(id, "testuser").unwrap();
         settle(&cm, id, JobState::Suspended);
-        cm.resume_job(id, "u").unwrap();
+        cm.resume_job(id, "testuser").unwrap();
         settle(&cm, id, JobState::Running);
         // Second resume on an already-running job is rejected.
-        assert!(cm.resume_job(id, "u").is_err());
+        assert!(cm.resume_job(id, "testuser").is_err());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -4412,7 +4430,7 @@ mod tests {
         settle(&cm, id, JobState::Running);
         assert_eq!(cm.get_node("n1").unwrap().alloc_resources.cpus, 2);
 
-        cm.suspend_job(id, "u").unwrap();
+        cm.suspend_job(id, "testuser").unwrap();
         settle(&cm, id, JobState::Suspended);
         // Allocation is retained while suspended (plain scontrol suspend parity).
         let job = cm.get_job(id).unwrap();
@@ -4520,7 +4538,7 @@ mod tests {
         )
         .unwrap();
         settle(&cm, id, JobState::Running);
-        cm.suspend_job(id, "u").unwrap();
+        cm.suspend_job(id, "testuser").unwrap();
         settle(&cm, id, JobState::Suspended);
 
         let scanned = cm.get_jobs(
@@ -7471,7 +7489,7 @@ mod tests {
         let cm = test_cluster(&dir).await;
 
         let job_id = submit_and_wait(&cm, basic_spec("j"));
-        cm.cancel_job(job_id, "u").unwrap();
+        cm.cancel_job(job_id, "testuser").unwrap();
         settle(&cm, job_id, JobState::Cancelled);
 
         let result = cm.complete_job(job_id, 1, JobState::Failed);
@@ -7523,6 +7541,50 @@ mod tests {
             result.is_err(),
             "cancelling an already-cancelled job must fail"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancel_job_wrong_user_rejected() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        let job_id = submit_and_wait(&cm, basic_spec("auth-cancel"));
+        let result = cm.cancel_job(job_id, "other_user");
+        assert!(
+            result.is_err(),
+            "non-owner must not cancel another user's job"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("cannot") && err_msg.contains("cancel"),
+            "error should mention the denied action: {err_msg}"
+        );
+
+        // Job must still be alive.
+        let job = cm.get_job(job_id).unwrap();
+        assert!(!job.state.is_terminal());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancel_job_root_allowed() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        let job_id = submit_and_wait(&cm, basic_spec("root-cancel"));
+        cm.cancel_job(job_id, "root").unwrap();
+        settle(&cm, job_id, JobState::Cancelled);
+        assert_eq!(cm.get_job(job_id).unwrap().state, JobState::Cancelled);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancel_job_empty_user_allowed() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        let job_id = submit_and_wait(&cm, basic_spec("internal-cancel"));
+        cm.cancel_job(job_id, "").unwrap();
+        settle(&cm, job_id, JobState::Cancelled);
+        assert_eq!(cm.get_job(job_id).unwrap().state, JobState::Cancelled);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -292,7 +292,7 @@ impl SlurmController for ControllerService {
 
         self.cluster
             .cancel_job(job_id, &req.user)
-            .map_err(|e| Status::internal(e.to_string()))?;
+            .map_err(cluster_err_to_status)?;
 
         // Send cancel signal to agents so the process is actually killed
         if let Some(job) = job {
@@ -333,7 +333,7 @@ impl SlurmController for ControllerService {
             .ok_or_else(|| Status::not_found(format!("job {job_id} not found")))?;
         self.cluster
             .suspend_job(job_id, &req.user)
-            .map_err(|e| Status::failed_precondition(e.to_string()))?;
+            .map_err(cluster_err_to_status)?;
         let cluster = self.cluster.clone();
         tokio::spawn(async move {
             crate::scheduler_loop::send_suspend_to_agents(&cluster, &job, false).await;
@@ -367,7 +367,7 @@ impl SlurmController for ControllerService {
             .ok_or_else(|| Status::not_found(format!("job {job_id} not found")))?;
         self.cluster
             .resume_job(job_id, &req.user)
-            .map_err(|e| Status::failed_precondition(e.to_string()))?;
+            .map_err(cluster_err_to_status)?;
         let cluster = self.cluster.clone();
         tokio::spawn(async move {
             crate::scheduler_loop::send_suspend_to_agents(&cluster, &job, true).await;
@@ -1988,6 +1988,13 @@ fn reservation_rpc_status(err: ReservationError) -> Status {
         ReservationError::AlreadyExists(m) => Status::already_exists(m),
         ReservationError::Raft(m) => Status::internal(m),
     }
+}
+
+fn cluster_err_to_status(err: anyhow::Error) -> Status {
+    if err.downcast_ref::<spur_core::auth::AuthError>().is_some() {
+        return Status::permission_denied(err.to_string());
+    }
+    Status::internal(err.to_string())
 }
 
 fn node_complete_to_status(err: NodeCompleteError) -> Status {

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -333,7 +333,7 @@ impl SlurmController for ControllerService {
             .ok_or_else(|| Status::not_found(format!("job {job_id} not found")))?;
         self.cluster
             .suspend_job(job_id, &req.user)
-            .map_err(cluster_err_to_status)?;
+            .map_err(cluster_err_to_precondition_status)?;
         let cluster = self.cluster.clone();
         tokio::spawn(async move {
             crate::scheduler_loop::send_suspend_to_agents(&cluster, &job, false).await;
@@ -367,7 +367,7 @@ impl SlurmController for ControllerService {
             .ok_or_else(|| Status::not_found(format!("job {job_id} not found")))?;
         self.cluster
             .resume_job(job_id, &req.user)
-            .map_err(cluster_err_to_status)?;
+            .map_err(cluster_err_to_precondition_status)?;
         let cluster = self.cluster.clone();
         tokio::spawn(async move {
             crate::scheduler_loop::send_suspend_to_agents(&cluster, &job, true).await;
@@ -1995,6 +1995,13 @@ fn cluster_err_to_status(err: anyhow::Error) -> Status {
         return Status::permission_denied(err.to_string());
     }
     Status::internal(err.to_string())
+}
+
+fn cluster_err_to_precondition_status(err: anyhow::Error) -> Status {
+    if err.downcast_ref::<spur_core::auth::AuthError>().is_some() {
+        return Status::permission_denied(err.to_string());
+    }
+    Status::failed_precondition(err.to_string())
 }
 
 fn node_complete_to_status(err: NodeCompleteError) -> Status {

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -404,12 +404,12 @@ message CancelJobRequest {
 
 message SuspendJobRequest {
   uint32 job_id = 1;
-  string user = 2;   // Advisory (parity/forward-compat), not enforced.
+  string user = 2;   // For authorization (owner or root required).
 }
 
 message ResumeJobRequest {
   uint32 job_id = 1;
-  string user = 2;
+  string user = 2;   // For authorization (owner or root required).
 }
 
 message UpdateJobRequest {


### PR DESCRIPTION
## Summary

- Cancel, suspend, and resume previously accepted a `user` parameter but ignored it (`_user`). Any user could operate on any other user's job.
- Adds `ClusterManager::check_job_owner()` that allows the request only if the caller is the job owner, root, or an internal (empty-user) daemon call. Returns `AuthError::NotJobOwner` otherwise.
- The gRPC layer now maps auth errors to `PERMISSION_DENIED` instead of generic `INTERNAL`.

Note: the identity is still client-asserted (the CLI sends `whoami::username()` as a plain string). This prevents accidental cross-user operations but does not stop a malicious user who explicitly overrides `-u`. Cryptographic identity verification (JWT or similar) is a separate effort.

## Test plan

- [x] Unit tests: wrong user rejected, owner allowed, root allowed, empty user (internal) allowed
- [x] `cargo clippy` clean, full test suite passes (223 spurctld tests, 0 failures)
- [x] Bare-metal cluster (4 nodes): submit as `vm`, cancel as `vm` (ok), cancel as `alice` (denied with clear error), cancel as `root` (ok)