### PR TITLE
feat(config): add production security baseline

### DIFF
--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -41,6 +41,9 @@ pub struct SlurmConfig {
     pub auth: AuthConfig,
 
     #[serde(default)]
+    pub security: SecurityConfig,
+
+    #[serde(default)]
     pub partitions: Vec<PartitionConfig>,
 
     #[serde(default)]
@@ -447,6 +450,33 @@ impl Default for AuthConfig {
     }
 }
 
+/// Development-only fallback used for node admission JWTs when security.mode = "dev".
+pub const DEV_ADMISSION_JWT_KEY: &str = "spur-default-key";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SecurityConfig {
+    /// Security boundary for config validation: "dev" keeps local defaults,
+    /// "production" fails fast on insecure settings.
+    #[serde(default)]
+    pub mode: SecurityMode,
+}
+
+impl Default for SecurityConfig {
+    fn default() -> Self {
+        Self {
+            mode: SecurityMode::Dev,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SecurityMode {
+    #[default]
+    Dev,
+    Production,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PartitionConfig {
     pub name: String,
@@ -816,6 +846,48 @@ impl SlurmConfig {
                 value: "0 (must be at least 1)".into(),
             });
         }
+        if matches!(self.security.mode, SecurityMode::Production) {
+            self.validate_production_security()?;
+        }
+        Ok(())
+    }
+
+    fn validate_production_security(&self) -> Result<(), ConfigError> {
+        let auth_plugin = self.auth.plugin.trim().to_ascii_lowercase();
+        if auth_plugin == "none" {
+            return Err(ConfigError::InvalidValue {
+                field: "auth.plugin".into(),
+                value: "none is only allowed when security.mode = \"dev\"".into(),
+            });
+        }
+
+        if !matches!(auth_plugin.as_str(), "jwt" | "munge") {
+            return Err(ConfigError::InvalidValue {
+                field: "auth.plugin".into(),
+                value: self.auth.plugin.clone(),
+            });
+        }
+
+        if matches!(self.admission.mode, AdmissionMode::Open) {
+            return Err(ConfigError::InvalidValue {
+                field: "admission.mode".into(),
+                value: "open is only allowed when security.mode = \"dev\"".into(),
+            });
+        }
+
+        if auth_plugin == "jwt" || matches!(self.admission.mode, AdmissionMode::Token) {
+            let jwt_key = self.auth.jwt_key.as_deref().map(str::trim).unwrap_or("");
+            if jwt_key.is_empty() {
+                return Err(ConfigError::MissingField("auth.jwt_key".into()));
+            }
+            if jwt_key == DEV_ADMISSION_JWT_KEY {
+                return Err(ConfigError::InvalidValue {
+                    field: "auth.jwt_key".into(),
+                    value: format!("{DEV_ADMISSION_JWT_KEY} is a development-only fallback"),
+                });
+            }
+        }
+
         Ok(())
     }
 
@@ -1104,6 +1176,121 @@ high_cardinality = true
         assert_eq!(
             config.metrics.effective_listen_addr().unwrap(),
             "127.0.0.1:6822".parse().unwrap()
+        );
+    }
+
+    #[test]
+    fn security_mode_defaults_to_dev() {
+        let config = SlurmConfig::load_from_str(r#"cluster_name = "x""#).unwrap();
+        assert_eq!(config.security.mode, SecurityMode::Dev);
+    }
+
+    #[test]
+    fn production_security_accepts_token_admission_with_jwt_key() {
+        let toml = r#"
+cluster_name = "prod"
+
+[security]
+mode = "production"
+
+[auth]
+plugin = "jwt"
+jwt_key = "replace-with-a-generated-secret"
+
+[admission]
+mode = "token"
+"#;
+        let config = SlurmConfig::load_from_str(toml).unwrap();
+        assert_eq!(config.security.mode, SecurityMode::Production);
+        assert_eq!(config.admission.mode, AdmissionMode::Token);
+    }
+
+    #[test]
+    fn production_security_rejects_auth_none() {
+        let toml = r#"
+cluster_name = "prod"
+
+[security]
+mode = "production"
+
+[auth]
+plugin = "none"
+jwt_key = "replace-with-a-generated-secret"
+
+[admission]
+mode = "token"
+"#;
+        let err = SlurmConfig::load_from_str(toml).unwrap_err();
+        assert!(
+            err.to_string().contains("auth.plugin"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn production_security_rejects_missing_jwt_key_for_token_auth() {
+        let toml = r#"
+cluster_name = "prod"
+
+[security]
+mode = "production"
+
+[auth]
+plugin = "jwt"
+
+[admission]
+mode = "token"
+"#;
+        let err = SlurmConfig::load_from_str(toml).unwrap_err();
+        assert!(
+            err.to_string().contains("auth.jwt_key"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn production_security_rejects_open_admission() {
+        let toml = r#"
+cluster_name = "prod"
+
+[security]
+mode = "production"
+
+[auth]
+plugin = "jwt"
+jwt_key = "replace-with-a-generated-secret"
+
+[admission]
+mode = "open"
+"#;
+        let err = SlurmConfig::load_from_str(toml).unwrap_err();
+        assert!(
+            err.to_string().contains("admission.mode"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn production_security_rejects_dev_admission_jwt_key() {
+        let toml = format!(
+            r#"
+cluster_name = "prod"
+
+[security]
+mode = "production"
+
+[auth]
+plugin = "jwt"
+jwt_key = "{DEV_ADMISSION_JWT_KEY}"
+
+[admission]
+mode = "token"
+"#
+        );
+        let err = SlurmConfig::load_from_str(&toml).unwrap_err();
+        assert!(
+            err.to_string().contains("development-only fallback"),
+            "unexpected error: {err}"
         );
     }
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -4113,6 +4113,7 @@ mod tests {
             accounting: Default::default(),
             scheduler: Default::default(),
             auth: Default::default(),
+            security: Default::default(),
             partitions: vec![spur_core::config::PartitionConfig {
                 name: "default".into(),
                 default: true,

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -303,6 +303,7 @@ fn default_config() -> spur_core::config::SlurmConfig {
         accounting: Default::default(),
         scheduler: Default::default(),
         auth: Default::default(),
+        security: Default::default(),
         partitions: vec![spur_core::config::PartitionConfig {
             name: "default".into(),
             default: true,

--- a/crates/spurctld/src/metrics_server.rs
+++ b/crates/spurctld/src/metrics_server.rs
@@ -148,6 +148,7 @@ mod tests {
             accounting: Default::default(),
             scheduler: Default::default(),
             auth: Default::default(),
+            security: Default::default(),
             partitions: vec![spur_core::config::PartitionConfig {
                 name: "default".into(),
                 default: true,

--- a/crates/spurctld/src/rpc_middleware.rs
+++ b/crates/spurctld/src/rpc_middleware.rs
@@ -169,6 +169,7 @@ mod tests {
                 accounting: Default::default(),
                 scheduler: Default::default(),
                 auth: Default::default(),
+                security: Default::default(),
                 partitions: vec![spur_core::config::PartitionConfig {
                     name: "default".into(),
                     default: true,

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -26,6 +26,38 @@ use crate::sched_stats::SchedStatsCollector;
 const FORWARDED_HEADER: &str = "x-spur-forwarded";
 const LEADER_HEADER: &str = "x-spur-leader";
 
+#[allow(clippy::result_large_err)]
+fn admission_jwt_key_for_config(
+    config: &spur_core::config::SlurmConfig,
+) -> Result<&str, Status> {
+    use spur_core::config::{DEV_ADMISSION_JWT_KEY, SecurityMode};
+
+    if let Some(jwt_key) = config
+        .auth
+        .jwt_key
+        .as_deref()
+        .map(str::trim)
+        .filter(|key| !key.is_empty())
+    {
+        if matches!(config.security.mode, SecurityMode::Production)
+            && jwt_key == DEV_ADMISSION_JWT_KEY
+        {
+            return Err(Status::failed_precondition(
+                "production admission token mode cannot use the development JWT fallback key",
+            ));
+        }
+        return Ok(jwt_key);
+    }
+
+    if matches!(config.security.mode, SecurityMode::Dev) {
+        return Ok(DEV_ADMISSION_JWT_KEY);
+    }
+
+    Err(Status::failed_precondition(
+        "production admission token mode requires auth.jwt_key",
+    ))
+}
+
 pub struct ControllerService {
     cluster: Arc<ClusterManager>,
     raft: Arc<RaftHandle>,
@@ -153,13 +185,7 @@ impl ControllerService {
         spur_core::admission::validate_token(token_id, secret, &token_store)
             .map_err(|e| Status::permission_denied(e.to_string()))?;
 
-        let jwt_key = self
-            .cluster
-            .config
-            .auth
-            .jwt_key
-            .as_deref()
-            .unwrap_or("spur-default-key");
+        let jwt_key = admission_jwt_key_for_config(&self.cluster.config)?;
 
         spur_core::admission::generate_node_token(hostname, jwt_key.as_bytes())
             .map_err(|e| Status::internal(e.to_string()))
@@ -628,13 +654,7 @@ impl SlurmController for ControllerService {
             if req.node_token.is_empty() {
                 return Err(Status::unauthenticated("node token required"));
             }
-            let jwt_key = self
-                .cluster
-                .config
-                .auth
-                .jwt_key
-                .as_deref()
-                .unwrap_or("spur-default-key");
+            let jwt_key = admission_jwt_key_for_config(&self.cluster.config)?;
             let identity =
                 spur_core::admission::verify_node_token(&req.node_token, jwt_key.as_bytes())
                     .map_err(|e| Status::unauthenticated(e.to_string()))?;
@@ -973,13 +993,7 @@ impl SlurmController for ControllerService {
             if req.node_token.is_empty() {
                 return Err(Status::unauthenticated("node token required"));
             }
-            let jwt_key = self
-                .cluster
-                .config
-                .auth
-                .jwt_key
-                .as_deref()
-                .unwrap_or("spur-default-key");
+            let jwt_key = admission_jwt_key_for_config(&self.cluster.config)?;
             let identity =
                 spur_core::admission::verify_node_token(&req.node_token, jwt_key.as_bytes())
                     .map_err(|e| Status::unauthenticated(e.to_string()))?;
@@ -2041,9 +2055,52 @@ fn validate_completion_report_state_for_rpc(
 mod tests {
     use super::*;
     use chrono::Duration;
+    use spur_core::config::{DEV_ADMISSION_JWT_KEY, SecurityMode};
     use spur_core::job::{JobState, NodeCompleteError};
     use spur_core::reservation::ReservationFlags;
     use tonic::Code;
+
+    fn token_admission_config() -> spur_core::config::SlurmConfig {
+        spur_core::config::SlurmConfig::load_from_str(
+            r#"
+cluster_name = "test"
+
+[admission]
+mode = "token"
+"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn dev_admission_jwt_key_uses_fallback_when_missing() {
+        let config = token_admission_config();
+        assert_eq!(
+            admission_jwt_key_for_config(&config).unwrap(),
+            DEV_ADMISSION_JWT_KEY
+        );
+    }
+
+    #[test]
+    fn production_admission_jwt_key_requires_configured_secret() {
+        let mut config = token_admission_config();
+        config.security.mode = SecurityMode::Production;
+
+        let status = admission_jwt_key_for_config(&config).unwrap_err();
+        assert_eq!(status.code(), Code::FailedPrecondition);
+        assert!(status.message().contains("auth.jwt_key"));
+    }
+
+    #[test]
+    fn production_admission_jwt_key_rejects_dev_fallback_secret() {
+        let mut config = token_admission_config();
+        config.security.mode = SecurityMode::Production;
+        config.auth.jwt_key = Some(DEV_ADMISSION_JWT_KEY.into());
+
+        let status = admission_jwt_key_for_config(&config).unwrap_err();
+        assert_eq!(status.code(), Code::FailedPrecondition);
+        assert!(status.message().contains("development JWT fallback"));
+    }
 
     #[test]
     fn submit_rpc_status_maps_invalid_argument() {

--- a/docs/deployment/kubernetes.rst
+++ b/docs/deployment/kubernetes.rst
@@ -27,7 +27,9 @@ Components
 - **spurd** — Node agent. Runs on each compute node (DaemonSet or Deployment).
 - **spur-k8s-operator** — Watches ``SpurJob`` custom resources and submits them to the controller.
 
-Example manifests for production-style deployment live in ``examples/k8s/``.
+Example manifests for a starter deployment live in ``examples/k8s/``. They
+keep development security defaults until you wire secrets and admission tokens
+for your cluster.
 
 Deploy
 ------
@@ -58,6 +60,9 @@ The ConfigMap (``examples/k8s/configmap.yaml``) embeds ``spur.conf``:
 
    cluster_name = "spur-k8s"
 
+   [security]
+   mode = "dev"
+
    [controller]
    peers = [
      "spurctld-0.spurctld.spur.svc.cluster.local:6821",
@@ -77,6 +82,9 @@ The ConfigMap (``examples/k8s/configmap.yaml``) embeds ``spur.conf``:
 Raft peers use StatefulSet DNS names. The node ID is auto-detected from the pod hostname ordinal.
 
 Adjust partition definitions and node resources to match your cluster hardware.
+For production, set ``security.mode = "production"``, supply a generated
+``auth.jwt_key`` through your secret-management workflow, and set
+``admission.mode = "token"`` before enabling worker registration.
 
 Submitting Jobs
 ---------------

--- a/docs/deployment/native-host.rst
+++ b/docs/deployment/native-host.rst
@@ -58,6 +58,33 @@ Create ``/etc/spur/spur.conf``. The repository includes ``examples/spur.conf``. 
    memory_mb = 512000
    gres = ["gpu:mi300x:8"]
 
+Production Security Baseline
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The example config above and ``examples/spur.conf`` are development-oriented.
+For production, opt into the security validation boundary so Spur fails fast
+instead of accepting local-only defaults:
+
+.. code-block:: toml
+
+   [security]
+   mode = "production"
+
+   [auth]
+   plugin = "jwt"
+   jwt_key = "<generated high-entropy secret>"
+
+   [admission]
+   mode = "token"
+
+Before starting ``spurctld`` in production:
+
+- Do not use ``auth.plugin = "none"``.
+- Set ``auth.jwt_key`` to a generated secret from your secret-management workflow.
+- Use ``admission.mode = "token"`` and issue join tokens for worker registration.
+- Do not use the development fallback key ``spur-default-key``.
+- Keep mTLS, Raft peer authentication, and broader authorization hardening on your deployment roadmap; they are not covered by this baseline.
+
 Start the controller:
 
 .. code-block:: bash

--- a/examples/k8s/configmap.yaml
+++ b/examples/k8s/configmap.yaml
@@ -7,6 +7,12 @@ data:
   spur.conf: |
     cluster_name = "spur-k8s"
 
+    # Development defaults for example manifests. Production deployments should
+    # set mode = "production", configure auth.jwt_key from your
+    # secret-management workflow, and use [admission] mode = "token".
+    [security]
+    mode = "dev"
+
     [controller]
     # Raft peers use StatefulSet DNS names on the dedicated Raft port.
     # node_id is auto-detected from the pod hostname ordinal (spurctld-N → N+1).

--- a/examples/spur.conf
+++ b/examples/spur.conf
@@ -1,5 +1,11 @@
 cluster_name = "mi300x-cluster"
 
+# Development example. This keeps local bring-up defaults that are not suitable
+# for production. For a hardened baseline, set [security].mode = "production",
+# configure auth.jwt_key, and use token-based node admission.
+[security]
+mode = "dev"
+
 [controller]
 listen_addr = "[::]:6817"
 state_dir = "/var/spool/spur"
@@ -21,7 +27,12 @@ fairshare_halflife_days = 14
 database_url = "postgresql://spur:spur@localhost/spur"
 
 [auth]
+# Development only. Production mode rejects plugin = "none".
 plugin = "none"
+
+[admission]
+# Development only. Production mode requires token admission.
+mode = "open"
 
 [[partitions]]
 name = "gpu"


### PR DESCRIPTION
## Summary
- Adds `security.mode = dev | production` and production config validation that rejects auth `none`, open node admission, missing/empty JWT secrets when token auth is used, and the development fallback key.
- Gates the existing `spur-default-key` node-admission JWT fallback to dev mode so production no longer silently uses it.
- Labels example configs as dev-only and adds production security baseline guidance for native-host and Kubernetes deployments.

## Scope
This is PR 1 of the Fleet/Spur integration security foundation. It is intentionally limited to Spur production security groundwork and does not implement full mTLS, full authorization, Raft peer authentication, or Fleet compatibility.

## Test plan
- [x] IDE diagnostics on edited Rust files: no linter errors reported.
- [ ] `cargo fmt` (not run: `cargo` is not available in this Windows shell).
- [ ] Targeted Rust tests for `spur-core` and `spurctld` (not run: `cargo` is not available in this Windows shell).