### PR TITLE
fix(spur-cli): use connect_channel for accounting CLI commands

### DIFF
--- a/crates/spur-cli/src/sacct.rs
+++ b/crates/spur-cli/src/sacct.rs
@@ -153,9 +153,10 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         })
         .unwrap_or_default();
 
-    let mut client = SlurmAccountingClient::connect(args.controller)
+    let channel = spur_client::connect_channel(&args.controller)
         .await
         .context("failed to connect to controller")?;
+    let mut client = SlurmAccountingClient::new(channel);
 
     let start_after = args
         .starttime

--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -110,9 +110,10 @@ fn parse_params(params: &[String]) -> std::collections::HashMap<String, String> 
 }
 
 async fn connect(addr: &str) -> Result<SlurmAccountingClient<tonic::transport::Channel>> {
-    SlurmAccountingClient::connect(addr.to_string())
+    let channel = spur_client::connect_channel(addr)
         .await
-        .context("failed to connect to controller")
+        .context("failed to connect to controller")?;
+    Ok(SlurmAccountingClient::new(channel))
 }
 
 /// Extract the fields shared by `add user` and `modify user` (both upsert

--- a/crates/spur-cli/src/sreport.rs
+++ b/crates/spur-cli/src/sreport.rs
@@ -66,9 +66,10 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         .and_then(parse_time_arg)
         .map(datetime_to_proto);
 
-    let mut client = SlurmAccountingClient::connect(args.controller.clone())
+    let channel = spur_client::connect_channel(&args.controller)
         .await
         .context("failed to connect to controller")?;
+    let mut client = SlurmAccountingClient::new(channel);
 
     match &args.command {
         SreportCommand::Cluster { report_type } => match report_type.to_lowercase().as_str() {

--- a/crates/spur-cli/src/sshare.rs
+++ b/crates/spur-cli/src/sshare.rs
@@ -42,9 +42,10 @@ pub async fn main() -> Result<()> {
 pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let args = SshareArgs::try_parse_from(&args)?;
 
-    let mut client = SlurmAccountingClient::connect(args.controller.clone())
+    let channel = spur_client::connect_channel(&args.controller)
         .await
         .context("failed to connect to controller")?;
+    let mut client = SlurmAccountingClient::new(channel);
 
     // Get accounts
     let accounts_resp = client


### PR DESCRIPTION
## Summary

- `sacct`, `sacctmgr`, `sreport`, and `sshare` passed the raw `SPUR_CONTROLLER_ADDR` value directly to `tonic::Endpoint::connect()`, which treats the entire string as a single URI. When multiple controllers are configured (comma-separated for HA), this produced "invalid URI / invalid authority" errors.
- All four commands now route through `spur_client::connect_channel()`, which splits on commas and does ordered failover with a 2-second connect timeout per endpoint. This matches the behavior of every other CLI command.

## Test plan

- [x] Reproduced "invalid authority" error on bare-metal cluster with multi-endpoint `SPUR_CONTROLLER_ADDR`
- [x] Verified fix: `sacct` and `sacctmgr` connect successfully with comma-separated endpoints
- [x] Verified failover: killed first controller, commands skip dead endpoint and connect to next live one
- [x] `cargo clippy` passes with 0 warnings
- [x] `cargo test` passes