### PR TITLE
fix(spur-spank): rename SPANK exports to Slurm-compatible symbols

### DIFF
--- a/crates/spur-spank/src/lib.rs
+++ b/crates/spur-spank/src/lib.rs
@@ -4,14 +4,14 @@
 //! SPANK plugin host.
 //!
 //! Loads existing Slurm SPANK plugins (.so files) via dlopen and provides
-//! the spank_* callback API (11 hooks, ~12 API functions).
+//! the `spank_*`/`slurm_*` callback API expected by `spank.h`.
 
 use std::collections::HashMap;
 use std::ffi::CStr;
-use std::os::raw::{c_char, c_int};
+use std::os::raw::{c_char, c_int, c_void};
 use std::path::{Path, PathBuf};
 
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 /// SPANK callback hook points (matches Slurm's spank.h).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -48,20 +48,44 @@ impl SpankHook {
     }
 }
 
-/// SPANK item IDs for spank_get_item (10 common items).
+/// SPANK item IDs for `spank_get_item`.
+///
+/// Discriminants match Slurm's `enum spank_item` in `spank.h`; plugins pass
+/// these numeric values, so the ordering must stay identical.
 #[repr(C)]
 pub enum SpankItem {
-    JobId = 0,
-    JobUid = 1,
-    JobGid = 2,
+    JobUid = 0,
+    JobGid = 1,
+    JobId = 2,
     JobStepId = 3,
     JobNnodes = 4,
     JobNodeid = 5,
     JobLocalTaskCount = 6,
     JobTotalTaskCount = 7,
-    JobArgv = 8,
-    TaskPid = 9,
+    JobNcpus = 8,
+    JobArgv = 9,
+    JobEnv = 10,
+    TaskId = 11,
+    TaskGlobalId = 12,
+    TaskExitStatus = 13,
+    TaskPid = 14,
 }
+
+/// `spank_err_t` return codes (subset of `spank.h`).
+///
+/// Plugins primarily check for `ESPANK_SUCCESS`; the remaining codes let
+/// callers distinguish common failures.
+pub const ESPANK_SUCCESS: c_int = 0;
+pub const ESPANK_ERROR: c_int = 1;
+pub const ESPANK_BAD_ARG: c_int = 2;
+pub const ESPANK_NOT_TASK: c_int = 3;
+pub const ESPANK_ENV_EXISTS: c_int = 4;
+pub const ESPANK_ENV_NOEXIST: c_int = 5;
+pub const ESPANK_NOSPACE: c_int = 6;
+pub const ESPANK_NOT_REMOTE: c_int = 7;
+pub const ESPANK_NOEXIST: c_int = 8;
+pub const ESPANK_NOT_AVAIL: c_int = 10;
+pub const ESPANK_NOT_LOCAL: c_int = 11;
 
 /// A loaded SPANK plugin.
 struct SpankPlugin {
@@ -100,6 +124,9 @@ impl Default for SpankHost {
 
 impl SpankHost {
     pub fn new() -> Self {
+        // Reachable from every host that constructs a SpankHost, keeping the
+        // exported symbols in the binary (see retain_exported_symbols).
+        retain_exported_symbols();
         Self {
             plugins: Vec::new(),
             context: SpankContext::default(),
@@ -151,6 +178,7 @@ impl SpankHost {
         let mut handle = SpankHandle {
             context: self.context.clone(),
             env: HashMap::new(),
+            job_control_env: HashMap::new(),
         };
         let handle_ptr = &mut handle as *mut SpankHandle;
 
@@ -212,111 +240,250 @@ impl SpankHost {
 pub struct SpankHandle {
     pub context: SpankContext,
     pub env: HashMap<String, String>,
+    /// Job-control environment (Slurm prepends `SPANK_` to these keys).
+    pub job_control_env: HashMap<String, String>,
 }
 
 /// Retrieve a job context item from the SPANK handle.
 ///
-/// The `item` parameter corresponds to `SpankItem` variants (0=JobId,
-/// 1=JobUid, etc.).  On success the value is written through `val` and 0
-/// is returned; on error -1 is returned.
+/// Matches Slurm's `spank_get_item(spank_t, spank_item_t, ...)`. Slurm
+/// declares it variadic; stable Rust cannot define C-variadic functions, so
+/// we take the single trailing result pointer directly. This is ABI
+/// compatible on the SysV x86-64 varargs convention for the scalar items we
+/// support (a single pointer passed in a register). Multi-argument items such
+/// as `S_JOB_ARGV`/`S_JOB_ENV` and the pid-to-id lookups are not supported.
 #[no_mangle]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub extern "C" fn spur_spank_get_item(
-    handle: *mut SpankHandle,
-    item: c_int,
-    val: *mut *mut std::ffi::c_void,
-) -> c_int {
+pub extern "C" fn spank_get_item(handle: *mut SpankHandle, item: c_int, val: *mut c_void) -> c_int {
     if handle.is_null() || val.is_null() {
-        return -1;
+        return ESPANK_BAD_ARG;
     }
     let handle = unsafe { &*handle };
-    match item {
-        0 => {
-            // SPANK_JOB_ID
-            unsafe {
-                *(val as *mut u32) = handle.context.job_id;
-            }
-            0
-        }
-        1 => {
-            // SPANK_JOB_UID
-            unsafe {
-                *(val as *mut u32) = handle.context.uid;
-            }
-            0
-        }
-        2 => {
-            // SPANK_JOB_GID
-            unsafe {
-                *(val as *mut u32) = handle.context.gid;
-            }
-            0
-        }
-        3 => {
-            // SPANK_JOB_STEPID
-            unsafe {
-                *(val as *mut u32) = handle.context.step_id;
-            }
-            0
-        }
-        4 => {
-            // SPANK_JOB_NNODES
-            unsafe {
-                *(val as *mut u32) = handle.context.num_nodes;
-            }
-            0
-        }
-        5 => {
-            // SPANK_JOB_NODEID
-            unsafe {
-                *(val as *mut u32) = handle.context.node_id;
-            }
-            0
-        }
-        6 => {
-            // SPANK_JOB_LOCAL_TASK_COUNT
-            unsafe {
-                *(val as *mut u32) = handle.context.local_task_count;
-            }
-            0
-        }
-        7 => {
-            // SPANK_JOB_TOTAL_TASK_COUNT
-            unsafe {
-                *(val as *mut u32) = handle.context.total_task_count;
-            }
-            0
-        }
-        // 8 = SPANK_JOB_ARGV — not yet implemented (requires pointer-to-array)
-        9 => {
-            // SPANK_TASK_PID
-            unsafe {
-                *(val as *mut u32) = handle.context.task_pid;
-            }
-            0
-        }
-        _ => -1,
+    let value = match item {
+        x if x == SpankItem::JobUid as c_int => handle.context.uid,
+        x if x == SpankItem::JobGid as c_int => handle.context.gid,
+        x if x == SpankItem::JobId as c_int => handle.context.job_id,
+        x if x == SpankItem::JobStepId as c_int => handle.context.step_id,
+        x if x == SpankItem::JobNnodes as c_int => handle.context.num_nodes,
+        x if x == SpankItem::JobNodeid as c_int => handle.context.node_id,
+        x if x == SpankItem::JobLocalTaskCount as c_int => handle.context.local_task_count,
+        x if x == SpankItem::JobTotalTaskCount as c_int => handle.context.total_task_count,
+        x if x == SpankItem::TaskPid as c_int => handle.context.task_pid,
+        _ => return ESPANK_BAD_ARG,
+    };
+    unsafe {
+        *(val as *mut u32) = value;
     }
+    ESPANK_SUCCESS
 }
 
-/// Set an environment variable in the SPANK handle's per-invocation map.
+/// Set an environment variable in the job's environment.
 ///
-/// Returns 0 on success, -1 if any pointer is null.
+/// Matches Slurm's `spank_setenv`. When `overwrite == 0` and the variable
+/// already exists, returns `ESPANK_ENV_EXISTS` without modifying it.
 #[no_mangle]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub extern "C" fn spur_spank_set_var(
+pub extern "C" fn spank_setenv(
     handle: *mut SpankHandle,
-    key: *const c_char,
+    var: *const c_char,
     val: *const c_char,
+    overwrite: c_int,
 ) -> c_int {
-    if handle.is_null() || key.is_null() || val.is_null() {
-        return -1;
+    if handle.is_null() || var.is_null() || val.is_null() {
+        return ESPANK_BAD_ARG;
     }
     let handle = unsafe { &mut *handle };
-    let key = unsafe { CStr::from_ptr(key) }.to_string_lossy().to_string();
-    let val = unsafe { CStr::from_ptr(val) }.to_string_lossy().to_string();
-    handle.env.insert(key, val);
-    0
+    let key = unsafe { CStr::from_ptr(var) }.to_string_lossy().to_string();
+    let value = unsafe { CStr::from_ptr(val) }.to_string_lossy().to_string();
+    if overwrite == 0 && handle.env.contains_key(&key) {
+        return ESPANK_ENV_EXISTS;
+    }
+    handle.env.insert(key, value);
+    ESPANK_SUCCESS
+}
+
+/// Copy a job environment variable into `buf` (matches Slurm's `spank_getenv`).
+#[no_mangle]
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub extern "C" fn spank_getenv(
+    handle: *mut SpankHandle,
+    var: *const c_char,
+    buf: *mut c_char,
+    len: c_int,
+) -> c_int {
+    if handle.is_null() || var.is_null() || buf.is_null() || len < 0 {
+        return ESPANK_BAD_ARG;
+    }
+    let handle = unsafe { &*handle };
+    let key = unsafe { CStr::from_ptr(var) }.to_string_lossy().to_string();
+    copy_env_value(&handle.env, &key, buf, len)
+}
+
+/// Unset a job environment variable (matches Slurm's `spank_unsetenv`).
+#[no_mangle]
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub extern "C" fn spank_unsetenv(handle: *mut SpankHandle, var: *const c_char) -> c_int {
+    if handle.is_null() || var.is_null() {
+        return ESPANK_BAD_ARG;
+    }
+    let handle = unsafe { &mut *handle };
+    let key = unsafe { CStr::from_ptr(var) }.to_string_lossy().to_string();
+    handle.env.remove(&key);
+    ESPANK_SUCCESS
+}
+
+/// Set a variable in the job-control environment (matches Slurm's
+/// `spank_job_control_setenv`). Slurm prepends `SPANK_` to the stored key.
+#[no_mangle]
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub extern "C" fn spank_job_control_setenv(
+    handle: *mut SpankHandle,
+    name: *const c_char,
+    value: *const c_char,
+    overwrite: c_int,
+) -> c_int {
+    if handle.is_null() || name.is_null() || value.is_null() {
+        return ESPANK_BAD_ARG;
+    }
+    let handle = unsafe { &mut *handle };
+    let name = unsafe { CStr::from_ptr(name) }.to_string_lossy();
+    let key = format!("SPANK_{name}");
+    let value = unsafe { CStr::from_ptr(value) }
+        .to_string_lossy()
+        .to_string();
+    if overwrite == 0 && handle.job_control_env.contains_key(&key) {
+        return ESPANK_ENV_EXISTS;
+    }
+    handle.job_control_env.insert(key, value);
+    ESPANK_SUCCESS
+}
+
+/// Copy a job-control environment variable into `buf` (matches Slurm's
+/// `spank_job_control_getenv`).
+#[no_mangle]
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub extern "C" fn spank_job_control_getenv(
+    handle: *mut SpankHandle,
+    name: *const c_char,
+    buf: *mut c_char,
+    len: c_int,
+) -> c_int {
+    if handle.is_null() || name.is_null() || buf.is_null() || len <= 0 {
+        return ESPANK_BAD_ARG;
+    }
+    let handle = unsafe { &*handle };
+    let name = unsafe { CStr::from_ptr(name) }.to_string_lossy();
+    let key = format!("SPANK_{name}");
+    copy_env_value(&handle.job_control_env, &key, buf, len)
+}
+
+/// Unset a job-control environment variable (matches Slurm's
+/// `spank_job_control_unsetenv`).
+#[no_mangle]
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
+pub extern "C" fn spank_job_control_unsetenv(
+    handle: *mut SpankHandle,
+    name: *const c_char,
+) -> c_int {
+    if handle.is_null() || name.is_null() {
+        return ESPANK_BAD_ARG;
+    }
+    let handle = unsafe { &mut *handle };
+    let name = unsafe { CStr::from_ptr(name) }.to_string_lossy();
+    handle.job_control_env.remove(&format!("SPANK_{name}"));
+    ESPANK_SUCCESS
+}
+
+/// Return a static string for a `spank_err_t` code (matches `spank_strerror`).
+#[no_mangle]
+pub extern "C" fn spank_strerror(err: c_int) -> *const c_char {
+    let s: &CStr = match err {
+        ESPANK_SUCCESS => c"Success",
+        ESPANK_BAD_ARG => c"Bad argument",
+        ESPANK_NOT_TASK => c"Not in task context",
+        ESPANK_ENV_EXISTS => c"Environment variable exists",
+        ESPANK_ENV_NOEXIST => c"No such environment variable",
+        ESPANK_NOSPACE => c"Buffer too small",
+        ESPANK_NOT_REMOTE => c"Valid only in remote context",
+        ESPANK_NOEXIST => c"Id/pid does not exist on this node",
+        ESPANK_NOT_AVAIL => c"Item not available from this callback",
+        ESPANK_NOT_LOCAL => c"Valid only in local or allocator context",
+        _ => c"Generic error",
+    };
+    s.as_ptr()
+}
+
+/// Copy `map[key]` into the C buffer `buf` of size `len`, NUL-terminating.
+///
+/// Returns `ESPANK_ENV_NOEXIST` if absent, `ESPANK_NOSPACE` if truncated.
+fn copy_env_value(map: &HashMap<String, String>, key: &str, buf: *mut c_char, len: c_int) -> c_int {
+    let Some(value) = map.get(key) else {
+        return ESPANK_ENV_NOEXIST;
+    };
+    let bytes = value.as_bytes();
+    let cap = len as usize;
+    // Reserve one byte for the trailing NUL.
+    if bytes.len() + 1 > cap {
+        return ESPANK_NOSPACE;
+    }
+    unsafe {
+        std::ptr::copy_nonoverlapping(bytes.as_ptr() as *const c_char, buf, bytes.len());
+        *buf.add(bytes.len()) = 0;
+    }
+    ESPANK_SUCCESS
+}
+
+/// Slurm logging functions exported to plugins.
+///
+/// Slurm declares these variadic (`printf`-style). Stable Rust cannot define
+/// C-variadic functions, so these take only the format string and log it
+/// verbatim via `tracing`. This keeps symbols resolvable and is ABI-safe on
+/// the SysV varargs convention (extra args are ignored); the trade-off is that
+/// `%`-style format specifiers are not expanded.
+macro_rules! spank_log_fn {
+    ($name:ident, $level:ident) => {
+        #[no_mangle]
+        #[allow(clippy::not_unsafe_ptr_arg_deref)]
+        pub extern "C" fn $name(fmt: *const c_char) {
+            if fmt.is_null() {
+                return;
+            }
+            let msg = unsafe { CStr::from_ptr(fmt) }.to_string_lossy();
+            $level!(target: "spank_plugin", "{msg}");
+        }
+    };
+}
+
+spank_log_fn!(slurm_error, error);
+spank_log_fn!(slurm_info, info);
+spank_log_fn!(slurm_verbose, info);
+spank_log_fn!(slurm_debug, debug);
+spank_log_fn!(slurm_debug2, debug);
+spank_log_fn!(slurm_debug3, debug);
+spank_log_fn!(slurm_spank_log, info);
+
+/// Reference every exported SPANK symbol so the linker cannot drop them from
+/// the host binary (see `SpankHost::new`). Pairs with `-Wl,--export-dynamic`
+/// so `dlsym` in loaded plugins can resolve them.
+fn retain_exported_symbols() {
+    let anchors: &[*const c_void] = &[
+        spank_get_item as *const c_void,
+        spank_setenv as *const c_void,
+        spank_getenv as *const c_void,
+        spank_unsetenv as *const c_void,
+        spank_job_control_setenv as *const c_void,
+        spank_job_control_getenv as *const c_void,
+        spank_job_control_unsetenv as *const c_void,
+        spank_strerror as *const c_void,
+        slurm_error as *const c_void,
+        slurm_info as *const c_void,
+        slurm_verbose as *const c_void,
+        slurm_debug as *const c_void,
+        slurm_debug2 as *const c_void,
+        slurm_debug3 as *const c_void,
+        slurm_spank_log as *const c_void,
+    ];
+    std::hint::black_box(anchors);
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -465,6 +632,154 @@ mod tests {
         assert_eq!(ctx.job_id, 0);
         assert_eq!(ctx.uid, 0);
         assert_eq!(ctx.task_pid, 0);
+    }
+
+    #[test]
+    fn test_spank_item_ids_match_slurm() {
+        // Discriminants must equal Slurm's enum spank_item values.
+        assert_eq!(SpankItem::JobUid as c_int, 0);
+        assert_eq!(SpankItem::JobGid as c_int, 1);
+        assert_eq!(SpankItem::JobId as c_int, 2);
+        assert_eq!(SpankItem::JobStepId as c_int, 3);
+        assert_eq!(SpankItem::JobNnodes as c_int, 4);
+        assert_eq!(SpankItem::JobNodeid as c_int, 5);
+        assert_eq!(SpankItem::JobLocalTaskCount as c_int, 6);
+        assert_eq!(SpankItem::JobTotalTaskCount as c_int, 7);
+        assert_eq!(SpankItem::JobNcpus as c_int, 8);
+        assert_eq!(SpankItem::JobArgv as c_int, 9);
+        assert_eq!(SpankItem::TaskPid as c_int, 14);
+    }
+
+    fn test_handle() -> SpankHandle {
+        SpankHandle {
+            context: SpankContext {
+                job_id: 42,
+                uid: 1000,
+                gid: 1001,
+                step_id: 3,
+                num_nodes: 2,
+                node_id: 1,
+                local_task_count: 4,
+                total_task_count: 8,
+                task_pid: 12345,
+            },
+            env: HashMap::new(),
+            job_control_env: HashMap::new(),
+        }
+    }
+
+    fn get_item_u32(handle: &mut SpankHandle, item: SpankItem) -> Option<u32> {
+        let mut out: u32 = 0;
+        let rc = spank_get_item(
+            handle,
+            item as c_int,
+            &mut out as *mut u32 as *mut std::ffi::c_void,
+        );
+        (rc == ESPANK_SUCCESS).then_some(out)
+    }
+
+    #[test]
+    fn test_spank_get_item_returns_correct_fields() {
+        let mut handle = test_handle();
+        assert_eq!(get_item_u32(&mut handle, SpankItem::JobId), Some(42));
+        assert_eq!(get_item_u32(&mut handle, SpankItem::JobUid), Some(1000));
+        assert_eq!(get_item_u32(&mut handle, SpankItem::JobGid), Some(1001));
+        assert_eq!(get_item_u32(&mut handle, SpankItem::TaskPid), Some(12345));
+    }
+
+    #[test]
+    fn test_spank_setenv_overwrite_semantics() {
+        let mut handle = test_handle();
+        let var = std::ffi::CString::new("FOO").unwrap();
+        let val1 = std::ffi::CString::new("one").unwrap();
+        let val2 = std::ffi::CString::new("two").unwrap();
+
+        assert_eq!(
+            spank_setenv(&mut handle, var.as_ptr(), val1.as_ptr(), 0),
+            ESPANK_SUCCESS
+        );
+        // overwrite = 0 on existing key must not clobber.
+        assert_eq!(
+            spank_setenv(&mut handle, var.as_ptr(), val2.as_ptr(), 0),
+            ESPANK_ENV_EXISTS
+        );
+        assert_eq!(handle.env.get("FOO").map(String::as_str), Some("one"));
+        // overwrite = 1 replaces it.
+        assert_eq!(
+            spank_setenv(&mut handle, var.as_ptr(), val2.as_ptr(), 1),
+            ESPANK_SUCCESS
+        );
+        assert_eq!(handle.env.get("FOO").map(String::as_str), Some("two"));
+    }
+
+    #[test]
+    fn test_spank_getenv_roundtrip_and_errors() {
+        let mut handle = test_handle();
+        let var = std::ffi::CString::new("BAR").unwrap();
+        let val = std::ffi::CString::new("baz").unwrap();
+        spank_setenv(&mut handle, var.as_ptr(), val.as_ptr(), 1);
+
+        let mut buf = [0i8; 16];
+        assert_eq!(
+            spank_getenv(
+                &mut handle,
+                var.as_ptr(),
+                buf.as_mut_ptr(),
+                buf.len() as c_int
+            ),
+            ESPANK_SUCCESS
+        );
+        let out = unsafe { CStr::from_ptr(buf.as_ptr()) }.to_str().unwrap();
+        assert_eq!(out, "baz");
+
+        // Missing key.
+        let missing = std::ffi::CString::new("NOPE").unwrap();
+        assert_eq!(
+            spank_getenv(
+                &mut handle,
+                missing.as_ptr(),
+                buf.as_mut_ptr(),
+                buf.len() as c_int
+            ),
+            ESPANK_ENV_NOEXIST
+        );
+
+        // Buffer too small (value "baz" needs 4 bytes incl. NUL).
+        let mut tiny = [0i8; 2];
+        assert_eq!(
+            spank_getenv(
+                &mut handle,
+                var.as_ptr(),
+                tiny.as_mut_ptr(),
+                tiny.len() as c_int
+            ),
+            ESPANK_NOSPACE
+        );
+    }
+
+    #[test]
+    fn test_spank_job_control_setenv_prefixes_key() {
+        let mut handle = test_handle();
+        let name = std::ffi::CString::new("TOKEN").unwrap();
+        let val = std::ffi::CString::new("secret").unwrap();
+        assert_eq!(
+            spank_job_control_setenv(&mut handle, name.as_ptr(), val.as_ptr(), 0),
+            ESPANK_SUCCESS
+        );
+        assert_eq!(
+            handle
+                .job_control_env
+                .get("SPANK_TOKEN")
+                .map(String::as_str),
+            Some("secret")
+        );
+    }
+
+    #[test]
+    fn test_spank_strerror_success() {
+        let ptr = spank_strerror(ESPANK_SUCCESS);
+        let s = unsafe { CStr::from_ptr(ptr) }.to_str().unwrap();
+        assert_eq!(s, "Success");
     }
 
     #[test]

--- a/crates/spur-spank/src/lib.rs
+++ b/crates/spur-spank/src/lib.rs
@@ -7,7 +7,7 @@
 //! the `spank_*`/`slurm_*` callback API expected by `spank.h`.
 
 use std::collections::HashMap;
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int, c_void};
 use std::path::{Path, PathBuf};
 
@@ -93,13 +93,14 @@ struct SpankPlugin {
     #[cfg(unix)]
     lib: libloading::Library,
     name: String,
+    /// Plugstack arguments, passed to every hook as `argv` (owned so the
+    /// pointers handed to the plugin stay valid for its lifetime).
+    argv: Vec<CString>,
 }
 
 /// The SPANK plugin host — manages loading and invoking plugins.
 pub struct SpankHost {
     plugins: Vec<SpankPlugin>,
-    /// Current job context for spank_get_item.
-    context: SpankContext,
 }
 
 /// Job context available to SPANK plugins.
@@ -124,18 +125,14 @@ impl Default for SpankHost {
 
 impl SpankHost {
     pub fn new() -> Self {
-        // Reachable from every host that constructs a SpankHost, keeping the
-        // exported symbols in the binary (see retain_exported_symbols).
-        retain_exported_symbols();
         Self {
             plugins: Vec::new(),
-            context: SpankContext::default(),
         }
     }
 
-    /// Load a SPANK plugin from a .so file.
+    /// Load a SPANK plugin from a .so file, with its plugstack arguments.
     #[cfg(unix)]
-    pub fn load_plugin(&mut self, path: &Path) -> anyhow::Result<()> {
+    pub fn load_plugin(&mut self, path: &Path, args: &[String]) -> anyhow::Result<()> {
         use anyhow::Context;
 
         let lib = unsafe {
@@ -149,12 +146,25 @@ impl SpankHost {
             .unwrap_or("unknown")
             .to_string();
 
+        // Drop args containing interior NUL rather than failing the load.
+        let argv = args
+            .iter()
+            .filter_map(|a| match CString::new(a.as_str()) {
+                Ok(c) => Some(c),
+                Err(_) => {
+                    warn!(plugin = %name, arg = %a, "skipping SPANK arg with interior NUL");
+                    None
+                }
+            })
+            .collect();
+
         info!(plugin = %name, path = %path.display(), "loaded SPANK plugin");
 
         self.plugins.push(SpankPlugin {
             path: path.to_path_buf(),
             lib,
             name,
+            argv,
         });
 
         Ok(())
@@ -162,25 +172,18 @@ impl SpankHost {
 
     /// Not available on non-unix platforms.
     #[cfg(not(unix))]
-    pub fn load_plugin(&mut self, path: &Path) -> anyhow::Result<()> {
+    pub fn load_plugin(&mut self, path: &Path, args: &[String]) -> anyhow::Result<()> {
         anyhow::bail!("SPANK plugins only supported on Unix");
     }
 
-    /// Set the job context for subsequent hook calls.
-    pub fn set_context(&mut self, ctx: SpankContext) {
-        self.context = ctx;
-    }
-
-    /// Invoke a hook across all loaded plugins.
-    pub fn invoke_hook(&self, hook: SpankHook) -> Result<(), SpankError> {
+    /// Invoke a hook across all loaded plugins against a caller-owned handle.
+    ///
+    /// The handle is threaded through every plugin (and reused across hooks by
+    /// the caller), so env changes made by one plugin are visible to the next
+    /// and can be read back after the call returns.
+    pub fn invoke_hook(&self, hook: SpankHook, handle: &mut SpankHandle) -> Result<(), SpankError> {
         let symbol = hook.symbol_name();
-
-        let mut handle = SpankHandle {
-            context: self.context.clone(),
-            env: HashMap::new(),
-            job_control_env: HashMap::new(),
-        };
-        let handle_ptr = &mut handle as *mut SpankHandle;
+        let handle_ptr = handle as *mut SpankHandle;
 
         for plugin in &self.plugins {
             #[cfg(unix)]
@@ -196,7 +199,13 @@ impl SpankHost {
                 match func {
                     Ok(f) => {
                         debug!(plugin = %plugin.name, path = %plugin.path.display(), hook = symbol, "invoking SPANK hook");
-                        let rc = unsafe { f(handle_ptr, 0, std::ptr::null_mut()) };
+                        // Slurm passes exactly `ac` argv elements (no NULL terminator).
+                        let mut argv: Vec<*mut c_char> = plugin
+                            .argv
+                            .iter()
+                            .map(|a| a.as_ptr() as *mut c_char)
+                            .collect();
+                        let rc = unsafe { f(handle_ptr, argv.len() as c_int, argv.as_mut_ptr()) };
                         if rc != 0 {
                             warn!(
                                 plugin = %plugin.name,
@@ -244,6 +253,17 @@ pub struct SpankHandle {
     pub job_control_env: HashMap<String, String>,
 }
 
+impl SpankHandle {
+    /// Create a handle seeded with the job context and its environment.
+    pub fn new(context: SpankContext, env: HashMap<String, String>) -> Self {
+        Self {
+            context,
+            env,
+            job_control_env: HashMap::new(),
+        }
+    }
+}
+
 /// Retrieve a job context item from the SPANK handle.
 ///
 /// Matches Slurm's `spank_get_item(spank_t, spank_item_t, ...)`. Slurm
@@ -269,6 +289,17 @@ pub extern "C" fn spank_get_item(handle: *mut SpankHandle, item: c_int, val: *mu
         x if x == SpankItem::JobLocalTaskCount as c_int => handle.context.local_task_count,
         x if x == SpankItem::JobTotalTaskCount as c_int => handle.context.total_task_count,
         x if x == SpankItem::TaskPid as c_int => handle.context.task_pid,
+        // Known Slurm items we don't source from the handle yet: report
+        // "not available" rather than conflating with an invalid id.
+        x if x == SpankItem::JobNcpus as c_int
+            || x == SpankItem::JobArgv as c_int
+            || x == SpankItem::JobEnv as c_int
+            || x == SpankItem::TaskId as c_int
+            || x == SpankItem::TaskGlobalId as c_int
+            || x == SpankItem::TaskExitStatus as c_int =>
+        {
+            return ESPANK_NOT_AVAIL
+        }
         _ => return ESPANK_BAD_ARG,
     };
     unsafe {
@@ -311,6 +342,8 @@ pub extern "C" fn spank_getenv(
     buf: *mut c_char,
     len: c_int,
 ) -> c_int {
+    // spank.h defines the bad-arg bound as `len < 0` here but `len <= 0` for
+    // spank_job_control_getenv; the asymmetry is intentional to match Slurm.
     if handle.is_null() || var.is_null() || buf.is_null() || len < 0 {
         return ESPANK_BAD_ARG;
     }
@@ -415,7 +448,8 @@ pub extern "C" fn spank_strerror(err: c_int) -> *const c_char {
 
 /// Copy `map[key]` into the C buffer `buf` of size `len`, NUL-terminating.
 ///
-/// Returns `ESPANK_ENV_NOEXIST` if absent, `ESPANK_NOSPACE` if truncated.
+/// Returns `ESPANK_ENV_NOEXIST` if the key is absent, or `ESPANK_NOSPACE` if
+/// the value plus its NUL would not fit (in which case nothing is written).
 fn copy_env_value(map: &HashMap<String, String>, key: &str, buf: *mut c_char, len: c_int) -> c_int {
     let Some(value) = map.get(key) else {
         return ESPANK_ENV_NOEXIST;
@@ -461,30 +495,6 @@ spank_log_fn!(slurm_debug, debug);
 spank_log_fn!(slurm_debug2, debug);
 spank_log_fn!(slurm_debug3, debug);
 spank_log_fn!(slurm_spank_log, info);
-
-/// Reference every exported SPANK symbol so the linker cannot drop them from
-/// the host binary (see `SpankHost::new`). Pairs with `-Wl,--export-dynamic`
-/// so `dlsym` in loaded plugins can resolve them.
-fn retain_exported_symbols() {
-    let anchors: &[*const c_void] = &[
-        spank_get_item as *const c_void,
-        spank_setenv as *const c_void,
-        spank_getenv as *const c_void,
-        spank_unsetenv as *const c_void,
-        spank_job_control_setenv as *const c_void,
-        spank_job_control_getenv as *const c_void,
-        spank_job_control_unsetenv as *const c_void,
-        spank_strerror as *const c_void,
-        slurm_error as *const c_void,
-        slurm_info as *const c_void,
-        slurm_verbose as *const c_void,
-        slurm_debug as *const c_void,
-        slurm_debug2 as *const c_void,
-        slurm_debug3 as *const c_void,
-        slurm_spank_log as *const c_void,
-    ];
-    std::hint::black_box(anchors);
-}
 
 #[derive(Debug, thiserror::Error)]
 pub enum SpankError {
@@ -590,10 +600,11 @@ mod tests {
     #[test]
     fn test_spank_host_empty_invoke() {
         let host = SpankHost::new();
+        let mut handle = SpankHandle::new(SpankContext::default(), HashMap::new());
         // Invoking hooks on empty host should succeed (no plugins to fail)
-        assert!(host.invoke_hook(SpankHook::Init).is_ok());
-        assert!(host.invoke_hook(SpankHook::TaskExit).is_ok());
-        assert!(host.invoke_hook(SpankHook::JobEpilog).is_ok());
+        assert!(host.invoke_hook(SpankHook::Init, &mut handle).is_ok());
+        assert!(host.invoke_hook(SpankHook::TaskExit, &mut handle).is_ok());
+        assert!(host.invoke_hook(SpankHook::JobEpilog, &mut handle).is_ok());
     }
 
     #[test]
@@ -685,6 +696,18 @@ mod tests {
         assert_eq!(get_item_u32(&mut handle, SpankItem::JobUid), Some(1000));
         assert_eq!(get_item_u32(&mut handle, SpankItem::JobGid), Some(1001));
         assert_eq!(get_item_u32(&mut handle, SpankItem::TaskPid), Some(12345));
+    }
+
+    #[test]
+    fn test_spank_get_item_not_available_vs_bad_arg() {
+        let mut handle = test_handle();
+        let mut out: u32 = 0;
+        let out_ptr = &mut out as *mut u32 as *mut std::ffi::c_void;
+        assert_eq!(
+            spank_get_item(&mut handle, SpankItem::JobNcpus as c_int, out_ptr),
+            ESPANK_NOT_AVAIL
+        );
+        assert_eq!(spank_get_item(&mut handle, 9999, out_ptr), ESPANK_BAD_ARG);
     }
 
     #[test]
@@ -783,20 +806,16 @@ mod tests {
     }
 
     #[test]
-    fn test_spank_host_set_context() {
-        let mut host = SpankHost::new();
-        host.set_context(SpankContext {
-            job_id: 42,
-            uid: 1000,
-            gid: 1000,
-            step_id: 0,
-            num_nodes: 1,
-            node_id: 0,
-            local_task_count: 1,
-            total_task_count: 1,
-            task_pid: 12345,
-        });
-        // Context is set without panicking
-        assert_eq!(host.plugin_count(), 0);
+    fn test_spank_handle_new_seeds_context_and_env() {
+        let mut env = HashMap::new();
+        env.insert("A".to_string(), "1".to_string());
+        let ctx = SpankContext {
+            job_id: 7,
+            ..Default::default()
+        };
+        let handle = SpankHandle::new(ctx, env);
+        assert_eq!(handle.context.job_id, 7);
+        assert_eq!(handle.env.get("A").map(String::as_str), Some("1"));
+        assert!(handle.job_control_env.is_empty());
     }
 }

--- a/crates/spur-tests/src/t58_spank.rs
+++ b/crates/spur-tests/src/t58_spank.rs
@@ -107,4 +107,49 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(host.plugin_count(), 0);
     }
+
+    // -- T58.8: Item IDs match Slurm's enum spank_item --------------------
+
+    #[test]
+    fn t58_8_item_ids_match_slurm() {
+        use std::os::raw::c_int;
+        assert_eq!(SpankItem::JobUid as c_int, 0);
+        assert_eq!(SpankItem::JobGid as c_int, 1);
+        assert_eq!(SpankItem::JobId as c_int, 2);
+        assert_eq!(SpankItem::TaskPid as c_int, 14);
+    }
+
+    // -- T58.9: spank_setenv / spank_getenv round-trip --------------------
+
+    #[test]
+    fn t58_9_setenv_getenv_roundtrip() {
+        use std::ffi::{CStr, CString};
+        use std::os::raw::c_int;
+
+        let mut handle = SpankHandle {
+            context: SpankContext::default(),
+            env: std::collections::HashMap::new(),
+            job_control_env: std::collections::HashMap::new(),
+        };
+        let var = CString::new("SPANK_TEST").unwrap();
+        let val = CString::new("hello").unwrap();
+
+        assert_eq!(
+            spank_setenv(&mut handle, var.as_ptr(), val.as_ptr(), 0),
+            ESPANK_SUCCESS
+        );
+
+        let mut buf = [0i8; 32];
+        assert_eq!(
+            spank_getenv(
+                &mut handle,
+                var.as_ptr(),
+                buf.as_mut_ptr(),
+                buf.len() as c_int
+            ),
+            ESPANK_SUCCESS
+        );
+        let out = unsafe { CStr::from_ptr(buf.as_ptr()) }.to_str().unwrap();
+        assert_eq!(out, "hello");
+    }
 }

--- a/crates/spur-tests/src/t58_spank.rs
+++ b/crates/spur-tests/src/t58_spank.rs
@@ -36,9 +36,11 @@ mod tests {
     #[test]
     fn t58_3_empty_host_invoke() {
         let host = SpankHost::new();
-        assert!(host.invoke_hook(SpankHook::Init).is_ok());
-        assert!(host.invoke_hook(SpankHook::TaskExit).is_ok());
-        assert!(host.invoke_hook(SpankHook::JobEpilog).is_ok());
+        let mut handle =
+            SpankHandle::new(SpankContext::default(), std::collections::HashMap::new());
+        assert!(host.invoke_hook(SpankHook::Init, &mut handle).is_ok());
+        assert!(host.invoke_hook(SpankHook::TaskExit, &mut handle).is_ok());
+        assert!(host.invoke_hook(SpankHook::JobEpilog, &mut handle).is_ok());
     }
 
     // -- T58.4: Missing plugstack file returns error ----------------------
@@ -78,12 +80,11 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    // -- T58.6: Context can be set ----------------------------------------
+    // -- T58.6: Handle carries job context --------------------------------
 
     #[test]
-    fn t58_6_set_context() {
-        let mut host = SpankHost::new();
-        host.set_context(SpankContext {
+    fn t58_6_handle_context() {
+        let ctx = SpankContext {
             job_id: 100,
             uid: 1000,
             gid: 1000,
@@ -93,9 +94,10 @@ mod tests {
             local_task_count: 4,
             total_task_count: 8,
             task_pid: 54321,
-        });
-        // No panic, context accepted
-        assert_eq!(host.plugin_count(), 0);
+        };
+        let handle = SpankHandle::new(ctx, std::collections::HashMap::new());
+        assert_eq!(handle.context.job_id, 100);
+        assert_eq!(handle.context.task_pid, 54321);
     }
 
     // -- T58.7: Load nonexistent plugin fails -----------------------------
@@ -103,7 +105,7 @@ mod tests {
     #[test]
     fn t58_7_load_nonexistent_plugin() {
         let mut host = SpankHost::new();
-        let result = host.load_plugin(Path::new("/nonexistent/plugin.so"));
+        let result = host.load_plugin(Path::new("/nonexistent/plugin.so"), &[]);
         assert!(result.is_err());
         assert_eq!(host.plugin_count(), 0);
     }
@@ -126,11 +128,8 @@ mod tests {
         use std::ffi::{CStr, CString};
         use std::os::raw::c_int;
 
-        let mut handle = SpankHandle {
-            context: SpankContext::default(),
-            env: std::collections::HashMap::new(),
-            job_control_env: std::collections::HashMap::new(),
-        };
+        let mut handle =
+            SpankHandle::new(SpankContext::default(), std::collections::HashMap::new());
         let var = CString::new("SPANK_TEST").unwrap();
         let val = CString::new("hello").unwrap();
 
@@ -151,5 +150,31 @@ mod tests {
         );
         let out = unsafe { CStr::from_ptr(buf.as_ptr()) }.to_str().unwrap();
         assert_eq!(out, "hello");
+    }
+
+    // -- T58.10: job env seeded into the handle is readable via getenv ----
+
+    #[test]
+    fn t58_10_seeded_env_visible_to_getenv() {
+        use std::ffi::{CStr, CString};
+        use std::os::raw::c_int;
+
+        let mut env = std::collections::HashMap::new();
+        env.insert("SLURM_JOB_ID".to_string(), "4242".to_string());
+        let mut handle = SpankHandle::new(SpankContext::default(), env);
+
+        let var = CString::new("SLURM_JOB_ID").unwrap();
+        let mut buf = [0i8; 16];
+        assert_eq!(
+            spank_getenv(
+                &mut handle,
+                var.as_ptr(),
+                buf.as_mut_ptr(),
+                buf.len() as c_int
+            ),
+            ESPANK_SUCCESS
+        );
+        let out = unsafe { CStr::from_ptr(buf.as_ptr()) }.to_str().unwrap();
+        assert_eq!(out, "4242");
     }
 }

--- a/crates/spur-tests/src/t58_spank.rs
+++ b/crates/spur-tests/src/t58_spank.rs
@@ -110,17 +110,6 @@ mod tests {
         assert_eq!(host.plugin_count(), 0);
     }
 
-    // -- T58.8: Item IDs match Slurm's enum spank_item --------------------
-
-    #[test]
-    fn t58_8_item_ids_match_slurm() {
-        use std::os::raw::c_int;
-        assert_eq!(SpankItem::JobUid as c_int, 0);
-        assert_eq!(SpankItem::JobGid as c_int, 1);
-        assert_eq!(SpankItem::JobId as c_int, 2);
-        assert_eq!(SpankItem::TaskPid as c_int, 14);
-    }
-
     // -- T58.9: spank_setenv / spank_getenv round-trip --------------------
 
     #[test]

--- a/crates/spurd/build.rs
+++ b/crates/spurd/build.rs
@@ -1,12 +1,38 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+/// SPANK C/`slurm_*` API symbols (defined in spur-spank) that dlopen'd plugins
+/// resolve against this executable. They have no direct caller in spurd.
+const SPANK_SYMBOLS: &[&str] = &[
+    "spank_get_item",
+    "spank_setenv",
+    "spank_getenv",
+    "spank_unsetenv",
+    "spank_job_control_setenv",
+    "spank_job_control_getenv",
+    "spank_job_control_unsetenv",
+    "spank_strerror",
+    "slurm_error",
+    "slurm_info",
+    "slurm_verbose",
+    "slurm_debug",
+    "slurm_debug2",
+    "slurm_debug3",
+    "slurm_spank_log",
+];
+
 fn main() {
-    // SPANK plugins are dlopen'd at runtime and resolve the spank_*/slurm_*
-    // API symbols (defined in spur-spank) against this executable. Rust does
-    // not place #[no_mangle] symbols in the dynamic symbol table by default,
-    // so export them explicitly. GNU ld / lld only.
-    if cfg!(target_os = "linux") {
-        println!("cargo::rustc-link-arg-bins=-Wl,--export-dynamic");
+    // GNU ld / lld only; the flags below are meaningless elsewhere. Guard on the
+    // target (not host) OS so cross-compiles behave correctly.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("linux") {
+        return;
     }
+
+    // --undefined forces the linker to pull each symbol from the spur-spank rlib
+    // despite having no caller; --export-dynamic then places them in the dynamic
+    // symbol table so plugin dlsym resolves them.
+    for sym in SPANK_SYMBOLS {
+        println!("cargo::rustc-link-arg-bins=-Wl,--undefined={sym}");
+    }
+    println!("cargo::rustc-link-arg-bins=-Wl,--export-dynamic");
 }

--- a/crates/spurd/build.rs
+++ b/crates/spurd/build.rs
@@ -1,0 +1,12 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() {
+    // SPANK plugins are dlopen'd at runtime and resolve the spank_*/slurm_*
+    // API symbols (defined in spur-spank) against this executable. Rust does
+    // not place #[no_mangle] symbols in the dynamic symbol table by default,
+    // so export them explicitly. GNU ld / lld only.
+    if cfg!(target_os = "linux") {
+        println!("cargo::rustc-link-arg-bins=-Wl,--export-dynamic");
+    }
+}

--- a/crates/spurd/build.rs
+++ b/crates/spurd/build.rs
@@ -29,10 +29,25 @@ fn main() {
     }
 
     // --undefined forces the linker to pull each symbol from the spur-spank rlib
-    // despite having no caller; --export-dynamic then places them in the dynamic
-    // symbol table so plugin dlsym resolves them.
+    // despite having no caller.
     for sym in SPANK_SYMBOLS {
         println!("cargo::rustc-link-arg-bins=-Wl,--undefined={sym}");
     }
-    println!("cargo::rustc-link-arg-bins=-Wl,--export-dynamic");
+
+    // Export ONLY these symbols into the dynamic symbol table so plugin dlsym
+    // resolves them. A scoped --dynamic-list avoids --export-dynamic exposing
+    // every global in the binary.
+    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");
+    let list_path = std::path::Path::new(&out_dir).join("spank_dynamic_list.ld");
+    let mut list = String::from("{\n");
+    for sym in SPANK_SYMBOLS {
+        list.push_str(&format!("    {sym};\n"));
+    }
+    list.push_str("};\n");
+    std::fs::write(&list_path, list).expect("write dynamic list");
+    println!("cargo::rerun-if-changed=build.rs");
+    println!(
+        "cargo::rustc-link-arg-bins=-Wl,--dynamic-list={}",
+        list_path.display()
+    );
 }

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -251,6 +251,8 @@ impl AgentService {
                     for c in &completed {
                         let context = SpankContext {
                             job_id: c.job_id,
+                            uid: c.uid,
+                            gid: c.gid,
                             ..Default::default()
                         };
                         let mut handle = SpankHandle::new(context, HashMap::new());

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -18,7 +18,7 @@ use spur_proto::proto::*;
 
 use spur_sched::cons_tres::{AllocationResult, NodeAllocation};
 
-use spur_spank::{SpankHook, SpankHost};
+use spur_spank::{SpankContext, SpankHandle, SpankHook, SpankHost};
 
 use spur_core::config::HooksConfig;
 use spur_core::spur_env::SpurEnv;
@@ -94,7 +94,7 @@ impl AgentService {
                 Ok(entries) => {
                     let mut host = SpankHost::new();
                     for entry in &entries {
-                        if let Err(e) = host.load_plugin(&entry.path) {
+                        if let Err(e) = host.load_plugin(&entry.path, &entry.args) {
                             if entry.required {
                                 warn!(
                                     plugin = %entry.path.display(),
@@ -249,10 +249,15 @@ impl AgentService {
                 // Invoke SPANK TaskExit and JobEpilog hooks for completed jobs
                 if let Some(ref spank_host) = *spank {
                     for c in &completed {
-                        if let Err(e) = spank_host.invoke_hook(SpankHook::TaskExit) {
+                        let context = SpankContext {
+                            job_id: c.job_id,
+                            ..Default::default()
+                        };
+                        let mut handle = SpankHandle::new(context, HashMap::new());
+                        if let Err(e) = spank_host.invoke_hook(SpankHook::TaskExit, &mut handle) {
                             warn!(c.job_id, error = %e, "SPANK TaskExit hook failed");
                         }
-                        if let Err(e) = spank_host.invoke_hook(SpankHook::JobEpilog) {
+                        if let Err(e) = spank_host.invoke_hook(SpankHook::JobEpilog, &mut handle) {
                             warn!(c.job_id, error = %e, "SPANK JobEpilog hook failed");
                         }
                     }

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -15,7 +15,7 @@ use tokio::process::Command;
 use tracing::{debug, info, warn};
 
 use spur_core::job::JobId;
-use spur_spank::SpankHost;
+use spur_spank::{SpankContext, SpankHandle, SpankHost};
 
 /// Typed launch errors so callers can distinguish prolog failure from other failures.
 pub enum LaunchError {
@@ -257,16 +257,6 @@ async fn spawn_job_process(
     } = *cfg;
     info!(job_id, work_dir, "launching job");
 
-    // Invoke SPANK Init hook (after prolog, before process spawn)
-    if let Some(spank) = spank {
-        if let Err(e) = spank.invoke_hook(spur_spank::SpankHook::Init) {
-            warn!(job_id, error = %e, "SPANK Init hook failed");
-        }
-        if let Err(e) = spank.invoke_hook(spur_spank::SpankHook::TaskInit) {
-            warn!(job_id, error = %e, "SPANK TaskInit hook failed");
-        }
-    }
-
     // Set up cgroup for isolation
     let cgroup_path = setup_cgroup(job_id, cpus, memory_mb, cpu_ids)?;
 
@@ -343,6 +333,25 @@ async fn spawn_job_process(
     env.insert("OPENBLAS_NUM_THREADS".into(), cpus.to_string());
     env.insert("VECLIB_MAXIMUM_THREADS".into(), cpus.to_string());
     env.insert("NUMEXPR_NUM_THREADS".into(), cpus.to_string());
+
+    // Run SPANK Init/TaskInit against a handle seeded with the assembled env,
+    // then fold plugin edits back so both the container and command paths pick
+    // them up. Hooks run in the spurd (root) process, not the forked task.
+    if let Some(spank) = spank {
+        let context = SpankContext {
+            job_id,
+            uid,
+            gid,
+            ..Default::default()
+        };
+        let mut handle = SpankHandle::new(context, env);
+        for hook in [spur_spank::SpankHook::Init, spur_spank::SpankHook::TaskInit] {
+            if let Err(e) = spank.invoke_hook(hook, &mut handle) {
+                warn!(job_id, error = %e, "SPANK hook failed");
+            }
+        }
+        env = handle.env;
+    }
 
     // Container jobs: use explicit fork() + container_init() instead of bash wrapper.
     if let Some(ctn) = container {


### PR DESCRIPTION
## Fix SPANK ABI and wire up plugin env/args (#294)

Existing Slurm SPANK plugins failed against Spur's host: the API symbols used a `spur_spank_*` prefix, and even after loading, plugins couldn't affect the job. This makes the SPANK host drop-in compatible with Slurm's `spank.h`.

### What changed

**ABI / symbol compatibility**
- Renamed exports to Slurm's names and aligned signatures to `spank.h`: `spank_get_item`, `spank_setenv` (added the `overwrite` arg), plus new `spank_getenv`, `spank_unsetenv`, `spank_job_control_{set,get,unset}env`, `spank_strerror`, and the `slurm_error/info/verbose/debug/debug2/debug3` + `slurm_spank_log` loggers.
- Fixed `SpankItem` discriminants to match Slurm's `enum spank_item` (previously mis-ordered, so `S_JOB_ID` returned the gid).
- Added `ESPANK_*` return codes; `spank_get_item` now returns `ESPANK_NOT_AVAIL` for known-but-unsupported items vs `ESPANK_BAD_ARG` for unknown ids.
- Made `spurd` export these symbols in its dynamic symbol table so `dlopen`'d plugins resolve them, via linker flags (`--undefined` + `--export-dynamic`, guarded on the target OS) in `spurd/build.rs`.

**Functional wiring**
- `invoke_hook` now threads a caller-owned `SpankHandle`, so plugin env edits persist and are visible across hooks/plugins.
- The executor seeds the handle from the job's env + context, runs `Init`/`TaskInit` after the env is assembled, and folds plugin env changes back into the launched job (both container and command paths).
- Plugstack arguments are now delivered to hooks as `ac`/`argv` (previously always `0`/`NULL`).

### Testing
- Unit/integration tests updated and extended (`spur-spank` + `t58_spank`): item-ID ordering, `setenv` overwrite semantics, `getenv` round-trip/errors, env-in seeding, `NOT_AVAIL` vs `BAD_ARG`.
- `cargo clippy --workspace --exclude spur-ffi --all-targets` clean.
- **End-to-end on the bare-metal cluster**: built a real SPANK plugin (`slurm_spank_task_init`) using `spank_setenv`/`spank_get_item` and a plugstack arg. Confirmed it loads (`SPANK plugins loaded count=1`) and a job sees the injected env (`SPUR_SPANK_TEST=hello_from_spank`, `SPUR_SPANK_ARG=arg_from_plugstack`).

### Known limitations / follow-ups
- Logging functions are non-variadic (stable Rust can't define C-variadic fns), so `printf`-style format specifiers aren't expanded — the format string is logged verbatim.
- `spank_get_item` supports scalar items only (no `S_JOB_ARGV`/`S_JOB_ENV` or pid-to-id lookups).
- Hooks run in the `spurd` process, not the forked/privilege-dropped task.
- `job_control_env` isn't yet wired into prolog/epilog.
- Option-registration symbols (`spank_option_register`, etc.) are not yet provided.