### PR TITLE
feat(examples): add gpu-k8s-arc-sglang GPU Kubernetes deployment example

### DIFF
--- a/examples/gpu-k8s-arc-sglang/00-network/README.md
+++ b/examples/gpu-k8s-arc-sglang/00-network/README.md
@@ -1,0 +1,53 @@
+# 00-network — WireGuard mesh + host prerequisites (plan M0)
+
+The k0s cluster addresses nodes over the SPUR `spur0` mesh (10.44.0.0/16). Bring the mesh up before
+`k0sctl apply`. On this cluster all M0 gates must pass (gfx950 workers, flat routed underlay,
+direct egress) — record the results in `../RUNBOOK.md`.
+
+## Mesh (SPUR)
+
+```bash
+# Head:
+sudo spur net init --cidr 10.44.0.0/16 --port 51820        # head gets spur0 = 10.44.0.1
+# Each worker (map: gpu-node-1..4 -> 10.44.0.2..5):
+sudo spur net join --endpoint <head-underlay-ip>:51820 --server-key <pub> --address 10.44.0.<N>
+# Head registers each worker (full mesh: repeat so every worker peers every other):
+sudo spur net add-peer --key <node-pub> --allowed-ip 10.44.0.<N>/32 --endpoint <node-underlay-ip>:51820
+```
+
+## Pod routing over the mesh (Calico `bird`, no second overlay)
+
+We run Calico in BGP native-routing mode (`../10-cluster/k0sctl.yaml`), so pod traffic rides the
+WireGuard mesh directly — no VXLAN-on-WireGuard. For that, the mesh must **route pod CIDRs**, not
+just node IPs:
+
+1. Give each node a **deterministic pod /24** — kube-controller-manager `--allocate-node-cidrs`
+   populates `node.spec.podCIDR` (e.g. gpu-node-1 → 10.42.1.0/24 … gpu-node-4 → 10.42.4.0/24).
+2. Program that pod /24 into the node's WireGuard peer **AllowedIPs** (alongside its `/32` mesh IP),
+   on every peer (full mesh), so WireGuard forwards the raw pod packets Calico routes:
+   ```bash
+   sudo spur net add-peer --key <node-pub> \
+     --allowed-ip 10.44.0.<N>/32,10.42.<N>.0/24 --endpoint <node-underlay-ip>:51820
+   ```
+   Multi-CIDR AllowedIPs is the **spur-net enhancement** on the plan's gap list. Until `spur net`
+   emits it, add the pod-CIDR AllowedIPs + route by hand (`wg set … allowed-ips …` + `ip route add
+   10.42.<N>.0/24 dev spur0`), or switch to the VXLAN fallback in `k0sctl.yaml` (no mesh change).
+
+Calico BGP distributes the pod-CIDR *routes*; WireGuard AllowedIPs is what *permits* the traffic on
+the wire — both are required.
+
+## Host prerequisites (every node)
+
+```bash
+# Firewall: allow intra-mesh k8s ports on spur0 (firewalld/ufw block by default)
+#   6443/tcp (apiserver) · 10250/tcp (kubelet) · 179/tcp (Calico BGP, bird mode) ·
+#   8132/tcp (k0s konnectivity) · 9443/tcp (k0s API) · 2379-2380/tcp (etcd, HA controllers only)
+#   [VXLAN fallback only: also 4789/udp (Calico VXLAN)]
+# MTU: with bird (no overlay) calico mtu ~= spur0 MTU; with the VXLAN fallback use spur0-50.
+#   Set it in ../10-cluster/k0sctl.yaml.
+ip link show spur0
+# Pod egress (only if a node lacks its own egress — here all nodes have direct egress, so usually skip):
+#   sudo iptables -t nat -A POSTROUTING -s 10.42.0.0/16 -o <uplink> -j MASQUERADE
+```
+
+Log each command actually run into `../RUNBOOK.md`.

--- a/examples/gpu-k8s-arc-sglang/10-cluster/k0sctl.yaml
+++ b/examples/gpu-k8s-arc-sglang/10-cluster/k0sctl.yaml
@@ -1,0 +1,70 @@
+# k0s cluster definition — the single declarative source of truth for the control/worker layout.
+# Bring up / upgrade with:  k0sctl apply --config k0sctl.yaml
+# Get kubeconfig with:      k0sctl kubeconfig --config k0sctl.yaml > ../kubeconfig
+#
+# Node addressing model (mesh-first, SPUR-native):
+#   - ssh.address       = UNDERLAY ip (how k0sctl reaches the box; real IPs kept out of git — fill locally)
+#   - privateAddress    = spur0 MESH ip (what k8s uses as the node InternalIP)
+#   - --node-ip         = same mesh ip, so kubelet + calico advertise over the encrypted mesh
+# If you defer the WireGuard mesh (00-network), set privateAddress/--node-ip to the underlay ip instead;
+# the flat routed underlay works directly (see plan §1 note).
+apiVersion: k0sctl.k0sproject.io/v1beta1
+kind: Cluster
+metadata:
+  name: spur-mi355x
+spec:
+  hosts:
+    - role: controller                       # head-node (CPU-only) — control plane only, no kubelet/workloads
+      ssh: { address: HEAD_UNDERLAY_IP, user: LOGIN, keyPath: ~/.ssh/id_ed25519 }
+      privateAddress: 10.44.0.1
+
+    - role: worker                           # gpu-node-1 — 8x MI355X (gfx950)
+      ssh: { address: GPU1_UNDERLAY_IP, user: LOGIN, keyPath: ~/.ssh/id_ed25519 }
+      privateAddress: 10.44.0.2
+      installFlags: ["--kubelet-extra-args=--node-ip=10.44.0.2"]
+    - role: worker                           # gpu-node-2
+      ssh: { address: GPU2_UNDERLAY_IP, user: LOGIN, keyPath: ~/.ssh/id_ed25519 }
+      privateAddress: 10.44.0.3
+      installFlags: ["--kubelet-extra-args=--node-ip=10.44.0.3"]
+    - role: worker                           # gpu-node-3
+      ssh: { address: GPU3_UNDERLAY_IP, user: LOGIN, keyPath: ~/.ssh/id_ed25519 }
+      privateAddress: 10.44.0.4
+      installFlags: ["--kubelet-extra-args=--node-ip=10.44.0.4"]
+    - role: worker                           # gpu-node-4
+      ssh: { address: GPU4_UNDERLAY_IP, user: LOGIN, keyPath: ~/.ssh/id_ed25519 }
+      privateAddress: 10.44.0.5
+      installFlags: ["--kubelet-extra-args=--node-ip=10.44.0.5"]
+
+  k0s:
+    version: v1.32.4+k0s.0                     # PIN exactly in versions.lock.md (>=1.32 for the AMD DRA path)
+    dynamicConfig: false
+    config:
+      apiVersion: k0s.k0sproject.io/v1beta1
+      kind: ClusterConfig
+      metadata: { name: k0s }
+      spec:
+        network:
+          provider: calico                   # pure-upstream Calico (k0s ships it unmodified); NOT kube-router
+          podCIDR: 10.42.0.0/16              # clear of mesh 10.44.0.0/16
+          serviceCIDR: 10.43.0.0/16
+          calico:
+            mode: bird                         # BGP native routing — NO VXLAN/IPIP overlay: pods route straight
+                                               # over the WireGuard mesh (one overlay, not overlay-on-overlay).
+            wireguard: false                   # spur0 already encrypts; do NOT enable Calico's own WireGuard.
+            ipAutodetectionMethod: "interface=spur0"  # peer BGP + advertise routes over spur0 (real k0s field;
+                                               # Calico's default 'first-found' would wrongly pick the underlay NIC).
+            overlay: Never                     # disable Calico's own encap. NOTE (verified on hw 2026-07-09):
+                                               # k0s `mode: bird` ALONE leaves the IPPool at ipipMode:Always
+                                               # (IPIP-over-WireGuard = a 2nd overlay). If pods still route via
+                                               # tunl0 after install, patch it: `kubectl patch ippool
+                                               # default-ipv4-ippool --type merge -p '{"spec":{"ipipMode":"Never"}}'`.
+            mtu: 1420                          # ~ spur0 MTU (no VXLAN/IPIP header to subtract); DERIVE from real spur0.
+        # REQUIRES the SPUR mesh to CARRY pod CIDRs (see ../00-network): each peer's WireGuard AllowedIPs must
+        # include that node's pod /24, and per-node pod CIDRs must be deterministic (kube-controller-manager
+        # --allocate-node-cidrs -> node.spec.podCIDR). Otherwise BGP advertises routes but WireGuard drops the
+        # raw pod packets. This is the spur-net enhancement (plan gap: pod-CIDR-aware mesh + full mesh).
+        # FALLBACK (works with stock SPUR, no AllowedIPs change, ~50B more MTU) — a self-contained VXLAN overlay:
+        #   calico: { mode: vxlan, overlay: Always, mtu: 1370, ipAutodetectionMethod: "interface=spur0" }
+        # NOTE: k0s kubelet root is /var/lib/k0s/kubelet — device-plugin sockets live in
+        #       /var/lib/k0s/kubelet/device-plugins (see 20-gpu/amd-device-plugin.yaml).
+        telemetry: { enabled: false }

--- a/examples/gpu-k8s-arc-sglang/15-addons/README.md
+++ b/examples/gpu-k8s-arc-sglang/15-addons/README.md
@@ -1,0 +1,49 @@
+# 15-addons — the standard upstream pieces k0s does NOT bundle
+
+k0s ships a bare cluster (no ingress / LB / storage). We add the *documented upstream* components,
+so nothing here is distro-specific magic. Pin every version in `../versions.lock.md`.
+
+## Storage — local-path-provisioner (RWO, node-local)
+
+k8s has no default StorageClass; sglang's HF cache PVC needs one.
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/VERSION/deploy/local-path-storage.yaml
+# make it the cluster default so PVCs without a class bind:
+kubectl patch storageclass local-path \
+  -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+```
+Result: `storageClassName: local-path` (RWO). The serving PVC in `../40-serving` uses it.
+
+## Ingress — ingress-nginx (NodePort, mesh-reachable)
+
+No cloud LB here, so expose the ingress controller as a NodePort reachable over the mesh/underlay.
+
+```bash
+helm install ingress-nginx ingress-nginx \
+  --repo https://kubernetes.github.io/ingress-nginx --version VERSION \
+  -n ingress-nginx --create-namespace \
+  --set controller.service.type=NodePort \
+  --set controller.service.nodePorts.http=30080 \
+  --set controller.service.nodePorts.https=30443 \
+  --set controller.hostNetwork=false
+```
+Reach the served model at `http://<any-node-mesh-or-underlay-ip>:30080` via the Ingress in
+`../40-serving/ingress.yaml`.
+
+## Optional — MetalLB (only if you want real `LoadBalancer` IPs)
+
+Skip unless you have a spare IP range on the node subnet to hand out. If you do:
+```bash
+helm install metallb metallb --repo https://metallb.github.io/metallb -n metallb-system --create-namespace
+# then apply an IPAddressPool + L2Advertisement over your free range.
+```
+With MetalLB present, switch the serving Service to `type: LoadBalancer`. Without it, keep
+ingress-nginx NodePort (the default in this example).
+
+## Optional — metrics-server (kubectl top, HPA)
+
+```bash
+helm install metrics-server metrics-server \
+  --repo https://kubernetes-sigs.github.io/metrics-server -n kube-system --version VERSION
+```

--- a/examples/gpu-k8s-arc-sglang/20-gpu/amd-device-plugin.yaml
+++ b/examples/gpu-k8s-arc-sglang/20-gpu/amd-device-plugin.yaml
@@ -1,0 +1,86 @@
+# AMD GPU device plugin + node-labeller, adapted from github.com/ROCm/k8s-device-plugin for k0s.
+# Device-plugin socket dir is the STANDARD /var/lib/kubelet/device-plugins (verified on hw 2026-07-09:
+# k0s root-dir is /var/lib/k0s/kubelet but the pluginwatcher socket stays at /var/lib/kubelet/device-plugins).
+# Hosts already have the amdgpu kernel driver + ROCm in-box (Ubuntu 24.04 / kernel 6.8), so this is
+# the device-plugin-only path (no driver management / gpu-operator needed).
+# Apply:  kubectl apply -f amd-device-plugin.yaml
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: amdgpu-device-plugin-daemonset
+  namespace: kube-system
+spec:
+  selector: { matchLabels: { name: amdgpu-dp-ds } }
+  template:
+    metadata: { labels: { name: amdgpu-dp-ds } }
+    spec:
+      priorityClassName: system-node-critical
+      tolerations:
+        - { key: CriticalAddonsOnly, operator: Exists }
+      nodeSelector: { spur.amd.com/compute: "true" }   # GPU workers only (set by node-labels.sh)
+      containers:
+        - name: amdgpu-dp-cntr
+          image: rocm/k8s-device-plugin:latest          # PIN by digest in versions.lock.md
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: { drop: ["ALL"] }
+          volumeMounts:
+            - { name: dp, mountPath: /var/lib/kubelet/device-plugins }  # plugin writes its socket here…
+            - { name: sys, mountPath: /sys }
+      volumes:
+        - name: dp
+          hostPath: { path: /var/lib/kubelet/device-plugins }           # VERIFIED on hw: k0s keeps the device-plugin
+                                                                # socket at the STANDARD path (root-dir is /var/lib/k0s/kubelet)
+        - name: sys
+          hostPath: { path: /sys }
+---
+# node-labeller: advertises amd.com/gpu.family / .device-id / .vram etc. so GPU-family nodeSelectors
+# work without hand-labeling. (Upstream: k8s-ds-amdgpu-labeller.yaml)
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: amdgpu-node-labeller
+  namespace: kube-system
+spec:
+  selector: { matchLabels: { name: amdgpu-lbl-ds } }
+  template:
+    metadata: { labels: { name: amdgpu-lbl-ds } }
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccountName: amdgpu-node-labeller
+      nodeSelector: { spur.amd.com/compute: "true" }
+      containers:
+        - name: amdgpu-lbl-cntr
+          image: rocm/k8s-device-plugin:labeller-latest  # PIN by digest
+          command: ["./k8s-node-labeller"]
+          args: ["-family", "-device-id", "-vram", "-compute-partitioning-supported"]
+          securityContext:
+            privileged: true                              # reads /sys sysfs GPU topology
+          env:
+            - name: DS_NODE_NAME
+              valueFrom: { fieldRef: { fieldPath: spec.nodeName } }
+          volumeMounts:
+            - { name: sys, mountPath: /sys }
+      volumes:
+        - name: sys
+          hostPath: { path: /sys }
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: { name: amdgpu-node-labeller, namespace: kube-system }
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: { name: amdgpu-node-labeller }
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: { name: amdgpu-node-labeller }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: amdgpu-node-labeller }
+subjects:
+  - { kind: ServiceAccount, name: amdgpu-node-labeller, namespace: kube-system }

--- a/examples/gpu-k8s-arc-sglang/20-gpu/node-labels.sh
+++ b/examples/gpu-k8s-arc-sglang/20-gpu/node-labels.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Label nodes so the device plugin + ARC runners + serving pods land only on GPU workers.
+# Idempotent (--overwrite). Run once after the cluster is Ready (kubeconfig at the example root, ../kubeconfig).
+set -euo pipefail
+export KUBECONFIG="${KUBECONFIG:-$(dirname "$0")/../kubeconfig}"
+
+# GPU workers (k0s: control-plane node has no kubelet, so only workers appear).
+for n in $(kubectl get nodes -o name | sed 's|node/||'); do
+  # Heuristic: any node reporting amd.com/gpu is a GPU worker. Adjust if you label by hostname.
+  if kubectl get node "$n" -o jsonpath='{.status.allocatable.amd\.com/gpu}' 2>/dev/null | grep -qE '^[1-9]'; then
+    kubectl label node "$n" spur.amd.com/compute=true --overwrite
+    echo "labelled $n spur.amd.com/compute=true"
+  fi
+done
+
+# Chicken-and-egg: the device plugin needs the label before it advertises amd.com/gpu.
+# First run, label GPU workers explicitly by name instead (edit the list):
+#   for n in gpu-node-1 gpu-node-2 gpu-node-3 gpu-node-4; do
+#     kubectl label node "$n" spur.amd.com/compute=true --overwrite
+#   done

--- a/examples/gpu-k8s-arc-sglang/30-arc/Dockerfile.runner
+++ b/examples/gpu-k8s-arc-sglang/30-arc/Dockerfile.runner
@@ -1,0 +1,31 @@
+# ROCm-capable GitHub Actions runner image for the sglang fork CI.
+# Stock ghcr.io/actions/actions-runner has no ROCm, docker CLI, or kubectl.
+# Build + push:
+#   docker build -t ghcr.io/powderluv/sglang-runner:rocm -f Dockerfile.runner .
+#   docker push ghcr.io/powderluv/sglang-runner:rocm      # record the digest in versions.lock.md
+FROM ghcr.io/actions/actions-runner:latest
+USER root
+
+# docker CLI (talks to the dind sidecar), kubectl (used by the CPU deploy scale set), ROCm userspace.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      docker.io curl ca-certificates gnupg python3 python3-pip python3-venv \
+      libdrm-amdgpu1 libdrm2 libnuma1 pciutils && \
+    curl -fsSL https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl \
+      -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl && \
+    # Full ROCm release for gfx950 from TheRock's multi-arch nightly index. This installs the
+    # ROCm CLI tools (rocm-smi, amd-smi, rocminfo, rocprofiler, ...) as shims in /usr/local/bin,
+    # so the CI's ensure_vram_clear (rocm-smi) + arch assertion (rocminfo -> gfx950) run natively
+    # on the runner host. rocm-sdk-device-gfx950 pinned explicitly (workaround for TheRock #5347,
+    # where the `rocm` meta-package's device-* extra can be missing from published metadata).
+    pip install --break-system-packages --no-cache-dir \
+      --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+      "rocm[libraries,device-gfx950]" rocm-sdk-device-gfx950 && \
+    # rocm-smi dlopen()s the UNVERSIONED libdrm_amdgpu.so; libdrm-amdgpu1 ships only the .so.1
+    # (the unversioned symlink normally comes from -dev). Without this, rocm-smi can't read GPU
+    # names/VRAM ("Fail to open libdrm_amdgpu.so") and ensure_vram_clear degrades.
+    ln -sf libdrm_amdgpu.so.1 /usr/lib/x86_64-linux-gnu/libdrm_amdgpu.so && ldconfig && \
+    (getent group render || groupadd render) && (getent group video || groupadd video) && \
+    usermod -aG docker,video,render runner && \
+    rm -rf /var/lib/apt/lists/*
+
+USER runner

--- a/examples/gpu-k8s-arc-sglang/30-arc/cpu-deploy-values.yaml
+++ b/examples/gpu-k8s-arc-sglang/30-arc/cpu-deploy-values.yaml
@@ -1,0 +1,23 @@
+# Non-GPU runner scale set for the gated `kubectl apply` deploy job.
+# Runs on a GPU worker (only workers have a kubelet on k0s) but requests NO amd.com/gpu, so it never
+# consumes or queues behind a GPU. Uses an in-cluster ServiceAccount with RBAC into the sglang ns
+# (see ../40-serving/rbac-deployer.yaml). No dind needed -> default containerMode.
+#   helm install linux-cpu-deploy -n arc-runners -f cpu-deploy-values.yaml \
+#     oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set   # PIN --version
+githubConfigUrl: https://github.com/powderluv/sglang
+githubConfigSecret: sglang-arc-app
+runnerScaleSetName: linux-cpu-deploy               # == deploy job's runs-on
+minRunners: 0
+maxRunners: 1
+
+template:
+  spec:
+    nodeSelector: { spur.amd.com/compute: "true" }  # schedule on a worker (only workers run a kubelet)
+    serviceAccountName: sglang-deployer            # SA lives in arc-runners; RoleBinding in sglang ns
+    automountServiceAccountToken: true
+    containers:
+      - name: runner
+        image: ghcr.io/powderluv/sglang-runner:rocm   # same local image (Never); has kubectl baked in
+        imagePullPolicy: Never                        # built + imported to containerd on each node (no ghcr pull)
+        command: ["/home/runner/run.sh"]
+        # no resources.limits.amd.com/gpu  -> schedules without holding a GPU

--- a/examples/gpu-k8s-arc-sglang/30-arc/github-app-secret.example.yaml
+++ b/examples/gpu-k8s-arc-sglang/30-arc/github-app-secret.example.yaml
@@ -1,0 +1,15 @@
+# TEMPLATE ONLY — do not commit real values. Prefer sealed-secrets or SOPS for the actual secret.
+# The private key is the .pem downloaded when you generated a key for the GitHub App.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sglang-arc-app
+  namespace: arc-runners
+type: Opaque
+stringData:
+  github_app_id: "<APP_ID>"
+  github_app_installation_id: "<INSTALLATION_ID>"
+  # Paste the entire PEM private key here — the full contents of
+  # sglang-app.private-key.pem, INCLUDING its own BEGIN/END PEM lines.
+  github_app_private_key: |
+    <PASTE-FULL-PEM-PRIVATE-KEY-HERE>

--- a/examples/gpu-k8s-arc-sglang/30-arc/github-app-setup.md
+++ b/examples/gpu-k8s-arc-sglang/30-arc/github-app-setup.md
@@ -1,0 +1,48 @@
+# GitHub App setup for ARC (repository scope → powderluv/sglang)
+
+ARC (the `gha-runner-scale-set` model) authenticates to GitHub with a GitHub App.
+Create the App (UI flow — can't be fully API-automated). Consume the three resulting
+values (App ID, Installation ID, private key) to create the k8s secret.
+
+## 1. Create the App
+1. Go to **https://github.com/settings/apps** → **New GitHub App** (creates it under your `powderluv` account).
+2. **GitHub App name:** anything globally-unique, e.g. `arc-sglang-powderluv`.
+3. **Homepage URL:** anything, e.g. `https://github.com/powderluv/sglang`.
+4. **Webhook:** **uncheck "Active"** — ARC's scale-set listener long-polls, it does not need a webhook.
+5. **Permissions → Repository permissions:**
+   - **Administration: Read and write**  ← required for repo-scope runner registration
+   - **Metadata: Read-only**  ← auto-selected/mandatory
+   - *(optional, harmless)* Actions: Read-only
+   - Leave everything else "No access".
+6. **Where can this GitHub App be installed?** → **Only on this account**.
+7. Click **Create GitHub App**.
+
+## 2. Grab the App ID + private key
+- On the App's page, note the **App ID** (a number near the top).
+- Scroll to **Private keys** → **Generate a private key** → a `.pem` downloads. Keep it safe.
+
+## 3. Install the App on the fork
+1. On the App's page → **Install App** (left sidebar) → **Install** on your `powderluv` account.
+2. Choose **Only select repositories** → select **`powderluv/sglang`** → **Install**.
+3. After installing, the browser URL is `https://github.com/settings/installations/<INSTALLATION_ID>` —
+   note that **Installation ID** (a number). (Or fetch it via the API once it's installed.)
+
+## 4. Provide the three values securely
+- **App ID** and **Installation ID**: record the numbers (they're not secret).
+- **Private key**: **do NOT paste it in chat.** Save the `.pem` into the workspace at:
+  ```
+  ./sglang-app.private-key.pem
+  ```
+  Then create the k8s secret `sglang-arc-app` (keys `github_app_id`,
+  `github_app_installation_id`, `github_app_private_key`) in the `arc-runners` namespace, and
+  delete the key file. (It's gitignored so it can't be committed.)
+
+## Next steps
+```
+kubectl -n arc-runners create secret generic sglang-arc-app \
+  --from-literal=github_app_id=<APP_ID> \
+  --from-literal=github_app_installation_id=<INSTALL_ID> \
+  --from-file=github_app_private_key=./sglang-app.private-key.pem
+helm install arc ...gha-runner-scale-set-controller       # ARC controller
+helm install linux-mi35x-gpu-1 -f runner-scale-set-values.yaml ...gha-runner-scale-set   # GPU runners
+```

--- a/examples/gpu-k8s-arc-sglang/30-arc/install.md
+++ b/examples/gpu-k8s-arc-sglang/30-arc/install.md
@@ -1,0 +1,53 @@
+# 30-arc — install order (ARC controller → GitHub App secret → runner scale sets)
+
+Pin every chart version in `../versions.lock.md`. Uninstall in REVERSE order (scale sets before
+controller) or finalizers hang — see `../teardown.sh`.
+
+## 1. Controller (once per cluster)
+
+```bash
+helm install arc -n arc-systems --create-namespace \
+  oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller   # --version PIN
+kubectl -n arc-systems rollout status deploy/arc-gha-rs-controller
+```
+
+## 2. GitHub App secret + image pull secret (namespace arc-runners)
+
+```bash
+kubectl create ns arc-runners
+# GitHub App creds (see github-app-secret.example.yaml; prefer sealed-secrets/SOPS over kubectl create):
+kubectl -n arc-runners create secret generic sglang-arc-app \
+  --from-literal=github_app_id=<APP_ID> \
+  --from-literal=github_app_installation_id=<INSTALL_ID> \
+  --from-file=github_app_private_key=./sglang-app.private-key.pem
+# GHCR pull secret for the runner image:
+kubectl -n arc-runners create secret docker-registry ghcr-pull \
+  --docker-server=ghcr.io --docker-username=<gh-user> --docker-password=<gh-PAT-with-read:packages>
+```
+
+## 3. GPU runner scale set (the sglang CI runners)
+
+```bash
+helm install linux-mi35x-gpu-1 -n arc-runners -f runner-scale-set-values.yaml \
+  oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set              # --version PIN
+```
+
+## 4. CPU deploy scale set (runs `kubectl apply`, no GPU)
+
+```bash
+helm install linux-cpu-deploy -n arc-runners -f cpu-deploy-values.yaml \
+  oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set              # --version PIN
+```
+
+## Verify
+
+```bash
+kubectl -n arc-systems get pods                 # controller Running
+kubectl -n arc-runners get pods                 # AutoscalingListener(s) Running
+# In the fork: Settings → Actions → Runner scale sets shows linux-mi35x-gpu-1 and linux-cpu-deploy.
+```
+
+## GitHub App permissions (validate against current ARC docs at install time)
+
+Repository permissions: **Actions: Read**, **Administration: Read & write**, **Metadata: Read**.
+Install the App on `powderluv/sglang` only. Record App ID + Installation ID.

--- a/examples/gpu-k8s-arc-sglang/30-arc/runner-scale-set-values.yaml
+++ b/examples/gpu-k8s-arc-sglang/30-arc/runner-scale-set-values.yaml
@@ -1,0 +1,90 @@
+# GPU runner scale set for github.com/powderluv/sglang.
+# Install (AFTER the controller — see install.md):
+#   helm install linux-mi35x-gpu-1 -n arc-runners -f runner-scale-set-values.yaml \
+#     oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set   # PIN --version
+#
+# containerMode is INTENTIONALLY UNSET. ARC locks its auto-injected dind sidecar when containerMode
+# is set, so you cannot give it /dev/kfd. sglang's amd_ci_start_container.sh runs
+# `docker run --device=/dev/kfd --device=/dev/dri ...` against the dind daemon, so the devices must
+# live in the dind CONTAINER. We therefore hand-author the full pod spec below.
+githubConfigUrl: https://github.com/powderluv/sglang
+githubConfigSecret: sglang-arc-app                 # created from github-app-secret.example.yaml
+runnerScaleSetName: linux-mi35x-gpu-1              # MUST match ^linux-(mi[0-9]+[a-z]*)-gpu-[0-9]+
+                                                   #   (sglang scripts parse arch from the pod hostname)
+                                                   #   -> gfx950 detected as mi35x. Also == workflow runs-on.
+minRunners: 0
+maxRunners: 4                                       # <= number of GPU workers; 1 GPU each
+
+template:
+  metadata:
+    annotations:
+      # sglang's amd_ci_start_container.sh does `DEVICE_FLAG=$(cat /etc/podinfo/gha-render-devices)`
+      # when the file EXISTS (the downwardAPI mount always creates it), and only falls back to
+      # `--device /dev/dri` when the file is ABSENT. An empty value therefore collapses to NO
+      # /dev/dri at all -> ci_sglang sees /dev/kfd but no render node -> rocminfo finds no GPU.
+      # Interim: pass all render nodes (`--device /dev/dri`); safe while maxRunners <= GPUs/node.
+      # The device-plugin/CDI work (plan M2/M9) later replaces this with the allocated renderD(s).
+      spur.amd.com/render-devices: "--device /dev/dri"
+  spec:
+    nodeSelector: { spur.amd.com/compute: "true" }
+    # The sglang-runner:rocm image is built on each node and imported into containerd (k8s.io ns),
+    # so its pull is disabled (imagePullPolicy: Never below). To distribute via a registry instead,
+    # push it to ghcr and switch to imagePullPolicy: IfNotPresent + imagePullSecrets: [{name: ghcr-pull}].
+    initContainers:
+      - name: init-dind-externals
+        image: ghcr.io/powderluv/sglang-runner:rocm
+        imagePullPolicy: Never
+        command: ["cp", "-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
+        volumeMounts: [{ name: dind-externals, mountPath: /home/runner/tmpDir }]
+    containers:
+      - name: runner
+        image: ghcr.io/powderluv/sglang-runner:rocm      # PIN by digest in versions.lock.md
+        imagePullPolicy: Never                            # built + imported to containerd on each node
+        command: ["/home/runner/run.sh"]
+        env:
+          - { name: DOCKER_HOST, value: unix:///run/docker/docker.sock }
+        resources:
+          limits: { amd.com/gpu: 1 }                       # one MI355X per runner
+        securityContext: { privileged: true }
+        volumeMounts:
+          - { name: dind-sock, mountPath: /run/docker }
+          - { name: work, mountPath: /home/runner/_work }   # shared checkout — dind must see $GITHUB_WORKSPACE
+          - { name: podinfo, mountPath: /etc/podinfo }      # per-runner GPU pinning (below)
+      - name: dind
+        image: docker:dind                                  # PIN by digest
+        securityContext: { privileged: true }
+        env:
+          - { name: DOCKER_GROUP_GID, value: "123" }        # docker GID baked into the actions-runner base image
+          - name: POD_NAME                                  # names the per-pod dind graph subdir below
+            valueFrom: { fieldRef: { fieldPath: metadata.name } }
+        args: ["dockerd", "--host=unix:///run/docker/docker.sock", "--group=$(DOCKER_GROUP_GID)"]
+        volumeMounts:
+          - { name: dind-sock, mountPath: /run/docker }
+          - { name: work, mountPath: /home/runner/_work }   # shared checkout with the runner container
+          - { name: dind-externals, mountPath: /home/runner/externals }
+          # dockerd's image/layer store. MUST live on the node scratch disk, NOT the small root filesystem:
+          # the mi35x sglang image is tens of GB and filled ephemeral-storage -> NodeHasDiskPressure
+          # -> the runner pod was Evicted mid-pull ("runner lost communication"). subPathExpr gives
+          # each ephemeral runner its own data-root (concurrent dockerds must not share one).
+          - { name: dind-graph, mountPath: /var/lib/docker, subPathExpr: $(POD_NAME) }
+          - { name: dev-kfd, mountPath: /dev/kfd }          # <-- devices INTO the dind daemon
+          - { name: dev-dri, mountPath: /dev/dri }
+    volumes:
+      - { name: dind-sock, emptyDir: {} }
+      - { name: dind-externals, emptyDir: {} }
+      - { name: work, emptyDir: {} }
+      - { name: dev-kfd, hostPath: { path: /dev/kfd, type: CharDevice } }
+      - { name: dev-dri, hostPath: { path: /dev/dri, type: Directory } }
+      # dind image/layer store on the node scratch disk at /mnt/scratch (NOT the small root filesystem).
+      # DirectoryOrCreate makes the base dir; kubelet creates the per-pod subPathExpr subdir.
+      # NOTE: hostPath subdirs are not GC'd on pod delete — prune /mnt/scratch/sglang-dind/* periodically.
+      - { name: dind-graph, hostPath: { path: /mnt/scratch/sglang-dind, type: DirectoryOrCreate } }
+      # Per-runner GPU isolation: sglang reads /etc/podinfo/gha-render-devices to pin renderD nodes.
+      # Without it the CI falls back to --device /dev/dri (ALL GPUs). Until the device-plugin/CDI
+      # populates a real per-pod value, keep maxRunners <= #GPUs-per-node so "all" == "its own".
+      - name: podinfo
+        downwardAPI:
+          items:
+            - path: gha-render-devices
+              fieldRef:
+                fieldPath: "metadata.annotations['spur.amd.com/render-devices']"

--- a/examples/gpu-k8s-arc-sglang/40-serving/fork-ci.yml
+++ b/examples/gpu-k8s-arc-sglang/40-serving/fork-ci.yml
@@ -1,0 +1,59 @@
+# Goes in the sglang fork at .github/workflows/fork-ci.yml (github.com/powderluv/sglang).
+# Reuses sglang's own scripts/ci/amd/*.sh unchanged; adds a gated deploy of the serving pod.
+#
+# Two jobs:
+#   amd-gpu-test  — the working M5-full run: GPU runner (linux-mi35x-gpu-1) -> dind -> mi35x ROCm
+#                   container -> ungated subset of stage-a-test-1-gpu-small-amd (no HF token needed).
+#   deploy        — gated on a green amd-gpu-test. Runs on the NON-GPU linux-cpu-deploy scale set as
+#                   ServiceAccount sglang-deployer (in-cluster token, RBAC scoped to ns sglang) and
+#                   kubectl-applies the vendored serving manifest, then waits for the rollout.
+#
+# Cluster prereqs (already live, see spur-examples/gpu-k8s-arc-sglang/): the linux-cpu-deploy ARC
+# scale set (30-arc/cpu-deploy-values.yaml) + the deployer RBAC (40-serving/rbac-deployer.yaml).
+# Fork prereqs: vendor 40-serving/sglang-service-amd.yaml + ingress.yaml to deploy/k8s/ in the fork.
+name: Fork AMD CI (M5-full + gated deploy)
+on:
+  workflow_dispatch: {}
+  push: { branches: [main] }
+
+jobs:
+  amd-gpu-test:
+    runs-on: linux-mi35x-gpu-1                 # == runnerScaleSetName; ^linux-(mi..)-gpu-[0-9]+ -> gfx950
+    steps:
+      - uses: actions/checkout@v4
+      - name: Clear VRAM (runner has rocm-smi via the full-ROCm image)
+        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm || echo "vram-clear best-effort skipped"
+      - name: Start ROCm container (mi35x, bypass LOCAL_DOCKER_REGISTRY)
+        run: bash scripts/ci/amd/amd_ci_start_container.sh --custom-image lmsysorg/sglang:v0.5.14-rocm700-mi35x
+      - name: Assert GPU arch = gfx950 (inside ci_sglang)
+        run: bash scripts/ci/amd/amd_ci_exec.sh rocminfo | grep -q gfx950 && echo "gfx950 confirmed in ci_sglang"
+      - name: Install deps
+        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
+      # Ungated subset of stage-a-test-1-gpu-small-amd (the full suite also serves gated
+      # meta-llama/Llama-3.1-8B-Instruct, which 401s without an accepted HF license). To restore the
+      # full suite: add an HF_TOKEN secret + `env: HF_TOKEN: ${{ secrets.HF_TOKEN }}` and switch this
+      # step to: python3 run_suite.py --hw amd --suite stage-a-test-1-gpu-small-amd
+      - name: Run small AMD suite (ungated subset — Llama-3.1 gated tests skipped)
+        run: |
+          set -e
+          E="bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test python3"
+          $E registered/quant/test_awq_dequant.py
+          $E registered/quant/test_fused_rms_fp8_group_quant.py
+          $E registered/attention/test_wave_attention_kernels.py
+          $E registered/models/test_vit_pos_embed_interpolate.py
+
+  deploy:
+    needs: [amd-gpu-test]
+    if: success()
+    runs-on: linux-cpu-deploy                  # non-GPU scale set; runs as SA sglang-deployer
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy sglang serving to the cluster (in-cluster SA token, RBAC-scoped to ns sglang)
+        run: |
+          set -euo pipefail
+          # kubectl uses the auto-mounted in-cluster config (no kubeconfig); the sglang-deployer SA
+          # is authorized only for deploy/svc/pvc/pods/configmaps/ingress in ns sglang.
+          kubectl apply -f deploy/k8s/sglang-service-amd.yaml
+          # ingress is M7-ops (external access); don't fail the gated deploy if ingress-nginx isn't installed yet
+          kubectl apply -f deploy/k8s/ingress.yaml || echo "ingress apply skipped (ingress-nginx not installed — M7-ops)"
+          kubectl -n sglang rollout status deploy/sglang --timeout=20m

--- a/examples/gpu-k8s-arc-sglang/40-serving/ingress.yaml
+++ b/examples/gpu-k8s-arc-sglang/40-serving/ingress.yaml
@@ -1,0 +1,18 @@
+# Expose the sglang Service through ingress-nginx (installed in ../15-addons, NodePort :30080).
+# Reach it at http://<any-node-ip>:30080/  with Host: sglang.local  (or set a real DNS name).
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sglang
+  namespace: sglang
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: sglang.local
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend: { service: { name: sglang, port: { number: 30000 } } }

--- a/examples/gpu-k8s-arc-sglang/40-serving/rbac-deployer.yaml
+++ b/examples/gpu-k8s-arc-sglang/40-serving/rbac-deployer.yaml
@@ -1,0 +1,27 @@
+# RBAC for the gated CI deploy job. The CPU deploy runner pod (ns arc-runners) runs as this SA and
+# `kubectl apply`s the serving manifest into ns sglang using its in-cluster token.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: { name: sglang-deployer, namespace: arc-runners }
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: { name: sglang-deployer, namespace: sglang }
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["services", "persistentvolumeclaims", "pods", "configmaps"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: { name: sglang-deployer, namespace: sglang }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: Role, name: sglang-deployer }
+subjects:
+  - { kind: ServiceAccount, name: sglang-deployer, namespace: arc-runners }

--- a/examples/gpu-k8s-arc-sglang/40-serving/sglang-service-amd.yaml
+++ b/examples/gpu-k8s-arc-sglang/40-serving/sglang-service-amd.yaml
@@ -1,0 +1,76 @@
+# sglang serving on AMD MI355X (gfx950), adapted for k0s from sglang's docker/k8s-sglang-service.yaml.
+# NVIDIA-isms removed (the 3 k3s/upstream failure modes the review caught):
+#   - deleted `runtimeClassName: nvidia` + the RuntimeClass object  (no such handler on AMD/k0s)
+#   - Service is ClusterIP + Ingress (no `type: LoadBalancer` stuck pending; use MetalLB only if desired)
+#   - PVC is ReadWriteOnce on `local-path` (k0s has no RWX default)
+# Deploy:  kubectl apply -f sglang-service-amd.yaml   (done by the gated CI deploy job)
+# The `sglang` namespace + deployer RBAC + HF secret are created once by bootstrap.sh (the deploy
+# SA is namespaced and cannot create namespaces), so this file is workload-only.
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata: { name: hf-cache, namespace: sglang }
+spec:
+  accessModes: ["ReadWriteOnce"]           # local-path is RWO; a single serving replica per PVC
+  storageClassName: local-path
+  resources: { requests: { storage: 100Gi } }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: sglang, namespace: sglang }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: sglang } }
+  template:
+    metadata: { labels: { app: sglang } }
+    spec:
+      nodeSelector: { spur.amd.com/compute: "true" }
+      securityContext:
+        seccompProfile: { type: Unconfined }      # ROCm needs unconfined seccomp
+        supplementalGroups: [44, 992]             # video=44, render=992 (VERIFIED on the MI355X hosts; /dev/kfd is root:render)
+      containers:
+        - name: sglang
+          image: lmsysorg/sglang:v0.5.14-rocm700-mi35x   # gfx950 image (same one M5-full CI validated); PIN by digest in versions.lock.md
+          command: ["python3", "-m", "sglang.launch_server"]   # override ENTRYPOINT explicitly (matches upstream)
+          args:
+            - "--model-path=Qwen/Qwen2.5-7B-Instruct"   # ungated default (no HF gating); change as needed
+            - "--host=0.0.0.0"
+            - "--port=30000"
+            - "--tp=1"                                    # tensor-parallel = #GPUs requested below
+          ports: [{ containerPort: 30000 }]
+          resources:
+            limits: { amd.com/gpu: 1 }                    # device plugin injects /dev/kfd + /dev/dri
+          env:
+            # Only needed for gated models; harmless if the secret exists. Remove for ungated models.
+            - name: HF_TOKEN
+              valueFrom: { secretKeyRef: { name: hf-token, key: token, optional: true } }
+          volumeMounts:
+            - { name: hf-cache, mountPath: /root/.cache/huggingface }
+            - { name: shm, mountPath: /dev/shm }
+          startupProbe:                                   # gate liveness during cold load (/health is 503 until Up)
+            httpGet: { path: /health, port: 30000 }
+            periodSeconds: 15
+            timeoutSeconds: 10                            # default 1s is too tight for a GPU server under load
+            failureThreshold: 80                          # ~20 min worst-case cold 7B load onto an empty PVC
+          readinessProbe:
+            httpGet: { path: /health_generate, port: 30000 }
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 80
+          livenessProbe:
+            httpGet: { path: /health, port: 30000 }       # safe: startupProbe holds liveness off until server is Up
+            periodSeconds: 30
+            timeoutSeconds: 10                            # a busy /health must not read as "dead" (was killing healthy servers)
+            failureThreshold: 6
+      volumes:
+        - { name: hf-cache, persistentVolumeClaim: { claimName: hf-cache } }
+        - { name: shm, emptyDir: { medium: Memory, sizeLimit: 16Gi } }
+---
+apiVersion: v1
+kind: Service
+metadata: { name: sglang, namespace: sglang }
+spec:
+  type: ClusterIP
+  selector: { app: sglang }
+  ports: [{ name: http, port: 30000, targetPort: 30000 }]

--- a/examples/gpu-k8s-arc-sglang/50-rdma/README.md
+++ b/examples/gpu-k8s-arc-sglang/50-rdma/README.md
@@ -1,0 +1,61 @@
+# 50-rdma — expose the backend RoCEv2 fabric to pods (distributed inference)
+
+The GPU workers each have **8× AMD Pensando (ionic) 400 GbE RoCEv2 NICs** — one per MI355X GPU,
+rail-optimized (3.2 Tb/s/node), separate from the 200 G frontend NIC that carries `spur0`. This
+fabric is the **data plane for distributed inference** (RCCL collectives for multi-node TP/PP, and
+RDMA KV-cache transfer for prefill/decode disaggregation via Mooncake/MoRI).
+
+**Critical rule: RDMA does NOT go over `spur0`.** WireGuard can't carry RDMA and would destroy
+bandwidth/latency. The RoCE fabric is attached to pods as a **separate, direct** path (host NICs or
+Multus secondary interfaces); only the TCP rendezvous/bootstrap uses the pod network.
+
+This is AMD's documented MI355X + 8×-Pensando config — see the ROCm guides for
+[SGLang PD-disaggregation](https://rocm.docs.amd.com/projects/ai-developer-hub/en/latest/notebooks/inference/SGlang_PD_Disagg_On_AMD_GPU.html)
+and [SGLang distributed with Mooncake](https://rocm.docs.amd.com/en/latest/how-to/rocm-for-ai/inference/benchmark-docker/sglang-distributed.html).
+
+## Prerequisites (host / fabric — confirm with the provider)
+
+1. **Assign RoCEv2 rail IPs** to the 8 backend netdevs on every node (they are currently un-IP'd;
+   RoCEv2 v2 GIDs are derived from the netdev IP). Rail-optimized: one subnet per rail index across
+   nodes (e.g. rail-0 = `enP2p0s9` on every node in `10.200.0.0/24`, rail-1 in `10.200.1.0/24`, …).
+   The provider may already own this; confirm before assuming.
+2. **Lossless/managed RoCE**: PFC or DCQCN/ECN configured on the NICs **and** the switches. This is
+   a fabric-wide setting — confirm your provider's fabric config.
+3. **GPUDirect RDMA**: present here (amdgpu dmabuf + `ionic_rdma` peer/ATS). The serving image must
+   ship RCCL + the RDMA transport (see env below).
+4. **RDMA netns mode**: host is `shared`. For per-pod isolation (fractional/multi-tenant), switch to
+   `rdma system set netns exclusive`; for whole-node jobs, `shared` + hostNetwork is fine.
+
+## Two exposure models
+
+- **A. Whole-node (simplest, recommended for distributed serving):** `hostNetwork: true` — the pod
+  sees all 8 backend NICs + `/dev/infiniband` directly. No Multus needed. Best for a node dedicated
+  to one multi-GPU serving job. Add the `amd.com/roce` device-plugin resource only if you want the
+  scheduler to gate on RDMA availability.
+- **B. Isolated / fractional (Multus + SR-IOV):** keep Calico as the primary CNI; add **Multus** +
+  the **SR-IOV Network Device Plugin** (`isRdma: true`) advertising `amd.com/roce_ionic`, and a
+  **NetworkAttachmentDefinition** per rail. Pods request the RDMA resource + a `k8s.v1.cni.cncf.io/networks`
+  annotation and get only their allocated rails + RDMA cdevs. Required for multi-tenant nodes.
+
+Files here (`sriov-rdma-device-plugin.yaml`, `roce-net-attach-def.yaml`) implement model B; the
+`sglang-disagg-mori.yaml` (PD-disaggregation) and `sglang-2node-tp.yaml` (tensor-parallel) examples
+show both a hostNetwork variant and the annotations.
+
+## RCCL / RoCE env (in the serving pod)
+
+```
+NCCL_IB_DISABLE=0
+NCCL_IB_HCA=ionic_0,ionic_1,ionic_2,ionic_3,ionic_4,ionic_5,ionic_6,ionic_7   # the 8 RoCE devices
+NCCL_IB_GID_INDEX=3            # RoCEv2 GID (confirm the v2 gid index via `show_gids`)
+NCCL_SOCKET_IFNAME=eth0        # bootstrap/rendezvous over the POD network (Calico), not the RoCE NICs
+NCCL_IB_PCI_RELAXED_ORDERING=1
+```
+For sglang PD-disaggregation, also pass `--disaggregation-ib-device ionic_0,…` and use Mooncake for
+the KV-cache RDMA transport (per the ROCm guide).
+
+## SPUR angle
+
+SPUR should become **rail/topology-aware** — model NIC↔GPU affinity (which ionic NIC is PCIe-local
+to which GPU) so multi-GPU jobs get rail-aligned NICs (GPU-topology scheduling on the SPUR roadmap; the
+proto already carries `peer_gpus`/`link_type`). The k8s exposure above works independently of that;
+topology-awareness is an optimization SPUR adds later.

--- a/examples/gpu-k8s-arc-sglang/50-rdma/di-verify.md
+++ b/examples/gpu-k8s-arc-sglang/50-rdma/di-verify.md
@@ -1,0 +1,43 @@
+# Verifying DI (distributed inference) with sglang's own DI tests
+
+sglang ships a distributed-inference test we can reuse to validate this RoCE fabric once it's up:
+**`.github/workflows/nightly-amd-mi355x-disagg.yml`** — "Nightly Test (AMD MI355X 2N 1P1D Disagg)",
+a **2-node, 1-prefill / 1-decode disaggregation** benchmark on **exactly our hardware** (MI355X +
+8× Pensando RoCE NICs, KV-cache transferred over RDMA via MoRI/Mooncake). Runner label:
+`linux-sglang-mi35x-di`. It is driven via **Slurm**: the runner `salloc`s two MI355X nodes and runs
+`scripts/ci/slurm/launch_mi355x.sh` (+ `generate_matrix.py` / `process_result.py` / `summarize.py`).
+
+## Two ways to run it against our cluster
+
+**Path 1 — Slurm-native via SPUR (natural fit; reuses sglang's DI CI almost unchanged).**
+SPUR is Slurm-CLI compatible, so sglang's `salloc`/`sbatch`-based DI CI can target **SPUR** as the
+scheduler — SPUR allocates the 2 MI355X nodes on the RoCE fabric and launches the 1P1D benchmark
+directly on the nodes (bare, not k8s pods; RDMA over the backend fabric). Register a DI runner scale
+set named `linux-sglang-mi35x-di` (a CPU/login-style runner that shells out to `salloc` against
+SPUR). This is the strongest demonstration of SPUR's value — GPU-aware Slurm scheduling — *and*
+validates the fabric.
+
+> Reconciles with M2's "drain GPU nodes from the SPUR scheduler": the drain is not permanent. Use a
+> **partition/time split** — nodes serve the k8s/ARC path by default, and a SPUR partition reclaims
+> them for a DI benchmark run (or vice-versa). Permanent-drain + SPUR-salloc are mutually exclusive;
+> pick per run. (This is exactly the SPUR↔k8s coexistence the roadmap is about.)
+
+**Path 2 — k8s-native.**
+Deploy the 2-node sglang as pods (`sglang-2node-tp.yaml`, or a prefill+decode pair for 1P1D) and run
+sglang's disaggregation benchmark **client** against the served endpoints. More porting (sglang's DI
+CI is Slurm-shaped, not k8s-shaped), but keeps DI inside the k8s serving model.
+
+## The one gotcha sglang's own CI documents (applies directly to us)
+
+The disagg workflow skips a node because *"its ionic RDMA driver ABI mismatches the container, so
+**MoRI reports 'no active RDMA device'**."* These hosts run a recent `ionic_rdma` (e.g. 25.08.x) — the serving
+/ benchmark **container's RDMA userspace (rdma-core + the ionic provider) must match that host ABI**,
+or RDMA silently fails to initialize. **Verify first:** from inside the container, `ibv_devices`
+must list `ionic_0..7` and `ibv_devinfo -d ionic_0` must show `PORT_ACTIVE`; if not, rebuild the
+image against the matching ionic userspace before trusting any DI benchmark number.
+
+## Acceptance for the RDMA milestone
+
+1. `ibv_devinfo` inside a pod/job shows all 8 `ionic_*` PORT_ACTIVE (ABI matches).
+2. A RoCE loopback/bandwidth test between two nodes (`ib_write_bw`/`perftest`) hits ~line rate.
+3. sglang's 2N 1P1D disagg benchmark completes and its throughput/latency numbers are in range.

--- a/examples/gpu-k8s-arc-sglang/50-rdma/roce-net-attach-def.yaml
+++ b/examples/gpu-k8s-arc-sglang/50-rdma/roce-net-attach-def.yaml
@@ -1,0 +1,25 @@
+# NetworkAttachmentDefinitions (Multus) — one per RoCE rail. A pod annotated with these gets the
+# backend NIC(s) as secondary interfaces, in ADDITION to its Calico primary. RDMA rides these; the
+# Calico primary stays the pod/service + rendezvous network. Requires Multus + the SR-IOV device
+# plugin (sriov-rdma-device-plugin.yaml). resourceName must match `amd.com/roce_ionic`.
+#
+# One NAD per rail keeps NIC↔GPU rail alignment explicit; a distributed job requests all 8.
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: roce-rail-0
+  namespace: sglang
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: amd.com/roce_ionic
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "type": "sriov",
+      "name": "roce-rail-0",
+      "ipam": { "type": "static" }
+    }
+# ... repeat roce-rail-1 … roce-rail-7 (one per backend NIC / GPU rail).
+# For the simplest whole-node path you can skip NADs entirely and use hostNetwork: true (model A in
+# README.md); then the pod uses the host's backend NIC IPs directly and no Multus annotation is needed.

--- a/examples/gpu-k8s-arc-sglang/50-rdma/sglang-2node-tp.yaml
+++ b/examples/gpu-k8s-arc-sglang/50-rdma/sglang-2node-tp.yaml
@@ -1,0 +1,64 @@
+# EXAMPLE: 2-node sglang tensor-parallel (TP=16) over the RoCE fabric — illustrative, confirm at deploy.
+# Model A (whole-node, hostNetwork): each pod gets all 8 MI355X + all 8 ionic RoCE NICs + /dev/infiniband
+# directly; RCCL does inter-node collectives over RoCEv2 (NOT over spur0). A headless Service gives the
+# leader a stable name for --dist-init-addr (that rendezvous is TCP over the pod net; the data plane is RDMA).
+# For prefill/decode DISAGGREGATION (Mooncake KV-cache over RDMA) see the ROCm guide linked in README.md.
+---
+apiVersion: v1
+kind: Service
+metadata: { name: sglang-tp, namespace: sglang }
+spec:
+  clusterIP: None                       # headless: sglang-tp-0.sglang-tp is the leader's stable name
+  selector: { app: sglang-tp }
+  ports: [{ name: dist, port: 5000 }]
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata: { name: sglang-tp, namespace: sglang }
+spec:
+  serviceName: sglang-tp
+  replicas: 2                           # ordinal 0 = node-rank 0 (leader), ordinal 1 = node-rank 1
+  selector: { matchLabels: { app: sglang-tp } }
+  template:
+    metadata: { labels: { app: sglang-tp } }
+    spec:
+      hostNetwork: true                 # model A: direct backend NICs + /dev/infiniband (no Multus)
+      dnsPolicy: ClusterFirstWithHostNet
+      # spread the two replicas onto different GPU workers:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector: { matchLabels: { app: sglang-tp } }
+              topologyKey: kubernetes.io/hostname
+      nodeSelector: { spur.amd.com/compute: "true" }
+      securityContext:
+        seccompProfile: { type: Unconfined }
+        supplementalGroups: [44, 992]   # video=44, render=992 (VERIFIED on the MI355X hosts)
+      containers:
+        - name: sglang
+          image: lmsysorg/sglang:v0.5.14-rocm700-mi35x   # VERIFIED: ships RCCL + ionic RDMA provider; in-pod ibv_devinfo -> ionic_0..7 PORT_ACTIVE
+          command: ["/bin/bash", "-lc"]
+          args:
+            - >
+              RANK=${HOSTNAME##*-};
+              python3 -m sglang.launch_server
+              --model-path meta-llama/Llama-3.1-70B-Instruct
+              --tp 16 --nnodes 2 --node-rank ${RANK}
+              --dist-init-addr sglang-tp-0.sglang-tp:5000
+              --host 0.0.0.0 --port 30000
+          env:
+            - { name: NCCL_IB_DISABLE, value: "0" }
+            - { name: NCCL_IB_HCA, value: "ionic_0,ionic_1,ionic_2,ionic_3,ionic_4,ionic_5,ionic_6,ionic_7" }
+            - { name: NCCL_IB_GID_INDEX, value: "1" }   # VERIFIED via show_gids: index 1 = global IPv6 RoCEv2 GID (index 0 = fe80 link-local)
+            - { name: NCCL_SOCKET_IFNAME, value: "ens3" } # rendezvous over the frontend/pod net, not RoCE
+            - { name: NCCL_IB_PCI_RELAXED_ORDERING, value: "1" }
+          resources:
+            limits:
+              amd.com/gpu: 8
+              # amd.com/roce_ionic: 8        # uncomment for model B (Multus/SR-IOV) instead of hostNetwork
+          volumeMounts:
+            - { name: infiniband, mountPath: /dev/infiniband }   # RDMA verbs devices
+            - { name: shm, mountPath: /dev/shm }
+      volumes:
+        - { name: infiniband, hostPath: { path: /dev/infiniband } }   # model A; model B injects via device plugin
+        - { name: shm, emptyDir: { medium: Memory, sizeLimit: 32Gi } }

--- a/examples/gpu-k8s-arc-sglang/50-rdma/sglang-di-2node.yaml
+++ b/examples/gpu-k8s-arc-sglang/50-rdma/sglang-di-2node.yaml
@@ -1,0 +1,93 @@
+# Concrete DI validation: 2-node sglang tensor-parallel over the RoCE fabric (Model A / hostNetwork).
+# TP=2 across 2 nodes (1 MI355X each) -> every forward pass does an inter-node RCCL all-reduce, which
+# RCCL routes over RoCEv2 (ionic_0..7), NOT over spur0. Ungated Qwen2.5-7B keeps the download small.
+# Rendezvous (--dist-init-addr) is TCP over the mesh; the collective DATA plane is RDMA over the rails.
+# Pinned to gpu-node-3/gpu-node-4 (adjust to your nodes; sglang image cached there). To scale to TP=16 (full 2x8 GPUs) see sglang-2node-tp.yaml.
+---
+apiVersion: v1
+kind: Service
+metadata: { name: sglang-di, namespace: sglang }
+spec:
+  clusterIP: None                       # headless: sglang-di-0.sglang-di is the leader's stable name
+  publishNotReadyAddresses: true        # resolve sglang-di-0.sglang-di BEFORE the leader is Ready (rendezvous needs it)
+  selector: { app: sglang-di }
+  ports:
+    - { name: dist, port: 5000 }
+    - { name: http, port: 30000 }
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata: { name: sglang-di, namespace: sglang }
+spec:
+  serviceName: sglang-di
+  replicas: 2                           # ordinal 0 = node-rank 0 (leader), 1 = node-rank 1
+  podManagementPolicy: Parallel         # BOTH pods start at once — OrderedReady deadlocks (pod-0 Ready needs pod-1's rendezvous)
+  selector: { matchLabels: { app: sglang-di } }
+  template:
+    metadata: { labels: { app: sglang-di } }
+    spec:
+      hostNetwork: true                 # Model A: direct backend NICs + /dev/infiniband
+      dnsPolicy: ClusterFirstWithHostNet
+      nodeSelector: { spur.amd.com/compute: "true" }
+      affinity:
+        podAntiAffinity:                # one replica per node
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector: { matchLabels: { app: sglang-di } }
+              topologyKey: kubernetes.io/hostname
+        nodeAffinity:                   # pin to nodes with the image cached (avoid a 70G re-pull)
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - { key: kubernetes.io/hostname, operator: In, values: [gpu-node-3, gpu-node-4] }
+      securityContext:
+        seccompProfile: { type: Unconfined }
+        supplementalGroups: [44, 992]   # video, render (VERIFIED)
+      containers:
+        - name: sglang
+          image: lmsysorg/sglang:v0.5.14-rocm700-mi35x
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true            # RDMA verbs + memlock
+            capabilities: { add: ["IPC_LOCK"] }
+          command: ["/bin/bash", "-lc"]
+          args:
+            - >
+              ulimit -l unlimited || true;
+              RANK=${POD_NAME##*-};
+              echo "node-rank=${RANK} pod=${POD_NAME} host=$(hostname) memlock=$(ulimit -l)";
+              python3 -m sglang.launch_server
+              --model-path Qwen/Qwen2.5-7B-Instruct
+              --tp 2 --nnodes 2 --node-rank ${RANK}
+              --dist-init-addr sglang-di-0.sglang-di:5000
+              --host 0.0.0.0 --port 30000 --mem-fraction-static 0.8 --trust-remote-code
+          env:
+            - name: POD_NAME                              # hostNetwork makes $HOSTNAME the NODE name; use the pod name for the rank
+              valueFrom: { fieldRef: { fieldPath: metadata.name } }
+            - { name: NCCL_IB_DISABLE, value: "0" }
+            - { name: NCCL_IB_HCA, value: "ionic_0,ionic_1,ionic_2,ionic_3,ionic_4,ionic_5,ionic_6,ionic_7" }
+            - { name: NCCL_IB_GID_INDEX, value: "1" }     # global IPv6 RoCEv2 GID (VERIFIED)
+            # dmabuf GPUDirect segfaults the TP worker even WITH iommu=pt (no GPU fault in dmesg — a dmabuf/RCCL
+            # bug, not IOMMU). Disable GDR so RCCL stages GPU<->host<->NIC; with iommu=pt now active, host-memory
+            # RDMA registration should work (it failed under the earlier translated IOMMU -> "unhandled system error").
+            - { name: NCCL_NET_GDR_LEVEL, value: "0" }
+            - { name: NCCL_IB_PCI_RELAXED_ORDERING, value: "0" }  # ionic ibv_reg_mr rejects the relaxed-ordering MR flag with EINVAL ("Invalid argument")
+            - { name: NCCL_SOCKET_IFNAME, value: "spur0" } # bootstrap over the mesh (hostNetwork pod IP = mesh IP)
+            - { name: GLOO_SOCKET_IFNAME, value: "spur0" }
+            - { name: NCCL_DEBUG, value: "INFO" }          # confirm RCCL selects the IB/ionic (RoCE) transport
+          ports:
+            - { containerPort: 30000 }
+          resources:
+            limits: { amd.com/gpu: 1 }                     # 1 MI355X per node (TP=2 total)
+          volumeMounts:
+            - { name: infiniband, mountPath: /dev/infiniband }
+            - { name: shm, mountPath: /dev/shm }
+            - { name: hf, mountPath: /root/.cache/huggingface }
+          startupProbe:                                    # leader serves /health only after both nodes join
+            httpGet: { path: /health, port: 30000 }
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 80
+      volumes:
+        - { name: infiniband, hostPath: { path: /dev/infiniband } }
+        - { name: shm, emptyDir: { medium: Memory, sizeLimit: 16Gi } }
+        - { name: hf, hostPath: { path: /mnt/scratch/hf-cache-di, type: DirectoryOrCreate } }

--- a/examples/gpu-k8s-arc-sglang/50-rdma/sglang-disagg-mori.yaml
+++ b/examples/gpu-k8s-arc-sglang/50-rdma/sglang-disagg-mori.yaml
@@ -1,0 +1,164 @@
+# sglang prefill/decode (PD) disaggregation with the MoRI RDMA transport over the ionic RoCEv2 fabric.
+# Ground-truth config = sglang's nightly-amd-mi355x-disagg CI (MI355X + AMD Pensando ionic): backend=mori,
+# env MORI_DISABLE_AUTO_XGMI=1 / NCCL_IB_HCA=ionic / NCCL_IB_GID_INDEX=1 / NCCL_CROSS_NIC=1, KV over 4 ionic NICs.
+# Networking (per the disaggregation conn code): prefill+decode MUST be hostNetwork (ionic verbs live only in
+# the host netns); the prefill<->decode bootstrap+KV plane is DIRECT node-IP:port (no ClusterIP in the datapath);
+# SGLANG_HOST_IP is pinned to the node's mesh IP (status.hostIP) so rank_ip/session-host/bootstrap_host are routable.
+# Ungated Qwen2.5-7B, tp 1 (1 GPU/role). Prefill pinned to gpu-node-3 (10.44.0.4), decode to gpu-node-4 (10.44.0.5) — both
+# have iommu=pt + the image cached. The router derives bootstrap_host from the --prefill URL host, so it must be
+# the prefill NODE IP. requires GPUDirect? No — MoRI over RoCE; iommu=pt already validated on these nodes.
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata: { name: sglang-prefill, namespace: sglang }
+spec:
+  serviceName: sglang-prefill-hl
+  replicas: 1
+  selector: { matchLabels: { app: sglang-disagg, role: prefill } }
+  template:
+    metadata: { labels: { app: sglang-disagg, role: prefill } }
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      nodeSelector: { kubernetes.io/hostname: gpu-node-3 }
+      securityContext:
+        seccompProfile: { type: Unconfined }
+        supplementalGroups: [44, 992]
+      containers:
+        - name: sglang
+          image: lmsysorg/sglang:v0.5.14-rocm700-mi35x
+          imagePullPolicy: IfNotPresent
+          securityContext: { privileged: true, capabilities: { add: ["IPC_LOCK"] } }
+          command: ["/bin/bash", "-lc"]
+          args:
+            - >
+              ulimit -l unlimited || true;
+              echo "host_ip=$SGLANG_HOST_IP role=prefill $(date)";
+              exec python3 -m sglang.launch_server
+              --model-path Qwen/Qwen2.5-7B-Instruct --tp 1 --trust-remote-code --mem-fraction-static 0.8
+              --host 0.0.0.0 --port 30000
+              --disaggregation-mode prefill
+              --disaggregation-transfer-backend mori
+              --disaggregation-bootstrap-port 8998
+              --disaggregation-ib-device ionic_0,ionic_1,ionic_2,ionic_3
+          env:
+            - { name: SGLANG_HOST_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
+            - { name: MORI_DISABLE_AUTO_XGMI, value: "1" }   # force RoCE/RDMA path (not auto-XGMI)
+            - { name: NCCL_IB_HCA, value: "ionic" }          # select the Pensando ionic HCAs
+            - { name: NCCL_IB_GID_INDEX, value: "1" }         # RoCEv2 GID (verified)
+            - { name: NCCL_CROSS_NIC, value: "1" }
+            # MoRI ionic RoCE lane, from the mori env_setup QoS recipe: no-drop priority 3,
+            # DSCP 26 -> TC 104 (tc = dscp*4). MORI_DEBUG_INFO surfaces the RDMA QP + transfer.
+            - { name: MORI_RDMA_SL, value: "3" }
+            - { name: MORI_RDMA_TC, value: "104" }
+            - { name: MORI_DEBUG_INFO, value: "1" }
+          resources: { limits: { amd.com/gpu: 1 } }
+          volumeMounts:
+            - { name: infiniband, mountPath: /dev/infiniband }
+            - { name: shm, mountPath: /dev/shm }
+            - { name: hf, mountPath: /root/.cache/huggingface }
+          startupProbe:
+            httpGet: { path: /health, port: 30000 }
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 80
+      volumes:
+        - { name: infiniband, hostPath: { path: /dev/infiniband } }
+        - { name: shm, emptyDir: { medium: Memory, sizeLimit: 16Gi } }
+        - { name: hf, hostPath: { path: /mnt/scratch/hf-cache-di, type: DirectoryOrCreate } }
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata: { name: sglang-decode, namespace: sglang }
+spec:
+  serviceName: sglang-decode-hl
+  replicas: 1
+  selector: { matchLabels: { app: sglang-disagg, role: decode } }
+  template:
+    metadata: { labels: { app: sglang-disagg, role: decode } }
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      nodeSelector: { kubernetes.io/hostname: gpu-node-4 }
+      securityContext:
+        seccompProfile: { type: Unconfined }
+        supplementalGroups: [44, 992]
+      containers:
+        - name: sglang
+          image: lmsysorg/sglang:v0.5.14-rocm700-mi35x
+          imagePullPolicy: IfNotPresent
+          securityContext: { privileged: true, capabilities: { add: ["IPC_LOCK"] } }
+          command: ["/bin/bash", "-lc"]
+          args:
+            - >
+              ulimit -l unlimited || true;
+              echo "host_ip=$SGLANG_HOST_IP role=decode $(date)";
+              exec python3 -m sglang.launch_server
+              --model-path Qwen/Qwen2.5-7B-Instruct --tp 1 --trust-remote-code --mem-fraction-static 0.8
+              --host 0.0.0.0 --port 30001
+              --disaggregation-mode decode
+              --disaggregation-transfer-backend mori
+              --disaggregation-bootstrap-port 9001
+              --disaggregation-ib-device ionic_0,ionic_1,ionic_2,ionic_3
+              --log-level debug
+          env:
+            - { name: SGLANG_HOST_IP, valueFrom: { fieldRef: { fieldPath: status.hostIP } } }
+            - { name: MORI_DISABLE_AUTO_XGMI, value: "1" }
+            - { name: NCCL_IB_HCA, value: "ionic" }
+            - { name: NCCL_IB_GID_INDEX, value: "1" }
+            - { name: NCCL_CROSS_NIC, value: "1" }
+            # KVReceiver caches the prefill's ephemeral ZMQ rank_port for the whole process
+            # lifetime; if the prefill ever restarts, the decode must be restarted too (it does
+            # not re-resolve). Longer waiting-timeout so a slow first-request rendezvous survives.
+            - { name: SGLANG_DISAGGREGATION_WAITING_TIMEOUT, value: "600" }
+            - { name: MORI_RDMA_SL, value: "3" }
+            - { name: MORI_RDMA_TC, value: "104" }
+            - { name: MORI_DEBUG_INFO, value: "1" }
+          resources: { limits: { amd.com/gpu: 1 } }
+          volumeMounts:
+            - { name: infiniband, mountPath: /dev/infiniband }
+            - { name: shm, mountPath: /dev/shm }
+            - { name: hf, mountPath: /root/.cache/huggingface }
+      volumes:
+        - { name: infiniband, hostPath: { path: /dev/infiniband } }
+        - { name: shm, emptyDir: { medium: Memory, sizeLimit: 16Gi } }
+        - { name: hf, hostPath: { path: /mnt/scratch/hf-cache-di, type: DirectoryOrCreate } }
+---
+# Router / load balancer (pure HTTP, normal pod netns). Derives bootstrap_host from the --prefill URL host,
+# so --prefill / --decode MUST be the prefill/decode NODE mesh IPs (gpu-node-3=10.44.0.4, gpu-node-4=10.44.0.5), not ClusterIPs.
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: sglang-disagg-router, namespace: sglang }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: sglang-disagg, role: router } }
+  template:
+    metadata: { labels: { app: sglang-disagg, role: router } }
+    spec:
+      nodeSelector: { kubernetes.io/hostname: gpu-node-3 }   # co-locate on a node that has the image cached
+      containers:
+        - name: router
+          image: lmsysorg/sglang:v0.5.14-rocm700-mi35x
+          imagePullPolicy: IfNotPresent
+          command: ["python3", "-m", "sglang_router.launch_router"]
+          args:
+            - "--pd-disaggregation"
+            - "--prefill"
+            - "http://10.44.0.4:30000"
+            - "8998"
+            - "--decode"
+            - "http://10.44.0.5:30001"
+            - "--host"
+            - "0.0.0.0"
+            - "--port"
+            - "8000"
+            - "--disable-circuit-breaker"
+          ports: [{ containerPort: 8000 }]
+---
+apiVersion: v1
+kind: Service
+metadata: { name: sglang-disagg-router, namespace: sglang }
+spec:
+  type: ClusterIP
+  selector: { app: sglang-disagg, role: router }
+  ports: [{ name: http, port: 8000, targetPort: 8000 }]

--- a/examples/gpu-k8s-arc-sglang/50-rdma/sriov-rdma-device-plugin.yaml
+++ b/examples/gpu-k8s-arc-sglang/50-rdma/sriov-rdma-device-plugin.yaml
@@ -1,0 +1,34 @@
+# SR-IOV Network Device Plugin — advertises the 8 Pensando (ionic) RoCE NICs as a schedulable,
+# RDMA-capable resource so pods can request them and get /dev/infiniband injected.
+# Pair with Multus (install separately) + the NetworkAttachmentDefinitions in roce-net-attach-def.yaml.
+# Upstream: github.com/k8snetworkplumbingwg/sriov-network-device-plugin  (PIN the image digest).
+#
+# NOTE (confirm at deploy): Pensando PCI vendor id is 0x1dd8, driver "ionic". Verify with
+#   `lspci -nn | grep -i pensando` and `ls -l /sys/class/net/enP*/device/driver`.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sriovdp-config
+  namespace: kube-system
+data:
+  config.json: |
+    {
+      "resourceList": [
+        {
+          "resourceName": "roce_ionic",
+          "resourcePrefix": "amd.com",
+          "isRdma": true,
+          "selectors": {
+            "vendors": ["1dd8"],
+            "drivers": ["ionic"],
+            "isRdma": true
+          }
+        }
+      ]
+    }
+---
+# The DaemonSet itself is the upstream sriovdp; install it referencing this ConfigMap, e.g.:
+#   kubectl apply -f https://raw.githubusercontent.com/k8snetworkplumbingwg/sriov-network-device-plugin/master/deployments/sriovdp-daemonset.yaml
+# (pin the version). It mounts /var/lib/k0s/kubelet/device-plugins on k0s — verify the hostPath in
+# the DaemonSet matches the k0s kubelet root (same delta as ../20-gpu/amd-device-plugin.yaml).

--- a/examples/gpu-k8s-arc-sglang/Makefile
+++ b/examples/gpu-k8s-arc-sglang/Makefile
@@ -1,0 +1,35 @@
+# Convenience targets. Everything is idempotent-ish; read each script before running on real hardware.
+export KUBECONFIG ?= $(CURDIR)/kubeconfig
+
+.PHONY: up cluster gpu arc serve down capture nodes
+
+up:                    ## full ordered bring-up (network is manual — see 00-network/README.md)
+	./bootstrap.sh
+
+cluster:               ## k0s only
+	k0sctl apply --config 10-cluster/k0sctl.yaml
+	k0sctl kubeconfig --config 10-cluster/k0sctl.yaml > kubeconfig
+
+gpu:                   ## device plugin + node labels
+	kubectl apply -f 20-gpu/amd-device-plugin.yaml && ./20-gpu/node-labels.sh
+
+arc:                   ## reminder: follow 30-arc/install.md (needs secrets + pinned chart versions)
+	@echo "See 30-arc/install.md — controller, secrets, then both scale sets (pinned)."
+
+serve:                 ## namespace + deployer RBAC (workload is deployed by CI)
+	kubectl create namespace sglang --dry-run=client -o yaml | kubectl apply -f -
+	kubectl apply -f 40-serving/rbac-deployer.yaml
+
+nodes:                 ## quick health view
+	kubectl get nodes -o wide
+
+capture:               ## snapshot live cluster state for drift-checking against this tree
+	@d=state/$$(date +%Y%m%d-%H%M%S); mkdir -p $$d; \
+	 kubectl get all -A -o yaml > $$d/all.yaml; \
+	 kubectl get nodes -o yaml > $$d/nodes.yaml; \
+	 helm list -A > $$d/helm.txt 2>/dev/null || true; \
+	 kubectl get crd -o name > $$d/crds.txt; \
+	 echo "captured -> $$d"
+
+down:                  ## reverse-order teardown
+	./teardown.sh

--- a/examples/gpu-k8s-arc-sglang/README.md
+++ b/examples/gpu-k8s-arc-sglang/README.md
@@ -1,0 +1,56 @@
+# gpu-k8s-arc-sglang — reproducible SPUR-hosted GPU K8s cluster + ARC + sglang
+
+Goal: **every change we make to the cluster is captured as code or logged**, so bringing up a
+similar cluster later is `git clone && ./bootstrap.sh` (and eventually `spur k8s up`). This is the
+`gpu-k8s-arc-sglang` example in the **`spur-examples`** repo (e.g. `github.com/rocm/spur-examples`),
+kept separate from the core `rocm/spur` code; it is the concrete seed of the SPUR `spur cluster` /
+`spur k8s up` capability.
+
+**Distro: k0s** — bootstrapped declaratively via `k0sctl` from `10-cluster/k0sctl.yaml`,
+which doubles as the reproducible cluster spec SPUR will template. The **ARC + sglang integration is
+the worked example** in this tree: `30-arc/` (controller + GPU dind runner scale set + CPU deploy
+scale set for `github.com/powderluv/sglang`) and `40-serving/` (the AMD sglang serving manifest +
+the fork CI/CD workflow that tests on GPU and auto-deploys on green). Follow it to reproduce the
+whole GitHub-Actions-on-GPU-k8s loop, or swap `40-serving` for a different workload.
+
+## Principles
+
+1. **Declarative first.** Prefer a checked-in manifest / Helm values file / distro config over an
+   ad-hoc command. If a distro (k0s) offers a declarative cluster spec (`k0sctl.yaml`), that file
+   *is* the cluster definition.
+2. **Append-only runbook.** Anything genuinely done by hand goes in `RUNBOOK.md` **as it happens**
+   (command + host + result + how to undo), then gets promoted into a script under the numbered
+   dirs. Nothing about the cluster lives only in someone's shell history.
+3. **Pin everything.** `versions.lock.md` pins the distro/k8s version, every Helm chart version,
+   and every image by **digest** (not just tag), so a rebuild is byte-reproducible.
+4. **Idempotent + ordered.** `bootstrap.sh` re-runs safely; `teardown.sh` reverses in the correct
+   order (ARC runner scale sets *before* the controller, k8s before the mesh, re-admit drained
+   SPUR nodes last).
+5. **No plaintext secrets.** GitHub App key / HF token via sealed-secrets or SOPS; only templates
+   and `*.example` files are committed.
+
+## Layout
+
+```
+README.md             # this file
+RUNBOOK.md            # append-only chronological log of every cluster-mutating action (fill-in template)
+versions.lock.md      # pinned distro/k8s + Helm chart versions + image digests
+bootstrap.sh          # idempotent, ordered driver: network → cluster → addons → gpu → arc → serving
+teardown.sh           # reverse-order teardown
+Makefile              # up / gpu / arc / serve / down / capture
+00-network/           # WireGuard mesh, firewall ports, sysctls, MTU
+10-cluster/           # distro install config (k0sctl.yaml)
+15-addons/            # upstream pieces k0s doesn't bundle (storage, ingress, sealed-secrets)
+20-gpu/               # AMD device-plugin + node-labeller manifests, node labels, CDI
+30-arc/               # ARC controller + runner scale-set Helm values, GitHub App secret template
+40-serving/           # sglang serving manifest + fork CI workflow
+50-rdma/              # RoCEv2 fabric for distributed inference (multi-node TP/PP, PD-disagg)
+```
+
+## How changes get captured during deployment
+
+- Read-only probing → record in `RUNBOOK.md` under a dated heading.
+- Each milestone lands its artifacts in the matching numbered dir **and** a
+  one-line RUNBOOK entry referencing the file + the exact `kubectl/helm/curl` that applied it.
+- After each session: `make capture` snapshots live cluster state (`kubectl get all -A -o yaml`,
+  `helm list -A`, applied CRDs, node labels) into `state/<date>/` as a drift check against the tree.

--- a/examples/gpu-k8s-arc-sglang/RUNBOOK.md
+++ b/examples/gpu-k8s-arc-sglang/RUNBOOK.md
@@ -1,0 +1,38 @@
+# RUNBOOK — append-only cluster change log
+
+This is the operational run-log for the cluster: the operator records here, **as it happens**, every
+cluster-mutating (**CHG**) or read-only (**RO**) action taken at each phase of bring-up — the exact
+command, the host it ran on, the result, and how to undo it. Append a new dated section per phase as
+you work; never edit or delete past entries. Once something is reusable, promote it into a script
+under the numbered dirs and reference it from the entry here. For each entry, replace `YYYY-MM-DD`,
+mark the heading `CHG` or `RO`, and fill the bullets with what you actually ran.
+
+## YYYY-MM-DD — network prereqs (CHG/RO)
+
+- `<command>` — host `<node>` — result `<outcome>` — undo `<reverse command>`
+- `<next action…>`
+
+## YYYY-MM-DD — k0s cluster bring-up (CHG/RO)
+
+- `<command>` — host `<node>` — result `<outcome>` — undo `<reverse command>`
+- `<next action…>`
+
+## YYYY-MM-DD — GPU device plugin (CHG/RO)
+
+- `<command>` — host `<node>` — result `<outcome>` — undo `<reverse command>`
+- `<next action…>`
+
+## YYYY-MM-DD — ARC runners (CHG/RO)
+
+- `<command>` — host `<node>` — result `<outcome>` — undo `<reverse command>`
+- `<next action…>`
+
+## YYYY-MM-DD — gated serving deploy (CHG/RO)
+
+- `<command>` — host `<node>` — result `<outcome>` — undo `<reverse command>`
+- `<next action…>`
+
+## YYYY-MM-DD — RDMA / distributed inference (CHG/RO)
+
+- `<command>` — host `<node>` — result `<outcome>` — undo `<reverse command>`
+- `<next action…>`

--- a/examples/gpu-k8s-arc-sglang/bootstrap.sh
+++ b/examples/gpu-k8s-arc-sglang/bootstrap.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Ordered, mostly-idempotent bring-up of the SPUR-hosted GPU k8s cluster + ARC + sglang.
+# This is the human-runnable seed of `spur k8s up`. Each step logs to RUNBOOK.md by hand as you go.
+# Steps that need secrets/pins are marked MANUAL — do them, then re-run to continue.
+set -euo pipefail
+cd "$(dirname "$0")"
+export KUBECONFIG="${KUBECONFIG:-$PWD/kubeconfig}"
+
+echo "== 00-network =="            # MANUAL: bring up the WireGuard mesh + firewall (see 00-network/README.md)
+echo "   ensure spur0 mesh is up and M0 gates pass (record in RUNBOOK.md), then continue."
+
+echo "== 10-cluster (k0s via k0sctl) =="
+# MANUAL: fill real ssh addresses/pins in 10-cluster/k0sctl.yaml first.
+k0sctl apply --config 10-cluster/k0sctl.yaml
+k0sctl kubeconfig --config 10-cluster/k0sctl.yaml > kubeconfig
+kubectl get nodes -o wide
+
+echo "== 15-addons (local-path + ingress-nginx) =="   # see 15-addons/README.md for the pinned commands
+#  (run the helm/kubectl commands from 15-addons/README.md, pinned via versions.lock.md)
+
+echo "== 20-gpu (device plugin + labels) =="
+# First run: label GPU workers BY NAME before the plugin (nodeSelector chicken-and-egg).
+for n in gpu-node-1 gpu-node-2 gpu-node-3 gpu-node-4; do   # <-- edit to your real worker node names
+  kubectl label node "$n" spur.amd.com/compute=true --overwrite || true
+done
+kubectl apply -f 20-gpu/amd-device-plugin.yaml
+bash 20-gpu/node-labels.sh    # subsequent runs: relabel any node already reporting amd.com/gpu
+kubectl get nodes -o json | jq -r '.items[]|.metadata.name+" gpu="+(.status.allocatable["amd.com/gpu"]//"0")'
+
+echo "== 30-arc (controller + secrets + scale sets) =="   # MANUAL secrets — see 30-arc/install.md
+#  helm install arc ...controller ; create sglang-arc-app + ghcr-pull ; helm install both scale sets
+
+echo "== 40-serving (namespace + deployer RBAC; workload deployed by CI) =="
+kubectl create namespace sglang      --dry-run=client -o yaml | kubectl apply -f -
+kubectl create namespace arc-runners --dry-run=client -o yaml | kubectl apply -f -   # deployer SA lives here
+kubectl apply -f 40-serving/rbac-deployer.yaml
+# Optional: kubectl -n sglang create secret generic hf-token --from-literal=token=<HF_TOKEN>   # gated models only
+echo "   serving workload is applied by the fork CI deploy job (40-serving/fork-ci.yml) on green CI."
+
+echo "== done: run 'make capture' to snapshot state =="

--- a/examples/gpu-k8s-arc-sglang/teardown.sh
+++ b/examples/gpu-k8s-arc-sglang/teardown.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Reverse-order teardown. ARC runner scale sets MUST go before the controller or finalizers hang.
+set -uo pipefail
+cd "$(dirname "$0")"
+export KUBECONFIG="${KUBECONFIG:-$PWD/kubeconfig}"
+
+echo "== serving =="
+kubectl delete -f 40-serving/sglang-service-amd.yaml --ignore-not-found
+kubectl delete -f 40-serving/ingress.yaml --ignore-not-found
+kubectl delete namespace sglang --ignore-not-found
+
+echo "== ARC (scale sets BEFORE controller) =="
+helm uninstall linux-mi35x-gpu-1 -n arc-runners || true
+helm uninstall linux-cpu-deploy  -n arc-runners || true
+helm uninstall arc -n arc-systems || true          # controller last
+kubectl delete namespace arc-runners arc-systems --ignore-not-found
+
+echo "== gpu + addons =="
+kubectl delete -f 20-gpu/amd-device-plugin.yaml --ignore-not-found
+# helm uninstall ingress-nginx -n ingress-nginx ; kubectl delete -f <local-path-storage.yaml>
+
+echo "== cluster (k0s reset on every node) =="
+k0sctl reset --config 10-cluster/k0sctl.yaml || true
+
+echo "== mesh + SPUR =="
+echo "   MANUAL: reverse the SPUR scheduler drain (re-admit GPU nodes), then tear down the mesh:"
+echo "     on each node: sudo spur net leave   (or wg-quick down spur0)"
+echo "   reconcile the mesh back to hub-and-spoke if you keep SPUR running."

--- a/examples/gpu-k8s-arc-sglang/versions.lock.md
+++ b/examples/gpu-k8s-arc-sglang/versions.lock.md
@@ -1,0 +1,23 @@
+# versions.lock — pin everything (fill in at deploy time)
+
+Reproducibility depends on pinning. Record **exact versions** and, for images, the **digest**
+(`repo@sha256:…`), not just a tag. Update this file in the same commit as any change that bumps a
+version.
+
+| Layer | Component | Pinned version / digest | Source of truth | Notes |
+|---|---|---|---|---|
+| Distro | k8s distribution | **k0s** `v1.32.4+k0s.0` (bump to the pinned release) | `10-cluster/k0sctl.yaml` | locked 2026-07-09 |
+| Distro | Kubernetes version | 1.32.4 (from k0s `v1.32.4+k0s.0`; >=1.32 for AMD DRA) | k0s release | |
+| Network | CNI | **Calico `bird`** (BGP native, no overlay) over spur0 | `10-cluster/k0sctl.yaml` | VXLAN = fallback; needs spur-net AllowedIPs |
+| GPU | ROCm k8s-device-plugin | _TBD_ image `rocm/k8s-device-plugin@sha256:…` | `20-gpu/` | + node-labeller |
+| GPU | (host) amdgpu / ROCm | in-box on Ubuntu 24.04 / k6.8 | node image | record `rocm-smi --version` |
+| ARC | gha-runner-scale-set-controller | _TBD_ chart version | `30-arc/` | OCI chart |
+| ARC | gha-runner-scale-set | _TBD_ chart version | `30-arc/` | must match controller |
+| ARC | runner image | `ghcr.io/powderluv/sglang-runner@sha256:…` | `30-arc/Dockerfile` | ROCm + docker CLI + kubectl |
+| ARC | docker:dind | `docker@sha256:…` | `30-arc/` | sidecar |
+| Serving | sglang image | `rocm/sgl-dev@sha256:…` (gfx950/mi35x) | `40-serving/` | pin the mi35x tag by digest |
+| Serving | model | _TBD (ungated default preferred)_ | `40-serving/` | + HF license note |
+| Addons | ingress / LB / storage | _TBD (only if distro doesn't bundle)_ | `20/40` | k0s: ingress-nginx + MetalLB + local-path |
+
+Also record once, at deploy time: `uname -r`, `containerd --version` (CDI needs >=2.0 for the DRA
+path), `rocm-smi --version`, and the exact distro installer URL/commit.


### PR DESCRIPTION
## Summary

Adds a self-contained example under `examples/gpu-k8s-arc-sglang/` for standing up a **native k0s GPU Kubernetes cluster on SPUR nodes**: ARC (actions-runner-controller) CI runners for a sglang fork, **gated auto-deploy** of an sglang serving Deployment, and optional backend **RoCE/RDMA** for distributed inference.

Genericized from a working AMD MI355X (gfx950) 4-node deployment.

## What's included

- **Cluster (`10-cluster/`)** — k0s + Calico *bird* native routing over a WireGuard mesh (single overlay).
- **GPU (`20-gpu/`)** — AMD GPU device plugin + node labelling.
- **ARC (`30-arc/`)** — GPU runner scale set (hand-authored dind spec so `/dev/kfd`+`/dev/dri` reach the dind sidecar) **and** a non-GPU deploy runner with least-privilege RBAC; GitHub App setup docs.
- **Serving (`40-serving/`)** — sglang Deployment/Service/PVC/Ingress (ROCm, ungated model) + a gated fork-CI `deploy` job that `kubectl apply`s on green CI via an in-cluster ServiceAccount (scoped to the `sglang` namespace).
- **RDMA/DI (`50-rdma/`)** — RoCEv2 pod exposure (hostNetwork + SR-IOV options), 2-node tensor-parallel, and prefill/decode disaggregation (MoRI) reference manifests.
- Top-level `bootstrap.sh` / `teardown.sh` / `Makefile` / `README.md` / `RUNBOOK.md` template.

## Genericization / safety

Redacted for public publication: hostnames → `gpu-node-N` / `head-node`, provider mount path → `/mnt/scratch`, the internal operational RUNBOOK replaced with a fill-in template. Mesh/rail/pod subnets (`10.44.0.0/16`, etc.) are RFC1918 example config the example itself provisions. No secrets/tokens/keys — `github-app-secret.example.yaml` is a placeholder template.

## Status

Opened as a **draft / review branch**. Cluster bring-up, the GPU device plugin, ARC runners, and the gated serving deploy path were validated on real MI355X hardware. The `50-rdma/` distributed-inference manifests are references — cross-node RDMA KV-transfer has an open NIC-QoS (`nicctl` PFC/DCQCN) dependency noted inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
