### PR TITLE
fix(spurctld): evict job to nodefail on partial multi-node dispatch failure

### DIFF
--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -96,6 +96,13 @@ pub enum WalOperation {
         /// Controller-stamped instant of resume.
         at: chrono::DateTime<chrono::Utc>,
     },
+    /// Evict a single job to NodeFail: same effect as a node health-check
+    /// failure (frees allocations, feeds the auto-requeue path), but scoped
+    /// to one job instead of every job on a node. Used when a subset of a
+    /// job's assigned nodes never received the launch dispatch.
+    JobEvict {
+        job_id: JobId,
+    },
 
     // Node operations
     NodeRegister {
@@ -422,6 +429,17 @@ mod suspend_wal_tests {
                 }
                 _ => panic!("variant mismatch after round-trip"),
             }
+        }
+    }
+
+    #[test]
+    fn job_evict_op_round_trips() {
+        let op = WalOperation::JobEvict { job_id: 9 };
+        let json = serde_json::to_string(&op).unwrap();
+        let back: WalOperation = serde_json::from_str(&json).unwrap();
+        match back {
+            WalOperation::JobEvict { job_id } => assert_eq!(job_id, 9),
+            _ => panic!("wrong variant"),
         }
     }
 }

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -431,6 +431,11 @@ mod suspend_wal_tests {
             }
         }
     }
+}
+
+#[cfg(test)]
+mod evict_wal_tests {
+    use super::*;
 
     #[test]
     fn job_evict_op_round_trips() {

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -977,6 +977,27 @@ impl ClusterManager {
         Ok(())
     }
 
+    /// Evict a running job to NodeFail: same effect as the health-check path
+    /// (`evict_jobs_on_node`) that runs when an entire node goes Down, but
+    /// scoped to a single job. Used when only some of a job's assigned nodes
+    /// could be dispatched to, since a node that never launched the job will
+    /// never report completion. NodeFail feeds the existing auto-requeue path
+    /// in `notify_job_finished`.
+    pub fn evict_job(&self, job_id: JobId) -> anyhow::Result<()> {
+        {
+            let jobs = self.jobs.read();
+            let job = jobs
+                .get(&job_id)
+                .ok_or_else(|| anyhow::anyhow!("job {} not found", job_id))?;
+            if job.state.is_terminal() {
+                return Ok(());
+            }
+        }
+        let resp = self.propose(WalOperation::JobEvict { job_id })?;
+        self.run_all_finalized_side_effects(&resp);
+        Ok(())
+    }
+
     /// Register a node agent.
     #[allow(clippy::too_many_arguments)]
     pub fn register_node(
@@ -2719,7 +2740,7 @@ impl ClusterManager {
     /// Evict a single job by ID: transition to NodeFail, then free its
     /// allocations on every node it spans. Transition is validated first
     /// so allocations are never freed for a job that can't be evicted.
-    fn evict_job(
+    fn evict_job_locked(
         job_id: JobId,
         jobs: &mut HashMap<JobId, Job>,
         nodes: &mut HashMap<String, Node>,
@@ -2794,7 +2815,7 @@ impl ClusterManager {
             .collect();
 
         for jid in affected {
-            if let Some(fin) = Self::evict_job(jid, jobs, nodes, timestamp) {
+            if let Some(fin) = Self::evict_job_locked(jid, jobs, nodes, timestamp) {
                 response.jobs_finalized.push(fin);
             }
         }
@@ -2963,6 +2984,12 @@ impl ClusterManager {
                             warn!(job_id = *job_id, error = %e, "invalid resume transition in WAL apply")
                         }
                     }
+                }
+            }
+            WalOperation::JobEvict { job_id } => {
+                if let Some(fin) = Self::evict_job_locked(*job_id, &mut jobs, &mut nodes, timestamp)
+                {
+                    response.jobs_finalized.push(fin);
                 }
             }
             WalOperation::JobStart {
@@ -8233,6 +8260,50 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn evict_job_transitions_partial_dispatch_failure_to_nodefail() {
+        // A multi-node job where the dispatch RPC only reaches some of the
+        // assigned nodes must not be left running forever waiting on
+        // completions from a node that never launched it.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 4, 8000);
+        register_node(&cm, "n2", 4, 8000);
+
+        let mut spec = basic_spec("partial-dispatch-fail");
+        spec.num_nodes = 2;
+        let id = submit_and_wait(&cm, spec);
+
+        let alloc = scalar_alloc(2, 4000);
+        cm.start_job(
+            id,
+            vec!["n1".into(), "n2".into()],
+            scalar_alloc(4, 8000),
+            per_node_for(&["n1", "n2"], alloc),
+        )
+        .unwrap();
+        settle(&cm, id, JobState::Running);
+
+        // n1's dispatch succeeded, n2's never reached the agent.
+        cm.evict_job(id).unwrap();
+        settle(&cm, id, JobState::NodeFail);
+
+        let job = cm.get_job(id).unwrap();
+        assert_eq!(job.state, JobState::NodeFail);
+        assert!(
+            job.node_completions.is_empty(),
+            "node_completions must be cleared so a stray late report can't reopen the job"
+        );
+
+        for name in ["n1", "n2"] {
+            let node = cm.get_node(name).unwrap();
+            assert_eq!(
+                node.alloc_resources.cpus, 0,
+                "allocation on {name} must be freed on eviction"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn register_node_gets_partition_via_propose() {
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
@@ -9583,7 +9654,7 @@ mod tests {
     fn evict_job_returns_none_for_missing_job() {
         let mut jobs = HashMap::new();
         let mut nodes = HashMap::new();
-        let result = ClusterManager::evict_job(999, &mut jobs, &mut nodes, Utc::now());
+        let result = ClusterManager::evict_job_locked(999, &mut jobs, &mut nodes, Utc::now());
         assert!(result.is_none());
     }
 
@@ -9594,7 +9665,7 @@ mod tests {
         jobs.insert(1, make_running_job(1, &["n1"], 2));
         nodes.insert("n1".into(), make_test_node("n1", 4, 2));
 
-        let fin = ClusterManager::evict_job(1, &mut jobs, &mut nodes, Utc::now()).unwrap();
+        let fin = ClusterManager::evict_job_locked(1, &mut jobs, &mut nodes, Utc::now()).unwrap();
         assert_eq!(fin.job_id, 1);
         assert_eq!(fin.state, JobState::NodeFail);
         assert_eq!(fin.exit_code, -1);
@@ -9614,7 +9685,7 @@ mod tests {
         nodes.insert("n1".into(), make_test_node("n1", 4, 2));
         nodes.insert("n2".into(), make_test_node("n2", 4, 2));
 
-        ClusterManager::evict_job(1, &mut jobs, &mut nodes, Utc::now());
+        ClusterManager::evict_job_locked(1, &mut jobs, &mut nodes, Utc::now());
 
         assert_eq!(nodes["n1"].alloc_resources.cpus, 0);
         assert_eq!(nodes["n2"].alloc_resources.cpus, 0);
@@ -9629,7 +9700,7 @@ mod tests {
         jobs.insert(1, job);
         nodes.insert("n1".into(), make_test_node("n1", 4, 2));
 
-        let result = ClusterManager::evict_job(1, &mut jobs, &mut nodes, Utc::now());
+        let result = ClusterManager::evict_job_locked(1, &mut jobs, &mut nodes, Utc::now());
         assert!(result.is_none());
     }
 
@@ -9645,7 +9716,7 @@ mod tests {
         jobs.insert(1, job);
         nodes.insert("n1".into(), make_test_node("n1", 4, 2));
 
-        ClusterManager::evict_job(1, &mut jobs, &mut nodes, Utc::now());
+        ClusterManager::evict_job_locked(1, &mut jobs, &mut nodes, Utc::now());
 
         let job = &jobs[&1];
         assert!(job.suspended_at.is_none());
@@ -9661,7 +9732,7 @@ mod tests {
         jobs.insert(1, job);
         nodes.insert("n1".into(), make_test_node("n1", 4, 2));
 
-        let fin = ClusterManager::evict_job(1, &mut jobs, &mut nodes, Utc::now()).unwrap();
+        let fin = ClusterManager::evict_job_locked(1, &mut jobs, &mut nodes, Utc::now()).unwrap();
         assert_eq!(fin.state, JobState::NodeFail);
         assert_eq!(jobs[&1].state, JobState::NodeFail);
         assert_eq!(nodes["n1"].alloc_resources.cpus, 0);
@@ -9676,7 +9747,7 @@ mod tests {
         node.state = NodeState::Draining;
         nodes.insert("n1".into(), node);
 
-        ClusterManager::evict_job(1, &mut jobs, &mut nodes, Utc::now());
+        ClusterManager::evict_job_locked(1, &mut jobs, &mut nodes, Utc::now());
 
         assert_eq!(nodes["n1"].state, NodeState::Drain);
     }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -977,12 +977,15 @@ impl ClusterManager {
         Ok(())
     }
 
-    /// Evict a running job to NodeFail: same effect as the health-check path
-    /// (`evict_jobs_on_node`) that runs when an entire node goes Down, but
-    /// scoped to a single job. Used when only some of a job's assigned nodes
-    /// could be dispatched to, since a node that never launched the job will
-    /// never report completion. NodeFail feeds the existing auto-requeue path
-    /// in `notify_job_finished`.
+    /// Evict a running job to NodeFail: frees allocations and feeds the
+    /// existing auto-requeue path in `notify_job_finished`, same as the
+    /// health-check path (`evict_jobs_on_node`) that runs when an entire
+    /// node goes Down, but scoped to a single job. Used when only some of a
+    /// job's assigned nodes could be dispatched to, since a node that never
+    /// launched the job will never report completion. Unlike the
+    /// health-check path, this does not by itself cancel the job on nodes
+    /// that *did* launch it — the caller (`scheduler_loop`) is responsible
+    /// for sending the cancel RPC once eviction succeeds.
     pub fn evict_job(&self, job_id: JobId) -> anyhow::Result<()> {
         {
             let jobs = self.jobs.read();
@@ -2740,11 +2743,15 @@ impl ClusterManager {
     /// Evict a single job by ID: transition to NodeFail, then free its
     /// allocations on every node it spans. Transition is validated first
     /// so allocations are never freed for a job that can't be evicted.
+    /// Nodes that already reported completion via `JobNodeComplete` (which
+    /// frees a node's slice as it arrives, ahead of the whole job finishing)
+    /// are skipped so their resources aren't subtracted twice.
     fn evict_job_locked(
         job_id: JobId,
         jobs: &mut HashMap<JobId, Job>,
         nodes: &mut HashMap<String, Node>,
         timestamp: chrono::DateTime<Utc>,
+        reason: PendingReason,
     ) -> Option<JobFinalized> {
         let job = jobs.get_mut(&job_id)?;
 
@@ -2757,13 +2764,17 @@ impl ClusterManager {
         }
         job.exit_code = Some(-1);
         job.end_time = Some(timestamp);
-        job.pending_reason = PendingReason::NodeDown;
+        job.pending_reason = reason;
+        let already_deallocated: Vec<String> = job.node_completions.keys().cloned().collect();
         job.node_completions.clear();
 
         let alloc_nodes = job.allocated_nodes.clone();
         if let Some(ref total) = job.allocated_resources {
             let node_count = alloc_nodes.len().max(1) as u32;
             for alloc_node in &alloc_nodes {
+                if already_deallocated.iter().any(|n| n == alloc_node) {
+                    continue;
+                }
                 if let Some(node) = nodes.get_mut(alloc_node) {
                     let slice = job
                         .per_node_alloc
@@ -2815,7 +2826,9 @@ impl ClusterManager {
             .collect();
 
         for jid in affected {
-            if let Some(fin) = Self::evict_job_locked(jid, jobs, nodes, timestamp) {
+            if let Some(fin) =
+                Self::evict_job_locked(jid, jobs, nodes, timestamp, PendingReason::NodeDown)
+            {
                 response.jobs_finalized.push(fin);
             }
         }
@@ -2987,8 +3000,13 @@ impl ClusterManager {
                 }
             }
             WalOperation::JobEvict { job_id } => {
-                if let Some(fin) = Self::evict_job_locked(*job_id, &mut jobs, &mut nodes, timestamp)
-                {
+                if let Some(fin) = Self::evict_job_locked(
+                    *job_id,
+                    &mut jobs,
+                    &mut nodes,
+                    timestamp,
+                    PendingReason::JobLaunchFailure,
+                ) {
                     response.jobs_finalized.push(fin);
                 }
             }
@@ -8289,6 +8307,12 @@ mod tests {
 
         let job = cm.get_job(id).unwrap();
         assert_eq!(job.state, JobState::NodeFail);
+        assert_eq!(
+            job.pending_reason,
+            PendingReason::JobLaunchFailure,
+            "partial-dispatch eviction must report the job never fully launched, \
+             not a mid-run node failure"
+        );
         assert!(
             job.node_completions.is_empty(),
             "node_completions must be cleared so a stray late report can't reopen the job"
@@ -8301,6 +8325,78 @@ mod tests {
                 "allocation on {name} must be freed on eviction"
             );
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn evict_job_does_not_double_deallocate_a_node_that_already_completed() {
+        // Job A spans n1+n2 and shares n1 with unrelated Job B. n1 reports
+        // A's completion (freeing A's slice, moving A to Completing) before
+        // n2's dispatch failure is discovered and A is evicted. Evicting A
+        // must not subtract A's already-freed n1 slice a second time — doing
+        // so would incorrectly free capacity that actually still belongs to
+        // B, letting the node be oversubscribed.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16_000);
+        register_node(&cm, "n2", 4, 8000);
+
+        let mut spec_a = basic_spec("job-a-shares-n1");
+        spec_a.num_nodes = 2;
+        let job_a = submit_and_wait(&cm, spec_a);
+        cm.start_job(
+            job_a,
+            vec!["n1".into(), "n2".into()],
+            scalar_alloc(4, 8000),
+            per_node_for(&["n1", "n2"], scalar_alloc(2, 4000)),
+        )
+        .unwrap();
+        settle(&cm, job_a, JobState::Running);
+
+        let spec_b = basic_spec("job-b-shares-n1");
+        let job_b = submit_and_wait(&cm, spec_b);
+        cm.start_job(
+            job_b,
+            vec!["n1".into()],
+            scalar_alloc(3, 3000),
+            per_node_for(&["n1"], scalar_alloc(3, 3000)),
+        )
+        .unwrap();
+        settle(&cm, job_b, JobState::Running);
+
+        assert_eq!(
+            cm.get_node("n1").unwrap().alloc_resources.cpus,
+            5,
+            "n1 should hold both A's (2) and B's (3) allocations"
+        );
+
+        cm.apply_operation(&WalOperation::JobNodeComplete {
+            job_id: job_a,
+            node_name: "n1".into(),
+            exit_code: 0,
+            signal: 0,
+        });
+        settle(&cm, job_a, JobState::Completing);
+        assert_eq!(
+            cm.get_node("n1").unwrap().alloc_resources.cpus,
+            3,
+            "A's n1 slice must already be freed by its own completion report, \
+             leaving only B's 3 cpus"
+        );
+
+        cm.evict_job(job_a).unwrap();
+        settle(&cm, job_a, JobState::NodeFail);
+
+        assert_eq!(
+            cm.get_node("n1").unwrap().alloc_resources.cpus,
+            3,
+            "evicting A must not re-subtract its already-freed n1 slice and \
+             clobber B's still-running allocation"
+        );
+        assert_eq!(
+            cm.get_node("n2").unwrap().alloc_resources.cpus,
+            0,
+            "n2's slice must still be freed by the eviction"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -9654,7 +9750,13 @@ mod tests {
     fn evict_job_returns_none_for_missing_job() {
         let mut jobs = HashMap::new();
         let mut nodes = HashMap::new();
-        let result = ClusterManager::evict_job_locked(999, &mut jobs, &mut nodes, Utc::now());
+        let result = ClusterManager::evict_job_locked(
+            999,
+            &mut jobs,
+            &mut nodes,
+            Utc::now(),
+            PendingReason::NodeDown,
+        );
         assert!(result.is_none());
     }
 
@@ -9665,7 +9767,14 @@ mod tests {
         jobs.insert(1, make_running_job(1, &["n1"], 2));
         nodes.insert("n1".into(), make_test_node("n1", 4, 2));
 
-        let fin = ClusterManager::evict_job_locked(1, &mut jobs, &mut nodes, Utc::now()).unwrap();
+        let fin = ClusterManager::evict_job_locked(
+            1,
+            &mut jobs,
+            &mut nodes,
+            Utc::now(),
+            PendingReason::NodeDown,
+        )
+        .unwrap();
         assert_eq!(fin.job_id, 1);
         assert_eq!(fin.state, JobState::NodeFail);
         assert_eq!(fin.exit_code, -1);
@@ -9685,7 +9794,13 @@ mod tests {
         nodes.insert("n1".into(), make_test_node("n1", 4, 2));
         nodes.insert("n2".into(), make_test_node("n2", 4, 2));
 
-        ClusterManager::evict_job_locked(1, &mut jobs, &mut nodes, Utc::now());
+        ClusterManager::evict_job_locked(
+            1,
+            &mut jobs,
+            &mut nodes,
+            Utc::now(),
+            PendingReason::NodeDown,
+        );
 
         assert_eq!(nodes["n1"].alloc_resources.cpus, 0);
         assert_eq!(nodes["n2"].alloc_resources.cpus, 0);
@@ -9700,7 +9815,13 @@ mod tests {
         jobs.insert(1, job);
         nodes.insert("n1".into(), make_test_node("n1", 4, 2));
 
-        let result = ClusterManager::evict_job_locked(1, &mut jobs, &mut nodes, Utc::now());
+        let result = ClusterManager::evict_job_locked(
+            1,
+            &mut jobs,
+            &mut nodes,
+            Utc::now(),
+            PendingReason::NodeDown,
+        );
         assert!(result.is_none());
     }
 
@@ -9716,7 +9837,13 @@ mod tests {
         jobs.insert(1, job);
         nodes.insert("n1".into(), make_test_node("n1", 4, 2));
 
-        ClusterManager::evict_job_locked(1, &mut jobs, &mut nodes, Utc::now());
+        ClusterManager::evict_job_locked(
+            1,
+            &mut jobs,
+            &mut nodes,
+            Utc::now(),
+            PendingReason::NodeDown,
+        );
 
         let job = &jobs[&1];
         assert!(job.suspended_at.is_none());
@@ -9732,7 +9859,14 @@ mod tests {
         jobs.insert(1, job);
         nodes.insert("n1".into(), make_test_node("n1", 4, 2));
 
-        let fin = ClusterManager::evict_job_locked(1, &mut jobs, &mut nodes, Utc::now()).unwrap();
+        let fin = ClusterManager::evict_job_locked(
+            1,
+            &mut jobs,
+            &mut nodes,
+            Utc::now(),
+            PendingReason::NodeDown,
+        )
+        .unwrap();
         assert_eq!(fin.state, JobState::NodeFail);
         assert_eq!(jobs[&1].state, JobState::NodeFail);
         assert_eq!(nodes["n1"].alloc_resources.cpus, 0);
@@ -9747,7 +9881,13 @@ mod tests {
         node.state = NodeState::Draining;
         nodes.insert("n1".into(), node);
 
-        ClusterManager::evict_job_locked(1, &mut jobs, &mut nodes, Utc::now());
+        ClusterManager::evict_job_locked(
+            1,
+            &mut jobs,
+            &mut nodes,
+            Utc::now(),
+            PendingReason::NodeDown,
+        );
 
         assert_eq!(nodes["n1"].state, NodeState::Drain);
     }

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -349,12 +349,15 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
                         error!(job_id, error = %e, "failed to requeue job after dispatch failure");
                     }
                 } else if failures > 0 {
+                    // A node that never got the dispatch will never report completion, so evict
+                    // the whole job to NodeFail (same as a node dying mid-run) instead of hanging.
                     warn!(
                         job_id,
-                        successes,
-                        failures,
-                        "partial dispatch failure — job continues on successful nodes"
+                        successes, failures, "partial dispatch failure — evicting job to NodeFail"
                     );
+                    if let Err(e) = cluster_ref.evict_job(job_id) {
+                        error!(job_id, error = %e, "failed to evict job after partial dispatch failure");
+                    }
                 }
             });
         }

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use chrono::Utc;
 use tracing::{debug, error, info, warn};
@@ -19,6 +19,11 @@ use spur_sched::traits::{ClusterState, Scheduler};
 
 use crate::cluster::ClusterManager;
 use crate::raft::RaftHandle;
+
+/// Upper bound on a single CancelJob RPC (connect + call) when the caller
+/// awaits delivery. Best-effort cleanup must not stall eviction on an
+/// unreachable agent.
+const CANCEL_RPC_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Spawn the time-limit enforcement watchdog and power manager alongside the scheduler loop.
 pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
@@ -841,9 +846,8 @@ async fn dispatch_job_to_nodes(
 
     // If ALL dispatches failed, requeue the job back to Pending
     // so the scheduler can retry (e.g., container image may be
-    // imported later, or a transient agent error may resolve).
-    // Issue #91: previously marked as Failed immediately, which
-    // didn't give users a chance to fix the problem.
+    // imported later, or a transient agent error may resolve) rather
+    // than failing it outright and denying the user a chance to fix it.
     if successes == 0 && total > 0 {
         error!(
             job_id,
@@ -859,18 +863,17 @@ async fn dispatch_job_to_nodes(
             job_id,
             successes, failures, "partial dispatch failure — evicting job to NodeFail"
         );
-        // Capture the nodes that actually launched the job before eviction: if the
-        // job has `requeue` set, evict_job's requeue side effect resets the job to
-        // Pending and clears `allocated_nodes`, so reading it back afterward would
-        // silently skip the cancel RPC and leave the process running unmanaged.
+        // Cancel the job on nodes that DID launch it *before* evicting, and wait
+        // for those cancels to be delivered. Eviction can synchronously requeue
+        // the job to Pending (when `spec.requeue` is set), making it eligible for
+        // immediate re-dispatch on the next scheduler cycle; because CancelJob is
+        // keyed only by job_id, a cancel still in flight would otherwise be able
+        // to terminate a freshly re-dispatched attempt on the same node. Ordering
+        // the awaited cancel ahead of the requeue closes that race — the launched
+        // processes are stopped before the job can be relaunched anywhere.
+        cancel_job_on_nodes(&cluster, job_id, &succeeded_nodes, 9).await;
         if let Err(e) = cluster.evict_job(job_id) {
             error!(job_id, error = %e, "failed to evict job after partial dispatch failure");
-        } else {
-            // Nodes that did launch the job are now orphaned processes: the
-            // eviction above only freed allocations and marked the job
-            // NodeFail (or Pending, if requeued), it never told the agents
-            // that ran it to stop.
-            send_cancel_to_nodes(&cluster, job_id, &succeeded_nodes, 9).await;
         }
     }
 }
@@ -1157,55 +1160,104 @@ pub async fn send_cancel_to_agents(
 /// loop) should use this instead of `send_cancel_to_agents` so the cancel
 /// isn't at the mercy of `job.allocated_nodes` having been mutated in the
 /// meantime (e.g. cleared by a requeue-on-eviction side effect).
+///
+/// Fire-and-forget: each node's cancel runs on its own task and this returns
+/// immediately. Use `cancel_job_on_nodes` when the cancel must be delivered
+/// before subsequent work (e.g. a requeue that could re-dispatch the job).
 pub async fn send_cancel_to_nodes(
     cluster: &Arc<ClusterManager>,
     job_id: spur_core::job::JobId,
     node_names: &[String],
     signal: i32,
 ) {
+    for agent_addr in cancel_agent_addrs(cluster, job_id, node_names) {
+        tokio::spawn(cancel_one_agent(agent_addr, job_id, signal));
+    }
+}
+
+/// Like `send_cancel_to_nodes`, but awaits delivery of every cancel before
+/// returning so the caller can establish a happens-before ordering against
+/// later actions. Each RPC is bounded by `CANCEL_RPC_TIMEOUT` so an
+/// unreachable agent can't stall the caller indefinitely.
+pub async fn cancel_job_on_nodes(
+    cluster: &Arc<ClusterManager>,
+    job_id: spur_core::job::JobId,
+    node_names: &[String],
+    signal: i32,
+) {
+    let mut set = tokio::task::JoinSet::new();
+    for agent_addr in cancel_agent_addrs(cluster, job_id, node_names) {
+        set.spawn(cancel_one_agent(agent_addr, job_id, signal));
+    }
+    while set.join_next().await.is_some() {}
+}
+
+/// Resolve `node_names` to agent URLs, logging and skipping any node whose
+/// address is unknown.
+fn cancel_agent_addrs(
+    cluster: &Arc<ClusterManager>,
+    job_id: spur_core::job::JobId,
+    node_names: &[String],
+) -> Vec<String> {
+    let mut addrs = Vec::with_capacity(node_names.len());
     for node_name in node_names {
-        let node_info = cluster.get_node(node_name);
-        let (addr, port) = match node_info {
-            Some(ref n) if n.address.is_some() => (n.address.clone().unwrap(), n.port),
+        match cluster.get_node(node_name) {
+            Some(ref n) if n.address.is_some() => {
+                addrs.push(format!("http://{}:{}", n.address.clone().unwrap(), n.port));
+            }
             _ => {
                 warn!(
                     job_id,
                     node = %node_name,
                     "no agent address — cannot cancel job on node"
                 );
-                continue;
             }
-        };
+        }
+    }
+    addrs
+}
 
-        let agent_addr = format!("http://{}:{}", addr, port);
-        tokio::spawn(async move {
-            match SlurmAgentClient::connect(agent_addr.clone()).await {
-                Ok(mut client) => {
-                    if let Err(e) = client
-                        .cancel_job(AgentCancelJobRequest { job_id, signal })
-                        .await
-                    {
-                        warn!(
-                            job_id,
-                            signal,
-                            agent = %agent_addr,
-                            error = %e,
-                            "CancelJob RPC failed"
-                        );
-                    } else {
-                        info!(job_id, signal, agent = %agent_addr, "sent CancelJob");
-                    }
-                }
-                Err(e) => {
+/// Deliver one CancelJob RPC, bounded by `CANCEL_RPC_TIMEOUT`. Errors and
+/// timeouts are logged, never propagated: a cancel is best-effort cleanup and
+/// must not block the caller past the timeout.
+async fn cancel_one_agent(agent_addr: String, job_id: spur_core::job::JobId, signal: i32) {
+    let attempt = async {
+        match SlurmAgentClient::connect(agent_addr.clone()).await {
+            Ok(mut client) => {
+                if let Err(e) = client
+                    .cancel_job(AgentCancelJobRequest { job_id, signal })
+                    .await
+                {
                     warn!(
                         job_id,
+                        signal,
                         agent = %agent_addr,
                         error = %e,
-                        "failed to connect to agent for cancel"
+                        "CancelJob RPC failed"
                     );
+                } else {
+                    info!(job_id, signal, agent = %agent_addr, "sent CancelJob");
                 }
             }
-        });
+            Err(e) => {
+                warn!(
+                    job_id,
+                    agent = %agent_addr,
+                    error = %e,
+                    "failed to connect to agent for cancel"
+                );
+            }
+        }
+    };
+    if tokio::time::timeout(CANCEL_RPC_TIMEOUT, attempt)
+        .await
+        .is_err()
+    {
+        warn!(
+            job_id,
+            agent = %agent_addr,
+            "CancelJob RPC timed out"
+        );
     }
 }
 
@@ -1860,9 +1912,13 @@ mod tests {
 
             // n1 actually launched the job, so the controller must tell its
             // agent to stop it instead of leaving an orphaned process behind.
-            wait_for("cancel RPC sent to n1", || {
-                cancel_calls.load(Ordering::SeqCst) >= 1
-            });
+            // The cancel is awaited inside dispatch_job_to_nodes, so it has
+            // already been delivered by the time that call returned.
+            assert_eq!(
+                cancel_calls.load(Ordering::SeqCst),
+                1,
+                "n1 must have been cancelled before dispatch_job_to_nodes returned"
+            );
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -1906,8 +1962,11 @@ mod tests {
 
             // Same as the non-requeue case, but `spec.requeue` is set: eviction's
             // requeue side effect resets the job to Pending and clears
-            // `allocated_nodes` before this function returns, so the cancel RPC
-            // must not depend on reading `job.allocated_nodes` afterward.
+            // `allocated_nodes`. The cancel RPC must be delivered to n1 *before*
+            // that requeue makes the job eligible for re-dispatch, otherwise a
+            // job_id-keyed cancel still in flight could kill a fresh attempt.
+            // dispatch_job_to_nodes awaits the cancel before evicting, so by the
+            // time it returns both the cancel is delivered and the job is Pending.
             dispatch_job_to_nodes(
                 cm.clone(),
                 job_id,
@@ -1920,16 +1979,18 @@ mod tests {
             )
             .await;
 
-            // The requeue side effect puts the job back to Pending instead of
-            // leaving it in NodeFail.
-            settle(&cm, job_id, JobState::Pending);
-            assert!(cm.get_job(job_id).unwrap().allocated_nodes.is_empty());
-
-            // n1 actually launched the job, so the controller must still tell
-            // its agent to stop it, even though the job itself was requeued.
-            wait_for("cancel RPC sent to n1", || {
-                cancel_calls.load(Ordering::SeqCst) >= 1
-            });
+            // Cancel-before-requeue: the cancel is already delivered, and the
+            // requeue side effect has put the job back to Pending with its
+            // allocation cleared — no polling needed, both are guaranteed by the
+            // await ordering inside dispatch_job_to_nodes.
+            assert_eq!(
+                cancel_calls.load(Ordering::SeqCst),
+                1,
+                "n1 must have been cancelled before the requeue re-enabled dispatch"
+            );
+            let job = cm.get_job(job_id).unwrap();
+            assert_eq!(job.state, JobState::Pending);
+            assert!(job.allocated_nodes.is_empty());
         }
     }
 }

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -276,90 +276,16 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
             let cluster_ref = cluster.clone();
             let dispatch_nodes = all_nodes.clone();
             let allocated_nodelist = all_nodes.join(",");
-            tokio::spawn(async move {
-                let mut successes = 0u32;
-                let mut failures = 0u32;
-                let total = dispatch_nodes.len() as u32;
-
-                let mut set = tokio::task::JoinSet::new();
-                for (node_idx, node_name) in dispatch_nodes.iter().enumerate() {
-                    let node_info = cluster_ref.get_node(node_name);
-                    let (addr, port) = match node_info {
-                        Some(ref n) if n.address.is_some() => (n.address.clone().unwrap(), n.port),
-                        _ => {
-                            warn!(
-                                job_id,
-                                node = %node_name,
-                                "no agent address for node, skipping dispatch"
-                            );
-                            failures += 1;
-                            continue;
-                        }
-                    };
-
-                    let agent_addr = format!("http://{}:{}", addr, port);
-                    let spec = spec.clone();
-                    let peer_addrs = peer_addrs.clone();
-                    let task_offset = node_idx as u32 * tasks_per_node;
-                    let target_node = node_name.clone();
-                    let allocated = per_node_allocs.get(node_name).cloned().unwrap_or_default();
-                    let allocated_nodelist = allocated_nodelist.clone();
-                    set.spawn(async move {
-                        dispatch_to_agent(
-                            &agent_addr,
-                            &AgentDispatchParams {
-                                job_id,
-                                spec: &spec,
-                                peer_nodes: &peer_addrs,
-                                task_offset,
-                                target_node: &target_node,
-                                allocated: &allocated,
-                                allocated_nodelist: &allocated_nodelist,
-                            },
-                        )
-                        .await
-                    });
-                }
-
-                while let Some(result) = set.join_next().await {
-                    match result {
-                        Ok(Ok(())) => successes += 1,
-                        Ok(Err(e)) => {
-                            error!(job_id, error = %e, "dispatch to agent failed");
-                            failures += 1;
-                        }
-                        Err(e) => {
-                            error!(job_id, error = %e, "dispatch task panicked");
-                            failures += 1;
-                        }
-                    }
-                }
-
-                // If ALL dispatches failed, requeue the job back to Pending
-                // so the scheduler can retry (e.g., container image may be
-                // imported later, or a transient agent error may resolve).
-                // Issue #91: previously marked as Failed immediately, which
-                // didn't give users a chance to fix the problem.
-                if successes == 0 && total > 0 {
-                    error!(
-                        job_id,
-                        failures, "all dispatches failed — requeueing job to Pending"
-                    );
-                    if let Err(e) = cluster_ref.requeue_job(job_id) {
-                        error!(job_id, error = %e, "failed to requeue job after dispatch failure");
-                    }
-                } else if failures > 0 {
-                    // A node that never got the dispatch will never report completion, so evict
-                    // the whole job to NodeFail (same as a node dying mid-run) instead of hanging.
-                    warn!(
-                        job_id,
-                        successes, failures, "partial dispatch failure — evicting job to NodeFail"
-                    );
-                    if let Err(e) = cluster_ref.evict_job(job_id) {
-                        error!(job_id, error = %e, "failed to evict job after partial dispatch failure");
-                    }
-                }
-            });
+            tokio::spawn(dispatch_job_to_nodes(
+                cluster_ref,
+                job_id,
+                dispatch_nodes,
+                spec,
+                peer_addrs,
+                per_node_allocs,
+                allocated_nodelist,
+                tasks_per_node,
+            ));
         }
 
         let cycle_time_us = cycle_start.elapsed().as_micros().min(u64::MAX as u128) as u64;
@@ -832,6 +758,110 @@ async fn dispatch_to_agent(
     }
 
     Ok(())
+}
+
+/// Dispatch a job to every assigned node and act on the aggregate result:
+/// requeue to Pending if every node rejected the launch, or evict the job to
+/// NodeFail if only some nodes accepted it (a node that never launched the
+/// job will never report completion, so the job would otherwise hang).
+#[allow(clippy::too_many_arguments)]
+async fn dispatch_job_to_nodes(
+    cluster: Arc<ClusterManager>,
+    job_id: spur_core::job::JobId,
+    dispatch_nodes: Vec<String>,
+    spec: spur_core::job::JobSpec,
+    peer_addrs: Vec<String>,
+    per_node_allocs: std::collections::HashMap<String, spur_core::resource::ResourceAllocations>,
+    allocated_nodelist: String,
+    tasks_per_node: u32,
+) {
+    let mut successes = 0u32;
+    let mut failures = 0u32;
+    let total = dispatch_nodes.len() as u32;
+
+    let mut set = tokio::task::JoinSet::new();
+    for (node_idx, node_name) in dispatch_nodes.iter().enumerate() {
+        let node_info = cluster.get_node(node_name);
+        let (addr, port) = match node_info {
+            Some(ref n) if n.address.is_some() => (n.address.clone().unwrap(), n.port),
+            _ => {
+                warn!(
+                    job_id,
+                    node = %node_name,
+                    "no agent address for node, skipping dispatch"
+                );
+                failures += 1;
+                continue;
+            }
+        };
+
+        let agent_addr = format!("http://{}:{}", addr, port);
+        let spec = spec.clone();
+        let peer_addrs = peer_addrs.clone();
+        let task_offset = node_idx as u32 * tasks_per_node;
+        let target_node = node_name.clone();
+        let allocated = per_node_allocs.get(node_name).cloned().unwrap_or_default();
+        let allocated_nodelist = allocated_nodelist.clone();
+        set.spawn(async move {
+            dispatch_to_agent(
+                &agent_addr,
+                &AgentDispatchParams {
+                    job_id,
+                    spec: &spec,
+                    peer_nodes: &peer_addrs,
+                    task_offset,
+                    target_node: &target_node,
+                    allocated: &allocated,
+                    allocated_nodelist: &allocated_nodelist,
+                },
+            )
+            .await
+        });
+    }
+
+    while let Some(result) = set.join_next().await {
+        match result {
+            Ok(Ok(())) => successes += 1,
+            Ok(Err(e)) => {
+                error!(job_id, error = %e, "dispatch to agent failed");
+                failures += 1;
+            }
+            Err(e) => {
+                error!(job_id, error = %e, "dispatch task panicked");
+                failures += 1;
+            }
+        }
+    }
+
+    // If ALL dispatches failed, requeue the job back to Pending
+    // so the scheduler can retry (e.g., container image may be
+    // imported later, or a transient agent error may resolve).
+    // Issue #91: previously marked as Failed immediately, which
+    // didn't give users a chance to fix the problem.
+    if successes == 0 && total > 0 {
+        error!(
+            job_id,
+            failures, "all dispatches failed — requeueing job to Pending"
+        );
+        if let Err(e) = cluster.requeue_job(job_id) {
+            error!(job_id, error = %e, "failed to requeue job after dispatch failure");
+        }
+    } else if failures > 0 {
+        // A node that never got the dispatch will never report completion, so evict
+        // the whole job to NodeFail (same as a node dying mid-run) instead of hanging.
+        warn!(
+            job_id,
+            successes, failures, "partial dispatch failure — evicting job to NodeFail"
+        );
+        if let Err(e) = cluster.evict_job(job_id) {
+            error!(job_id, error = %e, "failed to evict job after partial dispatch failure");
+        } else if let Some(job) = cluster.get_job(job_id) {
+            // Nodes that did launch the job are now orphaned processes: the
+            // eviction above only freed allocations and marked the job
+            // NodeFail, it never told the agents that ran it to stop.
+            send_cancel_to_agents(&cluster, &job, 9).await;
+        }
+    }
 }
 
 /// Watchdog: gracefully terminate running jobs that exceed their time limit.
@@ -1506,5 +1536,309 @@ mod tests {
             job_preempt_mode(&job_in_partitions("gpu,cpu"), &parts),
             PreemptMode::Off
         );
+    }
+
+    // ── dispatch_job_to_nodes: real partial-dispatch-failure trigger path ──
+    //
+    // Exercises the actual JoinSet success/failure counting in
+    // dispatch_job_to_nodes (not a reimplementation of it) against a real
+    // agent over the network, so the eviction + cancel-RPC behavior it
+    // drives is verified end-to-end rather than by calling evict_job
+    // directly on an already-Running job.
+    mod dispatch_trigger_tests {
+        use super::*;
+        use spur_core::config::SlurmConfig;
+        use spur_core::node::NodeSource;
+        use std::sync::atomic::{AtomicU32, Ordering};
+        use tempfile::TempDir;
+        use tonic::transport::server::TcpIncoming;
+        use tonic::transport::Server;
+
+        /// Minimal SlurmAgent: always accepts launch_job and counts cancel_job
+        /// calls, so tests can assert the controller actually tried to stop
+        /// the job on nodes that did launch it.
+        struct MockAgent {
+            cancel_calls: Arc<AtomicU32>,
+        }
+
+        #[tonic::async_trait]
+        impl spur_proto::proto::slurm_agent_server::SlurmAgent for MockAgent {
+            type StreamJobOutputStream =
+                tonic::codegen::BoxStream<spur_proto::proto::StreamJobOutputChunk>;
+            type AttachJobStream = tonic::codegen::BoxStream<spur_proto::proto::AttachJobOutput>;
+
+            async fn launch_job(
+                &self,
+                _request: tonic::Request<spur_proto::proto::LaunchJobRequest>,
+            ) -> Result<tonic::Response<spur_proto::proto::LaunchJobResponse>, tonic::Status>
+            {
+                Ok(tonic::Response::new(spur_proto::proto::LaunchJobResponse {
+                    success: true,
+                    error: String::new(),
+                }))
+            }
+
+            async fn cancel_job(
+                &self,
+                _request: tonic::Request<spur_proto::proto::AgentCancelJobRequest>,
+            ) -> Result<tonic::Response<()>, tonic::Status> {
+                self.cancel_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(tonic::Response::new(()))
+            }
+
+            async fn suspend_job(
+                &self,
+                _request: tonic::Request<spur_proto::proto::AgentSuspendJobRequest>,
+            ) -> Result<tonic::Response<()>, tonic::Status> {
+                Ok(tonic::Response::new(()))
+            }
+
+            async fn get_node_resources(
+                &self,
+                _request: tonic::Request<()>,
+            ) -> Result<tonic::Response<spur_proto::proto::NodeResourcesResponse>, tonic::Status>
+            {
+                Ok(tonic::Response::new(Default::default()))
+            }
+
+            async fn exec_in_job(
+                &self,
+                _request: tonic::Request<spur_proto::proto::ExecInJobRequest>,
+            ) -> Result<tonic::Response<spur_proto::proto::ExecInJobResponse>, tonic::Status>
+            {
+                Ok(tonic::Response::new(Default::default()))
+            }
+
+            async fn run_command(
+                &self,
+                _request: tonic::Request<spur_proto::proto::RunCommandRequest>,
+            ) -> Result<tonic::Response<spur_proto::proto::RunCommandResponse>, tonic::Status>
+            {
+                Ok(tonic::Response::new(Default::default()))
+            }
+
+            async fn stream_job_output(
+                &self,
+                _request: tonic::Request<spur_proto::proto::StreamJobOutputRequest>,
+            ) -> Result<tonic::Response<Self::StreamJobOutputStream>, tonic::Status> {
+                Err(tonic::Status::unimplemented("not used in tests"))
+            }
+
+            async fn attach_job(
+                &self,
+                _request: tonic::Request<tonic::Streaming<spur_proto::proto::AttachJobInput>>,
+            ) -> Result<tonic::Response<Self::AttachJobStream>, tonic::Status> {
+                Err(tonic::Status::unimplemented("not used in tests"))
+            }
+        }
+
+        /// Spawn a real MockAgent gRPC server on an OS-assigned localhost
+        /// port. Returns the bound address and the shared cancel-call counter.
+        async fn spawn_mock_agent() -> (std::net::SocketAddr, Arc<AtomicU32>) {
+            let incoming = TcpIncoming::bind("127.0.0.1:0".parse().unwrap()).unwrap();
+            let addr = incoming.local_addr().unwrap();
+            let cancel_calls = Arc::new(AtomicU32::new(0));
+            let agent = MockAgent {
+                cancel_calls: cancel_calls.clone(),
+            };
+            tokio::spawn(async move {
+                let _ = Server::builder()
+                    .add_service(
+                        spur_proto::proto::slurm_agent_server::SlurmAgentServer::new(agent),
+                    )
+                    .serve_with_incoming(incoming)
+                    .await;
+            });
+            (addr, cancel_calls)
+        }
+
+        /// Reserve a localhost port with nothing listening on it, so a
+        /// connection attempt to it deterministically fails fast (connection
+        /// refused) instead of hanging.
+        async fn unreachable_addr() -> std::net::SocketAddr {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            drop(listener);
+            addr
+        }
+
+        fn test_config() -> SlurmConfig {
+            SlurmConfig {
+                cluster_name: "test".into(),
+                controller: spur_core::config::ControllerConfig {
+                    first_job_id: 1,
+                    ..Default::default()
+                },
+                accounting: Default::default(),
+                scheduler: Default::default(),
+                auth: Default::default(),
+                partitions: vec![spur_core::config::PartitionConfig {
+                    name: "default".into(),
+                    default: true,
+                    state: "UP".into(),
+                    nodes: "ALL".into(),
+                    selector: Default::default(),
+                    max_time: None,
+                    default_time: None,
+                    max_nodes: None,
+                    min_nodes: 1,
+                    allow_accounts: Vec::new(),
+                    allow_groups: Vec::new(),
+                    deny_accounts: Vec::new(),
+                    priority_tier: 1,
+                    preempt_mode: String::new(),
+                }],
+                nodes: Vec::new(),
+                network: Default::default(),
+                logging: Default::default(),
+                kubernetes: Default::default(),
+                notifications: Default::default(),
+                power: Default::default(),
+                federation: Default::default(),
+                topology: None,
+                isolation: Default::default(),
+                licenses: HashMap::new(),
+                burst_buffer: Default::default(),
+                update: Default::default(),
+                metrics: Default::default(),
+                rest_api: Default::default(),
+                hooks: Default::default(),
+                devices: Default::default(),
+                admission: Default::default(),
+            }
+        }
+
+        async fn test_cluster(dir: &TempDir) -> Arc<ClusterManager> {
+            let cm = Arc::new(ClusterManager::new(test_config(), dir.path()).unwrap());
+            let handle = crate::raft::start_raft(1, &["[::1]:0".into()], dir.path(), cm.clone())
+                .await
+                .unwrap();
+            handle
+                .raft
+                .wait(Some(std::time::Duration::from_secs(5)))
+                .metrics(|m| m.current_leader == Some(1), "leader elected")
+                .await
+                .expect("single-node raft did not self-elect within 5s");
+            cm.set_raft(handle.raft);
+            cm
+        }
+
+        /// Spin until an async mutation (Raft-committed state, or a
+        /// fire-and-forget cancel RPC) is visible. Bounded retry, not an
+        /// open-ended wait: fails loudly if the condition never holds.
+        fn wait_for<F: Fn() -> bool>(label: &str, f: F) {
+            for _ in 0..200 {
+                if f() {
+                    return;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(5));
+            }
+            panic!("timed out waiting for: {label}");
+        }
+
+        fn register_node_at(cm: &ClusterManager, name: &str, addr: std::net::SocketAddr) {
+            cm.register_node(
+                name.into(),
+                ResourceSet {
+                    cpus: 4,
+                    memory_mb: 8000,
+                    ..Default::default()
+                },
+                addr.ip().to_string(),
+                addr.port(),
+                String::new(),
+                String::new(),
+                NodeSource::NativeHost,
+                HashMap::new(),
+            )
+            .unwrap();
+            let n = name.to_string();
+            wait_for(&format!("node '{n}' registered"), || {
+                cm.get_node(&n).is_some()
+            });
+        }
+
+        fn submit_and_wait(cm: &ClusterManager, spec: JobSpec) -> spur_core::job::JobId {
+            let id = cm.submit_job(spec).unwrap();
+            wait_for(&format!("job {id} applied"), || cm.get_job(id).is_some());
+            id
+        }
+
+        fn settle(
+            cm: &ClusterManager,
+            job_id: spur_core::job::JobId,
+            expected: spur_core::job::JobState,
+        ) {
+            wait_for(&format!("job {job_id} -> {expected:?}"), || {
+                cm.get_job(job_id).is_some_and(|j| j.state == expected)
+            });
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn partial_dispatch_evicts_job_and_cancels_the_node_that_launched() {
+            use spur_core::job::JobState;
+
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+
+            let (good_addr, cancel_calls) = spawn_mock_agent().await;
+            let bad_addr = unreachable_addr().await;
+            register_node_at(&cm, "n1", good_addr);
+            register_node_at(&cm, "n2", bad_addr);
+
+            let mut spec = JobSpec {
+                name: "partial-dispatch".into(),
+                user: "testuser".into(),
+                num_nodes: 2,
+                num_tasks: 2,
+                cpus_per_task: 1,
+                work_dir: "/tmp".into(),
+                ..Default::default()
+            };
+            let job_id = submit_and_wait(&cm, spec.clone());
+            spec = cm.get_job(job_id).unwrap().spec;
+
+            let nodes = vec!["n1".to_string(), "n2".to_string()];
+            let per_node_allocs: HashMap<String, ResourceAllocations> = nodes
+                .iter()
+                .map(|n| (n.clone(), ResourceAllocations::with_scalar(1, 0)))
+                .collect();
+            cm.start_job(
+                job_id,
+                nodes.clone(),
+                ResourceAllocations::with_scalar(2, 0),
+                per_node_allocs.clone(),
+            )
+            .unwrap();
+            settle(&cm, job_id, JobState::Running);
+
+            // This calls the exact same function `run()` spawns per assignment:
+            // real network dispatch to both nodes, real JoinSet success/failure
+            // counting, and the real branch that decides to evict on a partial
+            // failure — n1 (real agent) accepts, n2 (nothing listening) fails.
+            dispatch_job_to_nodes(
+                cm.clone(),
+                job_id,
+                nodes,
+                spec,
+                Vec::new(),
+                per_node_allocs,
+                "n1,n2".into(),
+                1,
+            )
+            .await;
+
+            settle(&cm, job_id, JobState::NodeFail);
+            assert_eq!(
+                cm.get_job(job_id).unwrap().pending_reason,
+                spur_core::job::PendingReason::JobLaunchFailure
+            );
+
+            // n1 actually launched the job, so the controller must tell its
+            // agent to stop it instead of leaving an orphaned process behind.
+            wait_for("cancel RPC sent to n1", || {
+                cancel_calls.load(Ordering::SeqCst) >= 1
+            });
+        }
     }
 }

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -777,6 +777,7 @@ async fn dispatch_job_to_nodes(
 ) {
     let mut successes = 0u32;
     let mut failures = 0u32;
+    let mut succeeded_nodes: Vec<String> = Vec::new();
     let total = dispatch_nodes.len() as u32;
 
     let mut set = tokio::task::JoinSet::new();
@@ -800,10 +801,11 @@ async fn dispatch_job_to_nodes(
         let peer_addrs = peer_addrs.clone();
         let task_offset = node_idx as u32 * tasks_per_node;
         let target_node = node_name.clone();
+        let result_node = node_name.clone();
         let allocated = per_node_allocs.get(node_name).cloned().unwrap_or_default();
         let allocated_nodelist = allocated_nodelist.clone();
         set.spawn(async move {
-            dispatch_to_agent(
+            let result = dispatch_to_agent(
                 &agent_addr,
                 &AgentDispatchParams {
                     job_id,
@@ -815,15 +817,19 @@ async fn dispatch_job_to_nodes(
                     allocated_nodelist: &allocated_nodelist,
                 },
             )
-            .await
+            .await;
+            (result_node, result)
         });
     }
 
     while let Some(result) = set.join_next().await {
         match result {
-            Ok(Ok(())) => successes += 1,
-            Ok(Err(e)) => {
-                error!(job_id, error = %e, "dispatch to agent failed");
+            Ok((node_name, Ok(()))) => {
+                successes += 1;
+                succeeded_nodes.push(node_name);
+            }
+            Ok((node_name, Err(e))) => {
+                error!(job_id, node = %node_name, error = %e, "dispatch to agent failed");
                 failures += 1;
             }
             Err(e) => {
@@ -853,13 +859,18 @@ async fn dispatch_job_to_nodes(
             job_id,
             successes, failures, "partial dispatch failure — evicting job to NodeFail"
         );
+        // Capture the nodes that actually launched the job before eviction: if the
+        // job has `requeue` set, evict_job's requeue side effect resets the job to
+        // Pending and clears `allocated_nodes`, so reading it back afterward would
+        // silently skip the cancel RPC and leave the process running unmanaged.
         if let Err(e) = cluster.evict_job(job_id) {
             error!(job_id, error = %e, "failed to evict job after partial dispatch failure");
-        } else if let Some(job) = cluster.get_job(job_id) {
+        } else {
             // Nodes that did launch the job are now orphaned processes: the
             // eviction above only freed allocations and marked the job
-            // NodeFail, it never told the agents that ran it to stop.
-            send_cancel_to_agents(&cluster, &job, 9).await;
+            // NodeFail (or Pending, if requeued), it never told the agents
+            // that ran it to stop.
+            send_cancel_to_nodes(&cluster, job_id, &succeeded_nodes, 9).await;
         }
     }
 }
@@ -1138,13 +1149,27 @@ pub async fn send_cancel_to_agents(
     job: &spur_core::job::Job,
     signal: i32,
 ) {
-    for node_name in &job.allocated_nodes {
+    send_cancel_to_nodes(cluster, job.job_id, &job.allocated_nodes, signal).await;
+}
+
+/// Send CancelJob RPC to an explicit set of nodes for a job with a specific
+/// signal. Callers that already know which nodes ran the job (e.g. a dispatch
+/// loop) should use this instead of `send_cancel_to_agents` so the cancel
+/// isn't at the mercy of `job.allocated_nodes` having been mutated in the
+/// meantime (e.g. cleared by a requeue-on-eviction side effect).
+pub async fn send_cancel_to_nodes(
+    cluster: &Arc<ClusterManager>,
+    job_id: spur_core::job::JobId,
+    node_names: &[String],
+    signal: i32,
+) {
+    for node_name in node_names {
         let node_info = cluster.get_node(node_name);
         let (addr, port) = match node_info {
             Some(ref n) if n.address.is_some() => (n.address.clone().unwrap(), n.port),
             _ => {
                 warn!(
-                    job_id = job.job_id,
+                    job_id,
                     node = %node_name,
                     "no agent address — cannot cancel job on node"
                 );
@@ -1153,7 +1178,6 @@ pub async fn send_cancel_to_agents(
         };
 
         let agent_addr = format!("http://{}:{}", addr, port);
-        let job_id = job.job_id;
         tokio::spawn(async move {
             match SlurmAgentClient::connect(agent_addr.clone()).await {
                 Ok(mut client) => {
@@ -1836,6 +1860,73 @@ mod tests {
 
             // n1 actually launched the job, so the controller must tell its
             // agent to stop it instead of leaving an orphaned process behind.
+            wait_for("cancel RPC sent to n1", || {
+                cancel_calls.load(Ordering::SeqCst) >= 1
+            });
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn partial_dispatch_with_requeue_still_cancels_the_node_that_launched() {
+            use spur_core::job::JobState;
+
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+
+            let (good_addr, cancel_calls) = spawn_mock_agent().await;
+            let bad_addr = unreachable_addr().await;
+            register_node_at(&cm, "n1", good_addr);
+            register_node_at(&cm, "n2", bad_addr);
+
+            let mut spec = JobSpec {
+                name: "partial-dispatch-requeue".into(),
+                user: "testuser".into(),
+                num_nodes: 2,
+                num_tasks: 2,
+                cpus_per_task: 1,
+                work_dir: "/tmp".into(),
+                requeue: true,
+                ..Default::default()
+            };
+            let job_id = submit_and_wait(&cm, spec.clone());
+            spec = cm.get_job(job_id).unwrap().spec;
+
+            let nodes = vec!["n1".to_string(), "n2".to_string()];
+            let per_node_allocs: HashMap<String, ResourceAllocations> = nodes
+                .iter()
+                .map(|n| (n.clone(), ResourceAllocations::with_scalar(1, 0)))
+                .collect();
+            cm.start_job(
+                job_id,
+                nodes.clone(),
+                ResourceAllocations::with_scalar(2, 0),
+                per_node_allocs.clone(),
+            )
+            .unwrap();
+            settle(&cm, job_id, JobState::Running);
+
+            // Same as the non-requeue case, but `spec.requeue` is set: eviction's
+            // requeue side effect resets the job to Pending and clears
+            // `allocated_nodes` before this function returns, so the cancel RPC
+            // must not depend on reading `job.allocated_nodes` afterward.
+            dispatch_job_to_nodes(
+                cm.clone(),
+                job_id,
+                nodes,
+                spec,
+                Vec::new(),
+                per_node_allocs,
+                "n1,n2".into(),
+                1,
+            )
+            .await;
+
+            // The requeue side effect puts the job back to Pending instead of
+            // leaving it in NodeFail.
+            settle(&cm, job_id, JobState::Pending);
+            assert!(cm.get_job(job_id).unwrap().allocated_nodes.is_empty());
+
+            // n1 actually launched the job, so the controller must still tell
+            // its agent to stop it, even though the job itself was requeued.
             wait_for("cancel RPC sent to n1", || {
                 cancel_calls.load(Ordering::SeqCst) >= 1
             });


### PR DESCRIPTION
## What

Fixes SPUR-39: when a multi-node job's dispatch RPC fails on one node but succeeds on another, the job previously kept running short a node forever — the missing node was never recorded, so completion tracking could never be satisfied.

## Approach

On partial dispatch failure, evict the whole job to `NodeFail` (mirroring the existing node-health-check eviction path), which feeds the existing auto-requeue mechanism. Also sends a cancel RPC to whichever node(s) did successfully launch the job, so they don't keep running orphaned — including in the `--requeue` path, where the requeue side effect clears `allocated_nodes` before a naive post-hoc lookup would see it (a regression caught by live testing on the 2-node lab cluster and fixed by capturing the successfully-dispatched node identities before eviction runs).

Also fixes a related double-deallocation race in the shared `evict_job_locked` path (a node that already reported completion before eviction fires no longer gets its resources subtracted twice).

## Testing

- Unit tests covering: partial-dispatch eviction via the real scheduler dispatch path (not just calling the eviction function directly), the double-deallocation guard, and the `--requeue` cancel-ordering fix.
- Live-verified on a real 2-node cluster: simulated one node's agent being unreachable via iptables, confirmed the job evicts/requeues correctly and the successfully-dispatched node's process is actually cancelled (checked via logs and `ps`), including across multiple retry cycles.

## Review

Went through 2 independent adversarial reviews plus a cross-validation pass; all confirmed findings addressed.