### PR TITLE
fix(spurctld): retry accounting writes and reconcile drift from job store

### DIFF
--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -234,6 +234,16 @@ pub async fn record_job_end(
     Ok(())
 }
 
+/// The accounting DB's current state for a job, or `None` if no row exists yet.
+/// Used by the reconciliation pass to detect jobs missing or stale in accounting.
+pub async fn job_accounting_state(pool: &PgPool, job_id: i32) -> anyhow::Result<Option<String>> {
+    let row = sqlx::query("SELECT state FROM jobs WHERE job_id = $1")
+        .bind(job_id)
+        .fetch_optional(pool)
+        .await?;
+    Ok(row.map(|r| r.get("state")))
+}
+
 /// Update usage accounting for a completed job, from the row `record_job_end` just wrote.
 async fn update_usage(pool: &PgPool, row: PgRow, end_time: DateTime<Utc>) -> anyhow::Result<()> {
     let user: String = row.get("user_name");

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
+
 use chrono::{DateTime, Utc};
 use sqlx::postgres::PgRow;
 use sqlx::{PgPool, QueryBuilder, Row};
@@ -234,14 +236,45 @@ pub async fn record_job_end(
     Ok(())
 }
 
-/// The accounting DB's current state for a job, or `None` if no row exists yet.
-/// Used by the reconciliation pass to detect jobs missing or stale in accounting.
-pub async fn job_accounting_state(pool: &PgPool, job_id: i32) -> anyhow::Result<Option<String>> {
-    let row = sqlx::query("SELECT state FROM jobs WHERE job_id = $1")
-        .bind(job_id)
-        .fetch_optional(pool)
-        .await?;
-    Ok(row.map(|r| r.get("state")))
+/// A job row's accounting state, as seen by the reconciliation pass.
+pub struct AccountingRowState {
+    pub state: String,
+    /// True when the row is missing metadata that a proper `record_job_start`
+    /// would have populated (e.g. `record_job_end` created a bare row from
+    /// scratch because `record_job_start` never landed). A row in this shape
+    /// needs a `record_job_start` backfill even if `state` already matches.
+    pub needs_start_backfill: bool,
+}
+
+/// The accounting DB's current state for a batch of jobs, in a single query.
+/// Jobs with no row in `jobs` are simply absent from the returned map. Used
+/// by the reconciliation pass to detect jobs missing or stale in accounting.
+pub async fn job_accounting_states(
+    pool: &PgPool,
+    job_ids: &[i32],
+) -> anyhow::Result<HashMap<i32, AccountingRowState>> {
+    if job_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let rows =
+        sqlx::query("SELECT job_id, state, user_name, start_time FROM jobs WHERE job_id = ANY($1)")
+            .bind(job_ids)
+            .fetch_all(pool)
+            .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|r| {
+            let job_id: i32 = r.get("job_id");
+            let user_name: String = r.get("user_name");
+            let start_time: Option<DateTime<Utc>> = r.get("start_time");
+            let row = AccountingRowState {
+                state: r.get("state"),
+                needs_start_backfill: user_name.is_empty() || start_time.is_none(),
+            };
+            (job_id, row)
+        })
+        .collect())
 }
 
 /// Update usage accounting for a completed job, from the row `record_job_end` just wrote.

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 
 use chrono::{DateTime, Utc};
-use sqlx::postgres::PgRow;
+use sqlx::postgres::{PgConnection, PgRow};
 use sqlx::{PgPool, QueryBuilder, Row};
 
 /// Run database migrations (create tables if they don't exist).
@@ -126,9 +126,15 @@ ALTER TABLE associations ADD COLUMN IF NOT EXISTS default_qos TEXT;
 "#;
 
 /// Record a job start in the database.
+///
+/// Takes a `&mut PgConnection` (not a hard `&PgPool`) so callers can either
+/// acquire a standalone connection from a pool (as the notifier does) or pass
+/// one borrowed from an open `Transaction` (`Transaction` derefs to
+/// `PgConnection`) to run this alongside other writes atomically, as
+/// reconciliation's backfill-then-finalize does.
 #[allow(clippy::too_many_arguments)]
 pub async fn record_job_start(
-    pool: &PgPool,
+    conn: &mut PgConnection,
     job_id: i32,
     name: &str,
     user: &str,
@@ -177,7 +183,7 @@ pub async fn record_job_start(
     .bind(submit_time)
     .bind(start_time)
     .bind(reservation)
-    .execute(pool)
+    .execute(&mut *conn)
     .await?;
 
     // If end_time is already set, the end notification arrived first and skipped
@@ -186,21 +192,22 @@ pub async fn record_job_start(
         "SELECT user_name, account, start_time, num_tasks, cpus_per_task, end_time FROM jobs WHERE job_id = $1",
     )
     .bind(job_id)
-    .fetch_one(pool)
+    .fetch_one(&mut *conn)
     .await?;
 
     let end_time: Option<DateTime<Utc>> = row.get("end_time");
     if let Some(end_time) = end_time {
-        update_usage(pool, row, end_time).await?;
+        update_usage(conn, row, end_time).await?;
     }
 
     Ok(())
 }
 
-/// Record a job completion in the database.
+/// Record a job completion in the database. See `record_job_start` for why
+/// this takes a `&mut PgConnection` rather than a `&PgPool`.
 #[allow(clippy::too_many_arguments)]
 pub async fn record_job_end(
-    pool: &PgPool,
+    conn: &mut PgConnection,
     job_id: i32,
     state: &str,
     exit_code: i32,
@@ -228,10 +235,10 @@ pub async fn record_job_end(
     .bind(end_time)
     .bind(exit_signal)
     .bind(derived_exit_code)
-    .fetch_one(pool)
+    .fetch_one(&mut *conn)
     .await?;
 
-    update_usage(pool, row, end_time).await?;
+    update_usage(conn, row, end_time).await?;
 
     Ok(())
 }
@@ -278,7 +285,11 @@ pub async fn job_accounting_states(
 }
 
 /// Update usage accounting for a completed job, from the row `record_job_end` just wrote.
-async fn update_usage(pool: &PgPool, row: PgRow, end_time: DateTime<Utc>) -> anyhow::Result<()> {
+async fn update_usage(
+    conn: &mut PgConnection,
+    row: PgRow,
+    end_time: DateTime<Utc>,
+) -> anyhow::Result<()> {
     let user: String = row.get("user_name");
     let account: String = row.get("account");
     let start_time: Option<DateTime<Utc>> = row.get("start_time");
@@ -314,7 +325,7 @@ async fn update_usage(pool: &PgPool, row: PgRow, end_time: DateTime<Utc>) -> any
     .bind(period_start)
     .bind(period_end)
     .bind(cpu_seconds)
-    .execute(pool)
+    .execute(&mut *conn)
     .await?;
 
     Ok(())
@@ -806,6 +817,66 @@ mod job_history_tests {
         Ok(())
     }
 
+    /// Standalone-pool wrappers around `record_job_start`/`record_job_end`,
+    /// which now take a `&mut PgConnection` so reconciliation can run them
+    /// inside a transaction. Tests exercise the pool-per-call path here.
+    #[allow(clippy::too_many_arguments)]
+    async fn start(
+        pool: &PgPool,
+        job_id: i32,
+        name: &str,
+        user: &str,
+        account: &str,
+        partition: &str,
+        num_nodes: i32,
+        num_tasks: i32,
+        cpus_per_task: i32,
+        memory_mb: i64,
+        submit_time: DateTime<Utc>,
+        start_time: DateTime<Utc>,
+        reservation: &str,
+    ) -> anyhow::Result<()> {
+        let mut conn = pool.acquire().await?;
+        record_job_start(
+            &mut conn,
+            job_id,
+            name,
+            user,
+            account,
+            partition,
+            num_nodes,
+            num_tasks,
+            cpus_per_task,
+            memory_mb,
+            submit_time,
+            start_time,
+            reservation,
+        )
+        .await
+    }
+
+    async fn end(
+        pool: &PgPool,
+        job_id: i32,
+        state: &str,
+        exit_code: i32,
+        end_time: DateTime<Utc>,
+        exit_signal: i32,
+        derived_exit_code: i32,
+    ) -> anyhow::Result<()> {
+        let mut conn = pool.acquire().await?;
+        record_job_end(
+            &mut conn,
+            job_id,
+            state,
+            exit_code,
+            end_time,
+            exit_signal,
+            derived_exit_code,
+        )
+        .await
+    }
+
     #[tokio::test]
     #[ignore = "requires DATABASE_URL and PostgreSQL"]
     async fn get_job_history_query_builder() -> anyhow::Result<()> {
@@ -826,7 +897,7 @@ mod job_history_tests {
 
         delete_jobs(&pool, &ids).await.ok();
 
-        record_job_start(
+        start(
             &pool,
             id0,
             "job-a",
@@ -842,9 +913,9 @@ mod job_history_tests {
             "",
         )
         .await?;
-        record_job_end(&pool, id0, "COMPLETED", 0, t1 + Duration::minutes(5), 0, 0).await?;
+        end(&pool, id0, "COMPLETED", 0, t1 + Duration::minutes(5), 0, 0).await?;
 
-        record_job_start(
+        start(
             &pool,
             id1,
             "job-b",
@@ -860,9 +931,9 @@ mod job_history_tests {
             "",
         )
         .await?;
-        record_job_end(&pool, id1, "FAILED", 137, t1 + Duration::minutes(5), 9, 137).await?;
+        end(&pool, id1, "FAILED", 137, t1 + Duration::minutes(5), 9, 137).await?;
 
-        record_job_start(
+        start(
             &pool,
             id2,
             "job-c",
@@ -878,7 +949,7 @@ mod job_history_tests {
             "",
         )
         .await?;
-        record_job_end(&pool, id2, "COMPLETED", 0, t2 + Duration::minutes(5), 0, 0).await?;
+        end(&pool, id2, "COMPLETED", 0, t2 + Duration::minutes(5), 0, 0).await?;
 
         let by_user = get_job_history(&pool, Some(&user_a), None, None, None, &[], 100).await?;
         assert_eq!(by_user.len(), 2);
@@ -942,11 +1013,11 @@ mod job_history_tests {
 
         let submit1 = Utc::now() - Duration::hours(3);
         let start1 = Utc::now() - Duration::hours(2);
-        record_job_start(
+        start(
             &pool, id, "old-job", "root", "acct-old", "debug", 2, 4, 2, 8192, submit1, start1, "",
         )
         .await?;
-        record_job_end(
+        end(
             &pool,
             id,
             "FAILED",
@@ -959,7 +1030,7 @@ mod job_history_tests {
 
         let submit2 = Utc::now() - Duration::minutes(90);
         let start2 = Utc::now() - Duration::hours(1);
-        record_job_start(
+        start(
             &pool, id, "new-job", "vm", "acct-new", "gpu", 1, 1, 1, 1024, submit2, start2, "",
         )
         .await?;

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -47,8 +47,13 @@ impl SlurmAccounting for AccountingService {
             .map(|r| (r.memory_mb as i64, r.cpus as i32))
             .unwrap_or((0, 1));
 
+        let mut conn = self
+            .pool
+            .acquire()
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
         db::record_job_start(
-            &self.pool,
+            &mut conn,
             req.job_id as i32,
             &req.name,
             &req.user,
@@ -88,8 +93,13 @@ impl SlurmAccounting for AccountingService {
             _ => "UNKNOWN",
         };
 
+        let mut conn = self
+            .pool
+            .acquire()
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
         db::record_job_end(
-            &self.pool,
+            &mut conn,
             req.job_id as i32,
             state_str,
             req.exit_code,

--- a/crates/spurctld/src/accounting/mod.rs
+++ b/crates/spurctld/src/accounting/mod.rs
@@ -5,9 +5,11 @@ pub(crate) mod db;
 mod fairshare;
 mod grpc;
 mod notifier;
+mod reconcile;
 
 pub use grpc::accounting_server;
 pub use notifier::{AccountingNotifier, JobStartRecord};
+pub use reconcile::spawn_loop as spawn_reconcile_loop;
 
 use std::collections::{HashMap, HashSet};
 

--- a/crates/spurctld/src/accounting/notifier.rs
+++ b/crates/spurctld/src/accounting/notifier.rs
@@ -15,7 +15,9 @@ const RETRY_BACKOFF: Duration = Duration::from_millis(200);
 // Bounds how long a single attempt can pin one of the pool's 8 connections.
 // Without this, a hung (not fully down) Postgres connection lets 3 retries
 // each hold a connection indefinitely, rather than failing fast and freeing it.
-const ATTEMPT_TIMEOUT: Duration = Duration::from_secs(10);
+// Shared with reconcile.rs, which has the same hung-connection exposure on
+// its resync writes.
+pub(super) const ATTEMPT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Retry a fallible async operation up to `attempts` times, doubling `backoff`
 /// between tries. Each attempt is bounded by `ATTEMPT_TIMEOUT`. Returns the
@@ -88,9 +90,10 @@ impl AccountingNotifier {
         let start_time = record.start_time;
         let reservation = record.reservation.unwrap_or_default();
         tokio::spawn(async move {
-            let write = || {
+            let write = || async {
+                let mut conn = pool.acquire().await?;
                 super::db::record_job_start(
-                    &pool,
+                    &mut conn,
                     job_id as i32,
                     &name,
                     &user,
@@ -104,6 +107,7 @@ impl AccountingNotifier {
                     start_time,
                     &reservation,
                 )
+                .await
             };
             if let Err(e) = retry_with_backoff(write, RETRY_ATTEMPTS, RETRY_BACKOFF).await {
                 error!(job_id, error = %e, "failed to record job start in accounting after retries");
@@ -123,9 +127,10 @@ impl AccountingNotifier {
         let pool = self.pool.clone();
         let state_str = state.display().to_owned();
         tokio::spawn(async move {
-            let write = || {
+            let write = || async {
+                let mut conn = pool.acquire().await?;
                 super::db::record_job_end(
-                    &pool,
+                    &mut conn,
                     job_id as i32,
                     &state_str,
                     exit_code,
@@ -133,6 +138,7 @@ impl AccountingNotifier {
                     exit_signal,
                     derived_exit_code,
                 )
+                .await
             };
             if let Err(e) = retry_with_backoff(write, RETRY_ATTEMPTS, RETRY_BACKOFF).await {
                 error!(job_id, error = %e, "failed to record job end in accounting after retries");

--- a/crates/spurctld/src/accounting/notifier.rs
+++ b/crates/spurctld/src/accounting/notifier.rs
@@ -12,9 +12,14 @@ use spur_core::job::{JobId, JobState};
 
 const RETRY_ATTEMPTS: u32 = 3;
 const RETRY_BACKOFF: Duration = Duration::from_millis(200);
+// Bounds how long a single attempt can pin one of the pool's 8 connections.
+// Without this, a hung (not fully down) Postgres connection lets 3 retries
+// each hold a connection indefinitely, rather than failing fast and freeing it.
+const ATTEMPT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Retry a fallible async operation up to `attempts` times, doubling `backoff`
-/// between tries. Returns the last error if all attempts fail.
+/// between tries. Each attempt is bounded by `ATTEMPT_TIMEOUT`. Returns the
+/// last error (or a timeout error) if all attempts fail.
 async fn retry_with_backoff<F, Fut>(
     mut f: F,
     attempts: u32,
@@ -26,10 +31,16 @@ where
 {
     let mut attempt = 1;
     loop {
-        match f().await {
-            Ok(()) => return Ok(()),
-            Err(e) if attempt >= attempts => return Err(e),
-            Err(_) => {
+        match tokio::time::timeout(ATTEMPT_TIMEOUT, f()).await {
+            Ok(Ok(())) => return Ok(()),
+            Ok(Err(e)) if attempt >= attempts => return Err(e),
+            Err(_) if attempt >= attempts => {
+                return Err(anyhow::anyhow!(
+                    "operation timed out after {:?}",
+                    ATTEMPT_TIMEOUT
+                ));
+            }
+            Ok(Err(_)) | Err(_) => {
                 tokio::time::sleep(backoff).await;
                 backoff *= 2;
                 attempt += 1;

--- a/crates/spurctld/src/accounting/notifier.rs
+++ b/crates/spurctld/src/accounting/notifier.rs
@@ -1,11 +1,42 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::future::Future;
+use std::time::Duration;
+
 use chrono::{DateTime, Utc};
 use sqlx::PgPool;
-use tracing::warn;
+use tracing::error;
 
 use spur_core::job::{JobId, JobState};
+
+const RETRY_ATTEMPTS: u32 = 3;
+const RETRY_BACKOFF: Duration = Duration::from_millis(200);
+
+/// Retry a fallible async operation up to `attempts` times, doubling `backoff`
+/// between tries. Returns the last error if all attempts fail.
+async fn retry_with_backoff<F, Fut>(
+    mut f: F,
+    attempts: u32,
+    mut backoff: Duration,
+) -> anyhow::Result<()>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = anyhow::Result<()>>,
+{
+    let mut attempt = 1;
+    loop {
+        match f().await {
+            Ok(()) => return Ok(()),
+            Err(e) if attempt >= attempts => return Err(e),
+            Err(_) => {
+                tokio::time::sleep(backoff).await;
+                backoff *= 2;
+                attempt += 1;
+            }
+        }
+    }
+}
 
 pub struct JobStartRecord {
     pub job_id: JobId,
@@ -46,24 +77,25 @@ impl AccountingNotifier {
         let start_time = record.start_time;
         let reservation = record.reservation.unwrap_or_default();
         tokio::spawn(async move {
-            if let Err(e) = super::db::record_job_start(
-                &pool,
-                job_id as i32,
-                &name,
-                &user,
-                &account,
-                &partition,
-                num_nodes,
-                num_tasks,
-                cpus_per_task,
-                memory_mb,
-                submit_time,
-                start_time,
-                &reservation,
-            )
-            .await
-            {
-                warn!(job_id, error = %e, "failed to record job start in accounting");
+            let write = || {
+                super::db::record_job_start(
+                    &pool,
+                    job_id as i32,
+                    &name,
+                    &user,
+                    &account,
+                    &partition,
+                    num_nodes,
+                    num_tasks,
+                    cpus_per_task,
+                    memory_mb,
+                    submit_time,
+                    start_time,
+                    &reservation,
+                )
+            };
+            if let Err(e) = retry_with_backoff(write, RETRY_ATTEMPTS, RETRY_BACKOFF).await {
+                error!(job_id, error = %e, "failed to record job start in accounting after retries");
             }
         });
     }
@@ -80,19 +112,63 @@ impl AccountingNotifier {
         let pool = self.pool.clone();
         let state_str = state.display().to_owned();
         tokio::spawn(async move {
-            if let Err(e) = super::db::record_job_end(
-                &pool,
-                job_id as i32,
-                &state_str,
-                exit_code,
-                end_time,
-                exit_signal,
-                derived_exit_code,
-            )
-            .await
-            {
-                warn!(job_id, error = %e, "failed to record job end in accounting");
+            let write = || {
+                super::db::record_job_end(
+                    &pool,
+                    job_id as i32,
+                    &state_str,
+                    exit_code,
+                    end_time,
+                    exit_signal,
+                    derived_exit_code,
+                )
+            };
+            if let Err(e) = retry_with_backoff(write, RETRY_ATTEMPTS, RETRY_BACKOFF).await {
+                error!(job_id, error = %e, "failed to record job end in accounting after retries");
             }
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn retry_with_backoff_gives_up_after_all_attempts_fail() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let calls_clone = calls.clone();
+        let f = move || {
+            calls_clone.fetch_add(1, Ordering::SeqCst);
+            async { Err(anyhow::anyhow!("boom")) }
+        };
+
+        let result = retry_with_backoff(f, 3, Duration::from_millis(1)).await;
+
+        assert!(result.is_err());
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn retry_with_backoff_stops_on_first_success() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let calls_clone = calls.clone();
+        let f = move || {
+            let n = calls_clone.fetch_add(1, Ordering::SeqCst) + 1;
+            async move {
+                if n < 2 {
+                    Err(anyhow::anyhow!("transient"))
+                } else {
+                    Ok(())
+                }
+            }
+        };
+
+        let result = retry_with_backoff(f, 3, Duration::from_millis(1)).await;
+
+        assert!(result.is_ok());
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
     }
 }

--- a/crates/spurctld/src/accounting/reconcile.rs
+++ b/crates/spurctld/src/accounting/reconcile.rs
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Utc;
+use sqlx::PgPool;
+use tracing::{error, info, warn};
+
+use spur_core::job::{Job, JobId};
+
+use crate::cluster::ClusterManager;
+use crate::raft::RaftHandle;
+
+use super::db;
+
+/// Periodically re-issue accounting writes for jobs whose accounting DB
+/// record is missing or stale relative to the in-memory job store. Closes
+/// the gap left by a `notify_job_start`/`notify_job_end` write that
+/// exhausted its retries (see `notifier.rs`).
+pub fn spawn_loop(
+    pool: PgPool,
+    cluster: Arc<ClusterManager>,
+    raft: Arc<RaftHandle>,
+    interval: Duration,
+) {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        loop {
+            ticker.tick().await;
+            if !raft.is_leader() {
+                continue;
+            }
+            run_once(&pool, &cluster).await;
+        }
+    });
+}
+
+/// Only jobs that have actually started accrue an accounting record
+/// (`notify_job_start` fires from `start_job`), so jobs still pending are
+/// not candidates.
+async fn run_once(pool: &PgPool, cluster: &ClusterManager) {
+    let candidates: Vec<Job> = cluster
+        .get_jobs(&[], None, None, None, &[])
+        .into_iter()
+        .filter(|j| j.start_time.is_some())
+        .collect();
+    if candidates.is_empty() {
+        return;
+    }
+
+    let expected: Vec<(JobId, String)> = candidates
+        .iter()
+        .map(|j| (j.job_id, j.state.display().to_owned()))
+        .collect();
+
+    let mut accounting_states = HashMap::new();
+    for job in &candidates {
+        match db::job_accounting_state(pool, job.job_id as i32).await {
+            Ok(Some(state)) => {
+                accounting_states.insert(job.job_id, state);
+            }
+            Ok(None) => {}
+            Err(e) => {
+                warn!(job_id = job.job_id, error = %e, "reconciliation: failed to query accounting state");
+            }
+        }
+    }
+
+    let stale = jobs_needing_resync(&expected, &accounting_states);
+    if stale.is_empty() {
+        return;
+    }
+    info!(
+        count = stale.len(),
+        "reconciliation: resyncing jobs with missing or stale accounting records"
+    );
+
+    for job in candidates.iter().filter(|j| stale.contains(&j.job_id)) {
+        let row_missing = !accounting_states.contains_key(&job.job_id);
+        resync_job(pool, job, row_missing).await;
+    }
+}
+
+/// Diff in-memory job state against known accounting state. Pure so it can
+/// be unit tested without a database.
+fn jobs_needing_resync(
+    expected: &[(JobId, String)],
+    accounting: &HashMap<JobId, String>,
+) -> Vec<JobId> {
+    expected
+        .iter()
+        .filter(|(id, state)| accounting.get(id) != Some(state))
+        .map(|(id, _)| *id)
+        .collect()
+}
+
+async fn resync_job(pool: &PgPool, job: &Job, row_missing: bool) {
+    // record_job_start unconditionally sets state='RUNNING', so only call it
+    // when the row doesn't exist yet or the job hasn't reached a terminal
+    // state — otherwise it would clobber a correct terminal state.
+    if row_missing || !job.state.is_terminal() {
+        if let Err(e) = write_start(pool, job).await {
+            error!(job_id = job.job_id, error = %e, "reconciliation: failed to resync job start");
+            return;
+        }
+    }
+
+    if job.state.is_terminal() {
+        if let Err(e) = write_end(pool, job).await {
+            error!(job_id = job.job_id, error = %e, "reconciliation: failed to resync job end");
+        }
+    }
+}
+
+async fn write_start(pool: &PgPool, job: &Job) -> anyhow::Result<()> {
+    let spec = &job.spec;
+    let memory_mb = job
+        .allocated_resources
+        .as_ref()
+        .map(|r| r.memory_mb)
+        .unwrap_or(0);
+    let start_time = job.start_time.unwrap_or(job.submit_time);
+    db::record_job_start(
+        pool,
+        job.job_id as i32,
+        &spec.name,
+        &spec.user,
+        spec.account.as_deref().unwrap_or_default(),
+        spec.partition.as_deref().unwrap_or_default(),
+        spec.num_nodes as i32,
+        spec.num_tasks as i32,
+        spec.cpus_per_task as i32,
+        memory_mb as i64,
+        job.submit_time,
+        start_time,
+        spec.reservation.as_deref().unwrap_or_default(),
+    )
+    .await
+}
+
+async fn write_end(pool: &PgPool, job: &Job) -> anyhow::Result<()> {
+    let end_time = job.end_time.unwrap_or_else(Utc::now);
+    db::record_job_end(
+        pool,
+        job.job_id as i32,
+        job.state.display(),
+        job.exit_code.unwrap_or(0),
+        end_time,
+        job.exit_signal,
+        job.derived_exit_code,
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jobs_needing_resync_flags_missing_job() {
+        let expected = vec![(1, "RUNNING".to_string())];
+        let accounting = HashMap::new();
+
+        let stale = jobs_needing_resync(&expected, &accounting);
+
+        assert_eq!(stale, vec![1]);
+    }
+
+    #[test]
+    fn jobs_needing_resync_flags_stale_state() {
+        let expected = vec![(1, "COMPLETED".to_string())];
+        let mut accounting = HashMap::new();
+        accounting.insert(1, "RUNNING".to_string());
+
+        let stale = jobs_needing_resync(&expected, &accounting);
+
+        assert_eq!(stale, vec![1]);
+    }
+
+    #[test]
+    fn jobs_needing_resync_ignores_job_in_sync() {
+        let expected = vec![(1, "RUNNING".to_string())];
+        let mut accounting = HashMap::new();
+        accounting.insert(1, "RUNNING".to_string());
+
+        let stale = jobs_needing_resync(&expected, &accounting);
+
+        assert!(stale.is_empty());
+    }
+
+    #[test]
+    fn jobs_needing_resync_handles_mixed_batch() {
+        let expected = vec![
+            (1, "RUNNING".to_string()),
+            (2, "COMPLETED".to_string()),
+            (3, "FAILED".to_string()),
+        ];
+        let mut accounting = HashMap::new();
+        accounting.insert(1, "RUNNING".to_string()); // in sync
+        accounting.insert(2, "RUNNING".to_string()); // stale
+                                                     // job 3 missing entirely
+
+        let mut stale = jobs_needing_resync(&expected, &accounting);
+        stale.sort();
+
+        assert_eq!(stale, vec![2, 3]);
+    }
+}

--- a/crates/spurctld/src/accounting/reconcile.rs
+++ b/crates/spurctld/src/accounting/reconcile.rs
@@ -138,28 +138,55 @@ fn jobs_needing_resync(
         .collect()
 }
 
+/// Resync one job's accounting record. `write_start` and `write_end` (when
+/// both are needed) run inside a single transaction so a failure partway
+/// through — including `write_start` itself failing — rolls back cleanly
+/// instead of leaving the row in an intermediate state: `record_job_start`
+/// unconditionally sets `state='RUNNING'` with a wiped end time and exit
+/// code, and previously that reset was committed on its own statement, with
+/// `write_end` relied on to fix it back up immediately after. Any failure
+/// between the two — or a concurrent reader landing in the gap — could
+/// observe or permanently persist a correct terminal record clobbered back
+/// to `RUNNING`. The whole attempt is bounded by `ATTEMPT_TIMEOUT` so a
+/// wedged connection can't stall the reconciliation loop; a timed-out job is
+/// simply retried on the next pass.
 async fn resync_job(pool: &PgPool, job: &Job, row_missing: bool, needs_start_backfill: bool) {
     // record_job_start unconditionally sets state='RUNNING', so only call it
     // when the row doesn't exist yet, is missing start metadata a proper
     // record_job_start would have populated (see AccountingRowState), or the
     // job hasn't reached a terminal state — otherwise it would clobber a
-    // correct terminal state. The terminal case is corrected immediately
-    // below by write_end in the same pass.
-    if row_missing || needs_start_backfill || !job.state.is_terminal() {
-        if let Err(e) = write_start(pool, job).await {
-            error!(job_id = job.job_id, error = %e, "reconciliation: failed to resync job start");
-            return;
-        }
-    }
+    // correct terminal state. The terminal case is corrected in the same
+    // transaction by write_end below.
+    let needs_start = row_missing || needs_start_backfill || !job.state.is_terminal();
+    let is_terminal = job.state.is_terminal();
 
-    if job.state.is_terminal() {
-        if let Err(e) = write_end(pool, job).await {
-            error!(job_id = job.job_id, error = %e, "reconciliation: failed to resync job end");
+    let attempt = async {
+        let mut tx = pool.begin().await?;
+        if needs_start {
+            write_start(&mut tx, job).await?;
+        }
+        if is_terminal {
+            write_end(&mut tx, job).await?;
+        }
+        tx.commit().await?;
+        anyhow::Ok(())
+    };
+
+    match tokio::time::timeout(super::notifier::ATTEMPT_TIMEOUT, attempt).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => {
+            error!(job_id = job.job_id, error = %e, "reconciliation: failed to resync job accounting record");
+        }
+        Err(_) => {
+            error!(
+                job_id = job.job_id,
+                "reconciliation: resync timed out, will retry next cycle"
+            );
         }
     }
 }
 
-async fn write_start(pool: &PgPool, job: &Job) -> anyhow::Result<()> {
+async fn write_start(conn: &mut sqlx::PgConnection, job: &Job) -> anyhow::Result<()> {
     let spec = &job.spec;
     let memory_mb = job
         .allocated_resources
@@ -168,7 +195,7 @@ async fn write_start(pool: &PgPool, job: &Job) -> anyhow::Result<()> {
         .unwrap_or(0);
     let start_time = job.start_time.unwrap_or(job.submit_time);
     db::record_job_start(
-        pool,
+        conn,
         job.job_id as i32,
         &spec.name,
         &spec.user,
@@ -185,10 +212,10 @@ async fn write_start(pool: &PgPool, job: &Job) -> anyhow::Result<()> {
     .await
 }
 
-async fn write_end(pool: &PgPool, job: &Job) -> anyhow::Result<()> {
+async fn write_end(conn: &mut sqlx::PgConnection, job: &Job) -> anyhow::Result<()> {
     let end_time = job.end_time.unwrap_or_else(Utc::now);
     db::record_job_end(
-        pool,
+        conn,
         job.job_id as i32,
         job.state.display(),
         job.exit_code.unwrap_or(0),
@@ -382,8 +409,9 @@ mod tests {
         let job = test_job(job_id, JobState::Completed);
 
         // Simulate the outage: only the end notification ever lands.
+        let mut conn = pool.acquire().await?;
         db::record_job_end(
-            &pool,
+            &mut conn,
             job_id as i32,
             job.state.display(),
             0,
@@ -392,6 +420,7 @@ mod tests {
             0,
         )
         .await?;
+        drop(conn);
 
         let bare = db::job_accounting_states(&pool, &[job_id as i32])
             .await?
@@ -469,6 +498,101 @@ mod tests {
         assert!(
             stale.is_empty(),
             "a suspended job matching a RUNNING row must not be flagged stale"
+        );
+
+        delete_job(&pool, job_id as i32).await;
+        Ok(())
+    }
+
+    // Regression test for the core atomicity bug: record_job_start
+    // unconditionally resets state='RUNNING'/end_time=NULL, so a resync pass
+    // that backfills a job already holding a correct, complete terminal
+    // record must never leave that record clobbered if anything fails
+    // between write_start committing its (would-be-corrupting) write and
+    // write_end correcting it. write_start's own INSERT is single-statement
+    // atomic on its own — a bad value in it just fails outright without
+    // writing anything, old buggy code included — so this drives write_start
+    // to completion for real (proving it does flip the row to RUNNING with
+    // no end_time, exactly the corrupted shape the bug left behind) and then
+    // forces a real SQL failure on the same transaction before commit, the
+    // way a failing write_end or a dropped connection would. Only the
+    // transaction's rollback — not any additional application-level fixup —
+    // is what must protect the pre-existing terminal record here.
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL and PostgreSQL"]
+    async fn resync_job_transaction_rolls_back_a_partial_backfill() -> anyhow::Result<()> {
+        let pool = test_pool().await?;
+        let job_id = test_job_id(2);
+        delete_job(&pool, job_id as i32).await;
+
+        // Seed a correct, complete terminal record, as if a prior pass had
+        // already recorded it successfully.
+        let job = test_job(job_id, JobState::Completed);
+        {
+            let mut conn = pool.acquire().await?;
+            db::record_job_start(
+                &mut conn,
+                job_id as i32,
+                &job.spec.name,
+                &job.spec.user,
+                "",
+                "",
+                job.spec.num_nodes as i32,
+                job.spec.num_tasks as i32,
+                job.spec.cpus_per_task as i32,
+                0,
+                job.submit_time,
+                job.start_time.unwrap(),
+                "",
+            )
+            .await?;
+            db::record_job_end(
+                &mut conn,
+                job_id as i32,
+                "COMPLETED",
+                0,
+                job.end_time.unwrap(),
+                0,
+                0,
+            )
+            .await?;
+        }
+
+        // Run write_start (the real function resync_job calls) inside a
+        // transaction of our own, the same way resync_job's fix does.
+        let mut tx = pool.begin().await?;
+        write_start(&mut tx, &job).await?;
+
+        // Within the uncommitted transaction, the row is now exactly the
+        // corrupted shape the pre-fix bug used to leave committed: RUNNING
+        // with end_time wiped out.
+        let mid_row = sqlx::query("SELECT state, end_time FROM jobs WHERE job_id = $1")
+            .bind(job_id as i32)
+            .fetch_one(&mut *tx)
+            .await?;
+        let mid_state: String = mid_row.get("state");
+        let mid_end_time: Option<chrono::DateTime<Utc>> = mid_row.get("end_time");
+        assert_eq!(mid_state, "RUNNING");
+        assert!(mid_end_time.is_none());
+
+        // Simulate write_end failing (or a connection drop) before commit —
+        // any real SQL error on the same transaction has the same effect.
+        assert!(sqlx::query("SELECT 1/0").execute(&mut *tx).await.is_err());
+        drop(tx); // never committed: sqlx issues ROLLBACK
+
+        let row = sqlx::query("SELECT state, end_time FROM jobs WHERE job_id = $1")
+            .bind(job_id as i32)
+            .fetch_one(&pool)
+            .await?;
+        let state: String = row.get("state");
+        let end_time: Option<chrono::DateTime<Utc>> = row.get("end_time");
+        assert_eq!(
+            state, "COMPLETED",
+            "a rolled-back backfill must never leave the row RUNNING"
+        );
+        assert!(
+            end_time.is_some(),
+            "a rolled-back backfill must never wipe out end_time"
         );
 
         delete_job(&pool, job_id as i32).await;

--- a/crates/spurctld/src/accounting/reconcile.rs
+++ b/crates/spurctld/src/accounting/reconcile.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -9,12 +9,12 @@ use chrono::Utc;
 use sqlx::PgPool;
 use tracing::{error, info, warn};
 
-use spur_core::job::{Job, JobId};
+use spur_core::job::{Job, JobId, JobState};
 
 use crate::cluster::ClusterManager;
 use crate::raft::RaftHandle;
 
-use super::db;
+use super::db::{self, AccountingRowState};
 
 /// Periodically re-issue accounting writes for jobs whose accounting DB
 /// record is missing or stale relative to the in-memory job store. Closes
@@ -30,7 +30,14 @@ pub fn spawn_loop(
         let mut ticker = tokio::time::interval(interval);
         loop {
             ticker.tick().await;
-            if !raft.is_leader() {
+            // Consensus-backed check, not the cheap cached `is_leader()`:
+            // reconciliation writes bypass Raft entirely (they go straight to
+            // Postgres), so a partitioned former leader with a stale local
+            // view must not keep resyncing accounting state against a job
+            // store the rest of the cluster has moved on from. Residual risk:
+            // this only guards the start of a pass — leadership can still
+            // change during the writes `run_once` issues below.
+            if !raft.ensure_leader().await {
                 continue;
             }
             run_once(&pool, &cluster).await;
@@ -53,23 +60,33 @@ async fn run_once(pool: &PgPool, cluster: &ClusterManager) {
 
     let expected: Vec<(JobId, String)> = candidates
         .iter()
-        .map(|j| (j.job_id, j.state.display().to_owned()))
+        .map(|j| (j.job_id, accounting_expected_state(j.state)))
         .collect();
 
-    let mut accounting_states = HashMap::new();
-    for job in &candidates {
-        match db::job_accounting_state(pool, job.job_id as i32).await {
-            Ok(Some(state)) => {
-                accounting_states.insert(job.job_id, state);
-            }
-            Ok(None) => {}
+    let job_ids: Vec<i32> = candidates.iter().map(|j| j.job_id as i32).collect();
+    let (accounting_states, unknown): (HashMap<JobId, AccountingRowState>, HashSet<JobId>) =
+        match db::job_accounting_states(pool, &job_ids).await {
+            Ok(rows) => (
+                rows.into_iter()
+                    .map(|(id, row)| (id as JobId, row))
+                    .collect(),
+                HashSet::new(),
+            ),
             Err(e) => {
-                warn!(job_id = job.job_id, error = %e, "reconciliation: failed to query accounting state");
+                // A failed read is not evidence the rows are absent. Treating
+                // it as "missing" would make resync_job call write_start,
+                // which unconditionally resets a possibly-correct terminal
+                // record to RUNNING — so every candidate is excluded from
+                // resync this pass and picked up again on the next one.
+                warn!(error = %e, "reconciliation: failed to query accounting state, skipping this cycle");
+                (
+                    HashMap::new(),
+                    candidates.iter().map(|j| j.job_id).collect(),
+                )
             }
-        }
-    }
+        };
 
-    let stale = jobs_needing_resync(&expected, &accounting_states);
+    let stale = jobs_needing_resync(&expected, &accounting_states, &unknown);
     if stale.is_empty() {
         return;
     }
@@ -79,29 +96,56 @@ async fn run_once(pool: &PgPool, cluster: &ClusterManager) {
     );
 
     for job in candidates.iter().filter(|j| stale.contains(&j.job_id)) {
-        let row_missing = !accounting_states.contains_key(&job.job_id);
-        resync_job(pool, job, row_missing).await;
+        let row = accounting_states.get(&job.job_id);
+        let row_missing = row.is_none();
+        let needs_start_backfill = row.map(|r| r.needs_start_backfill).unwrap_or(false);
+        resync_job(pool, job, row_missing, needs_start_backfill).await;
+    }
+}
+
+/// What accounting should show for a job's current state. Accounting only
+/// ever models `RUNNING` or a terminal state (`record_job_start` always
+/// writes `RUNNING`; only `record_job_end` writes a terminal state), so
+/// in-memory states it has no representation for — `SUSPENDED`, `COMPLETING`
+/// — must map to `RUNNING` for comparison. Otherwise a suspended or
+/// completing job would be flagged stale on every single pass for as long as
+/// it stays in that state.
+fn accounting_expected_state(state: JobState) -> String {
+    if state.is_terminal() {
+        state.display().to_owned()
+    } else {
+        JobState::Running.display().to_owned()
     }
 }
 
 /// Diff in-memory job state against known accounting state. Pure so it can
-/// be unit tested without a database.
+/// be unit tested without a database. `unknown` holds jobs whose accounting
+/// read failed this pass — distinct from a confirmed-absent row, so they're
+/// skipped rather than treated as missing.
 fn jobs_needing_resync(
     expected: &[(JobId, String)],
-    accounting: &HashMap<JobId, String>,
+    accounting: &HashMap<JobId, AccountingRowState>,
+    unknown: &HashSet<JobId>,
 ) -> Vec<JobId> {
     expected
         .iter()
-        .filter(|(id, state)| accounting.get(id) != Some(state))
+        .filter(|(id, _)| !unknown.contains(id))
+        .filter(|(id, state)| match accounting.get(id) {
+            None => true,
+            Some(row) => row.needs_start_backfill || &row.state != state,
+        })
         .map(|(id, _)| *id)
         .collect()
 }
 
-async fn resync_job(pool: &PgPool, job: &Job, row_missing: bool) {
+async fn resync_job(pool: &PgPool, job: &Job, row_missing: bool, needs_start_backfill: bool) {
     // record_job_start unconditionally sets state='RUNNING', so only call it
-    // when the row doesn't exist yet or the job hasn't reached a terminal
-    // state — otherwise it would clobber a correct terminal state.
-    if row_missing || !job.state.is_terminal() {
+    // when the row doesn't exist yet, is missing start metadata a proper
+    // record_job_start would have populated (see AccountingRowState), or the
+    // job hasn't reached a terminal state — otherwise it would clobber a
+    // correct terminal state. The terminal case is corrected immediately
+    // below by write_end in the same pass.
+    if row_missing || needs_start_backfill || !job.state.is_terminal() {
         if let Err(e) = write_start(pool, job).await {
             error!(job_id = job.job_id, error = %e, "reconciliation: failed to resync job start");
             return;
@@ -158,13 +202,26 @@ async fn write_end(pool: &PgPool, job: &Job) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use spur_core::job::JobSpec;
+    use sqlx::Row;
+
+    fn synced_row(state: &str) -> AccountingRowState {
+        AccountingRowState {
+            state: state.to_string(),
+            needs_start_backfill: false,
+        }
+    }
+
+    fn no_unknown() -> HashSet<JobId> {
+        HashSet::new()
+    }
 
     #[test]
     fn jobs_needing_resync_flags_missing_job() {
         let expected = vec![(1, "RUNNING".to_string())];
         let accounting = HashMap::new();
 
-        let stale = jobs_needing_resync(&expected, &accounting);
+        let stale = jobs_needing_resync(&expected, &accounting, &no_unknown());
 
         assert_eq!(stale, vec![1]);
     }
@@ -173,9 +230,9 @@ mod tests {
     fn jobs_needing_resync_flags_stale_state() {
         let expected = vec![(1, "COMPLETED".to_string())];
         let mut accounting = HashMap::new();
-        accounting.insert(1, "RUNNING".to_string());
+        accounting.insert(1, synced_row("RUNNING"));
 
-        let stale = jobs_needing_resync(&expected, &accounting);
+        let stale = jobs_needing_resync(&expected, &accounting, &no_unknown());
 
         assert_eq!(stale, vec![1]);
     }
@@ -184,9 +241,9 @@ mod tests {
     fn jobs_needing_resync_ignores_job_in_sync() {
         let expected = vec![(1, "RUNNING".to_string())];
         let mut accounting = HashMap::new();
-        accounting.insert(1, "RUNNING".to_string());
+        accounting.insert(1, synced_row("RUNNING"));
 
-        let stale = jobs_needing_resync(&expected, &accounting);
+        let stale = jobs_needing_resync(&expected, &accounting, &no_unknown());
 
         assert!(stale.is_empty());
     }
@@ -199,13 +256,222 @@ mod tests {
             (3, "FAILED".to_string()),
         ];
         let mut accounting = HashMap::new();
-        accounting.insert(1, "RUNNING".to_string()); // in sync
-        accounting.insert(2, "RUNNING".to_string()); // stale
+        accounting.insert(1, synced_row("RUNNING")); // in sync
+        accounting.insert(2, synced_row("RUNNING")); // stale
                                                      // job 3 missing entirely
 
-        let mut stale = jobs_needing_resync(&expected, &accounting);
+        let mut stale = jobs_needing_resync(&expected, &accounting, &no_unknown());
         stale.sort();
 
         assert_eq!(stale, vec![2, 3]);
+    }
+
+    // Finding 1: a row whose state matches but is missing start metadata
+    // (record_job_end created it from scratch because record_job_start's
+    // retries exhausted) must still be flagged, or the gap is permanent.
+    #[test]
+    fn jobs_needing_resync_flags_bare_row_even_when_state_matches() {
+        let expected = vec![(1, "COMPLETED".to_string())];
+        let mut accounting = HashMap::new();
+        accounting.insert(
+            1,
+            AccountingRowState {
+                state: "COMPLETED".to_string(),
+                needs_start_backfill: true,
+            },
+        );
+
+        let stale = jobs_needing_resync(&expected, &accounting, &no_unknown());
+
+        assert_eq!(stale, vec![1]);
+    }
+
+    // Finding 2: a job whose read failed this pass must never be flagged as
+    // needing resync, even though it's also absent from `accounting` — a
+    // confirmed-absent row and a failed read are not the same thing, and
+    // conflating them can clobber a correct terminal record via write_start.
+    #[test]
+    fn jobs_needing_resync_skips_jobs_with_unknown_read_status() {
+        let expected = vec![(1, "COMPLETED".to_string()), (2, "RUNNING".to_string())];
+        let accounting = HashMap::new();
+        let mut unknown = HashSet::new();
+        unknown.insert(1);
+
+        let stale = jobs_needing_resync(&expected, &accounting, &unknown);
+
+        assert_eq!(stale, vec![2]);
+    }
+
+    // Finding 3: accounting only ever models RUNNING or a terminal state, so
+    // states it can't represent must map to RUNNING for comparison —
+    // otherwise a suspended/completing job is flagged stale forever.
+    #[test]
+    fn accounting_expected_state_maps_non_terminal_states_to_running() {
+        assert_eq!(accounting_expected_state(JobState::Running), "RUNNING");
+        assert_eq!(accounting_expected_state(JobState::Suspended), "RUNNING");
+        assert_eq!(accounting_expected_state(JobState::Completing), "RUNNING");
+        assert_eq!(accounting_expected_state(JobState::Completed), "COMPLETED");
+        assert_eq!(accounting_expected_state(JobState::Failed), "FAILED");
+    }
+
+    #[test]
+    fn jobs_needing_resync_ignores_suspended_job_matching_running_row() {
+        let expected = vec![(1, accounting_expected_state(JobState::Suspended))];
+        let mut accounting = HashMap::new();
+        accounting.insert(1, synced_row("RUNNING"));
+
+        let stale = jobs_needing_resync(&expected, &accounting, &no_unknown());
+
+        assert!(stale.is_empty());
+    }
+
+    fn test_job_id(slot: u32) -> u32 {
+        const BASE: u32 = 9_500_000;
+        BASE + (std::process::id() % 10_000) * 10 + slot
+    }
+
+    fn test_job(job_id: JobId, state: JobState) -> Job {
+        let spec = JobSpec {
+            name: "reconcile-test".into(),
+            user: format!("spur_reconcile_user_{}", std::process::id()),
+            num_nodes: 1,
+            num_tasks: 2,
+            cpus_per_task: 3,
+            work_dir: "/tmp".into(),
+            ..Default::default()
+        };
+        let mut job = Job::new(job_id, spec);
+        let start = Utc::now() - chrono::Duration::hours(1);
+        job.start_time = Some(start);
+        job.state = state;
+        if state.is_terminal() {
+            job.end_time = Some(start + chrono::Duration::minutes(5));
+            job.exit_code = Some(0);
+        }
+        job
+    }
+
+    async fn test_pool() -> anyhow::Result<PgPool> {
+        let url = std::env::var("DATABASE_URL")?;
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .max_connections(5)
+            .connect(&url)
+            .await?;
+        db::migrate(&pool).await?;
+        Ok(pool)
+    }
+
+    async fn delete_job(pool: &PgPool, job_id: i32) {
+        let _ = sqlx::query("DELETE FROM jobs WHERE job_id = $1")
+            .bind(job_id)
+            .execute(pool)
+            .await;
+    }
+
+    // Finding 1, end to end: simulate record_job_start's retries exhausting
+    // (only record_job_end ever lands, creating a bare row), then run the
+    // reconciliation resync path and confirm it backfills the row rather
+    // than leaving it permanently missing user_name/start_time.
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL and PostgreSQL"]
+    async fn resync_job_backfills_bare_row_left_by_a_missed_job_start() -> anyhow::Result<()> {
+        let pool = test_pool().await?;
+        let job_id = test_job_id(0);
+        delete_job(&pool, job_id as i32).await;
+
+        let job = test_job(job_id, JobState::Completed);
+
+        // Simulate the outage: only the end notification ever lands.
+        db::record_job_end(
+            &pool,
+            job_id as i32,
+            job.state.display(),
+            0,
+            job.end_time.unwrap(),
+            0,
+            0,
+        )
+        .await?;
+
+        let bare = db::job_accounting_states(&pool, &[job_id as i32])
+            .await?
+            .remove(&(job_id as i32))
+            .expect("bare row exists");
+        assert!(bare.needs_start_backfill);
+        assert_eq!(bare.state, "COMPLETED");
+
+        // The diff must flag this job even though state already matches.
+        let expected = vec![(job_id, accounting_expected_state(job.state))];
+        let mut accounting = HashMap::new();
+        accounting.insert(job_id, bare);
+        let stale = jobs_needing_resync(&expected, &accounting, &no_unknown());
+        assert_eq!(stale, vec![job_id]);
+
+        resync_job(&pool, &job, false, true).await;
+
+        let row = sqlx::query("SELECT user_name, start_time, state FROM jobs WHERE job_id = $1")
+            .bind(job_id as i32)
+            .fetch_one(&pool)
+            .await?;
+        let user_name: String = row.get("user_name");
+        let start_time: Option<chrono::DateTime<Utc>> = row.get("start_time");
+        let state: String = row.get("state");
+        assert_eq!(user_name, job.spec.user);
+        assert!(start_time.is_some(), "start_time must be backfilled");
+        assert_eq!(
+            state, "COMPLETED",
+            "terminal state must survive the backfill"
+        );
+
+        // Usage was skipped originally (start_time was NULL); the backfill
+        // must trigger it since end_time was already present.
+        let usage_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM usage WHERE user_name = $1 AND job_count > 0")
+                .bind(&job.spec.user)
+                .fetch_one(&pool)
+                .await?;
+        assert!(
+            usage_count > 0,
+            "usage must be backfilled along with the row"
+        );
+
+        delete_job(&pool, job_id as i32).await;
+        sqlx::query("DELETE FROM usage WHERE user_name = $1")
+            .bind(&job.spec.user)
+            .execute(&pool)
+            .await?;
+        Ok(())
+    }
+
+    // Finding 3, end to end: a suspended job's accounting row correctly shows
+    // RUNNING (accounting has no SUSPENDED state); a resync pass must not
+    // treat that as stale and must not clobber the row.
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL and PostgreSQL"]
+    async fn suspended_job_is_not_flagged_stale_against_a_running_row() -> anyhow::Result<()> {
+        let pool = test_pool().await?;
+        let job_id = test_job_id(1);
+        delete_job(&pool, job_id as i32).await;
+
+        let running_job = test_job(job_id, JobState::Running);
+        resync_job(&pool, &running_job, true, false).await;
+
+        let suspended_job = test_job(job_id, JobState::Suspended);
+        let row = db::job_accounting_states(&pool, &[job_id as i32])
+            .await?
+            .remove(&(job_id as i32))
+            .expect("row exists");
+        let expected = vec![(job_id, accounting_expected_state(suspended_job.state))];
+        let mut accounting = HashMap::new();
+        accounting.insert(job_id, row);
+
+        let stale = jobs_needing_resync(&expected, &accounting, &no_unknown());
+        assert!(
+            stale.is_empty(),
+            "a suspended job matching a RUNNING row must not be flagged stale"
+        );
+
+        delete_job(&pool, job_id as i32).await;
+        Ok(())
     }
 }

--- a/crates/spurctld/src/accounting/reconcile.rs
+++ b/crates/spurctld/src/accounting/reconcile.rs
@@ -104,14 +104,17 @@ async fn run_once(pool: &PgPool, cluster: &ClusterManager) {
 }
 
 /// What accounting should show for a job's current state. Accounting only
-/// ever models `RUNNING` or a terminal state (`record_job_start` always
-/// writes `RUNNING`; only `record_job_end` writes a terminal state), so
+/// ever models `RUNNING` or a finalized state (`record_job_start` always
+/// writes `RUNNING`; only `record_job_end` writes a finalized state), so
 /// in-memory states it has no representation for — `SUSPENDED`, `COMPLETING`
 /// — must map to `RUNNING` for comparison. Otherwise a suspended or
 /// completing job would be flagged stale on every single pass for as long as
-/// it stays in that state.
+/// it stays in that state. Uses `is_finalized()`, not `is_terminal()`, so a
+/// durably `Preempted` job (which `is_terminal()` excludes but which can get
+/// stranded there on a partial-proposal failure) is compared against its own
+/// state rather than against `RUNNING`.
 fn accounting_expected_state(state: JobState) -> String {
-    if state.is_terminal() {
+    if state.is_finalized() {
         state.display().to_owned()
     } else {
         JobState::Running.display().to_owned()
@@ -146,7 +149,7 @@ fn jobs_needing_resync(
 /// code, and previously that reset was committed on its own statement, with
 /// `write_end` relied on to fix it back up immediately after. Any failure
 /// between the two — or a concurrent reader landing in the gap — could
-/// observe or permanently persist a correct terminal record clobbered back
+/// observe or permanently persist a correct finalized record clobbered back
 /// to `RUNNING`. The whole attempt is bounded by `ATTEMPT_TIMEOUT` so a
 /// wedged connection can't stall the reconciliation loop; a timed-out job is
 /// simply retried on the next pass.
@@ -154,18 +157,18 @@ async fn resync_job(pool: &PgPool, job: &Job, row_missing: bool, needs_start_bac
     // record_job_start unconditionally sets state='RUNNING', so only call it
     // when the row doesn't exist yet, is missing start metadata a proper
     // record_job_start would have populated (see AccountingRowState), or the
-    // job hasn't reached a terminal state — otherwise it would clobber a
-    // correct terminal state. The terminal case is corrected in the same
+    // job hasn't reached a finalized state — otherwise it would clobber a
+    // correct finalized state. The finalized case is corrected in the same
     // transaction by write_end below.
-    let needs_start = row_missing || needs_start_backfill || !job.state.is_terminal();
-    let is_terminal = job.state.is_terminal();
+    let needs_start = row_missing || needs_start_backfill || !job.state.is_finalized();
+    let is_finalized = job.state.is_finalized();
 
     let attempt = async {
         let mut tx = pool.begin().await?;
         if needs_start {
             write_start(&mut tx, job).await?;
         }
-        if is_terminal {
+        if is_finalized {
             write_end(&mut tx, job).await?;
         }
         tx.commit().await?;
@@ -293,9 +296,9 @@ mod tests {
         assert_eq!(stale, vec![2, 3]);
     }
 
-    // Finding 1: a row whose state matches but is missing start metadata
-    // (record_job_end created it from scratch because record_job_start's
-    // retries exhausted) must still be flagged, or the gap is permanent.
+    // A row whose state matches but is missing start metadata (record_job_end
+    // created it from scratch because record_job_start's retries exhausted)
+    // must still be flagged, or the gap is permanent.
     #[test]
     fn jobs_needing_resync_flags_bare_row_even_when_state_matches() {
         let expected = vec![(1, "COMPLETED".to_string())];
@@ -313,10 +316,10 @@ mod tests {
         assert_eq!(stale, vec![1]);
     }
 
-    // Finding 2: a job whose read failed this pass must never be flagged as
-    // needing resync, even though it's also absent from `accounting` — a
+    // A job whose read failed this pass must never be flagged as needing
+    // resync, even though it's also absent from `accounting` — a
     // confirmed-absent row and a failed read are not the same thing, and
-    // conflating them can clobber a correct terminal record via write_start.
+    // conflating them can clobber a correct finalized record via write_start.
     #[test]
     fn jobs_needing_resync_skips_jobs_with_unknown_read_status() {
         let expected = vec![(1, "COMPLETED".to_string()), (2, "RUNNING".to_string())];
@@ -329,16 +332,42 @@ mod tests {
         assert_eq!(stale, vec![2]);
     }
 
-    // Finding 3: accounting only ever models RUNNING or a terminal state, so
-    // states it can't represent must map to RUNNING for comparison —
-    // otherwise a suspended/completing job is flagged stale forever.
+    // Accounting only ever models RUNNING or a finalized state, so states it
+    // can't represent must map to RUNNING for comparison — otherwise a
+    // suspended/completing job is flagged stale forever.
     #[test]
-    fn accounting_expected_state_maps_non_terminal_states_to_running() {
+    fn accounting_expected_state_maps_non_finalized_states_to_running() {
         assert_eq!(accounting_expected_state(JobState::Running), "RUNNING");
         assert_eq!(accounting_expected_state(JobState::Suspended), "RUNNING");
         assert_eq!(accounting_expected_state(JobState::Completing), "RUNNING");
         assert_eq!(accounting_expected_state(JobState::Completed), "COMPLETED");
         assert_eq!(accounting_expected_state(JobState::Failed), "FAILED");
+    }
+
+    // is_finalized(), not is_terminal(): a durably Preempted job (which
+    // is_terminal() excludes) must compare against its own state, not get
+    // mapped to RUNNING — otherwise a resync pass would clobber a correct
+    // PREEMPTED record with RUNNING/no-end_time on every single cycle.
+    #[test]
+    fn accounting_expected_state_uses_is_finalized_for_preempted() {
+        assert!(!JobState::Preempted.is_terminal());
+        assert!(JobState::Preempted.is_finalized());
+        assert_eq!(accounting_expected_state(JobState::Preempted), "PREEMPTED");
+    }
+
+    #[test]
+    fn jobs_needing_resync_flags_stale_preempted_row_stuck_at_running() {
+        // A durably-Preempted job whose accounting row is still RUNNING (the
+        // pre-fix behavior, since is_terminal() excluded Preempted from ever
+        // getting write_end'd) must be flagged for resync so it converges on
+        // PREEMPTED rather than being ignored forever.
+        let expected = vec![(1, accounting_expected_state(JobState::Preempted))];
+        let mut accounting = HashMap::new();
+        accounting.insert(1, synced_row("RUNNING"));
+
+        let stale = jobs_needing_resync(&expected, &accounting, &no_unknown());
+
+        assert_eq!(stale, vec![1]);
     }
 
     #[test]
@@ -371,7 +400,7 @@ mod tests {
         let start = Utc::now() - chrono::Duration::hours(1);
         job.start_time = Some(start);
         job.state = state;
-        if state.is_terminal() {
+        if state.is_finalized() {
             job.end_time = Some(start + chrono::Duration::minutes(5));
             job.exit_code = Some(0);
         }
@@ -395,8 +424,8 @@ mod tests {
             .await;
     }
 
-    // Finding 1, end to end: simulate record_job_start's retries exhausting
-    // (only record_job_end ever lands, creating a bare row), then run the
+    // End to end: simulate record_job_start's retries exhausting (only
+    // record_job_end ever lands, creating a bare row), then run the
     // reconciliation resync path and confirm it backfills the row rather
     // than leaving it permanently missing user_name/start_time.
     #[tokio::test]
@@ -449,7 +478,7 @@ mod tests {
         assert!(start_time.is_some(), "start_time must be backfilled");
         assert_eq!(
             state, "COMPLETED",
-            "terminal state must survive the backfill"
+            "finalized state must survive the backfill"
         );
 
         // Usage was skipped originally (start_time was NULL); the backfill
@@ -472,9 +501,9 @@ mod tests {
         Ok(())
     }
 
-    // Finding 3, end to end: a suspended job's accounting row correctly shows
-    // RUNNING (accounting has no SUSPENDED state); a resync pass must not
-    // treat that as stale and must not clobber the row.
+    // End to end: a suspended job's accounting row correctly shows RUNNING
+    // (accounting has no SUSPENDED state); a resync pass must not treat that
+    // as stale and must not clobber the row.
     #[tokio::test]
     #[ignore = "requires DATABASE_URL and PostgreSQL"]
     async fn suspended_job_is_not_flagged_stale_against_a_running_row() -> anyhow::Result<()> {

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -182,6 +182,13 @@ async fn main() -> anyhow::Result<()> {
                     let notifier = accounting::AccountingNotifier::new(pool.clone());
                     cluster.set_accounting(notifier);
 
+                    accounting::spawn_reconcile_loop(
+                        pool.clone(),
+                        cluster.clone(),
+                        raft_handle.clone(),
+                        std::time::Duration::from_secs(120),
+                    );
+
                     cluster.fairshare_cache().spawn_refresh_loop(
                         pool.clone(),
                         config.scheduler.fairshare_halflife_days,

--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -718,9 +718,21 @@ pub struct RaftHandle {
 }
 
 impl RaftHandle {
+    /// Cheap, locally-cached leadership check. Can be stale for the length of
+    /// an election timeout after a partition — callers that need a
+    /// consensus-backed answer (e.g. before writes that bypass Raft, like
+    /// accounting reconciliation) must use `ensure_leader` instead.
     pub fn is_leader(&self) -> bool {
         let metrics = self.raft.metrics().borrow().clone();
         metrics.current_leader == Some(self.node_id)
+    }
+
+    /// Consensus-backed leadership check: confirms leadership by exchanging
+    /// heartbeats with a quorum of followers, so a partitioned former leader
+    /// gets `false` rather than a stale cached `true`. Costs a network
+    /// round-trip; use for periodic/batch operations, not on every request.
+    pub async fn ensure_leader(&self) -> bool {
+        self.raft.ensure_linearizable().await.is_ok()
     }
 
     pub fn current_leader(&self) -> Option<NodeId> {


### PR DESCRIPTION
## What

Fixes SPUR-29: the accounting notifier fired Postgres writes fire-and-forget with no retry, so `sacct` and `squeue` would permanently diverge on any transient DB blip, with no visibility that it happened.

## Approach

- Bounded retry (3 attempts, exponential backoff, per-attempt timeout) on `notify_job_start`/`notify_job_end`'s DB writes, escalating to `error!` only after retries are exhausted.
- A periodic (120s) reconciliation pass that diffs in-memory job state against the accounting DB and re-issues writes for anything missing or stale, gated on a consensus-backed leadership check (`ensure_linearizable`, not just a locally-cached leader flag).
- The reconciliation diff logic accounts for: bare rows left by a `record_job_end` that ran without a preceding `record_job_start`, transient read failures during reconciliation (treated as "unknown, skip" rather than "confirmed missing," to avoid clobbering a correct record), and non-terminal states accounting doesn't model.
- **Found via review, empirically verified against a real Postgres instance**: the backfill-then-terminal-write sequence in `resync_job` was non-atomic — `record_job_start`'s upsert unconditionally resets a row to `state='RUNNING', end_time=NULL` even when only backfilling missing metadata on an already-terminal record, and a failure partway through left that corrupted state in place for a full reconciliation cycle. Fixed by wrapping the backfill-then-terminal-write sequence in a single database transaction, so any failure rolls back cleanly instead of leaving a partially-applied, incorrect state.
- Added a timeout around the reconciliation transaction (mirroring the same pattern already used for notifier retries), so a single wedged (not fully down) Postgres connection can't silently stall the entire reconciliation loop forever.
- Fixed a `Preempted`-job misclassification in reconciliation's state comparison (was using `is_terminal()`, which excludes `Preempted`; switched to `is_finalized()`, matching the convention used elsewhere in the codebase) — closes a narrow but real gap where a durably-preempted job's correct accounting record could get clobbered every cycle.

## Known limitations, documented not fixed

- Leadership can still change mid-reconciliation-pass for very large job backlogs (the consensus check only guards the start of a pass, not each individual write within it) — a real, disclosed residual risk that would need batch-size limits and periodic re-checking to close properly; out of scope for this pass.
- Two `#[ignore]`-gated DB tests in `reconcile.rs` share a test username derived only from process ID rather than a per-test discriminator (unlike the rest of the file's test-naming convention) — confirmed this causes no actual collision today (different job IDs, only one test touches the shared `usage` table) and these tests aren't part of the default CI run, so deferred rather than fixed in this already-substantial pass.

## Testing

- New DB-backed tests (`#[ignore]`-gated, matching the existing convention) validated against a real Postgres instance, including a test that specifically reproduces the transaction-rollback fix: forces a failure mid-transaction and confirms the original terminal record is left untouched rather than corrupted.
- Pure-logic unit tests for retry/backoff, diff functions, and the `is_finalized()` state-comparison fix, with no DB dependency.
- Live-verified on the real cluster across 2 rounds, including actual Postgres outage fault injection confirming the job's accounting record is correctly and fully backfilled after recovery — not left showing RUNNING with no end_time.

## Review

3 rounds of independent adversarial review (including GitHub Copilot's automated review, cross-validated — one round empirically verified the core bug against a live Postgres instance) + cross-validation passes, which found and required fixing real correctness bugs before this was mergeable — see commit history for details.