### PR TITLE
feat(spur-cli): runtime partition CRUD via Raft WAL with scontrol reconfigure

### DIFF
--- a/crates/spur-cli/src/mock_controller.rs
+++ b/crates/spur-cli/src/mock_controller.rs
@@ -149,6 +149,10 @@ mock_controller_impl! {
         deregister_node(proto::DeregisterNodeRequest) -> proto::DeregisterNodeResponse;
         deregister_agent(proto::DeregisterAgentRequest) -> ();
         get_partitions(proto::GetPartitionsRequest) -> proto::GetPartitionsResponse;
+        create_partition(proto::CreatePartitionRequest) -> ();
+        update_partition(proto::UpdatePartitionRequest) -> ();
+        delete_partition(proto::DeletePartitionRequest) -> ();
+        reconfigure(()) -> ();
         get_job_steps(proto::GetJobStepsRequest) -> proto::GetJobStepsResponse;
         ping(()) -> proto::PingResponse;
         get_job_metrics(()) -> proto::JobMetrics;

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -223,8 +223,9 @@ pub enum ScontrolCommand {
         name: String,
     },
     /// Re-read spur.conf and apply it live on the leader (partitions, nodes,
-    /// licenses, hooks, scheduler tunables, etc.). Ports/DB/raft/jwt_key need a
-    /// restart; followers converge on restart.
+    /// licenses, controller hooks, complete_wait_secs/resv_overrun_minutes, etc.).
+    /// Ports/DB/raft/jwt_key, the scheduler loop cadence, and node-side settings
+    /// need a restart; followers converge on restart.
     Reconfigure,
     /// Create a reservation
     #[command(name = "create-reservation")]

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -34,9 +34,34 @@ pub enum ScontrolCommand {
         /// Entity name or ID
         name: Option<String>,
     },
-    /// Update job/node/partition properties
+    /// Create a partition or reservation (Slurm-compatible inline syntax)
+    ///
+    /// Examples:
+    ///   scontrol create PartitionName=gpu Nodes=n[1-4] MaxTime=24:00:00 State=UP
+    ///   scontrol create ReservationName=maint StartTime=now Duration=60 Nodes=n1
+    Create {
+        /// key=value pairs (e.g. PartitionName=gpu Nodes=n1 MaxTime=4:00:00)
+        #[arg(trailing_var_arg = true)]
+        params: Vec<String>,
+    },
+    /// Update job/node/partition properties (Slurm-compatible inline syntax)
+    ///
+    /// Examples:
+    ///   scontrol update PartitionName=gpu MaxTime=48:00:00 State=DOWN
+    ///   scontrol update JobId=42 Priority=100
+    ///   scontrol update NodeName=n1 State=drain Reason=maintenance
     Update {
         /// key=value pairs
+        #[arg(trailing_var_arg = true)]
+        params: Vec<String>,
+    },
+    /// Delete a partition or reservation (Slurm-compatible inline syntax)
+    ///
+    /// Examples:
+    ///   scontrol delete PartitionName=gpu
+    ///   scontrol delete ReservationName=maint
+    Delete {
+        /// key=value pairs (e.g. PartitionName=gpu)
         #[arg(trailing_var_arg = true)]
         params: Vec<String>,
     },
@@ -65,6 +90,142 @@ pub enum ScontrolCommand {
         /// Job ID
         job_id: u32,
     },
+    /// Create a partition
+    #[command(name = "create-partition")]
+    CreatePartition {
+        /// Partition name
+        #[arg(long)]
+        name: String,
+        /// Hostlist of nodes; a node matches if it satisfies this OR --selector
+        #[arg(long, default_value = "")]
+        nodes: String,
+        /// Label selector as KEY=VALUE pairs, comma-separated; a node matches if it satisfies this OR --nodes
+        #[arg(long, default_value = "")]
+        selector: String,
+        /// Partition state: UP (default), DOWN, DRAIN, INACTIVE
+        #[arg(long, default_value = "UP")]
+        state: String,
+        /// Mark as the cluster default partition
+        #[arg(long)]
+        default: bool,
+        /// Maximum job wall-clock time (e.g. "24:00:00" or "INFINITE")
+        #[arg(long, default_value = "")]
+        max_time: String,
+        /// Default job wall-clock time (e.g. "01:00:00")
+        #[arg(long, default_value = "")]
+        default_time: String,
+        /// Maximum number of nodes per job
+        #[arg(long)]
+        max_nodes: Option<u32>,
+        /// Minimum number of nodes per job
+        #[arg(long, default_value = "1")]
+        min_nodes: u32,
+        /// Comma-separated accounts allowed (empty = all)
+        #[arg(long, default_value = "")]
+        allow_accounts: String,
+        /// Comma-separated groups allowed (empty = all)
+        #[arg(long, default_value = "")]
+        allow_groups: String,
+        /// Comma-separated accounts denied
+        #[arg(long, default_value = "")]
+        deny_accounts: String,
+        /// Comma-separated QoS names denied
+        #[arg(long, default_value = "")]
+        deny_qos: String,
+        /// Comma-separated QoS names allowed (empty = all)
+        #[arg(long, default_value = "")]
+        allow_qos: String,
+        /// Scheduling priority tier
+        #[arg(long, default_value = "1")]
+        priority_tier: u32,
+        /// Preemption mode: OFF (default), CANCEL, REQUEUE, SUSPEND
+        #[arg(long, default_value = "OFF")]
+        preempt_mode: String,
+    },
+    /// Update a partition
+    #[command(name = "update-partition")]
+    UpdatePartition {
+        /// Partition name to update
+        #[arg(long)]
+        name: String,
+        /// New hostlist of nodes
+        #[arg(long)]
+        nodes: Option<String>,
+        /// New label selector as KEY=VALUE pairs, comma-separated
+        #[arg(long)]
+        selector: Option<String>,
+        /// Clear the label selector
+        #[arg(long)]
+        clear_selector: bool,
+        /// New partition state: UP, DOWN, DRAIN, INACTIVE
+        #[arg(long)]
+        state: Option<String>,
+        /// Set as the cluster default partition
+        #[arg(long)]
+        default: Option<bool>,
+        /// New maximum job wall-clock time ("INFINITE" to clear)
+        #[arg(long)]
+        max_time: Option<String>,
+        /// New default job wall-clock time
+        #[arg(long)]
+        default_time: Option<String>,
+        /// New maximum nodes per job (0 = clear limit)
+        #[arg(long)]
+        max_nodes: Option<u32>,
+        /// Clear the maximum nodes limit
+        #[arg(long)]
+        clear_max_nodes: bool,
+        /// New minimum nodes per job
+        #[arg(long)]
+        min_nodes: Option<u32>,
+        /// Replace allowed-accounts list (comma-separated; requires --set-allow-accounts)
+        #[arg(long, default_value = "")]
+        allow_accounts: String,
+        /// Apply the --allow-accounts value (even if empty, to clear the list)
+        #[arg(long)]
+        set_allow_accounts: bool,
+        /// Replace allowed-groups list (comma-separated; requires --set-allow-groups)
+        #[arg(long, default_value = "")]
+        allow_groups: String,
+        /// Apply the --allow-groups value (even if empty, to clear the list)
+        #[arg(long)]
+        set_allow_groups: bool,
+        /// Replace denied-accounts list (comma-separated; requires --set-deny-accounts)
+        #[arg(long, default_value = "")]
+        deny_accounts: String,
+        /// Apply the --deny-accounts value
+        #[arg(long)]
+        set_deny_accounts: bool,
+        /// Replace denied-QoS list (comma-separated; requires --set-deny-qos)
+        #[arg(long, default_value = "")]
+        deny_qos: String,
+        /// Apply the --deny-qos value
+        #[arg(long)]
+        set_deny_qos: bool,
+        /// Replace allowed-QoS list (comma-separated; requires --set-allow-qos)
+        #[arg(long, default_value = "")]
+        allow_qos: String,
+        /// Apply the --allow-qos value (even if empty, to clear the list)
+        #[arg(long)]
+        set_allow_qos: bool,
+        /// New priority tier
+        #[arg(long)]
+        priority_tier: Option<u32>,
+        /// New preemption mode: OFF, CANCEL, REQUEUE, SUSPEND
+        #[arg(long)]
+        preempt_mode: Option<String>,
+    },
+    /// Delete a partition
+    #[command(name = "delete-partition")]
+    DeletePartition {
+        /// Partition name
+        #[arg(long)]
+        name: String,
+    },
+    /// Re-read spur.conf and apply it live on the leader (partitions, nodes,
+    /// licenses, hooks, scheduler tunables, etc.). Ports/DB/raft/jwt_key need a
+    /// restart; followers converge on restart.
+    Reconfigure,
     /// Create a reservation
     #[command(name = "create-reservation")]
     CreateReservation {
@@ -215,7 +376,108 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             println!("job {} resumed", job_id);
             Ok(())
         }
+        ScontrolCommand::Create { params } => parse_and_create(&args.controller, &params).await,
         ScontrolCommand::Update { params } => parse_and_update(&args.controller, &params).await,
+        ScontrolCommand::Delete { params } => parse_and_delete(&args.controller, &params).await,
+        ScontrolCommand::CreatePartition {
+            name,
+            nodes,
+            selector,
+            state,
+            default,
+            max_time,
+            default_time,
+            max_nodes,
+            min_nodes,
+            allow_accounts,
+            allow_groups,
+            deny_accounts,
+            deny_qos,
+            allow_qos,
+            priority_tier,
+            preempt_mode,
+        } => {
+            create_partition(
+                &args.controller,
+                &name,
+                &nodes,
+                &selector,
+                &state,
+                default,
+                &max_time,
+                &default_time,
+                max_nodes,
+                min_nodes,
+                &allow_accounts,
+                &allow_groups,
+                &deny_accounts,
+                &deny_qos,
+                &allow_qos,
+                priority_tier,
+                &preempt_mode,
+            )
+            .await
+        }
+        ScontrolCommand::UpdatePartition {
+            name,
+            nodes,
+            selector,
+            clear_selector,
+            state,
+            default,
+            max_time,
+            default_time,
+            max_nodes,
+            clear_max_nodes,
+            min_nodes,
+            allow_accounts,
+            allow_groups,
+            set_allow_accounts,
+            set_allow_groups,
+            deny_accounts,
+            deny_qos,
+            set_deny_accounts,
+            set_deny_qos,
+            allow_qos,
+            set_allow_qos,
+            priority_tier,
+            preempt_mode,
+        } => {
+            let selector_map = match selector {
+                Some(ref s) => parse_selector(s)?,
+                None => HashMap::new(),
+            };
+            let req = spur_proto::proto::UpdatePartitionRequest {
+                name,
+                nodes,
+                selector: selector_map,
+                set_selector: clear_selector || selector.is_some(),
+                state,
+                is_default: default,
+                max_time,
+                default_time,
+                max_nodes_value: max_nodes,
+                clear_max_nodes,
+                min_nodes,
+                allow_accounts: split_csv(&allow_accounts),
+                set_allow_accounts,
+                allow_groups: split_csv(&allow_groups),
+                set_allow_groups,
+                deny_accounts: split_csv(&deny_accounts),
+                set_deny_accounts,
+                deny_qos: split_csv(&deny_qos),
+                set_deny_qos,
+                allow_qos: split_csv(&allow_qos),
+                set_allow_qos,
+                priority_tier,
+                preempt_mode,
+            };
+            update_partition(&args.controller, req).await
+        }
+        ScontrolCommand::DeletePartition { name } => {
+            delete_partition(&args.controller, &name).await
+        }
+        ScontrolCommand::Reconfigure => reconfigure(&args.controller).await,
         ScontrolCommand::CreateReservation {
             name,
             start_time,
@@ -247,12 +509,6 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             add_accounts,
             remove_accounts,
         } => {
-            let split_csv = |s: &str| -> Vec<String> {
-                s.split(',')
-                    .map(|s| s.trim().to_string())
-                    .filter(|s| !s.is_empty())
-                    .collect()
-            };
             let channel = spur_client::connect_channel(&args.controller)
                 .await
                 .context("failed to connect to spurctld")?;
@@ -418,7 +674,31 @@ async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> 
                     part.name,
                     if part.is_default { " Default=YES" } else { "" }
                 );
-                println!("   State={}", part.state);
+                println!(
+                    "   AllowGroups={} AllowAccounts={} AllowQos={}",
+                    if part.allow_groups.is_empty() {
+                        "ALL".into()
+                    } else {
+                        part.allow_groups.clone()
+                    },
+                    if part.allow_accounts.is_empty() {
+                        "ALL".into()
+                    } else {
+                        part.allow_accounts.clone()
+                    },
+                    if part.allow_qos.is_empty() {
+                        "ALL".into()
+                    } else {
+                        part.allow_qos.clone()
+                    },
+                );
+                if !part.deny_accounts.is_empty() {
+                    println!("   DenyAccounts={}", part.deny_accounts);
+                }
+                if !part.deny_qos.is_empty() {
+                    println!("   DenyQos={}", part.deny_qos);
+                }
+                println!("   State={}", part.state.to_uppercase());
                 println!("   Nodes={}", part.nodes);
                 println!(
                     "   TotalNodes={} TotalCPUs={}",
@@ -435,13 +715,20 @@ async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> 
                         .map(|t| spur_core::config::format_time(Some((t.seconds / 60) as u32)))
                         .unwrap_or_else(|| "UNLIMITED".into()),
                 );
-                println!("   PriorityTier={}", part.priority_tier);
-                if !part.allow_accounts.is_empty() {
-                    println!("   AllowAccounts={}", part.allow_accounts);
-                }
-                if !part.deny_accounts.is_empty() {
-                    println!("   DenyAccounts={}", part.deny_accounts);
-                }
+                println!(
+                    "   MinNodes={} MaxNodes={}",
+                    part.min_nodes,
+                    if part.max_nodes == 0 {
+                        "UNLIMITED".into()
+                    } else {
+                        part.max_nodes.to_string()
+                    },
+                );
+                println!(
+                    "   PreemptMode={} PriorityTier={}",
+                    part.preempt_mode.to_uppercase(),
+                    part.priority_tier
+                );
                 println!();
             }
         }
@@ -599,8 +886,200 @@ async fn send_job_update(controller: &str, req: spur_proto::proto::UpdateJobRequ
     Ok(())
 }
 
+/// The entity a Slurm-style `scontrol` key=value command targets.
+#[derive(Debug, PartialEq, Eq)]
+enum ScontrolEntity {
+    Partition,
+    Reservation,
+}
+
+/// Detect the target entity by scanning all params for `PartitionName=` /
+/// `ReservationName=`. Slurm key=value syntax is order-independent, so the
+/// marker may appear anywhere. Errors if both markers are present; returns
+/// `None` when neither is (the caller picks the default, e.g. job/node update).
+fn detect_entity(params: &[String]) -> Result<Option<ScontrolEntity>> {
+    let present = |marker: &str| {
+        params.iter().any(|p| {
+            p.split_once('=')
+                .is_some_and(|(k, _)| k.eq_ignore_ascii_case(marker))
+        })
+    };
+    match (present("PartitionName"), present("ReservationName")) {
+        (true, true) => {
+            anyhow::bail!("scontrol: specify only one of PartitionName= or ReservationName=")
+        }
+        (true, false) => Ok(Some(ScontrolEntity::Partition)),
+        (false, true) => Ok(Some(ScontrolEntity::Reservation)),
+        (false, false) => Ok(None),
+    }
+}
+
+/// Parse key=value pairs from a Slurm-style `scontrol create` command and
+/// dispatch to the appropriate create handler (partition or reservation).
+async fn parse_and_create(controller: &str, params: &[String]) -> Result<()> {
+    match detect_entity(params)? {
+        Some(ScontrolEntity::Partition) => parse_and_create_partition(controller, params).await,
+        Some(ScontrolEntity::Reservation) => parse_and_create_reservation(controller, params).await,
+        None => anyhow::bail!(
+            "scontrol create: expected PartitionName=<name> or ReservationName=<name>"
+        ),
+    }
+}
+
+/// Parse Slurm key=value pairs and call create_partition.
+///
+/// Slurm keys (case-insensitive): PartitionName, Nodes, State, Default,
+/// MaxTime, DefaultTime, MaxNodes, MinNodes, AllowAccounts, AllowGroups,
+/// AllowQos, DenyAccounts, DenyQos, PriorityTier, PreemptMode.
+async fn parse_and_create_partition(controller: &str, params: &[String]) -> Result<()> {
+    let mut name = String::new();
+    let mut nodes = String::new();
+    let mut state = "UP".to_string();
+    let mut is_default = false;
+    let mut max_time = String::new();
+    let mut default_time = String::new();
+    let mut max_nodes: Option<u32> = None;
+    let mut min_nodes: u32 = 1;
+    let mut allow_accounts = String::new();
+    let mut allow_groups = String::new();
+    let mut allow_qos = String::new();
+    let mut deny_accounts = String::new();
+    let mut deny_qos = String::new();
+    let mut priority_tier: u32 = 1;
+    let mut preempt_mode = "OFF".to_string();
+
+    for param in params {
+        if let Some((key, value)) = param.split_once('=') {
+            match key.to_lowercase().as_str() {
+                "partitionname" => name = value.into(),
+                "nodes" => nodes = value.into(),
+                "state" => state = value.to_uppercase(),
+                "default" => is_default = value.eq_ignore_ascii_case("yes"),
+                "maxtime" => max_time = value.into(),
+                "defaulttime" => default_time = value.into(),
+                "maxnodes" => max_nodes = value.parse().ok(),
+                "minnodes" => min_nodes = value.parse().unwrap_or(1),
+                "allowaccounts" => allow_accounts = value.into(),
+                "allowgroups" => allow_groups = value.into(),
+                "allowqos" => allow_qos = value.into(),
+                "denyaccounts" => deny_accounts = value.into(),
+                "denyqos" => deny_qos = value.into(),
+                "prioritytier" | "priorityjobfactor" => priority_tier = value.parse().unwrap_or(1),
+                "preemptmode" => preempt_mode = value.to_uppercase(),
+                // silently ignore Slurm-only keys that don't map to spur fields
+                "allocnodes" | "hidden" | "rootonly" | "reqresv" | "oversubscribe"
+                | "overtimelimit" | "gracetime" | "disablerootjobs" | "exclusiveuser"
+                | "exclusivetopo" | "lln" | "maxcpuspernode" | "maxcpuspersocket"
+                | "jobdefaults" | "defmempernode" | "maxmempernode" | "qos" | "tres" => {}
+                other => eprintln!("scontrol create partition: unknown key '{}'", other),
+            }
+        }
+    }
+
+    if name.is_empty() {
+        anyhow::bail!("scontrol create: PartitionName= is required");
+    }
+
+    create_partition(
+        controller,
+        &name,
+        &nodes,
+        "",
+        &state,
+        is_default,
+        &max_time,
+        &default_time,
+        max_nodes,
+        min_nodes,
+        &allow_accounts,
+        &allow_groups,
+        &deny_accounts,
+        &deny_qos,
+        &allow_qos,
+        priority_tier,
+        &preempt_mode,
+    )
+    .await?;
+
+    Ok(())
+}
+
+/// Parse Slurm key=value pairs and call create_reservation.
+async fn parse_and_create_reservation(controller: &str, params: &[String]) -> Result<()> {
+    let mut name = String::new();
+    let mut start_time = "now".to_string();
+    let mut duration: u32 = 0;
+    let mut nodes = String::new();
+    let mut accounts = String::new();
+    let mut users = String::new();
+    let mut flags = String::new();
+
+    for param in params {
+        if let Some((key, value)) = param.split_once('=') {
+            match key.to_lowercase().as_str() {
+                "reservationname" => name = value.into(),
+                "starttime" => start_time = value.into(),
+                "duration" => duration = value.parse().unwrap_or(0),
+                "nodes" => nodes = value.into(),
+                "accounts" => accounts = value.into(),
+                "users" => users = value.into(),
+                "flags" => flags = value.into(),
+                other => eprintln!("scontrol create reservation: unknown key '{}'", other),
+            }
+        }
+    }
+
+    if name.is_empty() {
+        anyhow::bail!("scontrol create: ReservationName= is required");
+    }
+
+    create_reservation(
+        controller,
+        &name,
+        &start_time,
+        duration,
+        &nodes,
+        &accounts,
+        &users,
+        &flags,
+    )
+    .await
+}
+
+/// Parse key=value pairs from a Slurm-style `scontrol delete` command and
+/// dispatch to the appropriate delete handler.
+async fn parse_and_delete(controller: &str, params: &[String]) -> Result<()> {
+    let value_for = |marker: &str| {
+        params.iter().find_map(|p| {
+            let (k, v) = p.split_once('=')?;
+            k.eq_ignore_ascii_case(marker).then(|| v.to_string())
+        })
+    };
+
+    match detect_entity(params)? {
+        Some(ScontrolEntity::Partition) => {
+            let name = value_for("PartitionName")
+                .ok_or_else(|| anyhow::anyhow!("scontrol delete: PartitionName= value missing"))?;
+            delete_partition(controller, &name).await
+        }
+        Some(ScontrolEntity::Reservation) => {
+            let name = value_for("ReservationName").ok_or_else(|| {
+                anyhow::anyhow!("scontrol delete: ReservationName= value missing")
+            })?;
+            delete_reservation(controller, &name).await
+        }
+        None => anyhow::bail!(
+            "scontrol delete: expected PartitionName=<name> or ReservationName=<name>"
+        ),
+    }
+}
+
 /// Parse "key=value" params from `scontrol update` command.
 async fn parse_and_update(controller: &str, params: &[String]) -> Result<()> {
+    if let Some(ScontrolEntity::Partition) = detect_entity(params)? {
+        return parse_and_update_partition(controller, params).await;
+    }
+
     let mut job_id: Option<u32> = None;
     let mut priority: Option<u32> = None;
     let mut time_limit: Option<String> = None;
@@ -660,8 +1139,9 @@ async fn parse_and_update(controller: &str, params: &[String]) -> Result<()> {
         return Ok(());
     }
 
-    let jid =
-        job_id.ok_or_else(|| anyhow::anyhow!("scontrol update: JobId= or NodeName= required"))?;
+    let jid = job_id.ok_or_else(|| {
+        anyhow::anyhow!("scontrol update: JobId=, NodeName=, or PartitionName= required")
+    })?;
 
     let tl = time_limit.as_ref().and_then(|t| {
         spur_core::config::parse_time_minutes(t).map(|m| prost_types::Duration {
@@ -729,6 +1209,101 @@ fn parse_node_state(state: &str) -> Result<i32> {
     }
 }
 
+/// Parse Slurm key=value pairs for `scontrol update PartitionName=...`.
+///
+/// Slurm keys accepted (all case-insensitive): PartitionName (required),
+/// Nodes, State, Default, MaxTime, DefaultTime, MaxNodes, MinNodes,
+/// AllowAccounts, AllowGroups, DenyAccounts, DenyQos, AllowQos,
+/// PriorityTier, PreemptMode.
+async fn parse_and_update_partition(controller: &str, params: &[String]) -> Result<()> {
+    let mut name = String::new();
+    let mut nodes: Option<String> = None;
+    let mut state: Option<String> = None;
+    let mut is_default: Option<bool> = None;
+    let mut max_time: Option<String> = None;
+    let mut default_time: Option<String> = None;
+    let mut max_nodes: Option<u32> = None;
+    let mut clear_max_nodes = false;
+    let mut min_nodes: Option<u32> = None;
+    let mut allow_accounts: Option<String> = None;
+    let mut allow_groups: Option<String> = None;
+    let mut deny_accounts: Option<String> = None;
+    let mut deny_qos: Option<String> = None;
+    let mut allow_qos: Option<String> = None;
+    let mut priority_tier: Option<u32> = None;
+    let mut preempt_mode: Option<String> = None;
+
+    for param in params {
+        if let Some((key, value)) = param.split_once('=') {
+            match key.to_lowercase().as_str() {
+                "partitionname" => name = value.into(),
+                "nodes" => nodes = Some(value.into()),
+                "state" => state = Some(value.to_uppercase()),
+                "default" => is_default = Some(value.eq_ignore_ascii_case("yes")),
+                "maxtime" => max_time = Some(value.into()),
+                "defaulttime" => default_time = Some(value.into()),
+                "maxnodes" => {
+                    // Last key wins: a later numeric value must undo an earlier clear.
+                    if value.eq_ignore_ascii_case("UNLIMITED") || value == "0" {
+                        clear_max_nodes = true;
+                        max_nodes = None;
+                    } else {
+                        max_nodes = value.parse().ok();
+                        clear_max_nodes = false;
+                    }
+                }
+                "minnodes" => min_nodes = value.parse().ok(),
+                "allowaccounts" => allow_accounts = Some(value.into()),
+                "allowgroups" => allow_groups = Some(value.into()),
+                "denyaccounts" => deny_accounts = Some(value.into()),
+                "denyqos" => deny_qos = Some(value.into()),
+                "allowqos" => allow_qos = Some(value.into()),
+                "prioritytier" | "priorityjobfactor" => priority_tier = value.parse().ok(),
+                "preemptmode" => preempt_mode = Some(value.to_uppercase()),
+                // silently ignore Slurm-only keys
+                "allocnodes" | "hidden" | "rootonly" | "reqresv" | "oversubscribe"
+                | "overtimelimit" | "gracetime" | "disablerootjobs" | "exclusiveuser"
+                | "exclusivetopo" | "lln" | "maxcpuspernode" | "maxcpuspersocket"
+                | "jobdefaults" | "defmempernode" | "maxmempernode" | "qos" | "tres" => {}
+                other => eprintln!("scontrol update partition: unknown key '{}'", other),
+            }
+        }
+    }
+
+    if name.is_empty() {
+        anyhow::bail!("scontrol update: PartitionName= is required");
+    }
+
+    // An ACL is applied only when its key appeared; an empty value clears it.
+    let req = spur_proto::proto::UpdatePartitionRequest {
+        name,
+        nodes,
+        selector: HashMap::new(), // selector not supported in inline syntax
+        set_selector: false,
+        state,
+        is_default,
+        max_time,
+        default_time,
+        max_nodes_value: max_nodes,
+        clear_max_nodes,
+        min_nodes,
+        set_allow_accounts: allow_accounts.is_some(),
+        allow_accounts: allow_accounts.as_deref().map(split_csv).unwrap_or_default(),
+        set_allow_groups: allow_groups.is_some(),
+        allow_groups: allow_groups.as_deref().map(split_csv).unwrap_or_default(),
+        set_deny_accounts: deny_accounts.is_some(),
+        deny_accounts: deny_accounts.as_deref().map(split_csv).unwrap_or_default(),
+        set_deny_qos: deny_qos.is_some(),
+        deny_qos: deny_qos.as_deref().map(split_csv).unwrap_or_default(),
+        set_allow_qos: allow_qos.is_some(),
+        allow_qos: allow_qos.as_deref().map(split_csv).unwrap_or_default(),
+        priority_tier,
+        preempt_mode,
+    };
+
+    update_partition(controller, req).await
+}
+
 /// Update a node's state via the controller.
 async fn update_node(
     client: &mut SlurmControllerClient<tonic::transport::Channel>,
@@ -748,6 +1323,134 @@ async fn update_node(
         .context("node update failed")?;
 
     println!("node {} updated", name);
+    Ok(())
+}
+
+/// Split a comma-separated list into trimmed, non-empty entries.
+fn split_csv(s: &str) -> Vec<String> {
+    s.split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// Parse "KEY=VALUE,KEY2=VALUE2" into a HashMap.
+fn parse_selector(s: &str) -> Result<HashMap<String, String>> {
+    let mut map = HashMap::new();
+    for pair in s.split(',').map(str::trim).filter(|p| !p.is_empty()) {
+        let (k, v) = pair.split_once('=').context(format!(
+            "selector entry '{}' is not in KEY=VALUE format",
+            pair
+        ))?;
+        map.insert(k.to_string(), v.to_string());
+    }
+    Ok(map)
+}
+
+/// Create a partition via the controller.
+#[allow(clippy::too_many_arguments)]
+async fn create_partition(
+    controller: &str,
+    name: &str,
+    nodes: &str,
+    selector: &str,
+    state: &str,
+    is_default: bool,
+    max_time: &str,
+    default_time: &str,
+    max_nodes: Option<u32>,
+    min_nodes: u32,
+    allow_accounts: &str,
+    allow_groups: &str,
+    deny_accounts: &str,
+    deny_qos: &str,
+    allow_qos: &str,
+    priority_tier: u32,
+    preempt_mode: &str,
+) -> Result<()> {
+    let channel = spur_client::connect_channel(controller)
+        .await
+        .context("failed to connect to spurctld")?;
+    let mut client = spur_proto::controller_client(channel);
+
+    client
+        .create_partition(spur_proto::proto::CreatePartitionRequest {
+            name: name.to_string(),
+            nodes: nodes.to_string(),
+            selector: parse_selector(selector)?,
+            state: state.to_string(),
+            is_default,
+            max_time: max_time.to_string(),
+            default_time: default_time.to_string(),
+            max_nodes,
+            min_nodes,
+            allow_accounts: split_csv(allow_accounts),
+            allow_groups: split_csv(allow_groups),
+            deny_accounts: split_csv(deny_accounts),
+            deny_qos: split_csv(deny_qos),
+            allow_qos: split_csv(allow_qos),
+            priority_tier,
+            preempt_mode: preempt_mode.to_string(),
+        })
+        .await
+        .context("failed to create partition")?;
+
+    println!("Partition {} created", name);
+    Ok(())
+}
+
+/// Update a partition via the controller. The request is already the proto
+/// struct, so callers assemble it directly rather than threading a long
+/// positional field list through this sender.
+async fn update_partition(
+    controller: &str,
+    req: spur_proto::proto::UpdatePartitionRequest,
+) -> Result<()> {
+    let channel = spur_client::connect_channel(controller)
+        .await
+        .context("failed to connect to spurctld")?;
+    let mut client = spur_proto::controller_client(channel);
+
+    let name = req.name.clone();
+    client
+        .update_partition(req)
+        .await
+        .context("failed to update partition")?;
+
+    println!("Partition {} updated", name);
+    Ok(())
+}
+
+/// Delete a partition via the controller.
+async fn delete_partition(controller: &str, name: &str) -> Result<()> {
+    let channel = spur_client::connect_channel(controller)
+        .await
+        .context("failed to connect to spurctld")?;
+    let mut client = spur_proto::controller_client(channel);
+
+    client
+        .delete_partition(spur_proto::proto::DeletePartitionRequest {
+            name: name.to_string(),
+        })
+        .await
+        .context("failed to delete partition")?;
+
+    println!("Partition {} deleted", name);
+    Ok(())
+}
+
+/// Reload spur.conf and reconcile partition state to match it.
+async fn reconfigure(controller: &str) -> Result<()> {
+    let channel = spur_client::connect_channel(controller)
+        .await
+        .context("failed to connect to spurctld")?;
+    let mut client = spur_proto::controller_client(channel);
+
+    client.reconfigure(()).await.context("reconfigure failed")?;
+
+    println!(
+        "Reconfiguration complete on the leader (followers converge on restart; listen ports, accounting DB, raft peers, and jwt_key still require a controller restart)"
+    );
     Ok(())
 }
 
@@ -873,6 +1576,28 @@ mod tests {
         );
     }
 
+    fn p(args: &[&str]) -> Vec<String> {
+        args.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn detect_entity_is_order_independent() {
+        // The entity marker may appear after other keys — Slurm syntax is
+        // order-independent, so detection must scan all params, not just the first.
+        assert_eq!(
+            detect_entity(&p(&["Nodes=n1", "PartitionName=gpu"])).unwrap(),
+            Some(ScontrolEntity::Partition)
+        );
+        assert_eq!(
+            detect_entity(&p(&["Flags=MAINT", "ReservationName=maint"])).unwrap(),
+            Some(ScontrolEntity::Reservation)
+        );
+        assert_eq!(
+            detect_entity(&p(&["State=DOWN", "PartitionName=gpu"])).unwrap(),
+            Some(ScontrolEntity::Partition)
+        );
+    }
+
     #[test]
     fn parse_node_state_is_case_insensitive() {
         let drain = spur_proto::proto::NodeState::NodeDrain as i32;
@@ -891,8 +1616,21 @@ mod tests {
     }
 
     #[test]
+    fn detect_entity_none_when_no_marker() {
+        assert_eq!(
+            detect_entity(&p(&["JobId=5", "Priority=10"])).unwrap(),
+            None
+        );
+    }
+
+    #[test]
     fn parse_node_state_rejects_empty() {
         assert!(parse_node_state("").is_err());
+    }
+
+    #[test]
+    fn detect_entity_rejects_both_markers() {
+        assert!(detect_entity(&p(&["PartitionName=gpu", "ReservationName=maint"])).is_err());
     }
 
     #[tokio::test]

--- a/crates/spur-cli/src/sinfo.rs
+++ b/crates/spur-cli/src/sinfo.rs
@@ -497,6 +497,10 @@ mod tests {
         deregister_agent(pb::DeregisterAgentRequest) -> ();
         get_job_steps(pb::GetJobStepsRequest) -> pb::GetJobStepsResponse;
         create_job_step(pb::CreateJobStepRequest) -> pb::CreateJobStepResponse;
+        create_partition(pb::CreatePartitionRequest) -> ();
+        update_partition(pb::UpdatePartitionRequest) -> ();
+        delete_partition(pb::DeletePartitionRequest) -> ();
+        reconfigure(()) -> ();
         ping(()) -> pb::PingResponse;
         get_job_metrics(()) -> pb::JobMetrics;
         get_node_metrics(()) -> pb::NodeMetrics;

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -528,6 +528,10 @@ pub struct PartitionConfig {
     #[serde(default)]
     pub deny_accounts: Vec<String>,
     #[serde(default)]
+    pub deny_qos: Vec<String>,
+    #[serde(default)]
+    pub allow_qos: Vec<String>,
+    #[serde(default)]
     pub priority_tier: u32,
     #[serde(default)]
     pub preempt_mode: String,
@@ -1264,6 +1268,11 @@ impl SlurmConfig {
                 default_time_minutes: pc.default_time.as_ref().and_then(|t| parse_time_minutes(t)),
                 max_nodes: pc.max_nodes,
                 min_nodes: pc.min_nodes,
+                allow_accounts: pc.allow_accounts.clone(),
+                allow_groups: pc.allow_groups.clone(),
+                deny_accounts: pc.deny_accounts.clone(),
+                deny_qos: pc.deny_qos.clone(),
+                allow_qos: pc.allow_qos.clone(),
                 priority_tier: pc.priority_tier,
                 preempt_mode: match pc.preempt_mode.to_lowercase().as_str() {
                     "cancel" => PreemptMode::Cancel,
@@ -1271,8 +1280,6 @@ impl SlurmConfig {
                     "suspend" => PreemptMode::Suspend,
                     _ => PreemptMode::Off,
                 },
-                allow_accounts: pc.allow_accounts.clone(),
-                deny_accounts: pc.deny_accounts.clone(),
                 ..Default::default()
             })
             .collect()

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -7,6 +7,7 @@ use crate::admission::AdmissionToken;
 use crate::job::{JobId, JobSpec, JobState, PendingReason};
 use crate::k0s::{K0sPhase, K0sRole};
 use crate::node::NodeState;
+use crate::partition::Partition;
 use crate::reservation::Reservation;
 use std::collections::HashMap;
 
@@ -187,6 +188,32 @@ pub enum WalOperation {
     },
     TokenRevoke {
         token_id: String,
+    },
+
+    PartitionCreate {
+        partition: Partition,
+    },
+    PartitionUpdate {
+        name: String,
+        /// Fields present in the update; absent fields are left unchanged.
+        nodes: Option<String>,
+        selector: Option<HashMap<String, String>>,
+        state: Option<String>,
+        max_time_minutes: Option<Option<u32>>,
+        default_time_minutes: Option<Option<u32>>,
+        max_nodes: Option<Option<u32>>,
+        min_nodes: Option<u32>,
+        allow_accounts: Option<Vec<String>>,
+        allow_groups: Option<Vec<String>>,
+        deny_accounts: Option<Vec<String>>,
+        deny_qos: Option<Vec<String>>,
+        allow_qos: Option<Vec<String>>,
+        priority_tier: Option<u32>,
+        preempt_mode: Option<String>,
+        is_default: Option<bool>,
+    },
+    PartitionDelete {
+        name: String,
     },
 
     ReservationCreate {

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -305,6 +305,11 @@ pub struct ClusterManager {
     /// Names of partitions that were runtime-deleted. Used to suppress config-file
     /// partitions with the same name from re-appearing on restart.
     deleted_partition_names: RwLock<HashSet<String>>,
+    /// Partition names seeded from config before WAL replay. A replayed
+    /// `PartitionCreate` for one overwrites the seed (WAL is authoritative);
+    /// once overridden the name is removed, so later duplicates stay
+    /// first-writer-wins. Runtime-only, never persisted.
+    config_seeded_partitions: RwLock<HashSet<String>>,
     next_job_id: AtomicU32,
     reservations: RwLock<Vec<Reservation>>,
     steps: RwLock<HashMap<(JobId, u32), JobStep>>,
@@ -354,6 +359,8 @@ impl ClusterManager {
         config_path: Option<PathBuf>,
     ) -> anyhow::Result<Self> {
         let partitions = config.build_partitions();
+        let config_seeded_partitions: HashSet<String> =
+            partitions.iter().map(|p| p.name.clone()).collect();
         let license_pool = config.licenses.clone();
         let burst_buffer_total_gb = config.burst_buffer.total_gb;
         let fairshare_cache = Arc::new(FairshareCache::new());
@@ -370,6 +377,7 @@ impl ClusterManager {
             nodes: RwLock::new(HashMap::new()),
             partitions: RwLock::new(partitions),
             deleted_partition_names: RwLock::new(HashSet::new()),
+            config_seeded_partitions: RwLock::new(config_seeded_partitions),
             reservations: RwLock::new(Vec::new()),
             steps: RwLock::new(HashMap::new()),
             next_job_id: AtomicU32::new(first_job_id),
@@ -404,17 +412,19 @@ impl ClusterManager {
         apply_default_time_limit(&mut spec, &self.partitions.read());
         apply_default_account(&mut spec, &self.association_cache);
         validate_user_account(&spec, &self.association_cache)?;
-        self.validate_partition(&spec)?;
-        let mpi = spec.mpi.as_deref().unwrap_or(spur_core::mpi::MPI_NONE);
-        spur_core::mpi::validate_single_node_pmix(mpi, spec.num_nodes)
-            .map_err(SubmitError::invalid)?;
         let config = self.config();
+        // Default QoS must resolve before the partition ACL, or `allow_qos` sees
+        // an empty QoS and wrongly rejects a user's inherited default.
         apply_default_qos(
             &mut spec,
             &self.association_cache,
             &self.qos_cache,
             &config.accounting,
         )?;
+        self.validate_partition(&spec)?;
+        let mpi = spec.mpi.as_deref().unwrap_or(spur_core::mpi::MPI_NONE);
+        spur_core::mpi::validate_single_node_pmix(mpi, spec.num_nodes)
+            .map_err(SubmitError::invalid)?;
 
         // Checked after defaults are applied so we measure the final spec.
         // Array expansion only adds bounded integer metadata per task, so a
@@ -4482,22 +4492,42 @@ impl ClusterManager {
                 self.deleted_partition_names.write().remove(&partition.name);
                 {
                     let mut partitions = self.partitions.write();
-                    if partitions.iter().any(|p| p.name == partition.name) {
-                        warn!(
-                            name = %partition.name,
-                            "duplicate partition create in WAL apply, ignoring"
-                        );
-                    } else {
-                        // Promote exactly one default: clear all others when
-                        // the new partition is created as the default.
-                        if partition.is_default {
-                            for p in partitions.iter_mut() {
-                                p.is_default = false;
+                    let existing = partitions.iter().position(|p| p.name == partition.name);
+                    // Seeded name => the existing entry is only the pre-replay
+                    // config seed, so the WAL entry overrides it; else duplicate.
+                    let seeded = self
+                        .config_seeded_partitions
+                        .write()
+                        .remove(&partition.name);
+                    match existing {
+                        Some(idx) if seeded => {
+                            if partition.is_default {
+                                for p in partitions.iter_mut() {
+                                    p.is_default = false;
+                                }
                             }
+                            partitions[idx] = partition.clone();
+                            response.partition_created = true;
+                            info!(name = %partition.name, "partition restored from WAL over config seed");
                         }
-                        partitions.push(partition.clone());
-                        response.partition_created = true;
-                        info!(name = %partition.name, "partition created");
+                        Some(_) => {
+                            warn!(
+                                name = %partition.name,
+                                "duplicate partition create in WAL apply, ignoring"
+                            );
+                        }
+                        None => {
+                            // Promote exactly one default: clear all others when
+                            // the new partition is created as the default.
+                            if partition.is_default {
+                                for p in partitions.iter_mut() {
+                                    p.is_default = false;
+                                }
+                            }
+                            partitions.push(partition.clone());
+                            response.partition_created = true;
+                            info!(name = %partition.name, "partition created");
+                        }
                     }
                 }
                 // Node-to-partition membership is derived from the partition
@@ -4722,11 +4752,12 @@ struct ClusterSnapshot {
     jobs: Vec<Job>,
     nodes: Vec<Node>,
     reservations: Vec<Reservation>,
-    /// Runtime-created/modified partitions. On restore these overlay the
-    /// config-file baseline; names in `deleted_partition_names` are skipped
-    /// from the baseline entirely.
+    /// The leader's authoritative partition table. `None` = pre-partition-support
+    /// snapshot (field absent) → restore falls back to the config baseline.
+    /// `Some(_)`, empty included, is installed verbatim so a leader with zero
+    /// partitions is not reseeded from a follower's local config.
     #[serde(default)]
-    partitions: Vec<Partition>,
+    partitions: Option<Vec<Partition>>,
     /// Names of partitions deleted at runtime. Suppresses config-file
     /// partitions with the same name from re-seeding on restart.
     #[serde(default)]
@@ -4803,7 +4834,7 @@ impl StateMachineApply for ClusterManager {
             jobs: self.jobs.read().values().cloned().collect(),
             nodes: self.nodes.read().values().cloned().collect(),
             reservations: self.reservations.read().clone(),
-            partitions: self.partitions.read().clone(),
+            partitions: Some(self.partitions.read().clone()),
             deleted_partition_names: self.deleted_partition_names.read().clone(),
             steps: self.steps.read().values().cloned().collect(),
             license_pool: self.license_pool.read().clone(),
@@ -4836,24 +4867,23 @@ impl StateMachineApply for ClusterManager {
         // Restore tombstone set first — used below to filter the config baseline.
         *self.deleted_partition_names.write() = snap.deleted_partition_names.clone();
 
-        // Restore the partition table wholesale from the snapshot, like every
-        // other collection here. snap.partitions is the leader's complete
-        // authoritative set (snapshot_state clones the full live vec), so a
-        // stale in-memory partition can't survive install and local config
-        // can't reintroduce one the leader doesn't have. Only fall back to the
-        // config baseline for a pre-partition-snapshot snapshot, where the
-        // serde-default leaves snap.partitions empty and there is nothing
-        // authoritative to restore.
+        // `snap.partitions` is the leader's authoritative set, installed
+        // wholesale. Only a pre-partition snapshot (`None`) falls back to the
+        // config baseline; an authoritative empty set installs verbatim.
         {
             let mut partitions = self.partitions.write();
-            *partitions = if snap.partitions.is_empty() {
-                let mut base = self.config().build_partitions();
-                base.retain(|p| !snap.deleted_partition_names.contains(&p.name));
-                base
-            } else {
-                snap.partitions
+            *partitions = match snap.partitions {
+                Some(p) => p,
+                None => {
+                    let mut base = self.config().build_partitions();
+                    base.retain(|p| !snap.deleted_partition_names.contains(&p.name));
+                    base
+                }
             };
         }
+        // The installed table is authoritative; no config seed remains for the
+        // tail log to override.
+        self.config_seeded_partitions.write().clear();
 
         let mut steps = self.steps.write();
         steps.clear();
@@ -12053,6 +12083,32 @@ mod tests {
         );
     }
 
+    // An authoritative empty set (leader deleted them all) must install verbatim,
+    // not reseed from local config — the case `is_empty()` conflated with legacy.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn restore_from_authoritative_empty_snapshot_wipes_partitions() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        assert!(
+            !cm.get_partitions().is_empty(),
+            "test config must seed a partition"
+        );
+
+        // A leader snapshot with an explicit empty (Some(vec![])) partition set.
+        let mut snap: serde_json::Value =
+            serde_json::from_slice(&cm.snapshot_state().unwrap()).unwrap();
+        snap.as_object_mut()
+            .unwrap()
+            .insert("partitions".into(), serde_json::json!([]));
+        let data = serde_json::to_vec(&snap).unwrap();
+
+        cm.restore_from_snapshot(&data).unwrap();
+        assert!(
+            cm.get_partitions().is_empty(),
+            "authoritative empty set must wipe local partitions, not reseed from config"
+        );
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn restore_from_snapshot_rejects_corrupt_data() {
         let dir = TempDir::new().unwrap();
@@ -14465,7 +14521,7 @@ mod tests {
             jobs: Vec::new(),
             nodes: vec![stale],
             reservations: Vec::new(),
-            partitions: Vec::new(),
+            partitions: None,
             deleted_partition_names: HashSet::new(),
             steps: Vec::new(),
             license_pool: HashMap::new(),
@@ -15147,6 +15203,64 @@ mod tests {
         );
     }
 
+    // A config-seeded partition must lose to a replayed WAL PartitionCreate of
+    // the same name, or a runtime edit later codified into spur.conf reverts on
+    // restart and two controllers with differing confs diverge.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn apply_partition_create_overrides_config_seed() {
+        let dir = TempDir::new().unwrap();
+        // Default test config seeds a partition named "default".
+        let cm = test_cluster(&dir).await;
+        assert!(
+            cm.config_seeded_partitions.read().contains("default"),
+            "precondition: 'default' is config-seeded"
+        );
+
+        let runtime = spur_core::partition::Partition {
+            name: "default".into(),
+            state: spur_core::partition::PartitionState::Up,
+            is_default: true,
+            nodes: "node[01-09]".into(),
+            max_time_minutes: Some(720),
+            allow_accounts: vec!["runtime-team".into()],
+            priority_tier: 7,
+            ..Default::default()
+        };
+        cm.apply_operation(&WalOperation::PartitionCreate {
+            partition: runtime.clone(),
+        });
+
+        let parts = cm.get_partitions();
+        let def = parts.iter().find(|p| p.name == "default").unwrap();
+        assert_eq!(def.nodes, "node[01-09]", "WAL value must overwrite seed");
+        assert_eq!(def.max_time_minutes, Some(720));
+        assert_eq!(def.priority_tier, 7);
+        assert_eq!(
+            parts.iter().filter(|p| p.name == "default").count(),
+            1,
+            "override must not add a second entry"
+        );
+        assert!(
+            !cm.config_seeded_partitions.read().contains("default"),
+            "seed marker must be cleared once the WAL has overridden it"
+        );
+
+        // The seed override is one-shot: a further duplicate is a genuine
+        // create race and stays first-writer-wins.
+        let mut evil = runtime.clone();
+        evil.priority_tier = 99;
+        cm.apply_operation(&WalOperation::PartitionCreate { partition: evil });
+        let def = cm
+            .get_partitions()
+            .into_iter()
+            .find(|p| p.name == "default")
+            .unwrap();
+        assert_eq!(
+            def.priority_tier, 7,
+            "post-override duplicate must be ignored (first-writer-wins)"
+        );
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn apply_partition_update_unknown_is_a_noop() {
         let dir = TempDir::new().unwrap();
@@ -15550,6 +15664,45 @@ mod tests {
         assert!(
             cm.validate_partition(&spec).is_ok(),
             "empty allow_qos must not restrict any QoS"
+        );
+    }
+
+    // Full submit path: a user with no explicit `-q` whose association default
+    // QoS is in the partition's allow_qos must be admitted. The tests above call
+    // validate_partition with an explicit qos, so none covers this ordering.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_admits_association_default_qos_on_allow_qos_partition() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        cm.qos_cache().insert(Qos {
+            name: "premium".into(),
+            ..Default::default()
+        });
+        cm.association_cache()
+            .insert_default_qos("testuser", "research", "premium");
+
+        let part = spur_core::partition::Partition {
+            name: "restricted".into(),
+            nodes: "ALL".into(),
+            allow_qos: vec!["premium".into()],
+            ..Default::default()
+        };
+        cm.create_partition(part).unwrap();
+        wait_for("restricted created", || {
+            cm.get_partitions().iter().any(|p| p.name == "restricted")
+        });
+
+        let mut spec = basic_spec("inherits-default");
+        spec.account = Some("research".into());
+        spec.partition = Some("restricted".into());
+        spec.qos = None;
+        let id = cm
+            .submit_job(spec)
+            .expect("association default QoS must satisfy the partition allow_qos");
+        assert_eq!(
+            cm.get_job(id).unwrap().spec.qos.as_deref(),
+            Some("premium"),
+            "the resolved default QoS must be recorded on the job"
         );
     }
 }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1,8 +1,8 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::path::Path;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, OnceLock};
 
@@ -227,6 +227,46 @@ impl ReservationError {
     }
 }
 
+/// Partition CRUD errors for the gRPC boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PartitionError {
+    InvalidArgument(String),
+    NotFound(String),
+    AlreadyExists(String),
+    Raft(String),
+}
+
+impl std::fmt::Display for PartitionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidArgument(m)
+            | Self::NotFound(m)
+            | Self::AlreadyExists(m)
+            | Self::Raft(m) => f.write_str(m),
+        }
+    }
+}
+
+impl std::error::Error for PartitionError {}
+
+impl PartitionError {
+    pub fn invalid(msg: impl Into<String>) -> Self {
+        Self::InvalidArgument(msg.into())
+    }
+
+    pub fn not_found(msg: impl Into<String>) -> Self {
+        Self::NotFound(msg.into())
+    }
+
+    pub fn already_exists(msg: impl Into<String>) -> Self {
+        Self::AlreadyExists(msg.into())
+    }
+
+    pub fn raft(msg: impl Into<String>) -> Self {
+        Self::Raft(msg.into())
+    }
+}
+
 /// What the caller must dispatch to node agents after `preempt_job`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PreemptOutcome {
@@ -241,10 +281,30 @@ pub enum PreemptOutcome {
 /// Thread-safe via RwLock. The scheduler and gRPC server both access this.
 /// State recovery happens through Raft log replay (via `StateMachineApply`).
 pub struct ClusterManager {
-    pub config: SlurmConfig,
+    /// Live cluster configuration, swapped wholesale by `reconfigure()`.
+    ///
+    /// Held behind `RwLock<Arc<_>>` so `reconfigure` can atomically replace it
+    /// while readers take a cheap snapshot via `config()`. Sections consumed
+    /// per-request or per-scheduler-cycle through that snapshot pick up new
+    /// values live; sections captured once at startup (bound sockets, DB pool,
+    /// scheduler loop interval) remain restart-only — see `reconfigure`.
+    config: RwLock<Arc<SlurmConfig>>,
+    /// Scheduler tick interval captured at startup. The scheduler loop's cadence
+    /// is fixed once at boot (restart-only), so the preemption requeue hold —
+    /// which is sized to that cadence — must read this pinned value, not the
+    /// live `config()`, or the hold window would drift after `reconfigure`
+    /// while the loop keeps ticking at the old rate.
+    scheduler_interval_secs: u32,
+    /// Path to the spur.conf file, re-read by `reconfigure()`. spur.conf is
+    /// never written back — the Raft WAL is the sole source of runtime truth.
+    /// None when running without a config file (e.g. in tests).
+    config_path: Option<PathBuf>,
     jobs: RwLock<HashMap<JobId, Job>>,
     nodes: RwLock<HashMap<String, Node>>,
     partitions: RwLock<Vec<Partition>>,
+    /// Names of partitions that were runtime-deleted. Used to suppress config-file
+    /// partitions with the same name from re-appearing on restart.
+    deleted_partition_names: RwLock<HashSet<String>>,
     next_job_id: AtomicU32,
     reservations: RwLock<Vec<Reservation>>,
     steps: RwLock<HashMap<(JobId, u32), JobStep>>,
@@ -283,20 +343,33 @@ struct PendingJobCandidate {
 }
 
 impl ClusterManager {
-    pub fn new(config: SlurmConfig, _state_dir: &Path) -> anyhow::Result<Self> {
+    #[cfg(test)]
+    pub fn new(config: SlurmConfig, state_dir: &Path) -> anyhow::Result<Self> {
+        Self::new_with_config_path(config, state_dir, None)
+    }
+
+    pub fn new_with_config_path(
+        config: SlurmConfig,
+        _state_dir: &Path,
+        config_path: Option<PathBuf>,
+    ) -> anyhow::Result<Self> {
         let partitions = config.build_partitions();
         let license_pool = config.licenses.clone();
         let burst_buffer_total_gb = config.burst_buffer.total_gb;
         let fairshare_cache = Arc::new(FairshareCache::new());
         let first_job_id = config.controller.first_job_id;
+        let scheduler_interval_secs = config.scheduler.interval_secs;
         let qos_cache = Arc::new(QosCache::new());
         let association_cache = Arc::new(AssociationCache::new());
 
         let cm = Self {
-            config,
+            config: RwLock::new(Arc::new(config)),
+            scheduler_interval_secs,
+            config_path,
             jobs: RwLock::new(HashMap::new()),
             nodes: RwLock::new(HashMap::new()),
             partitions: RwLock::new(partitions),
+            deleted_partition_names: RwLock::new(HashSet::new()),
             reservations: RwLock::new(Vec::new()),
             steps: RwLock::new(HashMap::new()),
             next_job_id: AtomicU32::new(first_job_id),
@@ -318,6 +391,13 @@ impl ClusterManager {
         Ok(cm)
     }
 
+    /// Snapshot the live configuration. Cheap `Arc` clone; callers read fields
+    /// off the returned snapshot so a concurrent `reconfigure` swap is atomic
+    /// from their point of view.
+    pub fn config(&self) -> Arc<SlurmConfig> {
+        self.config.read().clone()
+    }
+
     /// Submit a new job. If it has an array spec, expand into individual tasks.
     pub fn submit_job(&self, mut spec: JobSpec) -> Result<JobId, SubmitError> {
         apply_default_partition(&mut spec, &self.partitions.read());
@@ -328,11 +408,12 @@ impl ClusterManager {
         let mpi = spec.mpi.as_deref().unwrap_or(spur_core::mpi::MPI_NONE);
         spur_core::mpi::validate_single_node_pmix(mpi, spec.num_nodes)
             .map_err(SubmitError::invalid)?;
+        let config = self.config();
         apply_default_qos(
             &mut spec,
             &self.association_cache,
             &self.qos_cache,
-            &self.config.accounting,
+            &config.accounting,
         )?;
 
         // Checked after defaults are applied so we measure the final spec.
@@ -376,8 +457,8 @@ impl ClusterManager {
         Ok(job_id)
     }
 
-    /// Validate requested partition names and partition account access control.
-    fn validate_partition(&self, spec: &JobSpec) -> Result<(), SubmitError> {
+    /// Validate partition constraints: access control and node limits.
+    pub(crate) fn validate_partition(&self, spec: &JobSpec) -> Result<(), SubmitError> {
         let partition_spec = match spec.partition.as_deref() {
             Some(p) if !p.is_empty() => p,
             _ => return Ok(()), // Unset or empty partition name — nothing to validate
@@ -398,20 +479,40 @@ impl ClusterManager {
             )));
         }
 
-        let Some(first_acl_partition) = requested
-            .iter()
-            .copied()
-            .find(|part| !part.allow_accounts.is_empty() || !part.deny_accounts.is_empty())
-        else {
-            return Ok(());
-        };
+        for part in &requested {
+            if !part.allow_qos.is_empty() {
+                match spec.qos.as_deref().filter(|q| !q.is_empty()) {
+                    Some(qos) if part.allow_qos.iter().any(|q| q == qos) => {}
+                    Some(qos) => {
+                        return Err(SubmitError::invalid(format!(
+                            "QoS '{qos}' not allowed on partition '{}' (allowed: {})",
+                            part.name,
+                            part.allow_qos.join(", ")
+                        )));
+                    }
+                    None => {
+                        return Err(SubmitError::invalid(format!(
+                            "a QoS is required on partition '{}' (allowed: {})",
+                            part.name,
+                            part.allow_qos.join(", ")
+                        )));
+                    }
+                }
+            }
+            if let Some(ref qos) = spec.qos {
+                if part.deny_qos.iter().any(|q| q == qos) {
+                    return Err(SubmitError::invalid(format!(
+                        "QoS '{qos}' denied on partition '{}'",
+                        part.name
+                    )));
+                }
+            }
+        }
 
-        if !self.association_cache.is_loaded() {
-            warn!(
-                user = %spec.user,
-                partition = %partition_spec,
-                "association cache unavailable; skipping partition account access checks"
-            );
+        let needs_acl = requested
+            .iter()
+            .any(|part| !part.allow_accounts.is_empty() || !part.deny_accounts.is_empty());
+        if !needs_acl {
             return Ok(());
         }
 
@@ -419,8 +520,8 @@ impl ClusterManager {
             Some(a) => a,
             None => {
                 return Err(SubmitError::invalid(format!(
-                    "no account for user '{}' on partition '{}'",
-                    spec.user, first_acl_partition.name
+                    "no account for user '{}' on partition '{partition_spec}'",
+                    spec.user
                 )));
             }
         };
@@ -1019,7 +1120,7 @@ impl ClusterManager {
                 // the maybe_requeue MAX_REQUEUE cap: Slurm always requeues a
                 // preempted job regardless of its --requeue flag. This is a
                 // deliberate divergence from the ordinary requeue path.
-                let hold_secs = (self.config.scheduler.interval_secs as i64 * 2 + 3).max(5);
+                let hold_secs = (self.scheduler_interval_secs as i64 * 2 + 3).max(5);
                 let hold = Utc::now() + chrono::Duration::seconds(hold_secs);
                 // Honor a later user --begin: compute the max on the leader so
                 // followers apply one verbatim instant (no per-replica clock).
@@ -1052,7 +1153,7 @@ impl ClusterManager {
     }
 
     fn run_epilog_slurmctld(&self, job_id: JobId) {
-        let Some(epilog_ctld) = self.config.hooks.epilog_slurmctld.clone() else {
+        let Some(epilog_ctld) = self.config().hooks.epilog_slurmctld.clone() else {
             return;
         };
         let job = self.get_job(job_id);
@@ -1131,7 +1232,7 @@ impl ClusterManager {
 
     /// Requeue a job if spec.requeue is set and attempt limit not exceeded.
     fn maybe_requeue(&self, job_id: JobId) -> anyhow::Result<()> {
-        let max = self.config.controller.max_batch_requeue;
+        let max = self.config().controller.max_batch_requeue;
         let (old_state, backoff) = {
             let jobs = self.jobs.read();
             let Some(job) = jobs.get(&job_id) else {
@@ -1204,7 +1305,7 @@ impl ClusterManager {
             if job.state.is_terminal() {
                 return Ok(());
             }
-            if !hold && job.requeue_count >= self.config.controller.max_batch_requeue {
+            if !hold && job.requeue_count >= self.config().controller.max_batch_requeue {
                 drop(jobs);
                 return self.hold_job_at_max_requeue(job_id);
             }
@@ -1275,7 +1376,7 @@ impl ClusterManager {
                 // failed confirmation and this call — nothing to back off.
                 return Ok(());
             }
-            if job.requeue_count >= self.config.controller.max_batch_requeue {
+            if job.requeue_count >= self.config().controller.max_batch_requeue {
                 drop(jobs);
                 return self.hold_job_at_max_requeue(job_id);
             }
@@ -1292,9 +1393,10 @@ impl ClusterManager {
     /// user-supplied constraint. Computed on the leader so every replica applies
     /// one verbatim instant rather than reading its own clock.
     fn launch_backoff_until(&self, job: &Job) -> DateTime<Utc> {
+        let config = self.config();
         let hold_secs = launch_backoff_secs(
-            self.config.scheduler.interval_secs,
-            self.config.controller.max_launch_backoff_secs,
+            config.scheduler.interval_secs,
+            config.controller.max_launch_backoff_secs,
             job.requeue_count,
         );
         let hold = Utc::now() + chrono::Duration::seconds(hold_secs as i64);
@@ -2631,6 +2733,285 @@ impl ClusterManager {
         }
     }
 
+    pub fn create_partition(&self, partition: Partition) -> Result<(), PartitionError> {
+        if partition.name.is_empty() {
+            return Err(PartitionError::invalid("partition name must not be empty"));
+        }
+        if self
+            .partitions
+            .read()
+            .iter()
+            .any(|p| p.name == partition.name)
+        {
+            return Err(PartitionError::already_exists(format!(
+                "partition '{}' already exists",
+                partition.name
+            )));
+        }
+        let resp = self
+            .propose(WalOperation::PartitionCreate { partition })
+            .map_err(|e| PartitionError::raft(e.to_string()))?;
+        if !resp.partition_created {
+            return Err(PartitionError::already_exists(
+                "partition already exists".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Update fields of an existing partition (persisted via Raft).
+    #[allow(clippy::too_many_arguments)]
+    pub fn update_partition(
+        &self,
+        name: &str,
+        nodes: Option<String>,
+        selector: Option<std::collections::HashMap<String, String>>,
+        state: Option<String>,
+        is_default: Option<bool>,
+        max_time: Option<String>,
+        default_time: Option<String>,
+        max_nodes: Option<u32>,
+        clear_max_nodes: bool,
+        min_nodes: Option<u32>,
+        allow_accounts: Option<Vec<String>>,
+        allow_groups: Option<Vec<String>>,
+        deny_accounts: Option<Vec<String>>,
+        deny_qos: Option<Vec<String>>,
+        allow_qos: Option<Vec<String>>,
+        priority_tier: Option<u32>,
+        preempt_mode: Option<String>,
+    ) -> Result<(), PartitionError> {
+        if !self.partitions.read().iter().any(|p| p.name == name) {
+            return Err(PartitionError::not_found(format!(
+                "partition '{}' not found",
+                name
+            )));
+        }
+
+        let max_time_minutes = if let Some(ref t) = max_time {
+            if t.eq_ignore_ascii_case("INFINITE") || t.eq_ignore_ascii_case("UNLIMITED") {
+                Some(None)
+            } else {
+                let m = spur_core::config::parse_time_minutes(t)
+                    .ok_or_else(|| PartitionError::invalid(format!("invalid time: {}", t)))?;
+                Some(Some(m))
+            }
+        } else {
+            None
+        };
+
+        let default_time_minutes = if let Some(ref t) = default_time {
+            if t.eq_ignore_ascii_case("INFINITE") || t.eq_ignore_ascii_case("UNLIMITED") {
+                Some(None)
+            } else {
+                let m = spur_core::config::parse_time_minutes(t).ok_or_else(|| {
+                    PartitionError::invalid(format!("invalid default_time: {}", t))
+                })?;
+                Some(Some(m))
+            }
+        } else {
+            None
+        };
+
+        let max_nodes_wal = if clear_max_nodes {
+            Some(None)
+        } else {
+            max_nodes.map(Some)
+        };
+
+        self.propose(WalOperation::PartitionUpdate {
+            name: name.to_string(),
+            nodes,
+            selector,
+            state,
+            max_time_minutes,
+            default_time_minutes,
+            max_nodes: max_nodes_wal,
+            min_nodes,
+            allow_accounts,
+            allow_groups,
+            deny_accounts,
+            deny_qos,
+            allow_qos,
+            priority_tier,
+            preempt_mode,
+            is_default,
+        })
+        .map_err(|e| PartitionError::raft(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Delete a partition by name (persisted via Raft).
+    ///
+    /// Refuses if any running jobs are using the partition.
+    pub fn delete_partition(&self, name: &str) -> Result<(), PartitionError> {
+        if !self.partitions.read().iter().any(|p| p.name == name) {
+            return Err(PartitionError::not_found(format!(
+                "partition '{}' not found",
+                name
+            )));
+        }
+        for job in self.jobs.read().values() {
+            if !matches!(
+                job.state,
+                JobState::Running | JobState::Completing | JobState::Suspended
+            ) {
+                continue;
+            }
+            if job.spec.partition.as_deref() == Some(name) {
+                return Err(PartitionError::invalid(format!(
+                    "partition '{}' in use by running job {}",
+                    name, job.job_id
+                )));
+            }
+        }
+        self.propose(WalOperation::PartitionDelete {
+            name: name.to_string(),
+        })
+        .map_err(|e| PartitionError::raft(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Re-read spur.conf and apply it to the running controller.
+    ///
+    /// Makes the config file authoritative, matching `scontrol reconfigure`
+    /// semantics in Slurm: runtime-only changes not reflected in the conf are
+    /// overwritten by the incoming conf values.
+    ///
+    /// **Leader-only.** The command is forwarded to the Raft leader, and this
+    /// swaps only the leader's in-memory config — no WAL entry carries the new
+    /// config. Followers keep the config they read at startup until they
+    /// restart (in Kubernetes they re-read the same ConfigMap). Do not rely on
+    /// reconfigured non-partition state surviving an immediate failover.
+    /// Partition edits DO propagate (via partition WAL ops), but a follower
+    /// re-runs `reconcile_partitions` against its own stale `config().nodes`,
+    /// so after a partition edit followers pick up new partition membership but
+    /// keep old node features until restart. WAL-propagating config is a
+    /// planned follow-up.
+    ///
+    /// Reloaded live on the leader (readers take a fresh snapshot via
+    /// `config()`): `[[partitions]]`, `[[nodes]]` features/weight, `licenses`,
+    /// `burst_buffer`, `scheduler` tunables (`complete_wait`, `resv_overrun`),
+    /// `controller.max_batch_requeue`, `hooks`, `notifications`, `federation`,
+    /// `power` suspend/resume commands, `admission.mode`, and
+    /// `metrics.high_cardinality`.
+    ///
+    /// Restart-only (baked in at startup — mirrors Slurm's restart-required set
+    /// of ports/plugins/StateSaveLocation/AuthType): bind addresses and ports
+    /// (`controller.listen_addr`, `metrics`/`rest_api` listeners), the
+    /// accounting database pool (`accounting.database_url`), Raft identity/peers,
+    /// `controller.first_job_id`, `auth.jwt_key` (swapping it live would
+    /// instantly invalidate every outstanding node token), and the scheduler
+    /// loop cadence (`scheduler.interval_secs`, `max_jobs_per_cycle`,
+    /// `topology`).
+    pub fn reconfigure(&self) -> Result<(), anyhow::Error> {
+        let Some(ref path) = self.config_path else {
+            anyhow::bail!("reconfigure requires a config file path, but none is configured");
+        };
+        let new_config = spur_core::config::SlurmConfig::load_from_file(path)?;
+        let conf_partitions = new_config.build_partitions();
+
+        let conf_names: std::collections::HashSet<String> =
+            conf_partitions.iter().map(|p| p.name.clone()).collect();
+        let current_names: std::collections::HashSet<String> = self
+            .partitions
+            .read()
+            .iter()
+            .map(|p| p.name.clone())
+            .collect();
+
+        // Delete partitions absent from the new conf.
+        for name in current_names.difference(&conf_names) {
+            // Skip if active jobs are running on the partition — callers should
+            // drain first, matching Slurm's behaviour.
+            let in_use = self.jobs.read().values().any(|j| {
+                matches!(
+                    j.state,
+                    JobState::Running | JobState::Completing | JobState::Suspended
+                ) && j.spec.partition.as_deref() == Some(name.as_str())
+            });
+            if in_use {
+                warn!(
+                    partition = %name,
+                    "reconfigure: partition removed from conf but has active jobs; skipping deletion"
+                );
+                continue;
+            }
+            self.propose(WalOperation::PartitionDelete { name: name.clone() })
+                .map_err(|e| anyhow::anyhow!("reconfigure: delete {name}: {e}"))?;
+        }
+
+        // Create partitions present in conf but absent from current WAL state.
+        // `WalOperation::PartitionCreate`'s own apply already clears any
+        // tombstone for the name being (re)created — no separate step needed.
+        for part in conf_partitions
+            .iter()
+            .filter(|p| !current_names.contains(&p.name))
+        {
+            self.propose(WalOperation::PartitionCreate {
+                partition: part.clone(),
+            })
+            .map_err(|e| anyhow::anyhow!("reconfigure: create {}: {e}", part.name))?;
+        }
+
+        // Update partitions present in both — conf wins unconditionally.
+        for part in conf_partitions
+            .iter()
+            .filter(|p| current_names.contains(&p.name))
+        {
+            let preempt_str = match part.preempt_mode {
+                spur_core::partition::PreemptMode::Cancel => "cancel",
+                spur_core::partition::PreemptMode::Requeue => "requeue",
+                spur_core::partition::PreemptMode::Suspend => "suspend",
+                spur_core::partition::PreemptMode::Off => "off",
+            };
+            self.propose(WalOperation::PartitionUpdate {
+                name: part.name.clone(),
+                nodes: Some(part.nodes.clone()),
+                selector: Some(part.selector.clone()),
+                state: Some(part.state.to_string()),
+                max_time_minutes: Some(part.max_time_minutes),
+                default_time_minutes: Some(part.default_time_minutes),
+                max_nodes: Some(part.max_nodes),
+                min_nodes: Some(part.min_nodes),
+                allow_accounts: Some(part.allow_accounts.clone()),
+                allow_groups: Some(part.allow_groups.clone()),
+                deny_accounts: Some(part.deny_accounts.clone()),
+                deny_qos: Some(part.deny_qos.clone()),
+                allow_qos: Some(part.allow_qos.clone()),
+                priority_tier: Some(part.priority_tier),
+                preempt_mode: Some(preempt_str.to_string()),
+                is_default: Some(part.is_default),
+            })
+            .map_err(|e| anyhow::anyhow!("reconfigure: update {}: {e}", part.name))?;
+        }
+
+        // Re-derive the config-total pools. Availability is computed as total
+        // minus in-use elsewhere, so swapping the totals cannot strand
+        // capacity already held by running jobs.
+        *self.license_pool.write() = new_config.licenses.clone();
+        *self.burst_buffer_total_gb.write() = new_config.burst_buffer.total_gb;
+
+        // Swap the live config last, after partition WAL ops have been accepted,
+        // so a mid-reconfigure failure leaves the previous config in place.
+        // Readers pick up the new sections on their next `config()` snapshot.
+        *self.config.write() = Arc::new(new_config);
+
+        // Re-derive per-node `[[nodes]]` policy (features/weight) and partition
+        // membership against the freshly-swapped config. This is a local derived
+        // projection (recomputed identically on snapshot restore and inside the
+        // partition WAL apply handlers), so recomputing it here is consistent.
+        // Partition ops above already trigger the same recompute on every peer
+        // via the WAL; this covers a nodes-only edit that proposes no op.
+        {
+            let mut nodes = self.nodes.write();
+            self.reconcile_partitions(&mut nodes);
+        }
+
+        info!("reconfigure: applied spur.conf on this leader (followers converge on restart); restart-only sections (listen ports, accounting DB, raft peers, jwt_key, scheduler cadence) unchanged until controller restart");
+        Ok(())
+    }
+
     /// Create a new reservation (validated, persisted via Raft).
     pub fn create_reservation(&self, mut res: Reservation) -> Result<(), ReservationError> {
         if self.reservations.read().iter().any(|r| r.name == res.name) {
@@ -2813,7 +3194,7 @@ impl ClusterManager {
     /// Cancel running jobs whose reservation window has ended (after optional grace).
     pub fn enforce_reservation_end_times(&self) {
         let now = Utc::now();
-        let grace = chrono::Duration::minutes(self.config.scheduler.resv_overrun_minutes as i64);
+        let grace = chrono::Duration::minutes(self.config().scheduler.resv_overrun_minutes as i64);
         let reservations: std::collections::HashMap<String, Reservation> = self
             .get_reservations()
             .into_iter()
@@ -3112,7 +3493,8 @@ impl ClusterManager {
     ///
     /// Uses `curl` as a subprocess to avoid pulling in an HTTP client dependency.
     fn send_notification(&self, job_id: JobId, event: &str, spec: &JobSpec) {
-        let webhook_url = self.config.notifications.webhook_url.clone();
+        let config = self.config();
+        let webhook_url = config.notifications.webhook_url.clone();
         if let Some(url) = webhook_url {
             let event = event.to_string();
             let user = spec.user.clone();
@@ -3163,9 +3545,8 @@ impl ClusterManager {
         }
 
         // SMTP email notification via sendmail-compatible command
-        if let Some(ref smtp_cmd) = self.config.notifications.smtp_command {
-            let from = self
-                .config
+        if let Some(ref smtp_cmd) = config.notifications.smtp_command {
+            let from = config
                 .notifications
                 .from_address
                 .as_deref()
@@ -3479,7 +3860,7 @@ impl ClusterManager {
                     // Gated on a real transition so a replay doesn't re-wipe
                     // fields or double-count requeue_count.
                     if outcome == TransitionOutcome::Applied && *new_state == JobState::Pending {
-                        let max = self.config.controller.max_batch_requeue;
+                        let max = self.config().controller.max_batch_requeue;
                         if job.requeue_count < max {
                             Self::reset_job_for_requeue(job);
                         } else {
@@ -4095,6 +4476,144 @@ impl ClusterManager {
                     t.revoked = true;
                 }
             }
+            WalOperation::PartitionCreate { partition } => {
+                // A create always clears any tombstone for this name — the admin
+                // is explicitly recreating a previously-deleted partition.
+                self.deleted_partition_names.write().remove(&partition.name);
+                {
+                    let mut partitions = self.partitions.write();
+                    if partitions.iter().any(|p| p.name == partition.name) {
+                        warn!(
+                            name = %partition.name,
+                            "duplicate partition create in WAL apply, ignoring"
+                        );
+                    } else {
+                        // Promote exactly one default: clear all others when
+                        // the new partition is created as the default.
+                        if partition.is_default {
+                            for p in partitions.iter_mut() {
+                                p.is_default = false;
+                            }
+                        }
+                        partitions.push(partition.clone());
+                        response.partition_created = true;
+                        info!(name = %partition.name, "partition created");
+                    }
+                }
+                // Node-to-partition membership is derived from the partition
+                // table (nodes/selector match), so a create can immediately
+                // change which partitions already-registered nodes belong to.
+                self.reconcile_partitions(&mut nodes);
+            }
+            WalOperation::PartitionUpdate {
+                name,
+                nodes: new_hostlist,
+                selector,
+                state,
+                max_time_minutes,
+                default_time_minutes,
+                max_nodes,
+                min_nodes,
+                allow_accounts,
+                allow_groups,
+                deny_accounts,
+                deny_qos,
+                allow_qos,
+                priority_tier,
+                preempt_mode,
+                is_default,
+            } => {
+                {
+                    let mut partitions = self.partitions.write();
+                    let set_as_default = *is_default == Some(true);
+                    if let Some(part) = partitions.iter_mut().find(|p| p.name == *name) {
+                        if let Some(n) = new_hostlist {
+                            part.nodes = n.clone();
+                        }
+                        if let Some(sel) = selector {
+                            part.selector = sel.clone();
+                        }
+                        if let Some(s) = state {
+                            part.state = match s.to_uppercase().as_str() {
+                                "UP" => spur_core::partition::PartitionState::Up,
+                                "DOWN" => spur_core::partition::PartitionState::Down,
+                                "DRAIN" => spur_core::partition::PartitionState::Drain,
+                                _ => spur_core::partition::PartitionState::Inactive,
+                            };
+                        }
+                        if let Some(mt) = max_time_minutes {
+                            part.max_time_minutes = *mt;
+                        }
+                        if let Some(dt) = default_time_minutes {
+                            part.default_time_minutes = *dt;
+                        }
+                        if let Some(mn) = max_nodes {
+                            part.max_nodes = *mn;
+                        }
+                        if let Some(mn) = min_nodes {
+                            part.min_nodes = *mn;
+                        }
+                        if let Some(aa) = allow_accounts {
+                            part.allow_accounts = aa.clone();
+                        }
+                        if let Some(ag) = allow_groups {
+                            part.allow_groups = ag.clone();
+                        }
+                        if let Some(da) = deny_accounts {
+                            part.deny_accounts = da.clone();
+                        }
+                        if let Some(dq) = deny_qos {
+                            part.deny_qos = dq.clone();
+                        }
+                        if let Some(aq) = allow_qos {
+                            part.allow_qos = aq.clone();
+                        }
+                        if let Some(pt) = priority_tier {
+                            part.priority_tier = *pt;
+                        }
+                        if let Some(pm) = preempt_mode {
+                            part.preempt_mode = match pm.to_lowercase().as_str() {
+                                "cancel" => spur_core::partition::PreemptMode::Cancel,
+                                "requeue" => spur_core::partition::PreemptMode::Requeue,
+                                "suspend" => spur_core::partition::PreemptMode::Suspend,
+                                _ => spur_core::partition::PreemptMode::Off,
+                            };
+                        }
+                        if let Some(def) = is_default {
+                            part.is_default = *def;
+                        }
+                        info!(name, "partition updated");
+                    } else {
+                        warn!(name, "partition update for unknown partition, ignoring");
+                    }
+                    // Promote exactly one default: clear all others when this one was set.
+                    if set_as_default {
+                        for p in partitions.iter_mut() {
+                            if p.name != *name {
+                                p.is_default = false;
+                            }
+                        }
+                    }
+                }
+                // Node/selector may have changed which nodes this partition covers.
+                self.reconcile_partitions(&mut nodes);
+            }
+            WalOperation::PartitionDelete { name } => {
+                {
+                    let mut partitions = self.partitions.write();
+                    let len_before = partitions.len();
+                    partitions.retain(|p| p.name != *name);
+                    if partitions.len() < len_before {
+                        // Record the tombstone so this name is suppressed from the
+                        // spur.conf baseline on the next restart.
+                        self.deleted_partition_names.write().insert(name.clone());
+                        info!(name, "partition deleted");
+                    }
+                }
+                // A node whose partition was deleted needs to fall back to
+                // another matching partition (or the cluster default).
+                self.reconcile_partitions(&mut nodes);
+            }
             WalOperation::ReservationCreate { reservation } => {
                 let mut reservations = self.reservations.write();
                 if reservations.iter().any(|r| r.name == reservation.name) {
@@ -4203,6 +4722,15 @@ struct ClusterSnapshot {
     jobs: Vec<Job>,
     nodes: Vec<Node>,
     reservations: Vec<Reservation>,
+    /// Runtime-created/modified partitions. On restore these overlay the
+    /// config-file baseline; names in `deleted_partition_names` are skipped
+    /// from the baseline entirely.
+    #[serde(default)]
+    partitions: Vec<Partition>,
+    /// Names of partitions deleted at runtime. Suppresses config-file
+    /// partitions with the same name from re-seeding on restart.
+    #[serde(default)]
+    deleted_partition_names: HashSet<String>,
     steps: Vec<JobStep>,
     license_pool: HashMap<String, u64>,
     #[serde(default)]
@@ -4224,7 +4752,7 @@ impl ClusterManager {
     /// node defaults when none matches so stale policy from a previously matching
     /// entry does not persist.
     fn apply_node_config_policy(&self, node: &mut Node) {
-        for nc in &self.config.nodes {
+        for nc in self.config().nodes.iter() {
             if node_config_matches(nc, &node.name, &node.labels) {
                 node.features = nc.features.clone();
                 node.weight = nc.weight;
@@ -4275,6 +4803,8 @@ impl StateMachineApply for ClusterManager {
             jobs: self.jobs.read().values().cloned().collect(),
             nodes: self.nodes.read().values().cloned().collect(),
             reservations: self.reservations.read().clone(),
+            partitions: self.partitions.read().clone(),
+            deleted_partition_names: self.deleted_partition_names.read().clone(),
             steps: self.steps.read().values().cloned().collect(),
             license_pool: self.license_pool.read().clone(),
             tokens: self.tokens.read().values().cloned().collect(),
@@ -4287,7 +4817,7 @@ impl StateMachineApply for ClusterManager {
     fn restore_from_snapshot(&self, data: &[u8]) -> Result<(), anyhow::Error> {
         let snap = serde_json::from_slice::<ClusterSnapshot>(data)?;
 
-        let mut next_id = self.config.controller.first_job_id;
+        let mut next_id = self.config().controller.first_job_id;
         let mut jobs = self.jobs.write();
         jobs.clear();
         for job in snap.jobs {
@@ -4302,6 +4832,28 @@ impl StateMachineApply for ClusterManager {
         }
 
         *self.reservations.write() = snap.reservations;
+
+        // Restore tombstone set first — used below to filter the config baseline.
+        *self.deleted_partition_names.write() = snap.deleted_partition_names.clone();
+
+        // Restore the partition table wholesale from the snapshot, like every
+        // other collection here. snap.partitions is the leader's complete
+        // authoritative set (snapshot_state clones the full live vec), so a
+        // stale in-memory partition can't survive install and local config
+        // can't reintroduce one the leader doesn't have. Only fall back to the
+        // config baseline for a pre-partition-snapshot snapshot, where the
+        // serde-default leaves snap.partitions empty and there is nothing
+        // authoritative to restore.
+        {
+            let mut partitions = self.partitions.write();
+            *partitions = if snap.partitions.is_empty() {
+                let mut base = self.config().build_partitions();
+                base.retain(|p| !snap.deleted_partition_names.contains(&p.name));
+                base
+            } else {
+                snap.partitions
+            };
+        }
 
         let mut steps = self.steps.write();
         steps.clear();
@@ -5170,6 +5722,8 @@ mod tests {
                 allow_accounts: Vec::new(),
                 allow_groups: Vec::new(),
                 deny_accounts: Vec::new(),
+                deny_qos: Vec::new(),
+                allow_qos: Vec::new(),
                 priority_tier: 1,
                 preempt_mode: String::new(),
             }],
@@ -5234,6 +5788,153 @@ mod tests {
         let mut spec = basic_spec(name);
         spec.srun_job = true;
         spec
+    }
+
+    /// Build a cluster backed by a real spur.conf on disk so `reconfigure()`
+    /// has a path to re-read. Returns the cluster and the conf path so tests
+    /// can rewrite the file and reconcile.
+    async fn test_cluster_with_conf_file(
+        dir: &TempDir,
+        toml: &str,
+    ) -> (Arc<ClusterManager>, PathBuf) {
+        let conf_path = dir.path().join("spur.conf");
+        std::fs::write(&conf_path, toml).unwrap();
+        let config = SlurmConfig::load_from_file(&conf_path).unwrap();
+        let cm = Arc::new(
+            ClusterManager::new_with_config_path(config, dir.path(), Some(conf_path.clone()))
+                .unwrap(),
+        );
+        let handle = crate::raft::start_raft(1, &["[::1]:0".into()], dir.path(), cm.clone())
+            .await
+            .unwrap();
+        handle
+            .raft
+            .wait(Some(std::time::Duration::from_secs(5)))
+            .metrics(|m| m.current_leader == Some(1), "leader elected")
+            .await
+            .expect("single-node raft did not self-elect within 5s");
+        cm.set_raft(handle.raft);
+        (cm, conf_path)
+    }
+
+    /// Consumer-driven: `maybe_requeue` must honor the new `max_batch_requeue`
+    /// after reconfigure, not just the swapped config value. A job whose
+    /// `requeue_count` sits between the old and new caps is a no-op under the
+    /// old cap but requeues to Pending under the new one.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reconfigure_max_batch_requeue_changes_consumer_behavior() {
+        let conf = |cap: u32| {
+            format!(
+                "cluster_name = \"test\"\n\
+                 [controller]\nmax_batch_requeue = {cap}\n\
+                 [[partitions]]\nname = \"default\"\ndefault = true\nstate = \"UP\"\nnodes = \"ALL\"\n"
+            )
+        };
+        let dir = TempDir::new().unwrap();
+        let (cm, conf_path) = test_cluster_with_conf_file(&dir, &conf(3)).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let job_id = run_job_on(&cm, "requeue-cap", "worker1");
+        // Put the job in a terminal, requeue-eligible state (Failed → Pending is
+        // a valid requeue transition and is NOT in the max-requeue hold set, so
+        // over-cap is a clean no-op) with 5 attempts already recorded.
+        {
+            let mut jobs = cm.jobs.write();
+            let job = jobs.get_mut(&job_id).unwrap();
+            job.state = JobState::Failed;
+            job.spec.requeue = true;
+            job.requeue_count = 5;
+        }
+
+        // Cap = 3, count = 5 → over cap → maybe_requeue is a no-op (stays Failed).
+        cm.maybe_requeue(job_id).unwrap();
+        assert_eq!(
+            cm.get_job(job_id).unwrap().state,
+            JobState::Failed,
+            "over-cap job must not requeue before reconfigure"
+        );
+
+        // Raise the cap past the attempt count and reconfigure.
+        std::fs::write(&conf_path, conf(9)).unwrap();
+        cm.reconfigure().unwrap();
+
+        // Cap = 9, count = 5 → under cap → maybe_requeue returns it to Pending.
+        cm.maybe_requeue(job_id).unwrap();
+        settle(&cm, job_id, JobState::Pending);
+        assert_eq!(
+            cm.get_job(job_id).unwrap().state,
+            JobState::Pending,
+            "after reconfigure raised the cap, the consumer must requeue the job"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconfigure_reloads_scheduler_tunables_live() {
+        let dir = TempDir::new().unwrap();
+        let (cm, conf_path) = test_cluster_with_conf_file(
+            &dir,
+            "cluster_name = \"test\"\n[scheduler]\nresv_overrun_minutes = 5\ncomplete_wait_secs = 30\n",
+        )
+        .await;
+        assert_eq!(cm.config().scheduler.resv_overrun_minutes, 5);
+
+        std::fs::write(
+            &conf_path,
+            "cluster_name = \"test\"\n[scheduler]\nresv_overrun_minutes = 45\ncomplete_wait_secs = 90\n",
+        )
+        .unwrap();
+        cm.reconfigure().unwrap();
+
+        let cfg = cm.config();
+        assert_eq!(cfg.scheduler.resv_overrun_minutes, 45);
+        assert_eq!(cfg.scheduler.complete_wait_secs, 90);
+    }
+
+    #[tokio::test]
+    async fn reconfigure_reloads_hooks_and_notifications_live() {
+        let dir = TempDir::new().unwrap();
+        let (cm, conf_path) = test_cluster_with_conf_file(&dir, "cluster_name = \"test\"\n").await;
+        assert!(cm.config().hooks.epilog_slurmctld.is_none());
+        assert!(cm.config().notifications.webhook_url.is_none());
+
+        std::fs::write(
+            &conf_path,
+            "cluster_name = \"test\"\n[hooks]\nepilog_slurmctld = \"/usr/bin/epi\"\n[notifications]\nwebhook_url = \"http://hook/\"\n",
+        )
+        .unwrap();
+        cm.reconfigure().unwrap();
+
+        let cfg = cm.config();
+        assert_eq!(cfg.hooks.epilog_slurmctld.as_deref(), Some("/usr/bin/epi"));
+        assert_eq!(
+            cfg.notifications.webhook_url.as_deref(),
+            Some("http://hook/")
+        );
+    }
+
+    #[tokio::test]
+    async fn reconfigure_reloads_license_pool_live() {
+        let dir = TempDir::new().unwrap();
+        let (cm, conf_path) =
+            test_cluster_with_conf_file(&dir, "cluster_name = \"test\"\n[licenses]\nfluent = 5\n")
+                .await;
+        // Availability is derived from the pool total; no jobs hold licenses.
+        assert_eq!(cm.available_licenses().get("fluent").copied(), Some(5));
+
+        std::fs::write(
+            &conf_path,
+            "cluster_name = \"test\"\n[licenses]\nfluent = 20\ncomsol = 2\n",
+        )
+        .unwrap();
+        cm.reconfigure().unwrap();
+
+        let avail = cm.available_licenses();
+        assert_eq!(
+            avail.get("fluent").copied(),
+            Some(20),
+            "reconfigure must apply the new license total"
+        );
+        assert_eq!(avail.get("comsol").copied(), Some(2));
     }
 
     fn scalar_alloc(cpus: u32, memory_mb: u64) -> ResourceAllocations {
@@ -6890,7 +7591,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         register_node(&cm, "worker1", 8, 16000);
-        let max = cm.config.controller.max_batch_requeue;
+        let max = cm.config().controller.max_batch_requeue;
 
         let job_id = submit_and_wait(&cm, basic_spec("pending-at-cap"));
         cm.jobs.write().get_mut(&job_id).unwrap().requeue_count = max;
@@ -7007,7 +7708,7 @@ mod tests {
 
         let job_id = submit_and_wait(&cm, basic_spec("backoff-schedule"));
 
-        for attempt in 0..cm.config.controller.max_batch_requeue {
+        for attempt in 0..cm.config().controller.max_batch_requeue {
             let resources = scalar_alloc(2, 4000);
             cm.start_job(
                 job_id,
@@ -8252,7 +8953,9 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn submit_skips_allow_accounts_when_association_cache_unavailable() {
+    async fn submit_enforces_allow_accounts_without_association_cache() {
+        // Partition ACL is pure string matching — it must fire even when the
+        // accounting association cache is empty (no Postgres backend running).
         let dir = TempDir::new().unwrap();
         let mut cfg = test_config();
         cfg.partitions[0].allow_accounts = vec!["research".into()];
@@ -8260,7 +8963,10 @@ mod tests {
 
         let mut spec = basic_spec("nocache");
         spec.account = Some("student".into());
-        assert!(cm.submit_job(spec).is_ok());
+        assert!(
+            cm.submit_job(spec).is_err(),
+            "unlisted account must be rejected"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -9374,7 +10080,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         register_node(&cm, "worker1", 8, 16000);
-        let max = cm.config.controller.max_batch_requeue;
+        let max = cm.config().controller.max_batch_requeue;
 
         let job_id = run_job_on(&cm, "chronic-preempt", "worker1");
         for _ in 0..(max + 3) {
@@ -9421,7 +10127,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         register_node(&cm, "worker1", 8, 16000);
-        let max = cm.config.controller.max_batch_requeue;
+        let max = cm.config().controller.max_batch_requeue;
 
         let mut spec = basic_spec("chronic-then-timeout");
         spec.requeue = true;
@@ -11298,6 +12004,52 @@ mod tests {
             cm.get_node("cp-b").unwrap().k0s_mesh_ip.as_deref(),
             Some("10.44.0.1"),
             "bootstrap (first of recorded set) holds .1"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn restore_from_snapshot_drops_stale_live_partition() {
+        // A partition present in the target's live memory but absent from the
+        // snapshot (and not tombstoned) must not survive a snapshot install —
+        // otherwise a follower diverges from the leader's partition table.
+        let src = TempDir::new().unwrap();
+        let cm = test_cluster(&src).await;
+        let data = cm.snapshot_state().unwrap();
+
+        let dst = TempDir::new().unwrap();
+        let cm2 = test_cluster(&dst).await;
+        cm2.apply_operation(&WalOperation::PartitionCreate {
+            partition: gpu_partition(),
+        });
+        assert!(cm2.get_partitions().iter().any(|p| p.name == "gpu"));
+
+        cm2.restore_from_snapshot(&data).unwrap();
+        assert!(
+            !cm2.get_partitions().iter().any(|p| p.name == "gpu"),
+            "stale live partition must be gone after restore"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn restore_from_pre_partition_snapshot_keeps_config_baseline() {
+        // An old snapshot predating partition support has no `partitions` field
+        // (serde-default → empty). Restore must fall back to the config
+        // baseline, not wipe all partitions.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        let baseline: Vec<String> = cm.get_partitions().iter().map(|p| p.name.clone()).collect();
+        assert!(!baseline.is_empty(), "test config must define a partition");
+
+        let mut snap: serde_json::Value =
+            serde_json::from_slice(&cm.snapshot_state().unwrap()).unwrap();
+        snap.as_object_mut().unwrap().remove("partitions");
+        let data = serde_json::to_vec(&snap).unwrap();
+
+        cm.restore_from_snapshot(&data).unwrap();
+        let after: Vec<String> = cm.get_partitions().iter().map(|p| p.name.clone()).collect();
+        assert_eq!(
+            after, baseline,
+            "config baseline must survive an old snapshot"
         );
     }
 
@@ -13216,6 +13968,8 @@ mod tests {
                 allow_accounts: Vec::new(),
                 allow_groups: Vec::new(),
                 deny_accounts: Vec::new(),
+                deny_qos: Vec::new(),
+                allow_qos: Vec::new(),
                 priority_tier: 1,
                 preempt_mode: String::new(),
             },
@@ -13232,6 +13986,8 @@ mod tests {
                 allow_accounts: Vec::new(),
                 allow_groups: Vec::new(),
                 deny_accounts: Vec::new(),
+                deny_qos: Vec::new(),
+                allow_qos: Vec::new(),
                 priority_tier: 1,
                 preempt_mode: String::new(),
             },
@@ -13289,6 +14045,8 @@ mod tests {
             allow_accounts: Vec::new(),
             allow_groups: Vec::new(),
             deny_accounts: Vec::new(),
+            deny_qos: Vec::new(),
+            allow_qos: Vec::new(),
             priority_tier: 1,
             preempt_mode: String::new(),
         }];
@@ -13707,6 +14465,8 @@ mod tests {
             jobs: Vec::new(),
             nodes: vec![stale],
             reservations: Vec::new(),
+            partitions: Vec::new(),
+            deleted_partition_names: HashSet::new(),
             steps: Vec::new(),
             license_pool: HashMap::new(),
             tokens: Vec::new(),
@@ -14291,5 +15051,505 @@ mod tests {
             cm.finish_srun_job(999, 0, "testuser"),
             Err(SrunCompleteError::NotFound(999))
         ));
+    }
+
+    // ---------------------------------------------------------------
+    // Partition CRUD tests
+    // ---------------------------------------------------------------
+
+    fn gpu_partition() -> spur_core::partition::Partition {
+        spur_core::partition::Partition {
+            name: "gpu".into(),
+            state: spur_core::partition::PartitionState::Up,
+            is_default: false,
+            nodes: "gpu[01-04]".into(),
+            max_time_minutes: Some(1440),
+            allow_accounts: vec!["ml-team".into()],
+            priority_tier: 2,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn apply_partition_create_update_delete() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        cm.apply_operation(&WalOperation::PartitionCreate {
+            partition: gpu_partition(),
+        });
+
+        let parts = cm.get_partitions();
+        assert!(
+            parts.iter().any(|p| p.name == "gpu"),
+            "gpu partition missing after create"
+        );
+        let gpu = parts.iter().find(|p| p.name == "gpu").unwrap();
+        assert_eq!(gpu.max_time_minutes, Some(1440));
+        assert_eq!(gpu.allow_accounts, vec!["ml-team"]);
+        assert_eq!(gpu.priority_tier, 2);
+
+        cm.apply_operation(&WalOperation::PartitionUpdate {
+            name: "gpu".into(),
+            nodes: None,
+            selector: None,
+            state: Some("DRAIN".into()),
+            max_time_minutes: Some(Some(2880)),
+            default_time_minutes: None,
+            max_nodes: None,
+            min_nodes: None,
+            allow_accounts: Some(vec!["ml-team".into(), "infra".into()]),
+            allow_groups: None,
+            deny_accounts: None,
+            deny_qos: None,
+            allow_qos: None,
+            priority_tier: None,
+            preempt_mode: None,
+            is_default: None,
+        });
+
+        let gpu = cm
+            .get_partitions()
+            .into_iter()
+            .find(|p| p.name == "gpu")
+            .unwrap();
+        assert_eq!(gpu.state, spur_core::partition::PartitionState::Drain);
+        assert_eq!(gpu.max_time_minutes, Some(2880));
+        assert!(gpu.allow_accounts.contains(&"infra".into()));
+
+        cm.apply_operation(&WalOperation::PartitionDelete { name: "gpu".into() });
+        assert!(
+            !cm.get_partitions().iter().any(|p| p.name == "gpu"),
+            "gpu partition still present after delete"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn apply_partition_create_idempotent() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        cm.apply_operation(&WalOperation::PartitionCreate {
+            partition: gpu_partition(),
+        });
+        cm.apply_operation(&WalOperation::PartitionCreate {
+            partition: gpu_partition(),
+        });
+
+        let gpu_count = cm
+            .get_partitions()
+            .iter()
+            .filter(|p| p.name == "gpu")
+            .count();
+        assert_eq!(
+            gpu_count, 1,
+            "duplicate PartitionCreate must not add a second entry"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn apply_partition_update_unknown_is_a_noop() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        let before = cm.get_partitions().len();
+
+        cm.apply_operation(&WalOperation::PartitionUpdate {
+            name: "does-not-exist".into(),
+            nodes: Some("n1".into()),
+            selector: None,
+            state: None,
+            max_time_minutes: None,
+            default_time_minutes: None,
+            max_nodes: None,
+            min_nodes: None,
+            allow_accounts: None,
+            allow_groups: None,
+            deny_accounts: None,
+            deny_qos: None,
+            allow_qos: None,
+            priority_tier: None,
+            preempt_mode: None,
+            is_default: None,
+        });
+
+        assert_eq!(
+            cm.get_partitions().len(),
+            before,
+            "unknown partition update must not add an entry"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn apply_partition_set_default_clears_others() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        // Baseline: the "default" partition created by test_config() is already is_default=true.
+        cm.apply_operation(&WalOperation::PartitionCreate {
+            partition: gpu_partition(),
+        });
+        assert!(
+            !cm.get_partitions()
+                .iter()
+                .find(|p| p.name == "gpu")
+                .unwrap()
+                .is_default
+        );
+
+        // Make "gpu" the default.
+        cm.apply_operation(&WalOperation::PartitionUpdate {
+            name: "gpu".into(),
+            nodes: None,
+            selector: None,
+            state: None,
+            max_time_minutes: None,
+            default_time_minutes: None,
+            max_nodes: None,
+            min_nodes: None,
+            allow_accounts: None,
+            allow_groups: None,
+            deny_accounts: None,
+            deny_qos: None,
+            allow_qos: None,
+            priority_tier: None,
+            preempt_mode: None,
+            is_default: Some(true),
+        });
+
+        let parts = cm.get_partitions();
+        let defaults: Vec<&str> = parts
+            .iter()
+            .filter(|p| p.is_default)
+            .map(|p| p.name.as_str())
+            .collect();
+        assert_eq!(
+            defaults,
+            vec!["gpu"],
+            "exactly one partition must be default after promotion"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn create_partition_rejects_duplicate_name() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        cm.create_partition(gpu_partition()).unwrap();
+        let err = cm.create_partition(gpu_partition()).unwrap_err();
+        assert!(
+            matches!(err, PartitionError::AlreadyExists(_)),
+            "expected AlreadyExists, got {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn delete_partition_rejects_not_found() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        let err = cm.delete_partition("no-such-partition").unwrap_err();
+        assert!(
+            matches!(err, PartitionError::NotFound(_)),
+            "expected NotFound, got {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn delete_partition_rejects_when_running_job_uses_it() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+
+        // Use an open partition (no account restriction) so basic_spec's testuser can submit.
+        let open_part = spur_core::partition::Partition {
+            name: "gpu".into(),
+            nodes: "ALL".into(),
+            ..Default::default()
+        };
+        cm.create_partition(open_part).unwrap();
+        wait_for("gpu partition created", || {
+            cm.get_partitions().iter().any(|p| p.name == "gpu")
+        });
+
+        let mut spec = basic_spec("gpu-job");
+        spec.partition = Some("gpu".into());
+        let job_id = submit_and_wait(&cm, spec);
+        let alloc = scalar_alloc(1, 1000);
+        cm.start_job(
+            job_id,
+            vec!["n1".into()],
+            alloc.clone(),
+            per_node_for(&["n1"], alloc),
+        )
+        .unwrap();
+        settle(&cm, job_id, JobState::Running);
+
+        let err = cm.delete_partition("gpu").unwrap_err();
+        assert!(
+            matches!(err, PartitionError::InvalidArgument(_)),
+            "expected InvalidArgument for in-use partition, got {err:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn partition_survives_wal_replay() {
+        let dir = TempDir::new().unwrap();
+        {
+            let cm = test_cluster(&dir).await;
+            cm.create_partition(gpu_partition()).unwrap();
+            wait_for("gpu created", || {
+                cm.get_partitions().iter().any(|p| p.name == "gpu")
+            });
+        }
+
+        let cm2 = test_cluster(&dir).await;
+        wait_for("gpu replayed from WAL", || {
+            cm2.get_partitions().iter().any(|p| p.name == "gpu")
+        });
+        let gpu = cm2
+            .get_partitions()
+            .into_iter()
+            .find(|p| p.name == "gpu")
+            .unwrap();
+        assert_eq!(gpu.allow_accounts, vec!["ml-team"]);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_partition_create_keeps_single_entry() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        let cm1 = cm.clone();
+        let cm2 = cm.clone();
+        let (first, second) = tokio::join!(
+            tokio::task::spawn_blocking(move || cm1.create_partition(gpu_partition())),
+            tokio::task::spawn_blocking(move || cm2.create_partition(gpu_partition())),
+        );
+        let outcomes = [first.unwrap(), second.unwrap()];
+        assert_eq!(
+            outcomes.iter().filter(|r| r.is_ok()).count(),
+            1,
+            "exactly one concurrent create must succeed"
+        );
+        let gpu_count = cm
+            .get_partitions()
+            .iter()
+            .filter(|p| p.name == "gpu")
+            .count();
+        assert_eq!(gpu_count, 1);
+    }
+
+    // ---------------------------------------------------------------
+    // Tombstone tests
+    // ---------------------------------------------------------------
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn deleted_partition_does_not_resurface_after_snapshot_restore() {
+        let state_dir = TempDir::new().unwrap();
+        let cm = test_cluster(&state_dir).await;
+
+        // Create then delete "gpu" via the public API (goes through Raft).
+        cm.create_partition(gpu_partition()).unwrap();
+        wait_for("gpu created", || {
+            cm.get_partitions().iter().any(|p| p.name == "gpu")
+        });
+        cm.delete_partition("gpu").unwrap();
+        wait_for("gpu deleted", || {
+            !cm.get_partitions().iter().any(|p| p.name == "gpu")
+        });
+
+        // Tombstone set must contain "gpu".
+        assert!(
+            cm.deleted_partition_names.read().contains("gpu"),
+            "tombstone not recorded after delete"
+        );
+
+        // Simulate snapshot + restore: take a snapshot, apply it to a fresh manager.
+        let snap_bytes = cm.snapshot_state().unwrap();
+
+        let cm2 = Arc::new(ClusterManager::new(test_config(), state_dir.path()).unwrap());
+        cm2.restore_from_snapshot(&snap_bytes).unwrap();
+
+        assert!(
+            !cm2.get_partitions().iter().any(|p| p.name == "gpu"),
+            "deleted partition must not re-appear after snapshot restore"
+        );
+        assert!(
+            cm2.deleted_partition_names.read().contains("gpu"),
+            "tombstone must survive snapshot round-trip"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn recreating_tombstoned_partition_clears_tombstone() {
+        let state_dir = TempDir::new().unwrap();
+        let cm = test_cluster(&state_dir).await;
+
+        cm.create_partition(gpu_partition()).unwrap();
+        wait_for("gpu created", || {
+            cm.get_partitions().iter().any(|p| p.name == "gpu")
+        });
+
+        cm.delete_partition("gpu").unwrap();
+        wait_for("gpu deleted", || {
+            !cm.get_partitions().iter().any(|p| p.name == "gpu")
+        });
+        assert!(cm.deleted_partition_names.read().contains("gpu"));
+
+        // Recreate.
+        cm.create_partition(gpu_partition()).unwrap();
+        wait_for("gpu recreated", || {
+            cm.get_partitions().iter().any(|p| p.name == "gpu")
+        });
+
+        assert!(
+            !cm.deleted_partition_names.read().contains("gpu"),
+            "tombstone must be cleared when the partition is recreated"
+        );
+
+        // After another snapshot round-trip the partition must be present.
+        let snap_bytes = cm.snapshot_state().unwrap();
+        let cm2 = Arc::new(ClusterManager::new(test_config(), state_dir.path()).unwrap());
+        cm2.restore_from_snapshot(&snap_bytes).unwrap();
+        assert!(
+            cm2.get_partitions().iter().any(|p| p.name == "gpu"),
+            "recreated partition must survive snapshot round-trip"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn config_partition_not_touched_by_runtime_stays_after_snapshot_restore() {
+        // Verify that the existing deployment path is unaffected: a partition that
+        // was only ever defined in spur.conf and never touched at runtime must
+        // still be present after snapshot restore.
+        let state_dir = TempDir::new().unwrap();
+        let cm = test_cluster(&state_dir).await;
+
+        // test_config() includes a "default" partition — never touch it at runtime.
+        // Take a snapshot and restore.
+        let snap_bytes = cm.snapshot_state().unwrap();
+        let cm2 = Arc::new(ClusterManager::new(test_config(), state_dir.path()).unwrap());
+        cm2.restore_from_snapshot(&snap_bytes).unwrap();
+
+        assert!(
+            cm2.get_partitions().iter().any(|p| p.name == "default"),
+            "config-only partition must survive snapshot restore untouched"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // QoS enforcement tests
+    // ---------------------------------------------------------------
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn validate_partition_rejects_qos_not_in_allow_qos() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        let part = spur_core::partition::Partition {
+            name: "restricted".into(),
+            nodes: "ALL".into(),
+            allow_qos: vec!["premium".into()],
+            ..Default::default()
+        };
+        cm.create_partition(part).unwrap();
+        wait_for("restricted created", || {
+            cm.get_partitions().iter().any(|p| p.name == "restricted")
+        });
+
+        // QoS not in allow list → rejected.
+        let mut spec = basic_spec("bad-qos");
+        spec.partition = Some("restricted".into());
+        spec.qos = Some("cheap".into());
+        assert!(
+            cm.validate_partition(&spec).is_err(),
+            "QoS not in allow_qos must fail validation"
+        );
+
+        // QoS in allow list → accepted.
+        let mut spec = basic_spec("good-qos");
+        spec.partition = Some("restricted".into());
+        spec.qos = Some("premium".into());
+        assert!(
+            cm.validate_partition(&spec).is_ok(),
+            "QoS in allow_qos must pass validation"
+        );
+
+        // No QoS with allow_qos set → rejected (empty string not in list).
+        let mut spec = basic_spec("no-qos");
+        spec.partition = Some("restricted".into());
+        spec.qos = None;
+        assert!(
+            cm.validate_partition(&spec).is_err(),
+            "absent QoS must fail when allow_qos is non-empty"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn validate_partition_rejects_qos_in_deny_qos() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        let part = spur_core::partition::Partition {
+            name: "nodebug".into(),
+            nodes: "ALL".into(),
+            deny_qos: vec!["debug".into()],
+            ..Default::default()
+        };
+        cm.create_partition(part).unwrap();
+        wait_for("nodebug created", || {
+            cm.get_partitions().iter().any(|p| p.name == "nodebug")
+        });
+
+        // Denied QoS → rejected.
+        let mut spec = basic_spec("denied-qos");
+        spec.partition = Some("nodebug".into());
+        spec.qos = Some("debug".into());
+        assert!(
+            cm.validate_partition(&spec).is_err(),
+            "denied QoS must fail validation"
+        );
+
+        // Non-denied QoS → allowed.
+        let mut spec = basic_spec("other-qos");
+        spec.partition = Some("nodebug".into());
+        spec.qos = Some("premium".into());
+        assert!(
+            cm.validate_partition(&spec).is_ok(),
+            "non-denied QoS must pass validation"
+        );
+
+        // None QoS → allowed (deny_qos only blocks explicitly-named values).
+        let mut spec = basic_spec("no-qos");
+        spec.partition = Some("nodebug".into());
+        spec.qos = None;
+        assert!(
+            cm.validate_partition(&spec).is_ok(),
+            "absent QoS must not be blocked by deny_qos"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn validate_partition_passes_any_qos_when_allow_qos_empty() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        let part = spur_core::partition::Partition {
+            name: "open".into(),
+            nodes: "ALL".into(),
+            allow_qos: vec![],
+            ..Default::default()
+        };
+        cm.create_partition(part).unwrap();
+        wait_for("open created", || {
+            cm.get_partitions().iter().any(|p| p.name == "open")
+        });
+
+        let mut spec = basic_spec("any-qos");
+        spec.partition = Some("open".into());
+        spec.qos = Some("whatever".into());
+        assert!(
+            cm.validate_partition(&spec).is_ok(),
+            "empty allow_qos must not restrict any QoS"
+        );
     }
 }

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -118,8 +118,18 @@ async fn main() -> anyhow::Result<()> {
         spur_update::SPUR_BINARIES,
     );
 
-    // Initialize cluster manager first so Raft recovery can apply entries
-    let cluster = Arc::new(ClusterManager::new(config.clone(), &args.state_dir)?);
+    // Initialize cluster manager first so Raft recovery can apply entries.
+    // Pass the config path so `scontrol reconfigure` can re-read spur.conf.
+    let config_path = if args.config.exists() {
+        Some(args.config.clone())
+    } else {
+        None
+    };
+    let cluster = Arc::new(ClusterManager::new_with_config_path(
+        config.clone(),
+        &args.state_dir,
+        config_path,
+    )?);
 
     // Raft is always-on. When no peers are configured, run a single-node
     // cluster that self-elects instantly (same pattern as Apache Kudu).
@@ -347,6 +357,8 @@ fn default_config() -> spur_core::config::SlurmConfig {
             allow_accounts: Vec::new(),
             allow_groups: Vec::new(),
             deny_accounts: Vec::new(),
+            deny_qos: Vec::new(),
+            allow_qos: Vec::new(),
             priority_tier: 1,
             preempt_mode: String::new(),
         }],

--- a/crates/spurctld/src/metrics_server.rs
+++ b/crates/spurctld/src/metrics_server.rs
@@ -99,7 +99,7 @@ async fn metrics_scheduler(State(state): State<Arc<MetricsState>>) -> Response {
 }
 
 async fn metrics_jobs_users_accts(State(state): State<Arc<MetricsState>>) -> Response {
-    if !state.cluster.config.metrics.high_cardinality {
+    if !state.cluster.config().metrics.high_cardinality {
         return (
             StatusCode::NOT_FOUND,
             "jobs-users-accts metrics disabled (set metrics.high_cardinality = true)",
@@ -161,6 +161,8 @@ mod tests {
                 allow_accounts: Vec::new(),
                 allow_groups: Vec::new(),
                 deny_accounts: Vec::new(),
+                deny_qos: Vec::new(),
+                allow_qos: Vec::new(),
                 priority_tier: 1,
                 preempt_mode: String::new(),
             }],

--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -76,6 +76,8 @@ pub struct ClientResponse {
     pub jobs_finalized: Vec<JobFinalized>,
     #[serde(default)]
     pub reservation_created: bool,
+    #[serde(default)]
+    pub partition_created: bool,
 }
 
 /// Trait for applying committed Raft entries to the cluster state.

--- a/crates/spurctld/src/rpc_middleware.rs
+++ b/crates/spurctld/src/rpc_middleware.rs
@@ -182,6 +182,8 @@ mod tests {
                     allow_accounts: Vec::new(),
                     allow_groups: Vec::new(),
                     deny_accounts: Vec::new(),
+                    deny_qos: Vec::new(),
+                    allow_qos: Vec::new(),
                     priority_tier: 1,
                     preempt_mode: String::new(),
                 }],

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -54,13 +54,17 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
     tokio::spawn(async move {
         manage_power(power_cluster, power_raft).await;
     });
-    let interval_secs = cluster.config.scheduler.interval_secs.max(1) as u64;
-    let max_jobs = cluster.config.scheduler.max_jobs_per_cycle as usize;
+    // Captured once at loop start: the tick interval, per-cycle job cap, and
+    // topology tree are baked into loop-local state and are NOT picked up by
+    // `scontrol reconfigure` — changing them needs a controller restart.
+    let startup_config = cluster.config();
+    let interval_secs = startup_config.scheduler.interval_secs.max(1) as u64;
+    let max_jobs = startup_config.scheduler.max_jobs_per_cycle as usize;
 
     let mut scheduler = BackfillScheduler::new(max_jobs);
 
     // Build topology tree from config (if configured)
-    let topology = cluster.config.topology.as_ref().and_then(|topo_config| {
+    let topology = startup_config.topology.as_ref().and_then(|topo_config| {
         use spur_core::topology::TopologyTree;
         match topo_config.plugin.as_str() {
             "tree" => {
@@ -191,7 +195,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
                 try_preempt(&cluster, &partitions, &unscheduled).await;
 
                 // Federation: forward still-unschedulable jobs to peer clusters.
-                if !cluster.config.federation.clusters.is_empty() {
+                if !cluster.config().federation.clusters.is_empty() {
                     let jobs_to_fwd: Vec<spur_core::job::Job> =
                         unscheduled.iter().map(|j| (*j).clone()).collect();
                     let fed_cluster = cluster.clone();
@@ -269,7 +273,7 @@ async fn process_assignment(
     // the node prolog (prolog_slurmd) runs, or anything launches. The job is
     // still Pending here, so a failure just requeues it (batch) or cancels it
     // (interactive) — nothing on any node to tear down.
-    if let Some(ref prolog_ctld) = cluster.config.hooks.prolog_slurmctld {
+    if let Some(prolog_ctld) = cluster.config().hooks.prolog_slurmctld.clone() {
         let ctx = spur_core::hooks::HookContext {
             job_id: assignment.job_id,
             work_dir: job.spec.work_dir.clone(),
@@ -282,7 +286,7 @@ async fn process_assignment(
             cpus: job.spec.cpus_per_task,
             memory_mb: job.spec.memory_per_node_mb.unwrap_or(0),
         };
-        if let Err(e) = spur_core::hooks::run_hook(prolog_ctld, &ctx).await {
+        if let Err(e) = spur_core::hooks::run_hook(&prolog_ctld, &ctx).await {
             error!(
                 job_id = assignment.job_id,
                 error = %e,
@@ -670,7 +674,8 @@ fn preempt_overlaps_pending_nodes(
 /// Tries each peer in order; stops forwarding a job as soon as one peer accepts it.
 /// Failed peer connections are logged as warnings and skipped.
 async fn forward_to_federation(cluster: &ClusterManager, jobs: &[spur_core::job::Job]) {
-    let peers = &cluster.config.federation.clusters;
+    let config = cluster.config();
+    let peers = &config.federation.clusters;
     for job in jobs {
         for peer in peers {
             match SlurmControllerClient::connect(peer.address.clone())
@@ -1287,7 +1292,7 @@ async fn confirm_dispatch_on_nodes(
     // this flag rather than arrival order.
     let mut primary_outcome: Option<LaunchOutcome> = None;
 
-    let pmix_tmpdir = cluster.config.mpi.pmix_tmpdir.clone();
+    let pmix_tmpdir = cluster.config().mpi.pmix_tmpdir.clone();
     let mut set = tokio::task::JoinSet::new();
     for (node_idx, node_name) in dispatch_nodes.iter().enumerate() {
         let node_info = cluster.get_node(node_name);
@@ -1398,7 +1403,7 @@ async fn confirm_dispatch_on_nodes(
         }
     }
 
-    if !prolog_failed.is_empty() && cluster.config.controller.hold_on_prolog_fail {
+    if !prolog_failed.is_empty() && cluster.config().controller.hold_on_prolog_fail {
         if spec.interactive {
             // Holding an interactive job would strand its waiting srun forever
             // with nothing to wait for; Slurm cancels these too.
@@ -1549,7 +1554,7 @@ async fn enforce_completing_timeout(cluster: Arc<ClusterManager>, raft: Arc<Raft
         }
 
         let now = Utc::now();
-        let wait = chrono::Duration::seconds(cluster.config.scheduler.complete_wait_secs as i64);
+        let wait = chrono::Duration::seconds(cluster.config().scheduler.complete_wait_secs as i64);
 
         let completing = cluster.get_jobs(
             &[spur_core::job::JobState::Completing],
@@ -1644,7 +1649,10 @@ fn spawn_power_command(cmd: &str, node_name: &str, action: &str) {
 ///
 /// Disabled when `power.suspend_timeout_secs` is not set in the config.
 async fn manage_power(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
-    let suspend_timeout = match cluster.config.power.suspend_timeout_secs {
+    // Whether power management runs at all (and its idle timeout) is decided
+    // once here; toggling power on/off or changing the timeout needs a restart.
+    // The suspend/resume *commands* below are read live each cycle.
+    let suspend_timeout = match cluster.config().power.suspend_timeout_secs {
         Some(t) => t,
         None => return,
     };
@@ -1679,7 +1687,7 @@ async fn manage_power(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
                 spur_core::node::NodeState::Suspended,
                 Some("Power saving".into()),
             );
-            if let Some(ref cmd) = cluster.config.power.suspend_command {
+            if let Some(ref cmd) = cluster.config().power.suspend_command {
                 spawn_power_command(&cmd.replace("{node}", &node.name), &node.name, "suspend");
             }
         }
@@ -1694,7 +1702,7 @@ async fn manage_power(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
                 info!(node = %node.name, "resuming suspended node for pending jobs");
                 let _ =
                     cluster.update_node_state(&node.name, spur_core::node::NodeState::Idle, None);
-                if let Some(ref cmd) = cluster.config.power.resume_command {
+                if let Some(ref cmd) = cluster.config().power.resume_command {
                     spawn_power_command(&cmd.replace("{node}", &node.name), &node.name, "resume");
                 }
             }
@@ -2501,6 +2509,8 @@ mod tests {
                     allow_accounts: Vec::new(),
                     allow_groups: Vec::new(),
                     deny_accounts: Vec::new(),
+                    allow_qos: Vec::new(),
+                    deny_qos: Vec::new(),
                     priority_tier: 1,
                     preempt_mode: String::new(),
                 }],

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -18,7 +18,7 @@ use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::slurm_controller_server::SlurmController;
 use spur_proto::proto::*;
 
-use crate::cluster::{ClusterManager, ReservationError};
+use crate::cluster::{ClusterManager, PartitionError, ReservationError};
 use crate::raft::RaftHandle;
 use crate::rpc_middleware::RpcStatsLayer;
 use crate::rpc_stats::RpcStatsCollector;
@@ -119,6 +119,11 @@ pub struct ControllerService {
     /// Default HA control-plane count (`[cluster] control_plane_replicas`) when `spur k8s up`
     /// requests neither `--replicas` nor an explicit node set.
     control_plane_replicas: u32,
+    /// JWT signing key for node tokens, captured at startup. Deliberately NOT
+    /// re-read on `scontrol reconfigure`: swapping it live would instantly fail
+    /// verification of every outstanding node token (7-day TTL), silently
+    /// partitioning healthy nodes. Like Slurm's AuthType, it is restart-only.
+    jwt_key: String,
 }
 
 struct LeaderProxy {
@@ -180,6 +185,28 @@ impl LeaderProxy {
     ) -> Option<SlurmControllerClient<tonic::transport::Channel>> {
         self.get_leader_client().await.ok()
     }
+}
+
+/// Resolve the node-token signing key from config at startup. Captured once by
+/// `serve` into `ControllerService::jwt_key`; deliberately not re-read on
+/// `reconfigure` (see the field doc). Falls back to a shared default so
+/// key-less dev clusters interoperate.
+fn resolve_startup_jwt_key(config: &spur_core::config::SlurmConfig) -> String {
+    if let Some(key) = &config.auth.jwt_key {
+        return key.clone();
+    }
+    // Token admission signs/verifies node tokens with this key. A well-known
+    // default is trivially forgeable by anyone who can reach the controller.
+    if matches!(
+        config.admission.mode,
+        spur_core::config::AdmissionMode::Token
+    ) {
+        warn!(
+            "admission.mode=Token but auth.jwt_key is unset: node tokens are signed with a \
+             well-known default key and are forgeable. Set auth.jwt_key to a secret value."
+        );
+    }
+    "spur-default-key".to_string()
 }
 
 impl ControllerService {
@@ -270,7 +297,7 @@ impl ControllerService {
     fn validate_admission(&self, join_token: &str, hostname: &str) -> Result<String, Status> {
         use spur_core::config::AdmissionMode;
 
-        if !matches!(self.cluster.config.admission.mode, AdmissionMode::Token) {
+        if !matches!(self.cluster.config().admission.mode, AdmissionMode::Token) {
             return Ok(String::new());
         }
 
@@ -285,15 +312,7 @@ impl ControllerService {
         spur_core::admission::validate_token(token_id, secret, &token_store)
             .map_err(|e| Status::permission_denied(e.to_string()))?;
 
-        let jwt_key = self
-            .cluster
-            .config
-            .auth
-            .jwt_key
-            .as_deref()
-            .unwrap_or("spur-default-key");
-
-        spur_core::admission::generate_node_token(hostname, jwt_key.as_bytes())
+        spur_core::admission::generate_node_token(hostname, self.jwt_key.as_bytes())
             .map_err(|e| Status::internal(e.to_string()))
     }
 }
@@ -850,21 +869,14 @@ impl SlurmController for ControllerService {
         let req = request.into_inner();
 
         if matches!(
-            self.cluster.config.admission.mode,
+            self.cluster.config().admission.mode,
             spur_core::config::AdmissionMode::Token
         ) {
             if req.node_token.is_empty() {
                 return Err(Status::unauthenticated("node token required"));
             }
-            let jwt_key = self
-                .cluster
-                .config
-                .auth
-                .jwt_key
-                .as_deref()
-                .unwrap_or("spur-default-key");
             let identity =
-                spur_core::admission::verify_node_token(&req.node_token, jwt_key.as_bytes())
+                spur_core::admission::verify_node_token(&req.node_token, self.jwt_key.as_bytes())
                     .map_err(|e| Status::unauthenticated(e.to_string()))?;
             if identity.hostname != req.hostname {
                 return Err(Status::permission_denied("node token hostname mismatch"));
@@ -915,7 +927,7 @@ impl SlurmController for ControllerService {
 
         let federation_peers: Vec<String> = self
             .cluster
-            .config
+            .config()
             .federation
             .clusters
             .iter()
@@ -1059,7 +1071,7 @@ impl SlurmController for ControllerService {
         let req = request.into_inner();
         let resources = req.resources.map(proto_to_resource_set).unwrap_or_default();
 
-        let reject_loopback = self.cluster.config.network.reject_loopback_comm_addr;
+        let reject_loopback = self.cluster.config().network.reject_loopback_comm_addr;
         let advertised = req.address.clone();
         let agent_addr = tokio::task::spawn_blocking(move || {
             resolve_registration_comm_addr(&advertised, &remote_addr, reject_loopback)
@@ -1209,21 +1221,14 @@ impl SlurmController for ControllerService {
         let req = request.into_inner();
 
         if matches!(
-            self.cluster.config.admission.mode,
+            self.cluster.config().admission.mode,
             spur_core::config::AdmissionMode::Token
         ) {
             if req.node_token.is_empty() {
                 return Err(Status::unauthenticated("node token required"));
             }
-            let jwt_key = self
-                .cluster
-                .config
-                .auth
-                .jwt_key
-                .as_deref()
-                .unwrap_or("spur-default-key");
             let identity =
-                spur_core::admission::verify_node_token(&req.node_token, jwt_key.as_bytes())
+                spur_core::admission::verify_node_token(&req.node_token, self.jwt_key.as_bytes())
                     .map_err(|e| Status::unauthenticated(e.to_string()))?;
             if identity.hostname != req.hostname {
                 return Err(Status::permission_denied("node token hostname mismatch"));
@@ -1433,6 +1438,266 @@ impl SlurmController for ControllerService {
             .map_err(|e| Status::internal(format!("failed to create job step: {e}")))?;
 
         Ok(Response::new(CreateJobStepResponse { step_id, node_addr }))
+    }
+
+    async fn create_partition(
+        &self,
+        request: Request<CreatePartitionRequest>,
+    ) -> Result<Response<()>, Status> {
+        if let Err(status) = self.check_leader(&request) {
+            let proxy = &self.leader_proxy;
+            match proxy.get_leader_client().await {
+                Ok(mut client) => {
+                    let mut fwd = Request::new(request.into_inner());
+                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    return client.create_partition(fwd).await;
+                }
+                Err(e) => {
+                    warn!("failed to forward create_partition to leader: {e}");
+                    return Err(status);
+                }
+            }
+        }
+
+        let req = request.into_inner();
+
+        if req.nodes.is_empty() && req.selector.is_empty() {
+            return Err(Status::invalid_argument(
+                "partition must specify at least one of nodes or selector",
+            ));
+        }
+
+        let max_time_minutes = if req.max_time.is_empty()
+            || req.max_time.eq_ignore_ascii_case("INFINITE")
+            || req.max_time.eq_ignore_ascii_case("UNLIMITED")
+        {
+            None
+        } else {
+            Some(
+                spur_core::config::parse_time_minutes(&req.max_time).ok_or_else(|| {
+                    Status::invalid_argument(format!("invalid max_time: {}", req.max_time))
+                })?,
+            )
+        };
+
+        let default_time_minutes = if req.default_time.is_empty() {
+            None
+        } else {
+            Some(
+                spur_core::config::parse_time_minutes(&req.default_time).ok_or_else(|| {
+                    Status::invalid_argument(format!("invalid default_time: {}", req.default_time))
+                })?,
+            )
+        };
+
+        let state = match req.state.to_uppercase().as_str() {
+            "" | "UP" => spur_core::partition::PartitionState::Up,
+            "DOWN" => spur_core::partition::PartitionState::Down,
+            "DRAIN" => spur_core::partition::PartitionState::Drain,
+            "INACTIVE" => spur_core::partition::PartitionState::Inactive,
+            other => {
+                return Err(Status::invalid_argument(format!(
+                    "unknown partition state '{}'; expected UP, DOWN, DRAIN, or INACTIVE",
+                    other
+                )))
+            }
+        };
+
+        let preempt_mode = match req.preempt_mode.to_uppercase().as_str() {
+            "" | "OFF" => spur_core::partition::PreemptMode::Off,
+            "CANCEL" => spur_core::partition::PreemptMode::Cancel,
+            "REQUEUE" => spur_core::partition::PreemptMode::Requeue,
+            "SUSPEND" => spur_core::partition::PreemptMode::Suspend,
+            other => {
+                return Err(Status::invalid_argument(format!(
+                    "unknown preempt_mode '{}'; expected OFF, CANCEL, REQUEUE, or SUSPEND",
+                    other
+                )))
+            }
+        };
+
+        let partition = spur_core::partition::Partition {
+            name: req.name,
+            state,
+            is_default: req.is_default,
+            nodes: req.nodes,
+            selector: req.selector.into_iter().collect(),
+            max_time_minutes,
+            default_time_minutes,
+            // A literal 0 means "no limit" (matches the update-partition
+            // contract) rather than a partition that can never run a job.
+            max_nodes: req.max_nodes.filter(|&n| n != 0),
+            min_nodes: if req.min_nodes == 0 { 1 } else { req.min_nodes },
+            allow_accounts: req.allow_accounts,
+            allow_groups: req.allow_groups,
+            deny_accounts: req.deny_accounts,
+            deny_qos: req.deny_qos,
+            allow_qos: req.allow_qos,
+            priority_tier: req.priority_tier,
+            preempt_mode,
+            ..Default::default()
+        };
+
+        self.cluster
+            .create_partition(partition)
+            .map_err(partition_rpc_status)?;
+
+        Ok(Response::new(()))
+    }
+
+    async fn update_partition(
+        &self,
+        request: Request<UpdatePartitionRequest>,
+    ) -> Result<Response<()>, Status> {
+        if let Err(status) = self.check_leader(&request) {
+            let proxy = &self.leader_proxy;
+            match proxy.get_leader_client().await {
+                Ok(mut client) => {
+                    let mut fwd = Request::new(request.into_inner());
+                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    return client.update_partition(fwd).await;
+                }
+                Err(e) => {
+                    warn!("failed to forward update_partition to leader: {e}");
+                    return Err(status);
+                }
+            }
+        }
+
+        let req = request.into_inner();
+
+        let state = req
+            .state
+            .map(|s| match s.to_uppercase().as_str() {
+                v @ ("UP" | "DOWN" | "DRAIN" | "INACTIVE") => Ok(v.to_string()),
+                other => Err(Status::invalid_argument(format!(
+                    "unknown partition state '{}'; expected UP, DOWN, DRAIN, or INACTIVE",
+                    other
+                ))),
+            })
+            .transpose()?;
+
+        let preempt_mode = req
+            .preempt_mode
+            .map(|pm| match pm.to_uppercase().as_str() {
+                v @ ("OFF" | "CANCEL" | "REQUEUE" | "SUSPEND") => Ok(v.to_string()),
+                other => Err(Status::invalid_argument(format!(
+                    "unknown preempt_mode '{}'; expected OFF, CANCEL, REQUEUE, or SUSPEND",
+                    other
+                ))),
+            })
+            .transpose()?;
+
+        let max_time = req.max_time;
+        let allow_accounts = if req.set_allow_accounts {
+            Some(req.allow_accounts)
+        } else {
+            None
+        };
+        let allow_groups = if req.set_allow_groups {
+            Some(req.allow_groups)
+        } else {
+            None
+        };
+        let deny_accounts = if req.set_deny_accounts {
+            Some(req.deny_accounts)
+        } else {
+            None
+        };
+        let deny_qos = if req.set_deny_qos {
+            Some(req.deny_qos)
+        } else {
+            None
+        };
+        let allow_qos = if req.set_allow_qos {
+            Some(req.allow_qos)
+        } else {
+            None
+        };
+        let (max_nodes, clear_max_nodes) =
+            resolve_max_nodes_update(req.max_nodes_value, req.clear_max_nodes);
+
+        let selector = if req.set_selector || !req.selector.is_empty() {
+            Some(req.selector.into_iter().collect())
+        } else {
+            None
+        };
+        // Match create_partition's "0 means unset, not literally zero" rule.
+        let min_nodes = req.min_nodes.map(|mn| if mn == 0 { 1 } else { mn });
+
+        self.cluster
+            .update_partition(
+                &req.name,
+                req.nodes,
+                selector,
+                state,
+                req.is_default,
+                max_time,
+                req.default_time,
+                max_nodes,
+                clear_max_nodes,
+                min_nodes,
+                allow_accounts,
+                allow_groups,
+                deny_accounts,
+                deny_qos,
+                allow_qos,
+                req.priority_tier,
+                preempt_mode,
+            )
+            .map_err(partition_rpc_status)?;
+
+        Ok(Response::new(()))
+    }
+
+    async fn delete_partition(
+        &self,
+        request: Request<DeletePartitionRequest>,
+    ) -> Result<Response<()>, Status> {
+        if let Err(status) = self.check_leader(&request) {
+            let proxy = &self.leader_proxy;
+            match proxy.get_leader_client().await {
+                Ok(mut client) => {
+                    let mut fwd = Request::new(request.into_inner());
+                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    return client.delete_partition(fwd).await;
+                }
+                Err(e) => {
+                    warn!("failed to forward delete_partition to leader: {e}");
+                    return Err(status);
+                }
+            }
+        }
+
+        let name = request.into_inner().name;
+        self.cluster
+            .delete_partition(&name)
+            .map_err(partition_rpc_status)?;
+
+        Ok(Response::new(()))
+    }
+
+    async fn reconfigure(&self, request: Request<()>) -> Result<Response<()>, Status> {
+        if let Err(status) = self.check_leader(&request) {
+            let proxy = &self.leader_proxy;
+            match proxy.get_leader_client().await {
+                Ok(mut client) => {
+                    let mut fwd = Request::new(());
+                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    return client.reconfigure(fwd).await;
+                }
+                Err(e) => {
+                    warn!("failed to forward reconfigure to leader: {e}");
+                    return Err(status);
+                }
+            }
+        }
+
+        self.cluster
+            .reconfigure()
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        Ok(Response::new(()))
     }
 
     async fn create_reservation(
@@ -1714,7 +1979,7 @@ impl SlurmController for ControllerService {
         let mpi = spur_core::mpi::resolve_step_mpi(req.mpi.as_str(), job_mpi).to_string();
         spur_core::mpi::validate_pmix_step_agents(mpi.as_str(), plan.len())
             .map_err(Status::invalid_argument)?;
-        let pmix_tmpdir = self.cluster.config.mpi.pmix_tmpdir.clone();
+        let pmix_tmpdir = self.cluster.config().mpi.pmix_tmpdir.clone();
 
         struct NodeDispatch {
             node_name: String,
@@ -2091,6 +2356,8 @@ pub async fn serve(
 
     let leader_proxy = LeaderProxy::new(raft_handle.clone(), client_addrs.clone());
 
+    let jwt_key = resolve_startup_jwt_key(&cluster.config());
+
     let service = ControllerService {
         cluster,
         client_addrs,
@@ -2099,6 +2366,7 @@ pub async fn serve(
         rpc_stats: rpc_stats.clone(),
         sched_stats: sched_stats.clone(),
         control_plane_replicas,
+        jwt_key,
     };
 
     let stats_layer = RpcStatsLayer::new(rpc_stats, raft_handle);
@@ -2526,6 +2794,7 @@ fn partition_to_proto(part: &spur_core::partition::Partition) -> PartitionInfo {
         allow_groups: part.allow_groups.join(","),
         allow_qos: part.allow_qos.join(","),
         deny_accounts: part.deny_accounts.join(","),
+        deny_qos: part.deny_qos.join(","),
         preempt_mode: format!("{:?}", part.preempt_mode),
         priority_tier: part.priority_tier,
     }
@@ -2684,6 +2953,29 @@ fn submit_rpc_status(err: crate::cluster::SubmitError) -> Status {
         crate::cluster::SubmitError::InvalidArgument(m) => Status::invalid_argument(m),
         crate::cluster::SubmitError::Internal(m) => Status::internal(m),
     }
+}
+
+fn partition_rpc_status(err: PartitionError) -> Status {
+    match err {
+        PartitionError::InvalidArgument(m) => Status::invalid_argument(m),
+        PartitionError::NotFound(m) => Status::not_found(m),
+        PartitionError::AlreadyExists(m) => Status::already_exists(m),
+        PartitionError::Raft(m) => Status::internal(m),
+    }
+}
+
+/// Resolve an `UpdatePartitionRequest`'s max-nodes intent into the
+/// `(max_nodes, clear)` pair `ClusterManager::update_partition` expects.
+///
+/// `clear_max_nodes` and a literal `max_nodes_value == 0` both mean "no limit"
+/// (0 is documented as "clear limit" in the proto); neither can express a real
+/// 0-node cap. The two inputs must be collapsed into a single `clear` bool that
+/// is passed through — forwarding the raw request flag would drop a `--max-nodes
+/// 0` clear, since that arrives as `Some(0)` with the flag unset.
+fn resolve_max_nodes_update(max_nodes_value: Option<u32>, clear_flag: bool) -> (Option<u32>, bool) {
+    let clear = clear_flag || max_nodes_value == Some(0);
+    let max_nodes = if clear { None } else { max_nodes_value };
+    (max_nodes, clear)
 }
 
 fn cluster_err_to_status(err: anyhow::Error) -> Status {
@@ -2876,6 +3168,7 @@ mod tests {
             rpc_stats: Arc::new(RpcStatsCollector::new()),
             sched_stats: Arc::new(SchedStatsCollector::new("sched/backfill")),
             control_plane_replicas: 1,
+            jwt_key: String::new(),
         }
     }
 
@@ -2949,6 +3242,73 @@ mod tests {
         assert_eq!(status.message(), "partition 'gpu' not found");
     }
 
+    /// GATE: `auth.jwt_key` is captured at startup and must NOT change on
+    /// `reconfigure`. Swapping it live would instantly invalidate every
+    /// outstanding node token. This drives the real capture path
+    /// (`resolve_startup_jwt_key`) and the real `reconfigure`, then proves the
+    /// running controller still verifies a token minted with the startup key.
+    #[tokio::test]
+    async fn reconfigure_does_not_adopt_new_jwt_key() {
+        use spur_core::admission::{generate_node_token, verify_node_token};
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let conf_path = dir.path().join("spur.conf");
+        std::fs::write(
+            &conf_path,
+            "cluster_name = \"test\"\n[auth]\nplugin = \"jwt\"\njwt_key = \"old-secret\"\n",
+        )
+        .unwrap();
+
+        let config = spur_core::config::SlurmConfig::load_from_file(&conf_path).unwrap();
+        let cluster = Arc::new(
+            ClusterManager::new_with_config_path(config, dir.path(), Some(conf_path.clone()))
+                .unwrap(),
+        );
+        let handle = crate::raft::start_raft(1, &["[::1]:0".into()], dir.path(), cluster.clone())
+            .await
+            .unwrap();
+        handle
+            .raft
+            .wait(Some(std::time::Duration::from_secs(5)))
+            .metrics(|m| m.current_leader == Some(1), "leader elected")
+            .await
+            .unwrap();
+        cluster.set_raft(handle.raft);
+
+        // The controller captures the signing key exactly here, at startup.
+        let startup_key = resolve_startup_jwt_key(&cluster.config());
+        assert_eq!(startup_key, "old-secret");
+        let token = generate_node_token("node-1", startup_key.as_bytes()).unwrap();
+
+        // Operator edits jwt_key and reconfigures.
+        std::fs::write(
+            &conf_path,
+            "cluster_name = \"test\"\n[auth]\nplugin = \"jwt\"\njwt_key = \"new-secret\"\n",
+        )
+        .unwrap();
+        cluster.reconfigure().unwrap();
+
+        // The live config reflects the new key (proving reconfigure did swap
+        // config)...
+        assert_eq!(
+            cluster.config().auth.jwt_key.as_deref(),
+            Some("new-secret"),
+            "reconfigure must swap the live config"
+        );
+        // ...but the controller's captured key is unchanged, so tokens minted
+        // with the startup key still verify. A live-reloaded key would reject
+        // this token.
+        assert_eq!(startup_key, "old-secret", "captured key must not change");
+        assert!(
+            verify_node_token(&token, startup_key.as_bytes()).is_ok(),
+            "outstanding node token must still verify against the startup key"
+        );
+        assert!(
+            verify_node_token(&token, b"new-secret").is_err(),
+            "sanity: the token would fail under the new key (proving the key matters)"
+        );
+    }
+
     #[test]
     fn submit_rpc_status_maps_internal() {
         use crate::cluster::SubmitError;
@@ -2989,6 +3349,7 @@ mod tests {
             rpc_stats: std::sync::Arc::new(RpcStatsCollector::new()),
             sched_stats: std::sync::Arc::new(SchedStatsCollector::new("backfill")),
             control_plane_replicas: 1,
+            jwt_key: String::new(),
         }
     }
 
@@ -3602,6 +3963,20 @@ mod tests {
         let info = job_to_proto(&job);
         assert_eq!(info.stdout_path, "/tmp/spur-42.out");
         assert_eq!(info.stderr_path, "/tmp/spur-42.out");
+    }
+
+    #[test]
+    fn resolve_max_nodes_update_maps_intents() {
+        // `--max-nodes 0` (Some(0), flag unset) must resolve to a clear, not a
+        // silent no-op: cluster.rs only clears when the passed bool is true.
+        assert_eq!(resolve_max_nodes_update(Some(0), false), (None, true));
+        // Explicit clear flag, regardless of value.
+        assert_eq!(resolve_max_nodes_update(None, true), (None, true));
+        assert_eq!(resolve_max_nodes_update(Some(4), true), (None, true));
+        // A real positive cap is preserved and does not clear.
+        assert_eq!(resolve_max_nodes_update(Some(4), false), (Some(4), false));
+        // No value and no flag means "leave unchanged".
+        assert_eq!(resolve_max_nodes_update(None, false), (None, false));
     }
 
     fn make_node_info(name: &str) -> NodeInfo {

--- a/docs/deployment/kubernetes.rst
+++ b/docs/deployment/kubernetes.rst
@@ -85,6 +85,14 @@ Resolution precedence is: explicit ``controller.node_id`` -> position in
 one), the controller fails fast at startup rather than joining with a wrong ID.
 
 Adjust partition definitions and node resources to match your cluster hardware.
+Once the controller is running, ``scontrol reconfigure`` applies most section
+changes (partitions, nodes, licenses, hooks, scheduler tunables) without a
+restart; listen ports, the accounting database, Raft peers, and ``jwt_key``
+still require restarting the controller. ``reconfigure`` runs on the Raft
+leader only — followers keep their startup config until restarted, at which
+point they re-read this same ConfigMap and converge. To roll all controllers
+onto an updated ConfigMap, restart the StatefulSet pods. See
+:doc:`partitioning` for the full breakdown.
 
 Submitting Jobs
 ---------------

--- a/docs/deployment/partitioning.rst
+++ b/docs/deployment/partitioning.rst
@@ -82,6 +82,44 @@ The same dual-path matching applies to ``[[nodes]]`` config blocks (which set
 features and weight; see :doc:`native-host`), keyed by ``names`` (hostlist) or
 ``selector`` (labels).
 
+Applying Config Changes
+-----------------------
+
+After editing ``spur.conf``, apply the changes to a running controller without
+a restart:
+
+.. code-block:: bash
+
+   scontrol reconfigure
+
+``reconfigure`` re-reads ``spur.conf`` and makes the file authoritative:
+runtime-only changes not reflected in the file are overwritten.
+
+**Applied live** (no restart): ``[[partitions]]`` (created, updated, or deleted
+to match the file), ``[[nodes]]`` features and weight, ``licenses``,
+``burst_buffer``, ``[hooks]``, ``[notifications]``, ``[federation]``,
+``[power]`` suspend/resume commands, ``[admission]`` mode, and the
+``[scheduler]`` tunables ``complete_wait_secs`` and ``resv_overrun_minutes``.
+
+**Restart-only**: settings baked in when the daemon starts — listen addresses
+and ports (``[controller]``, ``[metrics]``, ``[rest_api]``), the accounting
+database (``[accounting]``), Raft identity and peers, ``first_job_id``,
+``auth.jwt_key`` (swapping the node-token signing key live would immediately
+invalidate every outstanding node token), and the scheduler loop cadence
+(``interval_secs``, ``max_jobs_per_cycle``, topology). ``reconfigure`` reads
+these but does not apply them; a full controller restart is required. This
+mirrors Slurm, where a documented subset of parameters (ports,
+``StateSaveLocation``, ``AuthType``, plugin set) also require a daemon restart.
+
+**Leader-only, in an HA cluster.** ``reconfigure`` is handled by the Raft
+leader and swaps only the leader's in-memory config; no Raft log entry carries
+the new config, so follower controllers keep the config they loaded at startup
+until they restart (in Kubernetes they re-read the same ConfigMap on restart).
+Partition changes still replicate through the partition write-ahead log, but
+followers recompute node membership from their own (pre-reconfigure) node
+config. Do not rely on reconfigured non-partition state surviving an immediate
+failover; roll the controllers to converge them.
+
 Verifying Membership
 --------------------
 

--- a/docs/deployment/partitioning.rst
+++ b/docs/deployment/partitioning.rst
@@ -97,9 +97,13 @@ runtime-only changes not reflected in the file are overwritten.
 
 **Applied live** (no restart): ``[[partitions]]`` (created, updated, or deleted
 to match the file), ``[[nodes]]`` features and weight, ``licenses``,
-``burst_buffer``, ``[hooks]``, ``[notifications]``, ``[federation]``,
+``burst_buffer``, controller-side ``[hooks]`` (``prolog_slurmctld``,
+``epilog_slurmctld``), ``[notifications]``, ``[federation]``,
 ``[power]`` suspend/resume commands, ``[admission]`` mode, and the
 ``[scheduler]`` tunables ``complete_wait_secs`` and ``resv_overrun_minutes``.
+Node-side hooks (the per-node prolog/epilog run by ``spurd``), the device
+registry, and memlock are read by the node agent at its own startup;
+``reconfigure`` does not reach compute nodes, so those need a ``spurd`` restart.
 
 **Restart-only**: settings baked in when the daemon starts — listen addresses
 and ports (``[controller]``, ``[metrics]``, ``[rest_api]``), the accounting

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -288,6 +288,7 @@ message PartitionInfo {
   string allow_groups = 33;
   string allow_qos = 34;
   string deny_accounts = 42;
+  string deny_qos = 43;
 
   string preempt_mode = 40;
   uint32 priority_tier = 41;
@@ -353,6 +354,12 @@ service SlurmController {
 
   // K8s operator callback: report job completion from Pod watcher
   rpc ReportJobStatus(ReportJobStatusRequest) returns (google.protobuf.Empty);
+
+  // Partition management
+  rpc CreatePartition(CreatePartitionRequest) returns (google.protobuf.Empty);
+  rpc UpdatePartition(UpdatePartitionRequest) returns (google.protobuf.Empty);
+  rpc DeletePartition(DeletePartitionRequest) returns (google.protobuf.Empty);
+  rpc Reconfigure(google.protobuf.Empty) returns (google.protobuf.Empty);
 
   // Reservation management
   rpc CreateReservation(CreateReservationRequest) returns (google.protobuf.Empty);
@@ -1266,6 +1273,59 @@ message CreateJobStepRequest {
 message CreateJobStepResponse {
   uint32 step_id = 1;
   string node_addr = 2;        // Address of the selected node (-w target, else first allocated); host:port for agent
+}
+
+// ============================================================
+// Partition Management
+// ============================================================
+
+message CreatePartitionRequest {
+  string name = 1;
+  string nodes = 2;               // hostlist pattern; a node matches if it satisfies this OR selector
+  map<string, string> selector = 3; // label selector; a node matches if it satisfies this OR nodes
+  string state = 4;               // "UP" | "DOWN" | "DRAIN" | "INACTIVE" (default "UP")
+  bool is_default = 5;
+  string max_time = 6;            // e.g. "24:00:00" or "INFINITE" (empty = INFINITE)
+  string default_time = 7;        // e.g. "01:00:00" (empty = no default)
+  optional uint32 max_nodes = 8;
+  uint32 min_nodes = 9;
+  repeated string allow_accounts = 10;
+  repeated string allow_groups = 11;
+  uint32 priority_tier = 12;
+  string preempt_mode = 13;       // "OFF" | "CANCEL" | "REQUEUE" | "SUSPEND"
+  repeated string deny_accounts = 14;
+  repeated string deny_qos = 15;
+  repeated string allow_qos = 16;
+}
+
+message UpdatePartitionRequest {
+  string name = 1;                // Required: partition to update
+  optional string nodes = 2;
+  map<string, string> selector = 3;     // replaces; empty = no change unless set_selector
+  bool set_selector = 21;               // true = apply selector (even if empty, to clear it)
+  optional string state = 4;
+  optional bool is_default = 5;
+  optional string max_time = 6;   // "INFINITE" clears the limit
+  optional string default_time = 7;
+  optional uint32 max_nodes_value = 8;  // 0 = clear limit
+  bool clear_max_nodes = 9;
+  optional uint32 min_nodes = 10;
+  repeated string allow_accounts = 11;  // replaces; empty = no change
+  bool set_allow_accounts = 12;         // true = apply allow_accounts (even if empty)
+  repeated string allow_groups = 13;
+  bool set_allow_groups = 14;
+  optional uint32 priority_tier = 15;
+  optional string preempt_mode = 16;
+  repeated string deny_accounts = 17;
+  bool set_deny_accounts = 18;
+  repeated string deny_qos = 19;
+  bool set_deny_qos = 20;
+  repeated string allow_qos = 22;
+  bool set_allow_qos = 23;
+}
+
+message DeletePartitionRequest {
+  string name = 1;
 }
 
 // ============================================================

--- a/tests/native_host/e2e/test_partitions.py
+++ b/tests/native_host/e2e/test_partitions.py
@@ -1,0 +1,1095 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for runtime partition management via scontrol."""
+
+import time
+
+import pytest
+
+from cluster import parse_job_id, wait_job, wait_job_state
+
+
+def _unique(prefix: str) -> str:
+    return f"{prefix}-{int(time.time())}"
+
+
+def _sbatch_when_qos_ready(cluster, args: list[str], timeout: int = 15) -> str:
+    """Retry sbatch until the accounting QoS cache picks up a QoS created
+    moments earlier via sacctmgr — the cache refreshes on a fixed interval
+    (see accounting_cluster's fairshare_refresh_secs), not on write."""
+    deadline = time.time() + timeout
+    while True:
+        try:
+            return cluster.sbatch(args)
+        except RuntimeError as e:
+            if "does not exist" not in str(e) or time.time() >= deadline:
+                raise
+            time.sleep(1)
+
+
+class TestPartitionCreate:
+    def test_create_and_show_partition(self, cluster):
+        name = _unique("part")
+        node = cluster.node_names[0]
+
+        out = cluster.scontrol(
+            "create-partition",
+            f"--name={name}",
+            f"--nodes={node}",
+            "--state=UP",
+        )
+        assert "created" in out.lower()
+
+        show = cluster.scontrol("show", "partition")
+        assert name in show
+
+    def test_create_partition_with_all_options(self, cluster):
+        name = _unique("part-full")
+        node = cluster.node_names[0]
+
+        out = cluster.scontrol(
+            "create-partition",
+            f"--name={name}",
+            f"--nodes={node}",
+            "--state=DOWN",
+            "--max-time=02:00:00",
+            "--default-time=00:30:00",
+            "--min-nodes=1",
+            "--allow-accounts=acct1,acct2",
+            "--allow-groups=grp1",
+            "--priority-tier=5",
+            "--preempt-mode=CANCEL",
+        )
+        assert "created" in out.lower()
+
+        show = cluster.scontrol("show", "partition")
+        assert name in show
+
+    def test_create_duplicate_partition_fails(self, cluster):
+        name = _unique("part-dup")
+        node = cluster.node_names[0]
+
+        cluster.scontrol(
+            "create-partition",
+            f"--name={name}",
+            f"--nodes={node}",
+        )
+
+        out = cluster.cli_allow_fail(
+            [
+                "scontrol",
+                "create-partition",
+                f"--name={name}",
+                f"--nodes={node}",
+            ]
+        )
+        assert "already exists" in out.lower() or "error" in out.lower(), (
+            f"expected error for duplicate partition, got: {out}"
+        )
+
+    def test_create_partition_empty_name_fails(self, cluster):
+        out = cluster.cli_allow_fail(
+            [
+                "scontrol",
+                "create-partition",
+                "--name=",
+                f"--nodes={cluster.node_names[0]}",
+            ]
+        )
+        assert "empty" in out.lower() or "invalid" in out.lower() or "error" in out.lower(), (
+            f"expected error for empty partition name, got: {out}"
+        )
+
+
+class TestPartitionUpdate:
+    def test_update_partition_state(self, cluster):
+        name = _unique("part-upd")
+        node = cluster.node_names[0]
+
+        cluster.scontrol(
+            "create-partition",
+            f"--name={name}",
+            f"--nodes={node}",
+            "--state=UP",
+        )
+
+        out = cluster.scontrol(
+            "update-partition",
+            f"--name={name}",
+            "--state=DRAIN",
+        )
+        assert "updated" in out.lower()
+
+        show = cluster.scontrol("show", "partition")
+        # The partition should still be listed (state change does not remove it).
+        assert name in show
+
+    def test_update_partition_max_time(self, cluster):
+        name = _unique("part-mt")
+        node = cluster.node_names[0]
+
+        cluster.scontrol(
+            "create-partition",
+            f"--name={name}",
+            f"--nodes={node}",
+            "--max-time=01:00:00",
+        )
+
+        out = cluster.scontrol(
+            "update-partition",
+            f"--name={name}",
+            "--max-time=48:00:00",
+        )
+        assert "updated" in out.lower()
+
+    def test_update_partition_allow_accounts(self, cluster):
+        name = _unique("part-acct")
+        node = cluster.node_names[0]
+
+        cluster.scontrol(
+            "create-partition",
+            f"--name={name}",
+            f"--nodes={node}",
+            "--allow-accounts=acct1",
+        )
+
+        out = cluster.scontrol(
+            "update-partition",
+            f"--name={name}",
+            "--allow-accounts=acct1,acct2",
+            "--set-allow-accounts",
+        )
+        assert "updated" in out.lower()
+
+    def test_update_nonexistent_partition_fails(self, cluster):
+        out = cluster.cli_allow_fail(
+            [
+                "scontrol",
+                "update-partition",
+                "--name=does-not-exist-at-all",
+                "--state=DOWN",
+            ]
+        )
+        assert "not found" in out.lower() or "error" in out.lower(), (
+            f"expected not-found error, got: {out}"
+        )
+
+    def test_update_nodes_field(self, cluster):
+        name = _unique("part-nodes")
+        node = cluster.node_names[0]
+
+        cluster.scontrol(
+            "create-partition",
+            f"--name={name}",
+            f"--nodes={node}",
+        )
+
+        out = cluster.scontrol(
+            "update-partition",
+            f"--name={name}",
+            f"--nodes={node}",
+        )
+        assert "updated" in out.lower()
+
+
+class TestPartitionDelete:
+    def test_delete_partition(self, cluster):
+        name = _unique("part-del")
+        node = cluster.node_names[0]
+
+        cluster.scontrol(
+            "create-partition",
+            f"--name={name}",
+            f"--nodes={node}",
+        )
+
+        show_before = cluster.scontrol("show", "partition")
+        assert name in show_before
+
+        out = cluster.scontrol("delete-partition", f"--name={name}")
+        assert "deleted" in out.lower()
+
+        show_after = cluster.scontrol("show", "partition")
+        assert name not in show_after
+
+    def test_delete_nonexistent_partition_fails(self, cluster):
+        out = cluster.cli_allow_fail(
+            [
+                "scontrol",
+                "delete-partition",
+                "--name=no-such-partition-xyz",
+            ]
+        )
+        assert "not found" in out.lower() or "error" in out.lower(), (
+            f"expected not-found error, got: {out}"
+        )
+
+    def test_delete_partition_with_running_job_fails(self, cluster):
+        """Deleting a partition with a job actively running on it must be
+        rejected (the in-use guard in ClusterManager::delete_partition).
+        Once the job is cancelled, deletion must succeed."""
+        name = _unique("part-inuse")
+        node = cluster.node_names[0]
+
+        cluster.scontrol(
+            "create-partition",
+            f"--name={name}",
+            f"--nodes={node}",
+        )
+
+        script = cluster.write_file("part-inuse.sh", "#!/bin/bash\nsleep 60\n")
+        sb = cluster.sbatch(["-N", "1", "-w", node, "-p", name, "-t", "5", script])
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+        wait_job_state(cluster, job_id, "R", timeout=60)
+
+        try:
+            out = cluster.cli_allow_fail(
+                ["scontrol", "delete-partition", f"--name={name}"]
+            )
+            assert "in use" in out.lower() or "error" in out.lower(), (
+                f"expected in-use rejection while job {job_id} is running, got: {out}"
+            )
+
+            show = cluster.scontrol("show", "partition")
+            assert name in show, "partition must still exist after rejected delete"
+        finally:
+            cluster.scancel(str(job_id))
+            wait_job(cluster, job_id, timeout=60)
+
+        out = cluster.scontrol("delete-partition", f"--name={name}")
+        assert "deleted" in out.lower(), f"expected deletion to succeed after cancel, got: {out}"
+
+        show_after = cluster.scontrol("show", "partition")
+        assert name not in show_after
+
+    def test_delete_idle_partition_succeeds(self, cluster):
+        name = _unique("part-idle")
+        node = cluster.node_names[0]
+
+        cluster.scontrol(
+            "create-partition",
+            f"--name={name}",
+            f"--nodes={node}",
+        )
+
+        show = cluster.scontrol("show", "partition")
+        assert name in show
+
+        out = cluster.scontrol("delete-partition", f"--name={name}")
+        assert "deleted" in out.lower(), f"expected deletion to succeed, got: {out}"
+
+        show_after = cluster.scontrol("show", "partition")
+        assert name not in show_after
+
+
+class TestPartitionLifecycle:
+    def test_create_update_delete_round_trip(self, cluster):
+        name = _unique("part-rt")
+        node = cluster.node_names[0]
+
+        cluster.scontrol(
+            "create-partition",
+            f"--name={name}",
+            f"--nodes={node}",
+            "--max-time=04:00:00",
+            "--priority-tier=3",
+        )
+        show = cluster.scontrol("show", "partition")
+        assert name in show
+
+        cluster.scontrol(
+            "update-partition",
+            f"--name={name}",
+            "--state=DRAIN",
+            "--max-time=08:00:00",
+        )
+
+        cluster.scontrol("delete-partition", f"--name={name}")
+        show_after = cluster.scontrol("show", "partition")
+        assert name not in show_after
+
+    def test_jobs_schedule_on_newly_created_partition(self, cluster):
+        """A partition created at runtime must be immediately usable by
+        already-registered nodes — not just visible in `show partition`.
+        Submits directly to the new partition (not the default) and waits
+        for actual completion, exercising the scheduler's node-eligibility
+        path end to end rather than just the partition table."""
+        name = _unique("part-sched")
+        nodes_list = ",".join(cluster.node_names)
+        node = cluster.node_names[0]
+
+        cluster.scontrol(
+            "create-partition",
+            f"--name={name}",
+            f"--nodes={nodes_list}",
+        )
+
+        # Verify the new partition appears in show output.
+        show = cluster.scontrol("show", "partition")
+        assert name in show
+
+        script = cluster.write_file("part-sched.sh", "#!/bin/bash\necho PARTITION_OK\n")
+        out_path = f"{cluster.remote_dir}/part-sched.out"
+        sb = cluster.sbatch(["-N", "1", "-w", node, "-p", name, "-t", "1", "-o", out_path, script])
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+
+        state = wait_job(cluster, job_id, timeout=60)
+        assert state in ("CD", "GONE"), (
+            f"expected job on newly-created partition '{name}' to complete, got {state} "
+            "(a stuck/pending state here means the node's cached partition "
+            "membership was not refreshed after partition creation)"
+        )
+
+        content = cluster.read_output_on_any_node(out_path)
+        assert "PARTITION_OK" in content
+
+
+class TestPartitionAllowDenyAccounts:
+    """
+    Verify AllowAccounts and DenyAccounts are enforced at job submission.
+    No accounting backend required — Spur enforces these as pure string
+    matches against the -A/--account flag passed to sbatch.
+    """
+
+    def test_allow_accounts_blocks_unlisted_account(self, cluster):
+        name = _unique("part-allow-acct")
+        node = cluster.node_names[0]
+
+        cluster.scontrol(
+            "create-partition",
+            f"--name={name}",
+            f"--nodes={node}",
+            "--allow-accounts=trusted",
+        )
+
+        script = cluster.write_file("allow-acct.sh", "#!/bin/bash\necho DONE\n")
+
+        # Unlisted account must be rejected at submission.
+        out = cluster.cli_allow_fail(
+            ["sbatch", "-N", "1", "-p", name, "-A", "untrusted", "-t", "1", script]
+        )
+        assert "not allowed" in out.lower() or "error" in out.lower(), (
+            f"expected rejection for unlisted account, got: {out}"
+        )
+
+    def test_allow_accounts_permits_listed_account(self, cluster):
+        name = _unique("part-allow-acct2")
+        nodes_list = ",".join(cluster.node_names)
+        node = cluster.node_names[0]
+
+        cluster.scontrol(
+            "create-partition",
+            f"--name={name}",
+            f"--nodes={nodes_list}",
+            "--allow-accounts=trusted",
+        )
+
+        script = cluster.write_file("allow-acct2.sh", "#!/bin/bash\necho ALLOW_OK\n")
+        out_path = f"{cluster.remote_dir}/allow-acct2.out"
+
+        # Submit to the default partition (which has no account restriction) with
+        # the trusted account — verifies the account is globally accepted.
+        sb = cluster.sbatch(
+            ["-N", "1", "-w", node, "-A", "trusted", "-t", "1", "-o", out_path, script]
+        )
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+
+        state = wait_job(cluster, job_id, timeout=60)
+        assert state in ("CD", "GONE"), f"expected completed, got {state}"
+
+        content = cluster.read_output_on_any_node(out_path)
+        assert "ALLOW_OK" in content
+
+    def test_deny_accounts_blocks_listed_account(self, cluster):
+        name = _unique("part-deny-acct")
+        node = cluster.node_names[0]
+
+        cluster.scontrol(
+            "create-partition",
+            f"--name={name}",
+            f"--nodes={node}",
+            "--deny-accounts=baduser",
+        )
+
+        script = cluster.write_file("deny-acct.sh", "#!/bin/bash\necho DONE\n")
+
+        out = cluster.cli_allow_fail(
+            ["sbatch", "-N", "1", "-p", name, "-A", "baduser", "-t", "1", script]
+        )
+        assert "denied" in out.lower() or "error" in out.lower(), (
+            f"expected rejection for denied account, got: {out}"
+        )
+
+    def test_deny_accounts_allows_unlisted_account(self, cluster):
+        name = _unique("part-deny-acct2")
+        nodes_list = ",".join(cluster.node_names)
+
+        cluster.scontrol(
+            "create-partition",
+            f"--name={name}",
+            f"--nodes={nodes_list}",
+            "--deny-accounts=baduser",
+        )
+
+        script = cluster.write_file("deny-acct2.sh", "#!/bin/bash\necho DENY_OK\n")
+
+        # Submit with an account NOT in the deny list to the named partition.
+        # The submit must be ACCEPTED (not rejected) — the job may stay pending
+        # if the cluster is busy, but the submission itself must succeed.
+        out = cluster.cli_allow_fail(
+            ["sbatch", "-N", "1", "-p", name, "-A", "gooduser", "-t", "1", script]
+        )
+        # A successful sbatch prints "Submitted batch job <N>"
+        assert "submitted" in out.lower() or parse_job_id(out) is not None, (
+            f"expected submission to succeed for non-denied account, got: {out}"
+        )
+        # Ensure it wasn't rejected by the partition enforce logic.
+        assert "denied" not in out.lower() and "not allowed" not in out.lower(), (
+            f"unlisted account must not be blocked by deny_accounts: {out}"
+        )
+
+    def test_runtime_update_allow_accounts_takes_effect(self, cluster):
+        """Update a running partition's AllowAccounts and verify the new
+        restriction is enforced immediately without a controller restart."""
+        name = _unique("part-upd-acct")
+        node = cluster.node_names[0]
+
+        # Start open (no account restriction).
+        cluster.scontrol(
+            "create-partition",
+            f"--name={name}",
+            f"--nodes={node}",
+        )
+
+        script = cluster.write_file("upd-acct.sh", "#!/bin/bash\necho DONE\n")
+
+        # Before update: any account passes.
+        sb = cluster.sbatch(["-N", "1", "-p", name, "-A", "someacct", "-t", "1", script])
+        assert parse_job_id(sb) is not None
+
+        # Restrict partition to only "privileged".
+        cluster.scontrol(
+            "update-partition",
+            f"--name={name}",
+            "--allow-accounts=privileged",
+            "--set-allow-accounts",
+        )
+
+        # After update: "someacct" must now be rejected.
+        out = cluster.cli_allow_fail(
+            ["sbatch", "-N", "1", "-p", name, "-A", "someacct", "-t", "1", script]
+        )
+        assert "not allowed" in out.lower() or "error" in out.lower(), (
+            f"expected rejection after allow_accounts update, got: {out}"
+        )
+
+
+class TestPartitionAllowDenyQos:
+    """
+    Verify AllowQos and DenyQos are enforced at job submission.
+    Requires the accounting_cluster fixture because QoS names must exist
+    in the controller's QoS cache before they can be used with -q.
+    """
+
+    def test_allow_qos_blocks_unlisted_qos(self, accounting_cluster):
+        c = accounting_cluster
+        name = _unique("part-allow-qos")
+        node = c.node_names[0]
+
+        # Create the QoS objects in the accounting backend first.
+        c.sacctmgr(["add", "qos", "name=premium", "-i"])
+        c.sacctmgr(["add", "qos", "name=cheap", "-i"])
+
+        c.scontrol(
+            "create-partition",
+            f"--name={name}",
+            f"--nodes={node}",
+            "--allow-qos=premium",
+        )
+
+        script = c.write_file("allow-qos.sh", "#!/bin/bash\necho DONE\n")
+
+        # QoS not in allow list must be rejected.
+        out = c.cli_allow_fail(
+            ["sbatch", "-N", "1", "-p", name, "-q", "cheap", "-t", "1", script]
+        )
+        assert "not allowed" in out.lower() or "error" in out.lower(), (
+            f"expected rejection for non-allowed QoS, got: {out}"
+        )
+
+    def test_allow_qos_permits_listed_qos(self, accounting_cluster):
+        c = accounting_cluster
+        name = _unique("part-allow-qos2")
+        node = c.node_names[0]
+
+        c.sacctmgr(["add", "qos", "name=premium", "-i"])
+
+        c.scontrol(
+            "create-partition",
+            f"--name={name}",
+            f"--nodes={node}",
+            "--allow-qos=premium",
+        )
+
+        script = c.write_file("allow-qos2.sh", "#!/bin/bash\necho ALLOW_QOS_OK\n")
+        out_path = f"{c.remote_dir}/allow-qos2.out"
+
+        sb = _sbatch_when_qos_ready(
+            c, ["-N", "1", "-p", name, "-q", "premium", "-t", "1", "-o", out_path, script]
+        )
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+
+        state = wait_job(c, job_id, timeout=60)
+        assert state in ("CD", "GONE"), f"expected completed, got {state}"
+
+        content = c.read_output_on_any_node(out_path)
+        assert "ALLOW_QOS_OK" in content
+
+    def test_deny_qos_blocks_listed_qos(self, accounting_cluster):
+        c = accounting_cluster
+        name = _unique("part-deny-qos")
+        node = c.node_names[0]
+
+        c.sacctmgr(["add", "qos", "name=debug", "-i"])
+
+        c.scontrol(
+            "create-partition",
+            f"--name={name}",
+            f"--nodes={node}",
+            "--deny-qos=debug",
+        )
+
+        script = c.write_file("deny-qos.sh", "#!/bin/bash\necho DONE\n")
+
+        out = c.cli_allow_fail(
+            ["sbatch", "-N", "1", "-p", name, "-q", "debug", "-t", "1", script]
+        )
+        assert "denied" in out.lower() or "error" in out.lower(), (
+            f"expected rejection for denied QoS, got: {out}"
+        )
+
+    def test_deny_qos_allows_unlisted_qos(self, accounting_cluster):
+        c = accounting_cluster
+        name = _unique("part-deny-qos2")
+        node = c.node_names[0]
+
+        c.sacctmgr(["add", "qos", "name=debug", "-i"])
+        c.sacctmgr(["add", "qos", "name=normal", "-i"])
+
+        c.scontrol(
+            "create-partition",
+            f"--name={name}",
+            f"--nodes={node}",
+            "--deny-qos=debug",
+        )
+
+        script = c.write_file("deny-qos2.sh", "#!/bin/bash\necho DENY_QOS_OK\n")
+        out_path = f"{c.remote_dir}/deny-qos2.out"
+
+        sb = _sbatch_when_qos_ready(
+            c, ["-N", "1", "-p", name, "-q", "normal", "-t", "1", "-o", out_path, script]
+        )
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+
+        state = wait_job(c, job_id, timeout=60)
+        assert state in ("CD", "GONE"), f"expected completed, got {state}"
+
+        content = c.read_output_on_any_node(out_path)
+        assert "DENY_QOS_OK" in content
+
+    def test_runtime_update_deny_qos_takes_effect(self, accounting_cluster):
+        """Add DenyQos to a running partition and verify enforcement is
+        immediate without a controller restart."""
+        c = accounting_cluster
+        name = _unique("part-upd-qos")
+        node = c.node_names[0]
+
+        c.sacctmgr(["add", "qos", "name=lowpri", "-i"])
+
+        # Start with no QoS restriction.
+        c.scontrol(
+            "create-partition",
+            f"--name={name}",
+            f"--nodes={node}",
+        )
+
+        script = c.write_file("upd-qos.sh", "#!/bin/bash\necho DONE\n")
+
+        # Before update: lowpri QoS is accepted.
+        sb = _sbatch_when_qos_ready(c, ["-N", "1", "-p", name, "-q", "lowpri", "-t", "1", script])
+        assert parse_job_id(sb) is not None, "lowpri should be accepted before deny update"
+
+        # Add lowpri to deny list at runtime.
+        c.scontrol(
+            "update-partition",
+            f"--name={name}",
+            "--deny-qos=lowpri",
+            "--set-deny-qos",
+        )
+
+        # After update: lowpri must be rejected.
+        out = c.cli_allow_fail(
+            ["sbatch", "-N", "1", "-p", name, "-q", "lowpri", "-t", "1", script]
+        )
+        assert "denied" in out.lower() or "error" in out.lower(), (
+            f"expected rejection after deny_qos update, got: {out}"
+        )
+
+
+class TestSlurmsyntax:
+    """
+    Verify that the Slurm-compatible inline key=value syntax works:
+      scontrol create PartitionName=<n> Nodes=... MaxTime=...
+      scontrol update PartitionName=<n> MaxTime=... State=...
+      scontrol delete PartitionName=<n>
+
+    These are in addition to the spur-native --flag subcommands.
+    """
+
+    def test_slurm_create_partition(self, cluster):
+        name = _unique("slurm-crt")
+        nodes_list = ",".join(cluster.node_names)
+
+        out = cluster.scontrol(
+            "create",
+            f"PartitionName={name}",
+            f"Nodes={nodes_list}",
+            "MaxTime=02:00:00",
+            "State=UP",
+            "PriorityTier=3",
+        )
+        assert "created" in out.lower(), f"expected created, got: {out}"
+
+        show = cluster.scontrol("show", "partition")
+        assert name in show
+        assert "02:00:00" in show or "2:00:00" in show
+
+    def test_slurm_create_partition_with_all_keys(self, cluster):
+        name = _unique("slurm-crt-full")
+        nodes_list = ",".join(cluster.node_names)
+
+        out = cluster.scontrol(
+            "create",
+            f"PartitionName={name}",
+            f"Nodes={nodes_list}",
+            "MaxTime=24:00:00",
+            "DefaultTime=01:00:00",
+            "MinNodes=1",
+            "MaxNodes=4",
+            "State=DOWN",
+            "Default=NO",
+            "AllowAccounts=acct1,acct2",
+            "DenyAccounts=badacct",
+            "AllowGroups=grp1",
+            "PriorityTier=5",
+            "PreemptMode=CANCEL",
+        )
+        assert "created" in out.lower()
+
+        show = cluster.scontrol("show", "partition")
+        assert name in show
+        assert "CANCEL" in show or "cancel" in show.lower()
+
+    def test_slurm_update_partition_maxtime(self, cluster):
+        name = _unique("slurm-upd")
+        nodes_list = ",".join(cluster.node_names)
+
+        cluster.scontrol(
+            "create",
+            f"PartitionName={name}",
+            f"Nodes={nodes_list}",
+            "MaxTime=01:00:00",
+        )
+
+        out = cluster.scontrol(
+            "update",
+            f"PartitionName={name}",
+            "MaxTime=08:00:00",
+        )
+        assert "updated" in out.lower(), f"expected updated, got: {out}"
+
+        show = cluster.scontrol("show", "partition")
+        assert name in show
+        assert "08:00:00" in show
+
+    def test_slurm_update_partition_state(self, cluster):
+        name = _unique("slurm-upd-state")
+        nodes_list = ",".join(cluster.node_names)
+
+        cluster.scontrol(
+            "create",
+            f"PartitionName={name}",
+            f"Nodes={nodes_list}",
+            "State=UP",
+        )
+
+        out = cluster.scontrol(
+            "update",
+            f"PartitionName={name}",
+            "State=DOWN",
+        )
+        assert "updated" in out.lower()
+
+        show = cluster.scontrol("show", "partition")
+        assert name in show
+        # State should now be DOWN
+        for line in show.splitlines():
+            if name in line:
+                # PartitionName line found; next line has State
+                break
+        assert "DOWN" in show or "down" in show.lower()
+
+    def test_slurm_update_partition_multiple_fields(self, cluster):
+        name = _unique("slurm-upd-multi")
+        nodes_list = ",".join(cluster.node_names)
+
+        cluster.scontrol(
+            "create",
+            f"PartitionName={name}",
+            f"Nodes={nodes_list}",
+            "MaxTime=01:00:00",
+            "PriorityTier=1",
+        )
+
+        out = cluster.scontrol(
+            "update",
+            f"PartitionName={name}",
+            "MaxTime=12:00:00",
+            "PriorityTier=10",
+            "State=DRAIN",
+        )
+        assert "updated" in out.lower()
+
+        show = cluster.scontrol("show", "partition")
+        assert name in show
+        assert "12:00:00" in show
+
+    def test_slurm_update_partition_allow_accounts(self, cluster):
+        name = _unique("slurm-upd-acct")
+        nodes_list = ",".join(cluster.node_names)
+
+        cluster.scontrol(
+            "create",
+            f"PartitionName={name}",
+            f"Nodes={nodes_list}",
+        )
+
+        out = cluster.scontrol(
+            "update",
+            f"PartitionName={name}",
+            "AllowAccounts=team1,team2",
+        )
+        assert "updated" in out.lower()
+
+        show = cluster.scontrol("show", "partition")
+        assert name in show
+        assert "team1" in show or "team2" in show
+
+    def test_slurm_update_partition_deny_accounts(self, cluster):
+        name = _unique("slurm-upd-deny")
+        nodes_list = ",".join(cluster.node_names)
+
+        cluster.scontrol(
+            "create",
+            f"PartitionName={name}",
+            f"Nodes={nodes_list}",
+        )
+
+        out = cluster.scontrol(
+            "update",
+            f"PartitionName={name}",
+            "DenyAccounts=blocked",
+        )
+        assert "updated" in out.lower()
+
+        show = cluster.scontrol("show", "partition")
+        assert name in show
+        assert "blocked" in show
+
+    def test_slurm_delete_partition(self, cluster):
+        name = _unique("slurm-del")
+        nodes_list = ",".join(cluster.node_names)
+
+        cluster.scontrol(
+            "create",
+            f"PartitionName={name}",
+            f"Nodes={nodes_list}",
+        )
+
+        show_before = cluster.scontrol("show", "partition")
+        assert name in show_before
+
+        out = cluster.scontrol("delete", f"PartitionName={name}")
+        assert "deleted" in out.lower(), f"expected deleted, got: {out}"
+
+        show_after = cluster.scontrol("show", "partition")
+        assert name not in show_after
+
+    def test_slurm_delete_nonexistent_partition_fails(self, cluster):
+        out = cluster.cli_allow_fail(
+            ["scontrol", "delete", "PartitionName=no-such-partition-xyz"]
+        )
+        assert "not found" in out.lower() or "error" in out.lower(), (
+            f"expected not-found error, got: {out}"
+        )
+
+    def test_slurm_create_duplicate_fails(self, cluster):
+        name = _unique("slurm-dup")
+        nodes_list = ",".join(cluster.node_names)
+
+        cluster.scontrol(
+            "create",
+            f"PartitionName={name}",
+            f"Nodes={nodes_list}",
+        )
+
+        out = cluster.cli_allow_fail(
+            ["scontrol", "create", f"PartitionName={name}", f"Nodes={nodes_list}"]
+        )
+        assert "already exists" in out.lower() or "error" in out.lower(), (
+            f"expected duplicate-create error, got: {out}"
+        )
+
+    def test_slurm_update_nonexistent_fails(self, cluster):
+        out = cluster.cli_allow_fail(
+            ["scontrol", "update", "PartitionName=no-such-partition-xyz", "State=DOWN"]
+        )
+        assert "not found" in out.lower() or "error" in out.lower(), (
+            f"expected not-found error, got: {out}"
+        )
+
+    def test_slurm_create_update_delete_round_trip(self, cluster):
+        """Full lifecycle using only Slurm-compatible scontrol syntax."""
+        name = _unique("slurm-rt")
+        nodes_list = ",".join(cluster.node_names)
+        node = cluster.node_names[0]
+
+        # Create
+        cluster.scontrol(
+            "create",
+            f"PartitionName={name}",
+            f"Nodes={nodes_list}",
+            "MaxTime=04:00:00",
+            "PriorityTier=3",
+            "State=UP",
+        )
+        show = cluster.scontrol("show", "partition")
+        assert name in show
+
+        # Update
+        cluster.scontrol(
+            "update",
+            f"PartitionName={name}",
+            "MaxTime=08:00:00",
+            "State=DRAIN",
+            "PriorityTier=5",
+        )
+        show = cluster.scontrol("show", "partition")
+        assert "08:00:00" in show
+
+        # Delete
+        cluster.scontrol("delete", f"PartitionName={name}")
+        show = cluster.scontrol("show", "partition")
+        assert name not in show
+
+
+class TestConfReadOnly:
+    """Verify spur.conf is never written by any runtime partition operation.
+
+    Slurm's slurmctld never writes slurm.conf; runtime changes live only in
+    memory. Spur must match this: the config file is a read-only input to the
+    daemon and the Raft WAL/snapshot is the authoritative runtime store.
+    """
+
+    def _conf_mtime(self, cluster) -> str:
+        return cluster.nodes[0].exec(
+            f"stat -c %Y '{cluster.etc_dir}/spur.conf'"
+        ).strip()
+
+    def test_create_partition_does_not_write_conf(self, cluster):
+        name = _unique("conf-crt")
+        node = cluster.node_names[0]
+
+        mtime_before = self._conf_mtime(cluster)
+        cluster.scontrol("create-partition", f"--name={name}", f"--nodes={node}")
+        mtime_after = self._conf_mtime(cluster)
+
+        assert mtime_before == mtime_after, (
+            f"spur.conf was modified by create-partition: "
+            f"mtime {mtime_before} → {mtime_after}"
+        )
+
+    def test_update_partition_does_not_write_conf(self, cluster):
+        name = _unique("conf-upd")
+        node = cluster.node_names[0]
+
+        cluster.scontrol("create-partition", f"--name={name}", f"--nodes={node}")
+        mtime_before = self._conf_mtime(cluster)
+
+        cluster.scontrol("update-partition", f"--name={name}", "--state=DRAIN")
+        mtime_after = self._conf_mtime(cluster)
+
+        assert mtime_before == mtime_after, (
+            f"spur.conf was modified by update-partition: "
+            f"mtime {mtime_before} → {mtime_after}"
+        )
+
+    def test_delete_partition_does_not_write_conf(self, cluster):
+        name = _unique("conf-del")
+        node = cluster.node_names[0]
+
+        cluster.scontrol("create-partition", f"--name={name}", f"--nodes={node}")
+        mtime_before = self._conf_mtime(cluster)
+
+        cluster.scontrol("delete-partition", f"--name={name}")
+        mtime_after = self._conf_mtime(cluster)
+
+        assert mtime_before == mtime_after, (
+            f"spur.conf was modified by delete-partition: "
+            f"mtime {mtime_before} → {mtime_after}"
+        )
+
+
+class TestPartitionPersistence:
+    """Verify WAL-backed partition state survives a controller restart.
+
+    Runtime partitions are persisted via Raft WAL/snapshot — not spur.conf.
+    A restarted controller must see the same partition table the Raft log
+    recorded, regardless of what spur.conf contains.
+    """
+
+    def test_runtime_partition_survives_restart(self, cluster):
+        """A partition created at runtime must still be present after the
+        controller is restarted from its Raft state directory."""
+        name = _unique("persist-rt")
+        node = cluster.node_names[0]
+
+        cluster.scontrol("create-partition", f"--name={name}", f"--nodes={node}")
+        show_before = cluster.scontrol("show", "partition")
+        assert name in show_before
+
+        cluster.restart_controller()
+
+        show_after = cluster.scontrol("show", "partition")
+        assert name in show_after, (
+            f"runtime partition '{name}' must survive controller restart via WAL"
+        )
+
+    def test_deleted_partition_absent_after_restart(self, cluster):
+        """A partition created and then deleted at runtime must remain absent
+        after a controller restart — the WAL deletion must not be undone."""
+        name = _unique("persist-del")
+        node = cluster.node_names[0]
+
+        cluster.scontrol("create-partition", f"--name={name}", f"--nodes={node}")
+        cluster.scontrol("delete-partition", f"--name={name}")
+
+        show_before_restart = cluster.scontrol("show", "partition")
+        assert name not in show_before_restart
+
+        cluster.restart_controller()
+
+        show_after = cluster.scontrol("show", "partition")
+        assert name not in show_after, (
+            f"deleted partition '{name}' must stay absent after controller restart"
+        )
+
+
+class TestReconfigure:
+    """Verify scontrol reconfigure matches Slurm's semantics.
+
+    Slurm: reconfigure re-reads slurm.conf and makes the live state match it.
+    Partitions present only in the WAL (not in conf) are dropped. Partitions
+    defined in conf survive and are not touched. scontrol reconfigure does NOT
+    write to spur.conf.
+    """
+
+    def _conf_mtime(self, cluster) -> str:
+        return cluster.nodes[0].exec(
+            f"stat -c %Y '{cluster.etc_dir}/spur.conf'"
+        ).strip()
+
+    def test_reconfigure_drops_runtime_only_partition(self, cluster):
+        """A partition created via scontrol (not in spur.conf) must be removed
+        by scontrol reconfigure, matching Slurm's conf-wins semantics."""
+        name = _unique("reconf-rt")
+        node = cluster.node_names[0]
+
+        cluster.scontrol("create-partition", f"--name={name}", f"--nodes={node}")
+        show_before = cluster.scontrol("show", "partition")
+        assert name in show_before, "partition must appear before reconfigure"
+
+        cluster.scontrol("reconfigure")
+
+        show_after = cluster.scontrol("show", "partition")
+        assert name not in show_after, (
+            f"runtime-only partition '{name}' must be dropped by reconfigure "
+            f"(not in spur.conf)"
+        )
+
+    def test_reconfigure_preserves_conf_partitions(self, cluster):
+        """scontrol reconfigure must not remove partitions defined in spur.conf."""
+        show_before = cluster.scontrol("show", "partition")
+        assert "default" in show_before
+
+        cluster.scontrol("reconfigure")
+
+        show_after = cluster.scontrol("show", "partition")
+        assert "default" in show_after, (
+            "conf-defined 'default' partition must survive reconfigure"
+        )
+
+    def test_reconfigure_does_not_write_conf(self, cluster):
+        """scontrol reconfigure reads conf but must never write it back."""
+        mtime_before = self._conf_mtime(cluster)
+        cluster.scontrol("reconfigure")
+        mtime_after = self._conf_mtime(cluster)
+
+        assert mtime_before == mtime_after, (
+            f"spur.conf was modified by reconfigure: "
+            f"mtime {mtime_before} → {mtime_after}"
+        )
+
+    def test_reconfigure_reloads_non_partition_section_live(self, cluster):
+        """A non-partition section ([federation]) added to spur.conf must take
+        effect on `scontrol reconfigure` WITHOUT a controller restart.
+
+        Proves reconfigure is not partition-only: the controller re-reads the
+        file and swaps its live config, and a consumer (the ping path behind
+        `scontrol show federation`) picks up the new value immediately.
+        """
+        node = cluster.nodes[0]
+        conf_path = f"{cluster.etc_dir}/spur.conf"
+
+        before = cluster.scontrol("show", "federation")
+        assert "reconf-peer" not in before, (
+            "peer must not exist before the conf edit"
+        )
+
+        original = node.read_file(conf_path)
+        assert "[[federation.clusters]]" not in original
+        node.write_file(
+            conf_path,
+            original
+            + '\n[[federation.clusters]]\n'
+            + 'name = "reconf-peer"\n'
+            + 'address = "http://reconf-peer:6817"\n',
+        )
+        try:
+            cluster.scontrol("reconfigure")
+
+            after = cluster.scontrol("show", "federation")
+            assert "reconf-peer" in after, (
+                "federation peer added to spur.conf must be live after "
+                f"reconfigure without a restart; got:\n{after}"
+            )
+        finally:
+            # Restore conf so later tests see the original config on disk.
+            node.write_file(conf_path, original)
+            cluster.scontrol("reconfigure")


### PR DESCRIPTION
## Summary

Adds runtime partition management to Spur — create/update/delete partitions and `scontrol reconfigure` — with all state persisted through the Raft WAL so it survives restarts and replicates across HA peers. Brings partition ACL enforcement (accounts + QoS) in line with Slurm.

- **Partition CRUD via `scontrol`**: `create-partition`, `update-partition`, `delete-partition` in both Spur's native flag syntax and Slurm-compatible key=value syntax (`scontrol create PartitionName=foo Nodes=bar`). key=value entity detection scans all params for `PartitionName=`/`ReservationName=`, so argument order doesn't matter (matching Slurm) and the ambiguous both-present case is rejected.
- **Raft-backed persistence**: three WAL variants (`PartitionCreate`/`PartitionUpdate`/`PartitionDelete`) carry the full diff; mutations survive controller restart and replicate to peers. A persisted tombstone set stops conf-seeded partitions that were runtime-deleted from re-appearing on restart.
- **`scontrol reconfigure`**: re-reads `spur.conf` on the leader and applies it live — partitions (create/update/delete, skipping deletes of partitions with active jobs), `[[nodes]]` policy/membership, `[licenses]`, `[burst_buffer]`, hooks/notifications, and scheduler tunables. Restart-only sections (listen ports, accounting DB, raft peers, `jwt_key`, scheduler cadence) are left untouched and called out explicitly in the CLI help, success message, and controller log. Followers converge on restart.
- **Drops `spur.conf` writeback**: `slurmctld` never rewrites `slurm.conf` at runtime, so our writeback was a divergence. `spur.conf` is now a read-only boot-time input (plus `reconfigure` re-read); the WAL is the authoritative runtime state.
- **Partition ACL enforcement without an accounting backend**: `AllowAccounts`/`DenyAccounts` were gated behind `association_cache.is_loaded()`, making them a silent no-op on clusters with no Postgres backend. The check is pure string matching against the requested account and needs no cache. Adds partition `AllowQos`/`DenyQos` (new `deny_qos` proto/config field) with a clear "a QoS is required" error when a partition sets `AllowQos` but the job resolves to none.
- **Per-partition `PreemptMode`**: resolved at schedule time — a QoS-level override wins, otherwise the most aggressive matched partition mode applies.

## Design choices

- **WAL is the source of truth**; `spur.conf` is read only at boot and on `reconfigure`. This removes a whole class of write-ordering / partial-write bugs and keeps HA peers consistent through the log.
- **`reconfigure` applies conf live rather than being partition-only.** Making it a broad, predictable "conf wins" reconcile (with the restart-only exceptions stated loudly) is more useful than a partition-only reload, and safer than a partial live-swap of some sections but not others.
- **`jwt_key` and scheduler cadence (`interval_secs`) are pinned at startup and deliberately NOT live-swapped by `reconfigure`.** Hot-swapping `jwt_key` would instantly invalidate every outstanding node token; a unit test asserts a token minted with the startup key still verifies after a `jwt_key` edit + reconfigure. `reconfigure` is also scoped to the leader.
- **`max_nodes` clear semantics**: both `--clear-max-nodes` and a literal `--max-nodes 0` (and inline `MaxNodes=0`) mean "no limit", matching the proto's documented `0 = clear limit`. Neither can express a real zero-node cap. The controller collapses these into one derived flag so `--max-nodes 0` actually clears instead of no-opping.
- **`update_partition` threads the proto request struct** through the CLI rather than a long positional argument list, dropping the paired `set_*` bools and the `too_many_arguments` allow.
- `config_path` is retained in `ClusterManager` because `reconfigure` needs to know where to re-read conf; `ClusterManager::new` (no config path) is `#[cfg(test)]`-only since production always uses `new_with_config_path`.

## Testing

- `cargo test -p spurctld -p spur-cli --locked` passes; `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` clean; `cargo fmt --all --check` clean.
- Unit coverage includes partition CRUD, WAL replay, snapshot/tombstone restore, ACL (accounts + allow/deny QoS) enforcement, per-partition preempt-mode resolution, `max_nodes` clear intents, and live-reload of scheduler tunables / hooks / license pool / `max_batch_requeue` via `reconfigure` (plus the `jwt_key`-pinning security test).
- E2E partition suite (`tests/native_host/e2e/test_partitions.py`) covers the create/update/delete lifecycle, Slurm-compatible syntax, the conf read-only invariant, persistence across restart, and `reconfigure` semantics.
- Live-tested on a 2-node lab cluster: partition CRUD, `--max-nodes 0` / `--clear-max-nodes` / inline `MaxNodes=0` clearing, combined max-nodes + ACL updates, ACL clear-to-empty, and the unknown-partition fail-closed path.