### PR TITLE
feat(spur-cli): honor SRUN_/SALLOC_/SLURM_ env-var defaults for srun …

### DIFF
--- a/crates/spur-cli/src/env_defaults.rs
+++ b/crates/spur-cli/src/env_defaults.rs
@@ -1,0 +1,258 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Environment-variable defaults for `srun` and `salloc` flags.
+//!
+//! clap's `#[arg(env = ...)]` accepts a single variable name, but Slurm
+//! defines several aliases per flag (e.g. `--nodes` reads `SLURM_NNODES` and
+//! `SLURM_JOB_NUM_NODES`) and Spur additionally honors its native `SPUR_*`
+//! twins. The `apply_*` helpers resolve a flag from an ordered list of
+//! candidate variables and write it into the parsed args, but only when the
+//! flag was not set on the command line so that CLI always overrides env.
+
+use anyhow::{anyhow, Result};
+use clap::parser::ValueSource;
+use clap::ArgMatches;
+use std::fmt::Display;
+use std::str::FromStr;
+
+/// Return the first variable in `names` that is set and non-empty, together
+/// with the variable name that supplied it (used for error messages).
+fn first_set<'a>(names: &[&'a str]) -> Option<(&'a str, String)> {
+    names.iter().find_map(|&name| match std::env::var(name) {
+        Ok(v) if !v.is_empty() => Some((name, v)),
+        _ => None,
+    })
+}
+
+/// Return the value of the first variable in `names` that is set and non-empty.
+///
+/// Empty values are skipped so an exported-but-empty variable does not mask a
+/// later populated alias.
+pub fn env_first(names: &[&str]) -> Option<String> {
+    first_set(names).map(|(_, v)| v)
+}
+
+/// Resolve a boolean flag from `names` using Slurm's flag semantics.
+///
+/// Slurm enables a no-argument option when its variable is empty, `"yes"`
+/// (case-insensitive), or a non-zero number; disables it for `"0"`; and
+/// ignores (leaves unset) any other value. Returns `None` when no listed
+/// variable is present or every present value is unrecognized.
+pub fn env_flag(names: &[&str]) -> Option<bool> {
+    for name in names {
+        let Ok(val) = std::env::var(name) else {
+            continue;
+        };
+        let trimmed = val.trim();
+        if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("yes") {
+            return Some(true);
+        }
+        if let Ok(n) = trimmed.parse::<i64>() {
+            return Some(n != 0);
+        }
+        // Unrecognized value: skip and let a later alias decide.
+    }
+    None
+}
+
+/// True when the argument identified by `id` was provided on the command line
+/// (as opposed to a default or being absent). Env is applied only when this is
+/// false, giving CLI > env precedence.
+pub fn was_cli_set(matches: &ArgMatches, id: &str) -> bool {
+    matches.value_source(id) == Some(ValueSource::CommandLine)
+}
+
+/// Apply an env default to an `Option<String>` flag when it was not set on the
+/// command line.
+pub fn apply_str(matches: &ArgMatches, id: &str, names: &[&str], target: &mut Option<String>) {
+    if was_cli_set(matches, id) {
+        return;
+    }
+    if let Some(v) = env_first(names) {
+        *target = Some(v);
+    }
+}
+
+/// Apply an env default to a plain `String` flag (one carrying a default value).
+pub fn apply_string(matches: &ArgMatches, id: &str, names: &[&str], target: &mut String) {
+    if was_cli_set(matches, id) {
+        return;
+    }
+    if let Some(v) = env_first(names) {
+        *target = v;
+    }
+}
+
+/// Apply a comma-separated env default to a `Vec<String>` flag. The env value
+/// replaces (rather than appends to) the target, matching how a repeated flag
+/// with `value_delimiter` behaves.
+pub fn apply_csv(matches: &ArgMatches, id: &str, names: &[&str], target: &mut Vec<String>) {
+    if was_cli_set(matches, id) {
+        return;
+    }
+    if let Some(v) = env_first(names) {
+        *target = v.split(',').map(str::to_string).collect();
+    }
+}
+
+/// Apply a boolean-flag env default using Slurm's flag semantics.
+pub fn apply_flag(matches: &ArgMatches, id: &str, names: &[&str], target: &mut bool) {
+    if was_cli_set(matches, id) {
+        return;
+    }
+    if let Some(b) = env_flag(names) {
+        *target = b;
+    }
+}
+
+/// Apply a numeric env default. The error names the specific variable that
+/// supplied the bad value so a misconfigured `SLURM_NNODES=abc` is easy to
+/// diagnose.
+pub fn apply_num<T>(matches: &ArgMatches, id: &str, names: &[&str], target: &mut T) -> Result<()>
+where
+    T: FromStr,
+    T::Err: Display,
+{
+    if was_cli_set(matches, id) {
+        return Ok(());
+    }
+    if let Some((name, v)) = first_set(names) {
+        *target = v
+            .parse()
+            .map_err(|e| anyhow!("invalid value {:?} for {}: {}", v, name, e))?;
+    }
+    Ok(())
+}
+
+/// Test-only guard that isolates env-var tests from the runner's environment.
+///
+/// Clears every `SPUR_/SLURM_/SALLOC_/SRUN_`-prefixed variable on construction
+/// and on drop, so a CI runner that injects `SLURM_*` vars cannot perturb the
+/// resolvers and a panicking test cannot leak state into the next one. Tests
+/// using it must be `#[serial]`.
+#[cfg(test)]
+pub(crate) struct EnvGuard;
+
+#[cfg(test)]
+impl EnvGuard {
+    pub(crate) fn new() -> Self {
+        Self::clear();
+        EnvGuard
+    }
+
+    pub(crate) fn set(&self, key: &str, val: &str) {
+        std::env::set_var(key, val);
+    }
+
+    fn clear() {
+        let stale: Vec<String> = std::env::vars()
+            .map(|(k, _)| k)
+            .filter(|k| {
+                k.starts_with("SPUR_")
+                    || k.starts_with("SLURM_")
+                    || k.starts_with("SALLOC_")
+                    || k.starts_with("SRUN_")
+            })
+            .collect();
+        for k in stale {
+            std::env::remove_var(k);
+        }
+    }
+}
+
+#[cfg(test)]
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        Self::clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial(env_injection)]
+    fn env_first_returns_first_set() {
+        let guard = EnvGuard::new();
+        guard.set("SPUR_TEST_B", "second");
+        assert_eq!(
+            env_first(&["SPUR_TEST_A", "SPUR_TEST_B"]),
+            Some("second".to_string())
+        );
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn env_first_prefers_earlier_alias() {
+        let guard = EnvGuard::new();
+        guard.set("SPUR_TEST_A", "first");
+        guard.set("SPUR_TEST_B", "second");
+        assert_eq!(
+            env_first(&["SPUR_TEST_A", "SPUR_TEST_B"]),
+            Some("first".to_string())
+        );
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn env_first_skips_empty_value() {
+        let guard = EnvGuard::new();
+        guard.set("SPUR_TEST_A", "");
+        guard.set("SPUR_TEST_B", "populated");
+        assert_eq!(
+            env_first(&["SPUR_TEST_A", "SPUR_TEST_B"]),
+            Some("populated".to_string())
+        );
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn env_first_none_when_unset() {
+        let _guard = EnvGuard::new();
+        assert_eq!(env_first(&["SPUR_TEST_A"]), None);
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn env_flag_true_for_empty_yes_and_nonzero() {
+        let guard = EnvGuard::new();
+
+        guard.set("SPUR_TEST_FLAG", "");
+        assert_eq!(env_flag(&["SPUR_TEST_FLAG"]), Some(true));
+
+        guard.set("SPUR_TEST_FLAG", "YeS");
+        assert_eq!(env_flag(&["SPUR_TEST_FLAG"]), Some(true));
+
+        guard.set("SPUR_TEST_FLAG", "1");
+        assert_eq!(env_flag(&["SPUR_TEST_FLAG"]), Some(true));
+
+        guard.set("SPUR_TEST_FLAG", "5");
+        assert_eq!(env_flag(&["SPUR_TEST_FLAG"]), Some(true));
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn env_flag_false_for_zero() {
+        let guard = EnvGuard::new();
+        guard.set("SPUR_TEST_FLAG", "0");
+        assert_eq!(env_flag(&["SPUR_TEST_FLAG"]), Some(false));
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn env_flag_ignores_unrecognized_value() {
+        let guard = EnvGuard::new();
+        guard.set("SPUR_TEST_FLAG", "maybe");
+        assert_eq!(env_flag(&["SPUR_TEST_FLAG"]), None);
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn env_flag_none_when_unset() {
+        let _guard = EnvGuard::new();
+        assert_eq!(env_flag(&["SPUR_TEST_FLAG"]), None);
+    }
+}

--- a/crates/spur-cli/src/env_defaults.rs
+++ b/crates/spur-cli/src/env_defaults.rs
@@ -92,7 +92,13 @@ pub fn apply_csv(matches: &ArgMatches, id: &str, names: &[&str], target: &mut Ve
         return;
     }
     if let Some(v) = env_first(names) {
-        *target = v.split(',').map(str::to_string).collect();
+        // Trim and drop empties so a padded or trailing-comma list stays clean.
+        *target = v
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .collect();
     }
 }
 
@@ -118,7 +124,10 @@ where
         return Ok(());
     }
     if let Some((name, v)) = first_set(names) {
-        *target = v
+        // Trim so values with incidental whitespace (e.g. `SLURM_NTASKS="4 "`)
+        // parse instead of erroring.
+        let trimmed = v.trim();
+        *target = trimmed
             .parse()
             .map_err(|e| anyhow!("invalid value {:?} for {}: {}", v, name, e))?;
     }

--- a/crates/spur-cli/src/main.rs
+++ b/crates/spur-cli/src/main.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+mod env_defaults;
 mod exec;
 mod exit_fmt;
 mod format_engine;

--- a/crates/spur-cli/src/salloc.rs
+++ b/crates/spur-cli/src/salloc.rs
@@ -1,8 +1,9 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::env_defaults::{apply_csv, apply_flag, apply_str, apply_string};
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser};
 use spur_core::spur_env::SpurEnv;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{CancelJobRequest, GetJobRequest, JobSpec, SubmitJobRequest};
@@ -45,7 +46,9 @@ pub struct SallocArgs {
     pub time: String,
 
     /// GRES
-    #[arg(long)]
+    // Slurm semantics: comma-lists expand to multiple GRES; a repeated --gres
+    // replaces rather than accumulates (last wins).
+    #[arg(long, value_delimiter = ',', overrides_with = "gres")]
     pub gres: Vec<String>,
 
     /// GPUs
@@ -86,7 +89,9 @@ pub async fn main() -> Result<()> {
 }
 
 pub async fn main_with_args(args: Vec<String>) -> Result<()> {
-    let args = SallocArgs::try_parse_from(&args)?;
+    let matches = SallocArgs::command().try_get_matches_from(&args)?;
+    let mut args = SallocArgs::from_arg_matches(&matches)?;
+    resolve_salloc_env(&matches, &mut args);
 
     let name = args.job_name.unwrap_or_else(|| "interactive".into());
     let mut gres = args.gres;
@@ -276,6 +281,67 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     std::process::exit(status.code().unwrap_or(0));
 }
 
+/// Apply `SALLOC_*` environment-variable defaults (plus `SPUR_*` native twins)
+/// to any flag not set on the command line. Mirrors real Slurm: salloc reads
+/// command-prefixed `SALLOC_*` vars, and notably provides no env var for
+/// `--nodes`, `--ntasks`, `--cpus-per-task`, or `--job-name`. CLI overrides env.
+fn resolve_salloc_env(matches: &ArgMatches, args: &mut SallocArgs) {
+    apply_str(
+        matches,
+        "partition",
+        &["SPUR_PARTITION", "SALLOC_PARTITION"],
+        &mut args.partition,
+    );
+    apply_str(
+        matches,
+        "account",
+        &["SPUR_ACCOUNT", "SALLOC_ACCOUNT"],
+        &mut args.account,
+    );
+    apply_str(
+        matches,
+        "mem",
+        &["SPUR_MEM_PER_NODE", "SALLOC_MEM_PER_NODE"],
+        &mut args.mem,
+    );
+    apply_string(
+        matches,
+        "time",
+        &["SPUR_TIMELIMIT", "SALLOC_TIMELIMIT"],
+        &mut args.time,
+    );
+    apply_csv(
+        matches,
+        "gres",
+        &["SPUR_GRES", "SALLOC_GRES"],
+        &mut args.gres,
+    );
+    apply_str(
+        matches,
+        "gpus",
+        &["SPUR_GPUS", "SALLOC_GPUS"],
+        &mut args.gpus,
+    );
+    apply_str(
+        matches,
+        "constraint",
+        &["SPUR_CONSTRAINT", "SALLOC_CONSTRAINT"],
+        &mut args.constraint,
+    );
+    apply_str(
+        matches,
+        "reservation",
+        &["SPUR_RESERVATION", "SALLOC_RESERVATION"],
+        &mut args.reservation,
+    );
+    apply_flag(
+        matches,
+        "exclusive",
+        &["SPUR_EXCLUSIVE", "SALLOC_EXCLUSIVE"],
+        &mut args.exclusive,
+    );
+}
+
 fn parse_memory_mb(s: &str) -> Result<u64> {
     let s = s.trim();
     if let Some(gb) = s.strip_suffix('G').or_else(|| s.strip_suffix('g')) {
@@ -307,5 +373,115 @@ mod tests {
                 .expect("parse failed");
         assert_eq!(args.nodelist.as_deref(), Some("node001"));
         assert_eq!(args.exclude.as_deref(), Some("node002"));
+    }
+
+    // These mutate process-global env vars, so they run serially and use the
+    // shared EnvGuard, which clears every SPUR_/SLURM_/SALLOC_/SRUN_-prefixed
+    // var on construction and drop to stay independent of the runner's env.
+    use crate::env_defaults::EnvGuard;
+    use serial_test::serial;
+
+    fn resolve_from(cli: &[&str]) -> SallocArgs {
+        let matches = SallocArgs::command()
+            .try_get_matches_from(cli)
+            .expect("parse failed");
+        let mut args = SallocArgs::from_arg_matches(&matches).expect("from_arg_matches failed");
+        resolve_salloc_env(&matches, &mut args);
+        args
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn env_provides_defaults() {
+        let env = EnvGuard::new();
+        env.set("SALLOC_PARTITION", "gpu");
+        env.set("SALLOC_ACCOUNT", "proj");
+        let args = resolve_from(&["salloc"]);
+        assert_eq!(args.partition.as_deref(), Some("gpu"));
+        assert_eq!(args.account.as_deref(), Some("proj"));
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn cli_overrides_env() {
+        let env = EnvGuard::new();
+        env.set("SALLOC_PARTITION", "gpu");
+        let args = resolve_from(&["salloc", "--partition=cpu"]);
+        assert_eq!(args.partition.as_deref(), Some("cpu"));
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn spur_native_alias_works() {
+        let env = EnvGuard::new();
+        env.set("SPUR_PARTITION", "spur-part");
+        let args = resolve_from(&["salloc"]);
+        assert_eq!(args.partition.as_deref(), Some("spur-part"));
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn timelimit_env_overrides_default_but_not_cli() {
+        let env = EnvGuard::new();
+        env.set("SALLOC_TIMELIMIT", "2:00:00");
+        assert_eq!(resolve_from(&["salloc"]).time, "2:00:00");
+
+        let args = resolve_from(&["salloc", "--time=8:00:00"]);
+        assert_eq!(args.time, "8:00:00");
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn exclusive_flag_semantics() {
+        let env = EnvGuard::new();
+
+        env.set("SALLOC_EXCLUSIVE", "yes");
+        assert!(resolve_from(&["salloc"]).exclusive);
+
+        env.set("SALLOC_EXCLUSIVE", "0");
+        assert!(!resolve_from(&["salloc"]).exclusive);
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn gres_comma_split_and_more() {
+        let env = EnvGuard::new();
+        env.set("SALLOC_GRES", "gpu:2,fpga:1");
+        env.set("SALLOC_MEM_PER_NODE", "8G");
+        env.set("SALLOC_GPUS", "4");
+        env.set("SALLOC_CONSTRAINT", "mi300x");
+        let args = resolve_from(&["salloc"]);
+        assert_eq!(args.gres, vec!["gpu:2", "fpga:1"]);
+        assert_eq!(args.mem.as_deref(), Some("8G"));
+        assert_eq!(args.gpus.as_deref(), Some("4"));
+        assert_eq!(args.constraint.as_deref(), Some("mi300x"));
+    }
+
+    #[test]
+    fn cli_gres_comma_list_splits_into_multiple() {
+        let args =
+            SallocArgs::try_parse_from(["salloc", "--gres=gpu:1,fpga:2"]).expect("parse failed");
+        assert_eq!(args.gres, vec!["gpu:1", "fpga:2"]);
+    }
+
+    #[test]
+    fn cli_repeated_gres_last_wins() {
+        let args = SallocArgs::try_parse_from(["salloc", "--gres=gpu:1", "--gres=fpga:2"])
+            .expect("parse failed");
+        assert_eq!(args.gres, vec!["fpga:2"]);
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn slurm_faithful_no_env_for_nodes_or_job_name() {
+        let env = EnvGuard::new();
+        // These vars have no effect on salloc in real Slurm; Spur ignores them.
+        env.set("SALLOC_NNODES", "9");
+        env.set("SLURM_NNODES", "9");
+        env.set("SALLOC_JOB_NAME", "envname");
+        env.set("SLURM_JOB_NAME", "envname");
+        let args = resolve_from(&["salloc"]);
+        assert_eq!(args.nodes, 1, "nodes must stay at the CLI default");
+        assert!(args.job_name.is_none(), "job_name must stay unset");
     }
 }

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -407,13 +407,23 @@ fn resolve_srun_env(matches: &ArgMatches, args: &mut SrunArgs) -> Result<()> {
     apply_str(
         matches,
         "partition",
-        &["SPUR_PARTITION", "SLURM_PARTITION"],
+        &[
+            "SPUR_PARTITION",
+            "SPUR_JOB_PARTITION",
+            "SLURM_PARTITION",
+            "SLURM_JOB_PARTITION",
+        ],
         &mut args.partition,
     );
     apply_str(
         matches,
         "account",
-        &["SPUR_ACCOUNT", "SLURM_ACCOUNT"],
+        &[
+            "SPUR_ACCOUNT",
+            "SPUR_JOB_ACCOUNT",
+            "SLURM_ACCOUNT",
+            "SLURM_JOB_ACCOUNT",
+        ],
         &mut args.account,
     );
     apply_num(
@@ -1206,6 +1216,14 @@ mod tests {
 
     #[test]
     #[serial(env_injection)]
+    fn numeric_env_trims_whitespace() {
+        let env = EnvGuard::new();
+        env.set("SLURM_NTASKS", " 4 ");
+        assert_eq!(resolve_from(&["srun", "hostname"]).ntasks, 4);
+    }
+
+    #[test]
+    #[serial(env_injection)]
     fn invalid_numeric_env_errors() {
         let env = EnvGuard::new();
         env.set("SLURM_NNODES", "abc");
@@ -1259,6 +1277,15 @@ mod tests {
     }
 
     #[test]
+    #[serial(env_injection)]
+    fn gres_env_trims_whitespace_and_drops_empties() {
+        let env = EnvGuard::new();
+        env.set("SLURM_GRES", "gpu:1, fpga:2 ,");
+        let args = resolve_from(&["srun", "hostname"]);
+        assert_eq!(args.gres, vec!["gpu:1", "fpga:2"]);
+    }
+
+    #[test]
     fn cli_gres_comma_list_splits_into_multiple() {
         let args = SrunArgs::try_parse_from(["srun", "--gres=gpu:1,fpga:2", "hostname"])
             .expect("parse failed");
@@ -1305,5 +1332,28 @@ mod tests {
         // An explicit CLI value still wins over the inherited allocation env.
         let overridden = resolve_from(&["srun", "-n", "1", "hostname"]);
         assert_eq!(overridden.ntasks, 1);
+    }
+
+    /// Allocation context is exported under the `*_JOB_*` names
+    /// (SLURM_JOB_PARTITION / SLURM_JOB_ACCOUNT), so srun must read those to
+    /// inherit partition/account when run inside a Spur allocation.
+    #[test]
+    #[serial(env_injection)]
+    fn inherits_allocation_partition_and_account() {
+        let env = EnvGuard::new();
+        env.set("SLURM_JOB_PARTITION", "alloc-part");
+        env.set("SLURM_JOB_ACCOUNT", "alloc-acct");
+        let args = resolve_from(&["srun", "hostname"]);
+        assert_eq!(args.partition.as_deref(), Some("alloc-part"));
+        assert_eq!(args.account.as_deref(), Some("alloc-acct"));
+
+        // The direct input var takes precedence over the allocation twin.
+        env.set("SLURM_PARTITION", "input-part");
+        let direct = resolve_from(&["srun", "hostname"]);
+        assert_eq!(direct.partition.as_deref(), Some("input-part"));
+
+        // An explicit CLI value still wins over both.
+        let overridden = resolve_from(&["srun", "-p", "cli-part", "hostname"]);
+        assert_eq!(overridden.partition.as_deref(), Some("cli-part"));
     }
 }

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -1,8 +1,9 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::env_defaults::{apply_csv, apply_flag, apply_num, apply_str, apply_string};
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser};
 use spur_core::config::HooksConfig;
 use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
@@ -50,7 +51,9 @@ pub struct SrunArgs {
     pub time: Option<String>,
 
     /// GRES
-    #[arg(long)]
+    // Slurm semantics: comma-lists expand to multiple GRES; a repeated --gres
+    // replaces rather than accumulates (last wins).
+    #[arg(long, value_delimiter = ',', overrides_with = "gres")]
     pub gres: Vec<String>,
 
     /// Licenses (e.g., "fluent:5", "matlab:1")
@@ -160,7 +163,9 @@ pub async fn main() -> Result<()> {
 }
 
 pub async fn main_with_args(args: Vec<String>) -> Result<()> {
-    let args = SrunArgs::try_parse_from(&args)?;
+    let matches = SrunArgs::command().try_get_matches_from(&args)?;
+    let mut args = SrunArgs::from_arg_matches(&matches)?;
+    resolve_srun_env(&matches, &mut args)?;
 
     if args.command.is_empty() {
         eprintln!("srun: no command specified");
@@ -384,6 +389,163 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         output_streamed,
     )
     .await;
+
+    Ok(())
+}
+
+/// Apply environment-variable defaults to any flag not set on the command
+/// line. srun mirrors real Slurm: most flags read `SLURM_*` (inherited from an
+/// allocation's output vars), a few read genuine `SRUN_*`, and each also
+/// accepts its `SPUR_*` native twin. CLI always overrides env.
+fn resolve_srun_env(matches: &ArgMatches, args: &mut SrunArgs) -> Result<()> {
+    apply_str(
+        matches,
+        "job_name",
+        &["SPUR_JOB_NAME", "SLURM_JOB_NAME"],
+        &mut args.job_name,
+    );
+    apply_str(
+        matches,
+        "partition",
+        &["SPUR_PARTITION", "SLURM_PARTITION"],
+        &mut args.partition,
+    );
+    apply_str(
+        matches,
+        "account",
+        &["SPUR_ACCOUNT", "SLURM_ACCOUNT"],
+        &mut args.account,
+    );
+    apply_num(
+        matches,
+        "nodes",
+        &[
+            "SPUR_NNODES",
+            "SPUR_JOB_NUM_NODES",
+            "SLURM_NNODES",
+            "SLURM_JOB_NUM_NODES",
+        ],
+        &mut args.nodes,
+    )?;
+    apply_num(
+        matches,
+        "ntasks",
+        &["SPUR_NTASKS", "SPUR_NPROCS", "SLURM_NTASKS", "SLURM_NPROCS"],
+        &mut args.ntasks,
+    )?;
+    apply_num(
+        matches,
+        "cpus_per_task",
+        &["SPUR_CPUS_PER_TASK", "SLURM_CPUS_PER_TASK"],
+        &mut args.cpus_per_task,
+    )?;
+    apply_str(
+        matches,
+        "mem",
+        &["SPUR_MEM_PER_NODE", "SLURM_MEM_PER_NODE"],
+        &mut args.mem,
+    );
+    apply_str(
+        matches,
+        "time",
+        &["SPUR_TIMELIMIT", "SLURM_TIMELIMIT"],
+        &mut args.time,
+    );
+    apply_csv(
+        matches,
+        "gres",
+        &["SPUR_GRES", "SLURM_GRES"],
+        &mut args.gres,
+    );
+    apply_str(
+        matches,
+        "gpus",
+        &["SPUR_GPUS", "SLURM_GPUS"],
+        &mut args.gpus,
+    );
+    apply_str(
+        matches,
+        "chdir",
+        &[
+            "SPUR_REMOTE_CWD",
+            "SPUR_WORKING_DIR",
+            "SLURM_REMOTE_CWD",
+            "SLURM_WORKING_DIR",
+        ],
+        &mut args.chdir,
+    );
+    apply_str(
+        matches,
+        "cpu_bind",
+        &["SPUR_CPU_BIND", "SLURM_CPU_BIND"],
+        &mut args.cpu_bind,
+    );
+    apply_str(
+        matches,
+        "gpu_bind",
+        &["SPUR_GPU_BIND", "SLURM_GPU_BIND"],
+        &mut args.gpu_bind,
+    );
+    apply_str(
+        matches,
+        "constraint",
+        &["SPUR_CONSTRAINT", "SLURM_CONSTRAINT"],
+        &mut args.constraint,
+    );
+    apply_str(
+        matches,
+        "reservation",
+        &["SPUR_RESERVATION", "SLURM_RESERVATION"],
+        &mut args.reservation,
+    );
+    apply_string(
+        matches,
+        "mpi",
+        &["SPUR_MPI_TYPE", "SLURM_MPI_TYPE"],
+        &mut args.mpi,
+    );
+    apply_flag(
+        matches,
+        "label",
+        &["SPUR_LABELIO", "SLURM_LABELIO"],
+        &mut args.label,
+    );
+    apply_str(
+        matches,
+        "output",
+        &["SPUR_OUTPUT", "SRUN_OUTPUT"],
+        &mut args.output,
+    );
+    apply_str(
+        matches,
+        "error",
+        &["SPUR_ERROR", "SRUN_ERROR"],
+        &mut args.error,
+    );
+    apply_str(
+        matches,
+        "input",
+        &["SPUR_INPUT", "SRUN_INPUT"],
+        &mut args.input,
+    );
+    apply_str(
+        matches,
+        "container_image",
+        &["SPUR_CONTAINER", "SRUN_CONTAINER"],
+        &mut args.container_image,
+    );
+    apply_str(
+        matches,
+        "prolog",
+        &["SPUR_PROLOG", "SLURM_PROLOG"],
+        &mut args.prolog,
+    );
+    apply_str(
+        matches,
+        "epilog",
+        &["SPUR_EPILOG", "SLURM_EPILOG"],
+        &mut args.epilog,
+    );
 
     Ok(())
 }
@@ -958,5 +1120,190 @@ mod tests {
     #[test]
     fn build_command_script_preserves_quotes_in_arg() {
         assert_script_round_trips(&["echo", "it's a \"test\""]);
+    }
+
+    // These tests mutate process-global env vars, so they run serially and use
+    // the shared EnvGuard, which clears every SPUR_/SLURM_/SALLOC_/SRUN_-prefixed
+    // var on construction and drop, keeping them independent of the runner's
+    // environment (which may inject SLURM_* vars) and of each other.
+    use crate::env_defaults::EnvGuard;
+    use serial_test::serial;
+
+    /// Run the real matches-parse + env-resolve pipeline used by `main_with_args`.
+    fn resolve_from(cli: &[&str]) -> SrunArgs {
+        let matches = SrunArgs::command()
+            .try_get_matches_from(cli)
+            .expect("parse failed");
+        let mut args = SrunArgs::from_arg_matches(&matches).expect("from_arg_matches failed");
+        resolve_srun_env(&matches, &mut args).expect("resolve failed");
+        args
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn env_provides_default() {
+        let env = EnvGuard::new();
+        env.set("SLURM_PARTITION", "gpu");
+        let args = resolve_from(&["srun", "hostname"]);
+        assert_eq!(args.partition.as_deref(), Some("gpu"));
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn cli_overrides_env() {
+        let env = EnvGuard::new();
+        env.set("SLURM_PARTITION", "gpu");
+        let args = resolve_from(&["srun", "--partition=cpu", "hostname"]);
+        assert_eq!(args.partition.as_deref(), Some("cpu"));
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn spur_native_alias_works() {
+        let env = EnvGuard::new();
+        env.set("SPUR_PARTITION", "spur-part");
+        let args = resolve_from(&["srun", "hostname"]);
+        assert_eq!(args.partition.as_deref(), Some("spur-part"));
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn spur_alias_precedes_slurm_twin() {
+        let env = EnvGuard::new();
+        env.set("SPUR_PARTITION", "from-spur");
+        env.set("SLURM_PARTITION", "from-slurm");
+        let args = resolve_from(&["srun", "hostname"]);
+        assert_eq!(args.partition.as_deref(), Some("from-spur"));
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn nodes_alias_fallback_and_precedence() {
+        let env = EnvGuard::new();
+        env.set("SLURM_JOB_NUM_NODES", "3");
+        assert_eq!(resolve_from(&["srun", "hostname"]).nodes, 3);
+
+        // SLURM_NNODES is listed before SLURM_JOB_NUM_NODES, so it wins.
+        env.set("SLURM_NNODES", "5");
+        assert_eq!(resolve_from(&["srun", "hostname"]).nodes, 5);
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn ntasks_nprocs_fallback() {
+        let env = EnvGuard::new();
+        env.set("SLURM_NPROCS", "7");
+        assert_eq!(resolve_from(&["srun", "hostname"]).ntasks, 7);
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn numeric_env_parsed() {
+        let env = EnvGuard::new();
+        env.set("SLURM_NNODES", "4");
+        assert_eq!(resolve_from(&["srun", "hostname"]).nodes, 4);
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn invalid_numeric_env_errors() {
+        let env = EnvGuard::new();
+        env.set("SLURM_NNODES", "abc");
+        let matches = SrunArgs::command()
+            .try_get_matches_from(["srun", "hostname"])
+            .expect("parse failed");
+        let mut args = SrunArgs::from_arg_matches(&matches).expect("from_arg_matches failed");
+        assert!(resolve_srun_env(&matches, &mut args).is_err());
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn genuine_srun_vars() {
+        let env = EnvGuard::new();
+        env.set("SRUN_OUTPUT", "out-%j.log");
+        env.set("SRUN_ERROR", "err-%j.log");
+        env.set("SRUN_INPUT", "/dev/null");
+        env.set("SRUN_CONTAINER", "img.sqsh");
+        let args = resolve_from(&["srun", "hostname"]);
+        assert_eq!(args.output.as_deref(), Some("out-%j.log"));
+        assert_eq!(args.error.as_deref(), Some("err-%j.log"));
+        assert_eq!(args.input.as_deref(), Some("/dev/null"));
+        assert_eq!(args.container_image.as_deref(), Some("img.sqsh"));
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn label_flag_semantics() {
+        let env = EnvGuard::new();
+
+        env.set("SLURM_LABELIO", "yes");
+        assert!(resolve_from(&["srun", "hostname"]).label);
+
+        env.set("SLURM_LABELIO", "1");
+        assert!(resolve_from(&["srun", "hostname"]).label);
+
+        env.set("SLURM_LABELIO", "0");
+        assert!(!resolve_from(&["srun", "hostname"]).label);
+
+        env.set("SLURM_LABELIO", "maybe");
+        assert!(!resolve_from(&["srun", "hostname"]).label);
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn gres_comma_split() {
+        let env = EnvGuard::new();
+        env.set("SLURM_GRES", "gpu:1,fpga:2");
+        let args = resolve_from(&["srun", "hostname"]);
+        assert_eq!(args.gres, vec!["gpu:1", "fpga:2"]);
+    }
+
+    #[test]
+    fn cli_gres_comma_list_splits_into_multiple() {
+        let args = SrunArgs::try_parse_from(["srun", "--gres=gpu:1,fpga:2", "hostname"])
+            .expect("parse failed");
+        assert_eq!(args.gres, vec!["gpu:1", "fpga:2"]);
+    }
+
+    #[test]
+    fn cli_repeated_gres_last_wins() {
+        let args = SrunArgs::try_parse_from(["srun", "--gres=gpu:1", "--gres=fpga:2", "hostname"])
+            .expect("parse failed");
+        assert_eq!(args.gres, vec!["fpga:2"]);
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn defaults_unchanged_without_env() {
+        let _env = EnvGuard::new();
+        let args = resolve_from(&["srun", "hostname"]);
+        assert_eq!(args.nodes, 1);
+        assert_eq!(args.ntasks, 1);
+        assert_eq!(args.cpus_per_task, 1);
+        assert!(args.partition.is_none());
+        assert_eq!(args.mpi, "none");
+        assert!(!args.label);
+    }
+
+    /// srun launched inside an allocation inherits the allocation's task and
+    /// CPU counts: salloc/sbatch export SLURM_NTASKS and SLURM_CPUS_PER_TASK,
+    /// and srun reads them as defaults (matching Slurm). This is what feeds
+    /// `create_job_step` in step mode, so the step sizes to the allocation
+    /// rather than the bare `-n 1 -c 1` defaults.
+    #[test]
+    #[serial(env_injection)]
+    fn inherits_allocation_task_and_cpu_counts() {
+        let env = EnvGuard::new();
+        env.set("SLURM_NTASKS", "4");
+        env.set("SLURM_CPUS_PER_TASK", "2");
+        env.set("SLURM_JOB_NUM_NODES", "3");
+        let args = resolve_from(&["srun", "hostname"]);
+        assert_eq!(args.ntasks, 4);
+        assert_eq!(args.cpus_per_task, 2);
+        assert_eq!(args.nodes, 3);
+
+        // An explicit CLI value still wins over the inherited allocation env.
+        let overridden = resolve_from(&["srun", "-n", "1", "hostname"]);
+        assert_eq!(overridden.ntasks, 1);
     }
 }

--- a/crates/spur-core/src/resource.rs
+++ b/crates/spur-core/src/resource.rs
@@ -294,7 +294,15 @@ impl ResourceSet {
 }
 
 /// Parse a GRES string like "gpu:mi300x:4" or "gpu:2".
+///
+/// The input is trimmed and empty strings are rejected, so callers that split a
+/// comma-list (CLI `--gres`, `SLURM_GRES`, REST, FFI) can pass raw segments
+/// without worrying about incidental whitespace or trailing commas.
 pub fn parse_gres(gres: &str) -> Option<(String, Option<String>, u32)> {
+    let gres = gres.trim();
+    if gres.is_empty() {
+        return None;
+    }
     let parts: Vec<&str> = gres.split(':').collect();
     match parts.len() {
         1 => Some((parts[0].to_string(), None, 1)),
@@ -600,5 +608,12 @@ mod tests {
         );
         assert_eq!(parse_gres("gpu:2"), Some(("gpu".into(), None, 2)));
         assert_eq!(parse_gres("license"), Some(("license".into(), None, 1)));
+    }
+
+    #[test]
+    fn test_parse_gres_trims_and_rejects_empty() {
+        assert_eq!(parse_gres(" gpu:2 "), Some(("gpu".into(), None, 2)));
+        assert_eq!(parse_gres(""), None);
+        assert_eq!(parse_gres("   "), None);
     }
 }


### PR DESCRIPTION
…and salloc

## Summary

Adds environment-variable defaults for `srun` and `salloc`, aligning Spur with Slurm's precedence model (closes #279). Also fixes `--gres` CLI parsing to match Slurm semantics.

Precedence for every affected flag is now: **CLI arg > `SPUR_*` native twin > `SLURM_*`/`SRUN_*`/`SALLOC_*` > built-in default**.

## What changed

- **New shared helper module (`env_defaults.rs`)** — `apply_str`/`apply_string`/`apply_flag`/`apply_csv` resolve multi-alias env vars with correct CLI precedence, detected via `ArgMatches::value_source`. Includes a shared `EnvGuard` test fixture and unit tests.
- **`srun`** — parses into `ArgMatches`, then applies `SLURM_*` (plus genuine `SRUN_*` where Slurm uses them) and `SPUR_*` twins as defaults. This lets `srun` inside an allocation inherit `SLURM_NTASKS`/`SLURM_CPUS_PER_TASK`/`SLURM_NNODES`, so a step sizes to the allocation instead of the bare `-n1 -c1` defaults.
- **`salloc`** — same pattern for `SALLOC_*`/`SPUR_*`. Stays Slurm-faithful: `--nodes`, `--ntasks`, `--cpus-per-task`, and `--job-name` have **no** env var in real Slurm, so Spur ignores them too.
- **`--gres` fix (`srun` + `salloc`)** — added `value_delimiter = ','` + `overrides_with = "gres"` so a comma-list (`--gres=gpu:1,fpga:2`) expands to multiple GRES and a repeated `--gres` replaces (last wins), matching Slurm and Spur's own `sbatch`. Previously the CLI kept comma-lists as one un-parseable element and accumulated repeated flags.

## Design notes

- Clap's `#[arg(env=...)]` supports only one env var per flag, so multi-alias resolution is done in a post-parse step keyed off `value_source` (keeps CLI-set detection accurate even with `overrides_with`).
- Env-dependent tests run serially (`serial_test`) and use `EnvGuard`, which clears all `SPUR_/SLURM_/SALLOC_/SRUN_`-prefixed vars on construction/drop, keeping them independent of the runner's environment and of each other.

## Testing

- `cargo clippy -p spur-cli --all-targets` — clean.
- `cargo test -p spur-cli` — all 151 tests pass (new unit tests cover defaults, CLI override, alias precedence, numeric/bool/CSV parsing, gres comma-split, and last-wins).
- **Bare-metal cluster e2e** (3 nodes, non-Raft): verified on the deployed binaries:
  - `salloc`: `SALLOC_PARTITION` env default applied; CLI `-p` overrides it.
  - `srun`: `SLURM_NTASKS` env default applied to submitted job; CLI `-n` overrides it; `SPUR_NTASKS` takes precedence over the `SLURM_NTASKS` twin.

## Known gap / follow-up 

sbatch still resolves env defaults via clap's single SBATCH_* attribute per flag and does not yet honor SPUR_* twins (e.g. SPUR_PARTITION), unlike srun/salloc. Unifying sbatch onto env_defaults is deferred to a follow-up PR since it must preserve sbatch's CLI > env > #SBATCH directive precedence.