### PR TITLE
fix(raft): fail loudly on corrupt Raft WAL/snapshot state

### DIFF
--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -3489,54 +3489,55 @@ impl StateMachineApply for ClusterManager {
         serde_json::to_vec(&snap).map_err(Into::into)
     }
 
-    fn restore_from_snapshot(&self, data: &[u8]) {
-        if let Ok(snap) = serde_json::from_slice::<ClusterSnapshot>(data) {
-            let mut next_id = self.config.controller.first_job_id;
-            let mut jobs = self.jobs.write();
-            jobs.clear();
-            for job in snap.jobs {
-                next_id = next_id.max(job.job_id + 1);
-                jobs.insert(job.job_id, job);
-            }
+    fn restore_from_snapshot(&self, data: &[u8]) -> Result<(), anyhow::Error> {
+        let snap = serde_json::from_slice::<ClusterSnapshot>(data)?;
 
-            let mut nodes = self.nodes.write();
-            nodes.clear();
-            for node in snap.nodes {
-                nodes.insert(node.name.clone(), node);
-            }
-
-            *self.reservations.write() = snap.reservations;
-
-            let mut steps = self.steps.write();
-            steps.clear();
-            for step in snap.steps {
-                steps.insert((step.job_id, step.step_id), step);
-            }
-
-            // license_pool is the configured total (immutable); it is intentionally
-            // NOT restored from the snapshot so config stays authoritative and any
-            // historical drift in old snapshots is discarded. Availability is
-            // derived from the restored jobs. burst_buffer_total_gb follows the
-            // same rule; per-job BB staging phase rides along on each restored Job.
-
-            let mut tokens = self.tokens.write();
-            tokens.clear();
-            for token in snap.tokens {
-                tokens.insert(token.id.clone(), token);
-            }
-
-            self.next_job_id.store(next_id, Ordering::Relaxed);
-
-            // Re-evaluate partition membership and NodeConfig policy
-            // for all nodes against the current config.
-            self.reconcile_partitions(&mut nodes);
-
-            info!(
-                jobs = jobs.len(),
-                nodes = nodes.len(),
-                "restored cluster state from Raft snapshot"
-            );
+        let mut next_id = self.config.controller.first_job_id;
+        let mut jobs = self.jobs.write();
+        jobs.clear();
+        for job in snap.jobs {
+            next_id = next_id.max(job.job_id + 1);
+            jobs.insert(job.job_id, job);
         }
+
+        let mut nodes = self.nodes.write();
+        nodes.clear();
+        for node in snap.nodes {
+            nodes.insert(node.name.clone(), node);
+        }
+
+        *self.reservations.write() = snap.reservations;
+
+        let mut steps = self.steps.write();
+        steps.clear();
+        for step in snap.steps {
+            steps.insert((step.job_id, step.step_id), step);
+        }
+
+        // license_pool is the configured total (immutable); it is intentionally
+        // NOT restored from the snapshot so config stays authoritative and any
+        // historical drift in old snapshots is discarded. Availability is
+        // derived from the restored jobs. burst_buffer_total_gb follows the
+        // same rule; per-job BB staging phase rides along on each restored Job.
+
+        let mut tokens = self.tokens.write();
+        tokens.clear();
+        for token in snap.tokens {
+            tokens.insert(token.id.clone(), token);
+        }
+
+        self.next_job_id.store(next_id, Ordering::Relaxed);
+
+        // Re-evaluate partition membership and NodeConfig policy
+        // for all nodes against the current config.
+        self.reconcile_partitions(&mut nodes);
+
+        info!(
+            jobs = jobs.len(),
+            nodes = nodes.len(),
+            "restored cluster state from Raft snapshot"
+        );
+        Ok(())
     }
 }
 
@@ -7712,10 +7713,18 @@ mod tests {
         // Create a fresh cluster and restore
         let dir2 = TempDir::new().unwrap();
         let cm2 = test_cluster(&dir2).await;
-        cm2.restore_from_snapshot(&data);
+        cm2.restore_from_snapshot(&data).unwrap();
 
         assert!(cm2.get_job(1).is_some());
         assert!(cm2.get_node("n1").is_some());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn restore_from_snapshot_rejects_corrupt_data() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        assert!(cm.restore_from_snapshot(b"not valid json").is_err());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -49,6 +49,15 @@ struct Args {
     /// Foreground mode (don't daemonize)
     #[arg(short = 'D', long)]
     foreground: bool,
+
+    /// Tolerate unreadable/undeserializable Raft WAL entries, votes, or
+    /// snapshots during startup recovery by skipping them, instead of
+    /// refusing to start. These records represent already-committed cluster
+    /// state (nodes, jobs, ...), so a skipped record is silent data loss —
+    /// only pass this for deliberate forensic recovery once that loss has
+    /// been assessed as acceptable.
+    #[arg(long)]
+    allow_partial_wal_recovery: bool,
 }
 
 #[tokio::main]
@@ -129,7 +138,14 @@ async fn main() -> anyhow::Result<()> {
         (config.controller.peers.clone(), id)
     };
 
-    let handle = raft::start_raft(node_id, &peers, &args.state_dir, cluster.clone()).await?;
+    let handle = raft::start_raft_with_recovery_mode(
+        node_id,
+        &peers,
+        &args.state_dir,
+        cluster.clone(),
+        !args.allow_partial_wal_recovery,
+    )
+    .await?;
     info!(node_id, "Raft node started");
 
     let raft_addr: std::net::SocketAddr = config.controller.raft_listen_addr.parse()?;

--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -57,7 +57,7 @@ pub struct ClientResponse {
 pub trait StateMachineApply: Send + Sync {
     fn apply_operation(&self, op: &WalOperation) -> ClientResponse;
     fn snapshot_state(&self) -> Result<Vec<u8>, anyhow::Error>;
-    fn restore_from_snapshot(&self, data: &[u8]);
+    fn restore_from_snapshot(&self, data: &[u8]) -> Result<(), anyhow::Error>;
 }
 
 /// Disk-backed Raft storage.
@@ -94,21 +94,60 @@ struct PersistedSnapshot {
 }
 
 impl SpurStore {
+    /// Recover storage with `strict = true`: any unreadable/undeserializable vote,
+    /// log entry, or snapshot is a hard error. This is the safe default — see
+    /// `new_with_recovery_mode` for why silently skipping such records is
+    /// dangerous and should only ever be an explicit, deliberate choice.
     pub fn new(state_dir: &Path, applier: Arc<dyn StateMachineApply>) -> anyhow::Result<Self> {
+        Self::new_with_recovery_mode(state_dir, applier, true)
+    }
+
+    /// Recover storage from `{state_dir}/raft/`.
+    ///
+    /// `strict` controls what happens when a vote, log entry, or snapshot record
+    /// exists but cannot be deserialized (disk corruption, or a restart with a
+    /// `spurctld` build whose `WalOperation`/state schema has drifted from
+    /// whatever wrote the record). These are records of already-committed
+    /// cluster state — nodes, jobs, reservations — so losing one is a
+    /// correctness violation, not a cosmetic issue.
+    ///
+    /// `strict = true` (default, via `new`) refuses to start: the affected
+    /// record is named in the error so an operator can roll back to a
+    /// compatible binary. `strict = false` preserves the old behavior of
+    /// logging and skipping the record, for deliberate forensic recovery
+    /// when the loss has already been assessed as acceptable.
+    pub fn new_with_recovery_mode(
+        state_dir: &Path,
+        applier: Arc<dyn StateMachineApply>,
+        strict: bool,
+    ) -> anyhow::Result<Self> {
         let raft_dir = state_dir.join("raft");
         let log_dir = raft_dir.join("log");
         std::fs::create_dir_all(&log_dir)?;
 
         let mut inner = StoreInner::default();
+        let mut skipped_records = 0u64;
 
         let vote_path = raft_dir.join("vote.json");
         if vote_path.exists() {
             match std::fs::read_to_string(&vote_path) {
                 Ok(data) => match serde_json::from_str(&data) {
                     Ok(v) => inner.vote = Some(v),
-                    Err(e) => warn!("failed to parse vote.json: {e}"),
+                    Err(e) => {
+                        if strict {
+                            anyhow::bail!("failed to parse vote.json: {e}");
+                        }
+                        warn!("failed to parse vote.json: {e}");
+                        skipped_records += 1;
+                    }
                 },
-                Err(e) => warn!("failed to read vote.json: {e}"),
+                Err(e) => {
+                    if strict {
+                        anyhow::bail!("failed to read vote.json: {e}");
+                    }
+                    warn!("failed to read vote.json: {e}");
+                    skipped_records += 1;
+                }
             }
         }
 
@@ -121,9 +160,21 @@ impl SpurStore {
                             Ok(e) => {
                                 inner.log.insert(e.log_id.index, e);
                             }
-                            Err(e) => warn!("failed to parse log entry {:?}: {e}", path),
+                            Err(e) => {
+                                if strict {
+                                    anyhow::bail!("failed to parse log entry {path:?}: {e}");
+                                }
+                                warn!("failed to parse log entry {:?}: {e}", path);
+                                skipped_records += 1;
+                            }
                         },
-                        Err(e) => warn!("failed to read log entry {:?}: {e}", path),
+                        Err(e) => {
+                            if strict {
+                                anyhow::bail!("failed to read log entry {path:?}: {e}");
+                            }
+                            warn!("failed to read log entry {:?}: {e}", path);
+                            skipped_records += 1;
+                        }
                     }
                 }
             }
@@ -131,23 +182,43 @@ impl SpurStore {
 
         let snap_path = raft_dir.join("snapshot.json");
         if snap_path.exists() {
-            // Soft-fail: a corrupt snapshot triggers re-snapshot on the next leader term.
             match std::fs::read_to_string(&snap_path) {
                 Ok(data) => match serde_json::from_str::<PersistedSnapshot>(&data) {
-                    Ok(ps) => {
-                        inner.last_applied = ps.meta.last_log_id;
-                        inner.last_membership = ps.meta.last_membership.clone();
-                        applier.restore_from_snapshot(&ps.data);
+                    Ok(ps) => match applier.restore_from_snapshot(&ps.data) {
+                        Ok(()) => {
+                            inner.last_applied = ps.meta.last_log_id;
+                            inner.last_membership = ps.meta.last_membership.clone();
+                        }
+                        Err(e) => {
+                            if strict {
+                                anyhow::bail!("failed to restore state from snapshot.json: {e}");
+                            }
+                            warn!("failed to restore state from snapshot.json: {e}");
+                            skipped_records += 1;
+                        }
+                    },
+                    Err(e) => {
+                        if strict {
+                            anyhow::bail!("failed to parse snapshot.json: {e}");
+                        }
+                        warn!("failed to parse snapshot.json: {e}");
+                        skipped_records += 1;
                     }
-                    Err(e) => warn!("failed to parse snapshot.json: {e}"),
                 },
-                Err(e) => warn!("failed to read snapshot.json: {e}"),
+                Err(e) => {
+                    if strict {
+                        anyhow::bail!("failed to read snapshot.json: {e}");
+                    }
+                    warn!("failed to read snapshot.json: {e}");
+                    skipped_records += 1;
+                }
             }
         }
 
         let purged_path = raft_dir.join("purged.json");
         if purged_path.exists() {
-            // Hard-fail: a corrupt purged.json cannot be recovered safely.
+            // Always hard-fail: a corrupt purged.json cannot be recovered safely
+            // even in lenient mode, since it would silently un-purge history.
             let data = std::fs::read_to_string(&purged_path)?;
             inner.last_purged = Some(
                 serde_json::from_str::<LogId<NodeId>>(&data)
@@ -160,6 +231,14 @@ impl SpurStore {
             vote = ?inner.vote,
             "raft store recovered from disk"
         );
+        if skipped_records > 0 {
+            tracing::error!(
+                skipped_records,
+                "raft store recovered with GAPS: {skipped_records} record(s) could not be \
+                 deserialized and were dropped (lenient recovery mode) — cluster state may be \
+                 missing nodes, jobs, or other committed changes"
+            );
+        }
 
         Ok(Self {
             inner: RwLock::new(inner),
@@ -408,6 +487,22 @@ impl openraft::RaftStorage<SpurTypeConfig> for Arc<SpurStore> {
         snapshot: Box<Cursor<Vec<u8>>>,
     ) -> Result<(), StorageError<NodeId>> {
         let data = snapshot.into_inner();
+
+        // Unlike startup recovery (SpurStore::new), there is no lenient option
+        // here: this is a live snapshot pushed by the current Raft leader, not
+        // a one-time operator recovery decision. A follower that can't apply it
+        // must reject it rather than silently mark itself caught up while
+        // actually missing whatever the leader just sent. Validate before
+        // persisting: writing an unparseable snapshot to disk first would make
+        // the next (strict-by-default) startup hard-fail permanently on it.
+        self.applier.restore_from_snapshot(&data).map_err(|e| {
+            StorageError::from_io_error(
+                openraft::ErrorSubject::Store,
+                openraft::ErrorVerb::Write,
+                std::io::Error::other(e),
+            )
+        })?;
+
         self.persist_snapshot(meta, &data).map_err(|e| {
             StorageError::from_io_error(
                 openraft::ErrorSubject::Store,
@@ -415,8 +510,6 @@ impl openraft::RaftStorage<SpurTypeConfig> for Arc<SpurStore> {
                 e,
             )
         })?;
-
-        self.applier.restore_from_snapshot(&data);
 
         let mut inner = self.inner.write();
         inner.last_applied = meta.last_log_id;
@@ -657,11 +750,26 @@ pub fn build_peer_map(peers: &[String]) -> BTreeMap<NodeId, String> {
         .collect()
 }
 
+/// Test-only convenience wrapper around `start_raft_with_recovery_mode` with
+/// strict WAL/snapshot recovery (see `SpurStore::new`). Production startup
+/// (main.rs) calls `start_raft_with_recovery_mode` directly since it needs to
+/// thread through the `--allow-partial-wal-recovery` CLI flag.
+#[cfg(test)]
 pub async fn start_raft(
     node_id: NodeId,
     peers: &[String],
     state_dir: &Path,
     applier: Arc<dyn StateMachineApply>,
+) -> anyhow::Result<RaftHandle> {
+    start_raft_with_recovery_mode(node_id, peers, state_dir, applier, true).await
+}
+
+pub async fn start_raft_with_recovery_mode(
+    node_id: NodeId,
+    peers: &[String],
+    state_dir: &Path,
+    applier: Arc<dyn StateMachineApply>,
+    strict_wal_recovery: bool,
 ) -> anyhow::Result<RaftHandle> {
     let config = Config {
         heartbeat_interval: 500,
@@ -671,7 +779,11 @@ pub async fn start_raft(
     };
     let config = Arc::new(config.validate().map_err(|e| anyhow::anyhow!("{e}"))?);
 
-    let store = Arc::new(SpurStore::new(state_dir, applier)?);
+    let store = Arc::new(SpurStore::new_with_recovery_mode(
+        state_dir,
+        applier,
+        strict_wal_recovery,
+    )?);
     let peer_map = build_peer_map(peers);
     let network = Arc::new(SpurNetwork {
         peers: peer_map.clone(),
@@ -680,17 +792,22 @@ pub async fn start_raft(
     let (log_store, state_machine) = openraft::storage::Adaptor::new(store.clone());
     let raft = Raft::new(node_id, config, network, log_store, state_machine).await?;
 
-    // Symmetric bootstrap: every node calls initialize with the full
-    // membership. Openraft guarantees that when all nodes use the same
-    // membership, the voting protocol picks exactly one leader. On
-    // subsequent restarts initialize() returns "already initialized"
-    // (benign) and normal Raft elections take over.
-    let members: BTreeMap<NodeId, BasicNode> = peer_map
-        .iter()
-        .map(|(id, addr)| (*id, BasicNode::new(addr.clone())))
-        .collect();
-    if let Err(e) = raft.initialize(members).await {
-        debug!("raft initialize: {e} (already initialized)");
+    // Symmetric bootstrap only applies on first-ever startup; skip it once we
+    // have prior state, else openraft logs an ERROR rejecting it every restart.
+    let already_initialized = {
+        let inner = store.inner.read();
+        inner.vote.is_some() || !inner.log.is_empty() || inner.last_applied.is_some()
+    };
+    if already_initialized {
+        debug!("raft store has prior state; skipping redundant initialize()");
+    } else {
+        let members: BTreeMap<NodeId, BasicNode> = peer_map
+            .iter()
+            .map(|(id, addr)| (*id, BasicNode::new(addr.clone())))
+            .collect();
+        if let Err(e) = raft.initialize(members).await {
+            debug!("raft initialize: {e} (already initialized)");
+        }
     }
 
     info!(node_id, peers = ?peer_map, "raft node started");
@@ -714,7 +831,9 @@ mod tests {
         fn snapshot_state(&self) -> Result<Vec<u8>, anyhow::Error> {
             Ok(Vec::new())
         }
-        fn restore_from_snapshot(&self, _data: &[u8]) {}
+        fn restore_from_snapshot(&self, _data: &[u8]) -> Result<(), anyhow::Error> {
+            Ok(())
+        }
     }
 
     fn noop_applier() -> Arc<dyn StateMachineApply> {
@@ -925,5 +1044,210 @@ mod tests {
         .unwrap();
 
         assert!(SpurStore::new(dir.path(), noop_applier()).is_err());
+    }
+
+    /// Mirrors a real restart with a schema-incompatible binary: a WAL entry
+    /// whose payload variant this build's `WalOperation` enum doesn't know
+    /// about (e.g. written by a newer/older `spurctld`).
+    fn write_raw_log_entry(dir: &std::path::Path, index: u64, json: &str) {
+        std::fs::write(
+            dir.join("raft")
+                .join("log")
+                .join(format!("{index:020}.json")),
+            json,
+        )
+        .unwrap();
+    }
+
+    const UNKNOWN_VARIANT_ENTRY: &str = r#"{"log_id":{"leader_id":{"term":1,"node_id":1},"index":0},"payload":{"Normal":{"SomeFutureVariant":{}}}}"#;
+
+    #[test]
+    fn store_unknown_wal_variant_hard_fails_by_default() {
+        let dir = TempDir::new().unwrap();
+        SpurStore::new(dir.path(), noop_applier()).unwrap();
+        write_raw_log_entry(dir.path(), 0, UNKNOWN_VARIANT_ENTRY);
+
+        assert!(SpurStore::new(dir.path(), noop_applier()).is_err());
+    }
+
+    #[test]
+    fn store_unknown_wal_variant_lenient_mode_skips_and_continues() {
+        let dir = TempDir::new().unwrap();
+        SpurStore::new(dir.path(), noop_applier()).unwrap();
+        write_raw_log_entry(dir.path(), 0, UNKNOWN_VARIANT_ENTRY);
+
+        let store = SpurStore::new_with_recovery_mode(dir.path(), noop_applier(), false).unwrap();
+        assert!(store.inner.read().log.is_empty());
+    }
+
+    #[test]
+    fn store_corrupt_snapshot_hard_fails_by_default() {
+        let dir = TempDir::new().unwrap();
+        SpurStore::new(dir.path(), noop_applier()).unwrap();
+        std::fs::write(
+            dir.path().join("raft").join("snapshot.json"),
+            "not valid json",
+        )
+        .unwrap();
+
+        assert!(SpurStore::new(dir.path(), noop_applier()).is_err());
+    }
+
+    #[test]
+    fn store_corrupt_snapshot_lenient_mode_skips_and_continues() {
+        let dir = TempDir::new().unwrap();
+        SpurStore::new(dir.path(), noop_applier()).unwrap();
+        std::fs::write(
+            dir.path().join("raft").join("snapshot.json"),
+            "not valid json",
+        )
+        .unwrap();
+
+        assert!(SpurStore::new_with_recovery_mode(dir.path(), noop_applier(), false).is_ok());
+    }
+
+    #[test]
+    fn store_corrupt_vote_file_hard_fails_by_default() {
+        let dir = TempDir::new().unwrap();
+        SpurStore::new(dir.path(), noop_applier()).unwrap();
+        std::fs::write(dir.path().join("raft").join("vote.json"), "not valid json").unwrap();
+
+        assert!(SpurStore::new(dir.path(), noop_applier()).is_err());
+    }
+
+    #[test]
+    fn store_corrupt_vote_file_lenient_mode_skips_and_continues() {
+        let dir = TempDir::new().unwrap();
+        SpurStore::new(dir.path(), noop_applier()).unwrap();
+        std::fs::write(dir.path().join("raft").join("vote.json"), "not valid json").unwrap();
+
+        let store = SpurStore::new_with_recovery_mode(dir.path(), noop_applier(), false).unwrap();
+        assert!(store.inner.read().vote.is_none());
+    }
+
+    struct FailingRestoreApplier;
+    impl StateMachineApply for FailingRestoreApplier {
+        fn apply_operation(&self, _op: &WalOperation) -> ClientResponse {
+            ClientResponse::default()
+        }
+        fn snapshot_state(&self) -> Result<Vec<u8>, anyhow::Error> {
+            Ok(Vec::new())
+        }
+        fn restore_from_snapshot(&self, _data: &[u8]) -> Result<(), anyhow::Error> {
+            Err(anyhow::anyhow!("applier rejected snapshot payload"))
+        }
+    }
+
+    #[test]
+    fn store_snapshot_restore_failure_hard_fails_by_default() {
+        let dir = TempDir::new().unwrap();
+        let store = SpurStore::new(dir.path(), noop_applier()).unwrap();
+        let meta = SnapshotMeta {
+            last_log_id: Some(LogId {
+                leader_id: openraft::LeaderId {
+                    term: 1,
+                    node_id: 1,
+                },
+                index: 5,
+            }),
+            last_membership: StoredMembership::default(),
+            snapshot_id: "snap-5".into(),
+        };
+        store.persist_snapshot(&meta, b"opaque state").unwrap();
+
+        assert!(SpurStore::new(dir.path(), Arc::new(FailingRestoreApplier)).is_err());
+    }
+
+    #[test]
+    fn store_snapshot_restore_failure_lenient_mode_skips_and_continues() {
+        let dir = TempDir::new().unwrap();
+        let store = SpurStore::new(dir.path(), noop_applier()).unwrap();
+        let meta = SnapshotMeta {
+            last_log_id: Some(LogId {
+                leader_id: openraft::LeaderId {
+                    term: 1,
+                    node_id: 1,
+                },
+                index: 5,
+            }),
+            last_membership: StoredMembership::default(),
+            snapshot_id: "snap-5".into(),
+        };
+        store.persist_snapshot(&meta, b"opaque state").unwrap();
+
+        let store =
+            SpurStore::new_with_recovery_mode(dir.path(), Arc::new(FailingRestoreApplier), false)
+                .unwrap();
+        // A rejected restore must not advance last_applied/last_membership —
+        // otherwise Raft believes the state machine is caught up to the
+        // snapshot when it never actually restored anything.
+        let inner = store.inner.read();
+        assert!(inner.last_applied.is_none());
+        assert_eq!(inner.last_membership, StoredMembership::default());
+    }
+
+    #[tokio::test]
+    async fn start_raft_skips_redundant_initialize_on_restart() {
+        use std::time::Duration;
+
+        let dir = TempDir::new().unwrap();
+
+        let handle = start_raft(1, &["[::1]:0".into()], dir.path(), noop_applier())
+            .await
+            .unwrap();
+        handle
+            .raft
+            .wait(Some(Duration::from_secs(5)))
+            .metrics(|m| m.current_leader == Some(1), "leader elected")
+            .await
+            .expect("single-node raft did not self-elect within 5s");
+        handle.raft.shutdown().await.unwrap();
+
+        // Restart against the same state_dir: prior vote/log on disk means
+        // already_initialized is true, so initialize() must be skipped, yet
+        // the node must still become leader and be usable.
+        let handle = start_raft(1, &["[::1]:0".into()], dir.path(), noop_applier())
+            .await
+            .unwrap();
+        handle
+            .raft
+            .wait(Some(Duration::from_secs(5)))
+            .metrics(|m| m.current_leader == Some(1), "leader elected")
+            .await
+            .expect("restarted single-node raft did not resume leadership within 5s");
+    }
+
+    /// The HA follower-catch-up path: a leader pushes a snapshot via the Raft
+    /// `install_snapshot` RPC. If this node's applier can't apply it (e.g. a
+    /// schema-incompatible build in a multi-controller cluster), the RPC must
+    /// fail rather than mark the follower caught up on state it doesn't have.
+    #[tokio::test]
+    async fn install_snapshot_rejects_when_applier_cannot_restore() {
+        use openraft::RaftStorage;
+
+        let dir = TempDir::new().unwrap();
+        let mut store =
+            Arc::new(SpurStore::new(dir.path(), Arc::new(FailingRestoreApplier)).unwrap());
+
+        let meta = SnapshotMeta {
+            last_log_id: Some(LogId {
+                leader_id: openraft::LeaderId {
+                    term: 1,
+                    node_id: 2,
+                },
+                index: 10,
+            }),
+            last_membership: StoredMembership::default(),
+            snapshot_id: "snap-10".into(),
+        };
+
+        let result = store
+            .install_snapshot(&meta, Box::new(Cursor::new(b"opaque state".to_vec())))
+            .await;
+
+        assert!(result.is_err());
+        // A rejected snapshot must never reach disk: persisting it first would
+        // make the next (strict-by-default) startup hard-fail on it forever.
+        assert!(!dir.path().join("raft").join("snapshot.json").exists());
     }
 }

--- a/crates/spurd/src/reporter.rs
+++ b/crates/spurd/src/reporter.rs
@@ -128,6 +128,15 @@ impl NodeReporter {
                         .await
                     {
                         Ok(_) => debug!(load, free_mem, "heartbeat sent"),
+                        Err(e) if should_reregister(&e) => {
+                            warn!(
+                                error = %e,
+                                "controller does not recognize this node; re-registering"
+                            );
+                            if let Err(e) = self.register().await {
+                                warn!(error = %e, "re-registration after heartbeat rejection failed");
+                            }
+                        }
                         Err(e) => warn!(error = %e, "heartbeat failed"),
                     }
                 }
@@ -135,6 +144,14 @@ impl NodeReporter {
             }
         }
     }
+}
+
+/// A `NOT_FOUND` heartbeat means the controller lost this node's registration
+/// (e.g. it restarted and dropped the record) while this agent kept running.
+/// The controller never proactively tells an agent to re-register, so without
+/// this the agent would heartbeat into the same rejection forever.
+fn should_reregister(status: &tonic::Status) -> bool {
+    status.code() == tonic::Code::NotFound
 }
 
 /// Discover local node resources from sysfs / /proc + device registry.
@@ -492,5 +509,23 @@ mod tests {
 
         let resources = discover_resources(&reg);
         assert_eq!(resources.generic.get("bandwidth:lustre"), Some(&4096));
+    }
+
+    #[test]
+    fn should_reregister_on_not_found() {
+        assert!(should_reregister(&tonic::Status::not_found(
+            "node x not found — is the node registered?"
+        )));
+    }
+
+    #[test]
+    fn should_not_reregister_on_other_errors() {
+        assert!(!should_reregister(&tonic::Status::unavailable(
+            "transport error"
+        )));
+        assert!(!should_reregister(&tonic::Status::unauthenticated(
+            "node token required"
+        )));
+        assert!(!should_reregister(&tonic::Status::internal("boom")));
     }
 }


### PR DESCRIPTION
## Summary

`spurctld`'s startup recovery silently dropped any vote / log-entry / snapshot record it couldn't deserialize (`warn!` and continue), instead of treating it as the correctness violation it is. These records represent already-committed cluster state — nodes, jobs, reservations — so losing one silently is data loss, not a cosmetic issue.

Root-caused and reproduced live: a `spurctld` restart with a schema-drifted binary (e.g. a rebuild deployed mid-rollout via the Ansible playbook's checksum-based binary sync + unconditional restart) silently loses whichever committed entries land in the incompatible range, with zero operator-visible signal beyond a buried `journalctl` line. The same gap existed on the HA `install_snapshot` RPC path, where a follower could mark itself caught up on a snapshot it actually failed to apply.

(Note: the originally-suspected mechanism — openraft's `committed` log id never being persisted — was investigated and ruled out for the single-controller case; a restarting node trivially re-establishes commit status via normal leader election, so that gap alone doesn't explain data loss. The real, confirmed mechanism is deserialize failure on WAL/snapshot replay.)

## Approach

- `SpurStore::new` now defaults to **strict** recovery: any unreadable/corrupt vote, log entry, or snapshot is a hard startup failure naming the exact broken record — mirroring how `purged.json` corruption was already treated as fatal. The old skip-and-continue behavior is preserved as an explicit, named opt-in via `spurctld --allow-partial-wal-recovery`, for deliberate forensic recovery once a loss has been assessed as acceptable.
- `StateMachineApply::restore_from_snapshot` now returns `Result` instead of silently swallowing a bad payload. In lenient mode, a failed restore no longer advances `last_applied`/`last_membership` — otherwise Raft would believe the *entire* snapshot's worth of state was caught up even though nothing was actually restored, silently losing far more than the one assessed-acceptable record lenient mode is meant to represent.
- `install_snapshot` (the live HA follower-catch-up path) has **no lenient option** — a follower that can't apply a snapshot pushed by the leader must reject it, since this is live protocol traffic, not a one-time operator decision. It also **validates before persisting**: a rejected snapshot never reaches `raft/snapshot.json`, so it can't turn into a permanent hard-fail on every subsequent (strict-by-default) startup.
- `spurd` now self-re-registers when a heartbeat comes back `NOT_FOUND`, instead of retrying into a permanent rejection until someone notices and manually bounces the agent.
- `spurctld` no longer calls the symmetric-bootstrap `raft.initialize()` unconditionally on every restart — it only ever succeeds on a cluster's first-ever boot, so every subsequent restart was making openraft log an internal `ERROR` rejecting it, forever. Now skipped once the node's own recovered store shows prior state (vote, log entries, or a snapshot), avoiding both the wasted RPC and permanent log noise that would otherwise drown out the real failure signal this PR adds.

This PR went through a full review round (GitHub Copilot + an independent fresh-context code review, both cross-validated by a third independent agent before anything was changed) which caught two real high-severity bugs in the first draft — both described above are already fixed in the current diff:
1. Lenient-mode restore failure advancing `last_applied`/`last_membership` anyway.
2. `install_snapshot` persisting to disk before validating.

## Testing

- 13 unit tests: strict/lenient recovery for corrupt vote / log entry / snapshot, snapshot-restore-failure propagation (including the `last_applied`/`last_membership` invariant), `install_snapshot` rejection (including that a rejected snapshot never touches disk), the `initialize()`-skip-on-restart behavior, and the `spurd` re-registration predicate.
- `cargo test --locked` (full workspace): all passing. `cargo clippy --workspace --exclude spur-ffi --all-targets --locked`: clean.
- Live-validated on a 2-host lab cluster, both before and after every round of fixes:
  - **Pre-fix repro** with two real historical builds (no synthetic corruption): registering a node under one build, removing it under another, then restarting with the first — the removal was silently dropped and the node resurrected. Confirms the mechanism.
  - **Post-fix validation**: a node registered *before* a forced Raft snapshot survives a clean restart; a node registered *after* that snapshot also survives, replayed correctly on top of the snapshot with no gaps — and with zero `ERROR`/`WARN` lines in either case.

## Follow-ups (not in this PR)

- The Ansible playbook (`deploy/ansible`) restarts `spurctld` unconditionally on every run touching the controller group, and syncs binaries via plain checksum diff from the operator's local build — worth hardening separately (e.g. warn/refuse on unexpected binary drift).
- HA multi-controller `install_snapshot` is covered by unit tests and confirmed to fire correctly end-to-end for the compatible case on a live 3-controller cluster, but a genuine incompatible-payload rejection over the wire hasn't been reproduced live (hit unrelated environment/bootstrap flakiness in a hand-rolled 3-node setup — would need a more controlled setup, e.g. via the actual Ansible playbook, to pursue further).