### PR TITLE
feat(spur-cli): add -o/--output, -e/--error, -i/--input to srun

### DIFF
--- a/crates/spur-cli/src/sbatch.rs
+++ b/crates/spur-cli/src/sbatch.rs
@@ -758,6 +758,7 @@ pub async fn main_with_args(cli_args: Vec<String>) -> Result<()> {
         work_dir,
         stdout_path: args.output.unwrap_or_default(),
         stderr_path: args.error.unwrap_or_default(),
+        stdin_path: String::new(),
         environment,
         time_limit,
         time_min: None,

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -318,7 +318,11 @@ async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> 
                     format_ts(job.end_time.as_ref()),
                 );
                 println!("   WorkDir={}", job.work_dir);
-                println!("   StdOut={} StdErr={}", job.stdout_path, job.stderr_path);
+                print!("   StdOut={} StdErr={}", job.stdout_path, job.stderr_path);
+                if !job.stdin_path.is_empty() {
+                    print!(" StdIn={}", job.stdin_path);
+                }
+                println!();
                 println!(
                     "   ExitCode={} DerivedExitCode={} Priority={}",
                     format_exit(job.exit_code, job.exit_signal),

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -196,9 +196,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         }
     }
 
-    let stdout_path = args.output.clone().unwrap_or_default();
-    let stderr_path = args.error.clone().unwrap_or_default();
-    let stdin_path = args.input.clone().unwrap_or_default();
+    let io = resolve_io_paths(&args);
 
     let name = args.job_name.unwrap_or_else(|| args.command[0].clone());
 
@@ -261,9 +259,9 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         gres,
         script,
         work_dir: work_dir.clone(),
-        stdout_path: stdout_path.clone(),
-        stderr_path: stderr_path.clone(),
-        stdin_path: stdin_path.clone(),
+        stdout_path: io.stdout.clone(),
+        stderr_path: io.stderr.clone(),
+        stdin_path: io.stdin.clone(),
         environment,
         time_limit,
         constraint: args.constraint.unwrap_or_default(),
@@ -349,7 +347,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
                             job_id,
                             job.exit_code,
                             &work_dir,
-                            &stdout_path,
+                            &io.stdout,
                             &hooks,
                             false,
                         )
@@ -374,7 +372,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     }
 
     // Stream output to terminal only when the user didn't ask for file output.
-    let output_streamed = if stdout_path.is_empty() {
+    let output_streamed = if io.stdout.is_empty() {
         try_stream_output(&mut client, &nodelist, job_id).await
     } else {
         false
@@ -383,7 +381,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         &mut client,
         job_id,
         &work_dir,
-        &stdout_path,
+        &io.stdout,
         &hooks,
         output_streamed,
     )
@@ -588,6 +586,56 @@ fn resolve_output_path_client(pattern: &str, job_id: u32, work_dir: &str) -> Str
     }
 }
 
+struct ResolvedIoPaths {
+    stdout: String,
+    stderr: String,
+    stdin: String,
+}
+
+/// Resolve I/O paths from CLI args. When `-o` is set but `-e` is not,
+/// stderr follows stdout (Slurm default behavior).
+fn resolve_io_paths(args: &SrunArgs) -> ResolvedIoPaths {
+    let stdout = args.output.clone().unwrap_or_default();
+    let stderr = args.error.clone().unwrap_or_else(|| {
+        if stdout.is_empty() {
+            String::new()
+        } else {
+            stdout.clone()
+        }
+    });
+    let stdin = args.input.clone().unwrap_or_default();
+    ResolvedIoPaths {
+        stdout,
+        stderr,
+        stdin,
+    }
+}
+
+/// Write step output to a file, used by `run_as_step` for both stdout and stderr.
+async fn write_step_file(content: &str, pattern: &str, job_id: u32, work_dir: &str, append: bool) {
+    let resolved = resolve_output_path_client(pattern, job_id, work_dir);
+    if let Some(parent) = std::path::Path::new(&resolved).parent() {
+        tokio::fs::create_dir_all(parent).await.ok();
+    }
+    let result = if append {
+        use tokio::io::AsyncWriteExt;
+        match tokio::fs::OpenOptions::new()
+            .append(true)
+            .create(true)
+            .open(&resolved)
+            .await
+        {
+            Ok(mut f) => f.write_all(content.as_bytes()).await,
+            Err(e) => Err(e),
+        }
+    } else {
+        tokio::fs::write(&resolved, content).await
+    };
+    if let Err(e) = result {
+        eprintln!("srun: warning: failed to write to {}: {}", resolved, e);
+    }
+}
+
 /// When srun runs inside an allocation (SPUR_JOB_ID is set, e.g. inside an
 /// `salloc` interactive shell or sbatch script on the submit host), it
 /// dispatches the command to one of the allocation's nodes via the
@@ -628,6 +676,8 @@ async fn run_as_step(
         eprintln!("srun: warning: --input is not supported in step mode, ignoring");
     }
 
+    let io = resolve_io_paths(args);
+
     let env: std::collections::HashMap<String, String> = std::env::vars().collect();
 
     let resp = client
@@ -648,36 +698,20 @@ async fn run_as_step(
         eprintln!("srun: dispatched to node {}", resp.node);
     }
 
+    let stderr_appends = !io.stderr.is_empty() && io.stderr == io.stdout;
+
     if !resp.stdout.is_empty() {
-        if let Some(ref path) = args.output {
-            let resolved = resolve_output_path_client(path, job_id, work_dir);
-            if let Some(parent) = std::path::Path::new(&resolved).parent() {
-                tokio::fs::create_dir_all(parent).await.ok();
-            }
-            if let Err(e) = tokio::fs::write(&resolved, &resp.stdout).await {
-                eprintln!(
-                    "srun: warning: failed to write stdout to {}: {}",
-                    resolved, e
-                );
-            }
-        } else {
+        if io.stdout.is_empty() {
             print!("{}", resp.stdout);
+        } else {
+            write_step_file(&resp.stdout, &io.stdout, job_id, work_dir, false).await;
         }
     }
     if !resp.stderr.is_empty() {
-        if let Some(ref path) = args.error {
-            let resolved = resolve_output_path_client(path, job_id, work_dir);
-            if let Some(parent) = std::path::Path::new(&resolved).parent() {
-                tokio::fs::create_dir_all(parent).await.ok();
-            }
-            if let Err(e) = tokio::fs::write(&resolved, &resp.stderr).await {
-                eprintln!(
-                    "srun: warning: failed to write stderr to {}: {}",
-                    resolved, e
-                );
-            }
-        } else {
+        if io.stderr.is_empty() {
             eprint!("{}", resp.stderr);
+        } else {
+            write_step_file(&resp.stderr, &io.stderr, job_id, work_dir, stderr_appends).await;
         }
     }
 
@@ -831,5 +865,40 @@ mod tests {
             resolve_output_path_client("/shared/output-%j.txt", 7, "/work"),
             "/shared/output-7.txt"
         );
+    }
+
+    #[test]
+    fn resolve_io_paths_stderr_follows_stdout() {
+        let args =
+            SrunArgs::try_parse_from(["srun", "-o", "/tmp/out.txt", "hostname"]).expect("parse");
+        let io = resolve_io_paths(&args);
+        assert_eq!(io.stdout, "/tmp/out.txt");
+        assert_eq!(io.stderr, "/tmp/out.txt");
+        assert!(io.stdin.is_empty());
+    }
+
+    #[test]
+    fn resolve_io_paths_explicit_stderr_overrides() {
+        let args = SrunArgs::try_parse_from([
+            "srun",
+            "-o",
+            "/tmp/out.txt",
+            "-e",
+            "/tmp/err.txt",
+            "hostname",
+        ])
+        .expect("parse");
+        let io = resolve_io_paths(&args);
+        assert_eq!(io.stdout, "/tmp/out.txt");
+        assert_eq!(io.stderr, "/tmp/err.txt");
+    }
+
+    #[test]
+    fn resolve_io_paths_no_flags() {
+        let args = SrunArgs::try_parse_from(["srun", "hostname"]).expect("parse");
+        let io = resolve_io_paths(&args);
+        assert!(io.stdout.is_empty());
+        assert!(io.stderr.is_empty());
+        assert!(io.stdin.is_empty());
     }
 }

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -93,6 +93,18 @@ pub struct SrunArgs {
     #[arg(long, default_value = "none")]
     pub mpi: String,
 
+    /// Stdout file path (supports %j for job ID)
+    #[arg(short = 'o', long)]
+    pub output: Option<String>,
+
+    /// Stderr file path (supports %j for job ID)
+    #[arg(short = 'e', long)]
+    pub error: Option<String>,
+
+    /// Stdin file path
+    #[arg(short = 'i', long)]
+    pub input: Option<String>,
+
     /// Job step label output
     #[arg(short = 'l', long)]
     pub label: bool,
@@ -184,6 +196,10 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         }
     }
 
+    let stdout_path = args.output.clone().unwrap_or_default();
+    let stderr_path = args.error.clone().unwrap_or_default();
+    let stdin_path = args.input.clone().unwrap_or_default();
+
     let name = args.job_name.unwrap_or_else(|| args.command[0].clone());
 
     // Build a wrapper script from the command
@@ -245,6 +261,9 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         gres,
         script,
         work_dir: work_dir.clone(),
+        stdout_path: stdout_path.clone(),
+        stderr_path: stderr_path.clone(),
+        stdin_path: stdin_path.clone(),
         environment,
         time_limit,
         constraint: args.constraint.unwrap_or_default(),
@@ -330,6 +349,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
                             job_id,
                             job.exit_code,
                             &work_dir,
+                            &stdout_path,
                             &hooks,
                             false,
                         )
@@ -353,9 +373,21 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         }
     }
 
-    // Stream output if possible (best-effort), then poll for terminal state.
-    let output_streamed = try_stream_output(&mut client, &nodelist, job_id).await;
-    poll_for_completion(&mut client, job_id, &work_dir, &hooks, output_streamed).await;
+    // Stream output to terminal only when the user didn't ask for file output.
+    let output_streamed = if stdout_path.is_empty() {
+        try_stream_output(&mut client, &nodelist, job_id).await
+    } else {
+        false
+    };
+    poll_for_completion(
+        &mut client,
+        job_id,
+        &work_dir,
+        &stdout_path,
+        &hooks,
+        output_streamed,
+    )
+    .await;
 
     Ok(())
 }
@@ -422,6 +454,7 @@ async fn poll_for_completion(
     client: &mut SlurmControllerClient<tonic::transport::Channel>,
     job_id: u32,
     work_dir: &str,
+    stdout_path: &str,
     hooks: &HooksConfig,
     output_streamed: bool,
 ) {
@@ -446,6 +479,7 @@ async fn poll_for_completion(
                             job_id,
                             job.exit_code,
                             work_dir,
+                            stdout_path,
                             hooks,
                             output_streamed,
                         )
@@ -475,6 +509,7 @@ async fn handle_terminal_state(
     job_id: u32,
     exit_code: i32,
     work_dir: &str,
+    stdout_path: &str,
     hooks: &HooksConfig,
     output_streamed: bool,
 ) -> ! {
@@ -486,16 +521,18 @@ async fn handle_terminal_state(
         }
     }
 
+    let should_print = !output_streamed && stdout_path.is_empty();
+
     match state {
         JobState::JobCompleted => {
-            if !output_streamed {
-                print_job_output(work_dir, job_id).await;
+            if should_print {
+                print_job_output(work_dir, stdout_path, job_id).await;
             }
             std::process::exit(exit_code);
         }
         JobState::JobFailed => {
-            if !output_streamed {
-                print_job_output(work_dir, job_id).await;
+            if should_print {
+                print_job_output(work_dir, stdout_path, job_id).await;
             }
             eprintln!("srun: job {} failed with exit code {}", job_id, exit_code);
             std::process::exit(exit_code.max(1));
@@ -524,10 +561,30 @@ async fn handle_terminal_state(
 }
 
 /// Print job output file to stdout (best-effort).
-async fn print_job_output(work_dir: &str, job_id: u32) {
-    let path = format!("{}/spur-{}.out", work_dir, job_id);
+async fn print_job_output(work_dir: &str, stdout_path: &str, job_id: u32) {
+    let path = resolve_output_path_client(stdout_path, job_id, work_dir);
     if let Ok(content) = tokio::fs::read_to_string(&path).await {
         print!("{}", content);
+    }
+}
+
+/// Client-side output path resolution, mirroring the agent's logic.
+fn resolve_output_path_client(pattern: &str, job_id: u32, work_dir: &str) -> String {
+    let resolved = if pattern.is_empty() {
+        format!("spur-{}.out", job_id)
+    } else {
+        pattern
+            .replace("%j", &job_id.to_string())
+            .replace("%J", &job_id.to_string())
+    };
+
+    if std::path::Path::new(&resolved).is_absolute() {
+        resolved
+    } else {
+        std::path::PathBuf::from(work_dir)
+            .join(resolved)
+            .to_string_lossy()
+            .into()
     }
 }
 
@@ -567,6 +624,10 @@ async fn run_as_step(
         .into_inner()
         .step_id;
 
+    if args.input.is_some() {
+        eprintln!("srun: warning: --input is not supported in step mode, ignoring");
+    }
+
     let env: std::collections::HashMap<String, String> = std::env::vars().collect();
 
     let resp = client
@@ -586,11 +647,38 @@ async fn run_as_step(
     if !resp.node.is_empty() {
         eprintln!("srun: dispatched to node {}", resp.node);
     }
+
     if !resp.stdout.is_empty() {
-        print!("{}", resp.stdout);
+        if let Some(ref path) = args.output {
+            let resolved = resolve_output_path_client(path, job_id, work_dir);
+            if let Some(parent) = std::path::Path::new(&resolved).parent() {
+                tokio::fs::create_dir_all(parent).await.ok();
+            }
+            if let Err(e) = tokio::fs::write(&resolved, &resp.stdout).await {
+                eprintln!(
+                    "srun: warning: failed to write stdout to {}: {}",
+                    resolved, e
+                );
+            }
+        } else {
+            print!("{}", resp.stdout);
+        }
     }
     if !resp.stderr.is_empty() {
-        eprint!("{}", resp.stderr);
+        if let Some(ref path) = args.error {
+            let resolved = resolve_output_path_client(path, job_id, work_dir);
+            if let Some(parent) = std::path::Path::new(&resolved).parent() {
+                tokio::fs::create_dir_all(parent).await.ok();
+            }
+            if let Err(e) = tokio::fs::write(&resolved, &resp.stderr).await {
+                eprintln!(
+                    "srun: warning: failed to write stderr to {}: {}",
+                    resolved, e
+                );
+            }
+        } else {
+            eprint!("{}", resp.stderr);
+        }
     }
 
     // SrunEpilog: run locally after step completes (failure logged only)
@@ -675,5 +763,73 @@ mod tests {
         .expect("parse failed");
         assert_eq!(args.nodelist.as_deref(), Some("node001"));
         assert_eq!(args.exclude.as_deref(), Some("node002"));
+    }
+
+    #[test]
+    fn parses_output_error_input_short() {
+        let args = SrunArgs::try_parse_from([
+            "srun",
+            "-o",
+            "/tmp/out.txt",
+            "-e",
+            "/tmp/err.txt",
+            "-i",
+            "/tmp/in.txt",
+            "hostname",
+        ])
+        .expect("parse failed");
+        assert_eq!(args.output.as_deref(), Some("/tmp/out.txt"));
+        assert_eq!(args.error.as_deref(), Some("/tmp/err.txt"));
+        assert_eq!(args.input.as_deref(), Some("/tmp/in.txt"));
+    }
+
+    #[test]
+    fn parses_output_error_input_long() {
+        let args = SrunArgs::try_parse_from([
+            "srun",
+            "--output",
+            "job-%j.out",
+            "--error",
+            "job-%j.err",
+            "--input",
+            "/dev/null",
+            "hostname",
+        ])
+        .expect("parse failed");
+        assert_eq!(args.output.as_deref(), Some("job-%j.out"));
+        assert_eq!(args.error.as_deref(), Some("job-%j.err"));
+        assert_eq!(args.input.as_deref(), Some("/dev/null"));
+    }
+
+    #[test]
+    fn output_error_input_default_to_none() {
+        let args = SrunArgs::try_parse_from(["srun", "hostname"]).expect("parse failed");
+        assert!(args.output.is_none());
+        assert!(args.error.is_none());
+        assert!(args.input.is_none());
+    }
+
+    #[test]
+    fn resolve_output_path_client_defaults() {
+        assert_eq!(
+            resolve_output_path_client("", 42, "/work"),
+            "/work/spur-42.out"
+        );
+    }
+
+    #[test]
+    fn resolve_output_path_client_pattern() {
+        assert_eq!(
+            resolve_output_path_client("results-%j.log", 99, "/home/user"),
+            "/home/user/results-99.log"
+        );
+    }
+
+    #[test]
+    fn resolve_output_path_client_absolute() {
+        assert_eq!(
+            resolve_output_path_client("/shared/output-%j.txt", 7, "/work"),
+            "/shared/output-7.txt"
+        );
     }
 }

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -682,6 +682,14 @@ impl Job {
         self.resolve_path(self.spec.stderr_path.as_deref().unwrap_or("spur-%j.out"))
     }
 
+    /// Resolve stdin path, if set.
+    pub fn resolved_stdin(&self) -> Option<String> {
+        self.spec
+            .stdin_path
+            .as_deref()
+            .map(|p| self.resolve_path(p))
+    }
+
     fn resolve_path(&self, pattern: &str) -> String {
         let mut result = pattern.to_string();
         result = result.replace("%j", &self.job_id.to_string());
@@ -1384,5 +1392,21 @@ mod tests {
             assert_eq!(JobState::from_code_or_name(state.code()), Some(state));
             assert_eq!(JobState::from_code_or_name(state.display()), Some(state));
         }
+    }
+
+    #[test]
+    fn resolved_stdin_expands_pattern() {
+        let spec = JobSpec {
+            stdin_path: Some("input-%j.txt".into()),
+            ..Default::default()
+        };
+        let job = Job::new(42, spec);
+        assert_eq!(job.resolved_stdin(), Some("input-42.txt".into()));
+    }
+
+    #[test]
+    fn resolved_stdin_none_when_unset() {
+        let job = Job::new(1, JobSpec::default());
+        assert_eq!(job.resolved_stdin(), None);
     }
 }

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -335,6 +335,7 @@ pub struct JobSpec {
     pub work_dir: String,
     pub stdout_path: Option<String>,
     pub stderr_path: Option<String>,
+    pub stdin_path: Option<String>,
     pub environment: HashMap<String, String>,
 
     // Time
@@ -442,6 +443,7 @@ impl Default for JobSpec {
             work_dir: String::from("/tmp"),
             stdout_path: None,
             stderr_path: None,
+            stdin_path: None,
             environment: HashMap::new(),
             time_limit: None,
             time_min: None,

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -768,6 +768,7 @@ fn core_job_spec_to_proto(spec: &spur_core::job::JobSpec) -> spur_proto::proto::
         work_dir: spec.work_dir.clone(),
         stdout_path: spec.stdout_path.clone().unwrap_or_default(),
         stderr_path: spec.stderr_path.clone().unwrap_or_default(),
+        stdin_path: spec.stdin_path.clone().unwrap_or_default(),
         environment: spec.environment.clone(),
         time_limit: spec.time_limit.map(|d| prost_types::Duration {
             seconds: d.num_seconds(),

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -187,6 +187,7 @@ impl SlurmAccounting for AccountingService {
                 derived_exit_code: r.derived_exit_code,
                 stdout_path: String::new(),
                 stderr_path: String::new(),
+                stdin_path: String::new(),
                 resources: None,
                 priority: 0,
                 qos: String::new(),

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -573,6 +573,7 @@ fn core_spec_to_proto(s: &spur_core::job::JobSpec) -> ProtoJobSpec {
         work_dir: s.work_dir.clone(),
         stdout_path: s.stdout_path.clone().unwrap_or_default(),
         stderr_path: s.stderr_path.clone().unwrap_or_default(),
+        stdin_path: s.stdin_path.clone().unwrap_or_default(),
         environment: s.environment.clone(),
         time_limit: s.time_limit.map(|d| prost_types::Duration {
             seconds: d.num_seconds(),
@@ -668,6 +669,7 @@ async fn dispatch_to_agent(
         work_dir: spec.work_dir.clone(),
         stdout_path: spec.stdout_path.clone().unwrap_or_default(),
         stderr_path: spec.stderr_path.clone().unwrap_or_default(),
+        stdin_path: spec.stdin_path.clone().unwrap_or_default(),
         environment: spec.environment.clone(),
         time_limit: spec.time_limit.map(|d| prost_types::Duration {
             seconds: d.num_seconds(),

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1782,7 +1782,7 @@ fn job_to_proto(job: &spur_core::job::Job) -> JobInfo {
         derived_exit_code: job.derived_exit_code,
         stdout_path: job.resolved_stdout(),
         stderr_path: job.resolved_stderr(),
-        stdin_path: job.spec.stdin_path.clone().unwrap_or_default(),
+        stdin_path: job.resolved_stdin().unwrap_or_default(),
         resources: job.allocated_resources.as_ref().map(allocations_to_proto),
         priority: job.priority,
         qos: job.spec.qos.clone().unwrap_or_default(),

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1566,6 +1566,11 @@ fn proto_to_job_spec(spec: JobSpec) -> Result<spur_core::job::JobSpec, Status> {
         } else {
             Some(spec.stderr_path)
         },
+        stdin_path: if spec.stdin_path.is_empty() {
+            None
+        } else {
+            Some(spec.stdin_path)
+        },
         environment: spec.environment,
         time_limit: spec
             .time_limit
@@ -1777,6 +1782,7 @@ fn job_to_proto(job: &spur_core::job::Job) -> JobInfo {
         derived_exit_code: job.derived_exit_code,
         stdout_path: job.resolved_stdout(),
         stderr_path: job.resolved_stderr(),
+        stdin_path: job.spec.stdin_path.clone().unwrap_or_default(),
         resources: job.allocated_resources.as_ref().map(allocations_to_proto),
         priority: job.priority,
         qos: job.spec.qos.clone().unwrap_or_default(),

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -764,6 +764,7 @@ impl SlurmAgent for AgentService {
             environment: env,
             stdout_path: spec.stdout_path.clone(),
             stderr_path: spec.stderr_path.clone(),
+            stdin_path: spec.stdin_path.clone(),
             cpus: spec.cpus_per_task.max(1),
             memory_mb: spec.memory_per_node_mb,
             gpu_devices: allocated_device_ids,

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -317,6 +317,17 @@ async fn spawn_job_process(
         tokio::fs::create_dir_all(parent).await.ok();
     }
 
+    // Guard: stdin must not overlap stdout/stderr (truncation would destroy input)
+    if !stdin_path.is_empty() {
+        let stdin_resolved = resolve_output_path(stdin_path, job_id, work_dir);
+        if stdin_resolved == stdout_resolved || stdin_resolved == stderr_resolved {
+            anyhow::bail!(
+                "stdin path {} overlaps with an output path; this would truncate the input",
+                stdin_resolved
+            );
+        }
+    }
+
     let use_append = open_mode
         .as_deref()
         .map(|m| m.eq_ignore_ascii_case("append"))
@@ -334,7 +345,13 @@ async fn spawn_job_process(
             .await
             .context("failed to create stdout file")?
     };
-    let stderr_file = if use_append {
+    let stderr_file = if stderr_resolved == stdout_resolved {
+        tokio::fs::OpenOptions::new()
+            .append(true)
+            .open(&stdout_resolved)
+            .await
+            .context("failed to open stderr file (same as stdout)")?
+    } else if use_append {
         tokio::fs::OpenOptions::new()
             .append(true)
             .create(true)
@@ -366,6 +383,12 @@ async fn spawn_job_process(
 
     // Container jobs: use explicit fork() + container_init() instead of bash wrapper.
     if let Some(ctn) = container {
+        if !stdin_path.is_empty() {
+            warn!(
+                job_id,
+                "stdin redirection is not supported for container jobs, ignoring"
+            );
+        }
         let job = launch_container_job(
             cfg,
             ctn,
@@ -424,6 +447,21 @@ async fn spawn_job_process(
         Stdio::null()
     } else {
         let resolved = resolve_output_path(stdin_path, job_id, work_dir);
+        // spurd runs as root; check owner/group/other read bits against
+        // the job's uid/gid so users cannot exfiltrate root-readable files.
+        // Supplementary groups and ACLs are not checked.
+        if uid > 0 {
+            use std::os::unix::fs::MetadataExt;
+            let meta = std::fs::metadata(&resolved)
+                .with_context(|| format!("stdin file not found: {}", resolved))?;
+            let (fuid, fgid, mode) = (meta.uid(), meta.gid(), meta.mode());
+            let readable = (fuid == uid && mode & 0o400 != 0)
+                || (fgid == gid && mode & 0o040 != 0)
+                || (mode & 0o004 != 0);
+            if !readable {
+                anyhow::bail!("stdin file {} is not readable by uid {}", resolved, uid);
+            }
+        }
         let f = std::fs::File::open(&resolved)
             .with_context(|| format!("failed to open stdin file: {}", resolved))?;
         Stdio::from(f)

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -59,6 +59,7 @@ pub struct JobLaunchConfig {
     pub environment: HashMap<String, String>,
     pub stdout_path: String,
     pub stderr_path: String,
+    pub stdin_path: String,
     pub cpus: u32,
     pub memory_mb: u64,
     pub gpu_devices: Vec<u32>,
@@ -238,6 +239,7 @@ async fn spawn_job_process(
         ref environment,
         ref stdout_path,
         ref stderr_path,
+        ref stdin_path,
         cpus,
         memory_mb,
         gpu_devices: _,
@@ -418,12 +420,20 @@ async fn spawn_job_process(
 
     // Launch the process
     let mut cmd = Command::new(&launch_cmd);
+    let stdin_stdio: Stdio = if stdin_path.is_empty() {
+        Stdio::null()
+    } else {
+        let resolved = resolve_output_path(stdin_path, job_id, work_dir);
+        let f = std::fs::File::open(&resolved)
+            .with_context(|| format!("failed to open stdin file: {}", resolved))?;
+        Stdio::from(f)
+    };
     cmd.args(&launch_args)
         .current_dir(work_dir)
         .envs(&env)
         .stdout(stdout_file.into_std().await)
         .stderr(stderr_file.into_std().await)
-        .stdin(Stdio::null())
+        .stdin(stdin_stdio)
         // Run the batch process in its own process group (pgid == its pid) so
         // signals can target the whole job tree without touching spurd's group.
         .process_group(0);

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -100,6 +100,7 @@ message JobSpec {
   string stdout_path = 23;
   string stderr_path = 24;
   map<string, string> environment = 25;
+  string stdin_path = 26;
 
   // Time limits
   google.protobuf.Duration time_limit = 30;
@@ -188,6 +189,7 @@ message JobInfo {
   string stderr_path = 32;
   int32 exit_signal = 33;       // Terminating signal of primary node (0 = none)
   int32 derived_exit_code = 34; // Running max over srun step exit codes (0 if no steps)
+  string stdin_path = 35;
 
   ResourceAllocations resources = 40;
   uint32 priority = 41;


### PR DESCRIPTION
## Summary

- Add `-o/--output`, `-e/--error`, and `-i/--input` flags to `srun`, matching Slurm's I/O redirection interface. Previously, `srun -o /shared_nfs/uptime.out uptime` was silently ignored.
- `-o` and `-e` wire into the existing `JobSpec.stdout_path` / `stderr_path` proto fields that `sbatch` already uses. In step mode (inside `salloc`/`sbatch`), the RPC response is written to the specified files client-side.
- `-i` adds a new `stdin_path` field end-to-end (proto, core model, controller, scheduler, agent). The agent opens the file and passes it as the batch process's stdin instead of `/dev/null`.
- When `-o` is set, terminal streaming is suppressed since the agent writes to the file on the compute node. Without `-o`, behavior is unchanged.
- `scontrol show job` displays `StdIn=` when set.
- Step mode warns when `-i` is used since `RunStepRequest` has no stdin mechanism.

## Test plan

- [x] Unit tests: flag parsing (short/long), defaults, `resolve_output_path_client` (empty, pattern, absolute)
- [x] `cargo clippy` clean, `cargo test` green (full suite, 0 failures)
- [x] Bare-metal cluster (4-node):
  - `srun hostname` (no flags): output to default `spur-{id}.out` on compute node, no regression
  - `srun -o /tmp/test-output.out hostname`: output in file, nothing streamed to terminal
  - `srun -e /tmp/test-error.err bash -c "echo stderr >&2"`: stderr separated into file
  - `srun -o ... -e ...` together: both files written correctly
  - `srun -i /tmp/stdin.txt cat`: `cat` reads input file, writes to output file
  - `srun -o /tmp/job-%j.out hostname`: `%j` expanded to job ID in filename
  - `scontrol show job`: displays `StdOut=`, `StdErr=`, `StdIn=` correctly
  - `srun -o` / `-i` inside `sbatch` script (step mode): `-o` writes to file, `-i` prints warning