### PR TITLE
fix(spurctld): wire QOS priority into scheduling and preemption

### DIFF
--- a/crates/spur-core/src/partition.rs
+++ b/crates/spur-core/src/partition.rs
@@ -89,6 +89,32 @@ impl PreemptMode {
     }
 }
 
+/// Partitions a job requests, resolved by name. `spec` is a comma-separated
+/// OR list, matching the backfill scheduler's node-matching convention.
+pub fn matched_partitions<'a>(
+    spec: Option<&str>,
+    partitions: &'a [Partition],
+) -> Vec<&'a Partition> {
+    let Some(spec) = spec.filter(|s| !s.is_empty()) else {
+        return Vec::new();
+    };
+    spec.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .filter_map(|req| partitions.iter().find(|p| p.name == req))
+        .collect()
+}
+
+/// Highest `priority_tier` among a job's requested partitions (see
+/// `matched_partitions`), or 1 if none match.
+pub fn max_priority_tier(spec: Option<&str>, partitions: &[Partition]) -> u32 {
+    matched_partitions(spec, partitions)
+        .into_iter()
+        .map(|p| p.priority_tier)
+        .max()
+        .unwrap_or(1)
+}
+
 impl Default for Partition {
     fn default() -> Self {
         Self {
@@ -123,5 +149,30 @@ mod tests {
         assert!(PreemptMode::Cancel.aggressiveness() > PreemptMode::Requeue.aggressiveness());
         assert!(PreemptMode::Requeue.aggressiveness() > PreemptMode::Suspend.aggressiveness());
         assert!(PreemptMode::Suspend.aggressiveness() > PreemptMode::Off.aggressiveness());
+    }
+
+    fn partition_with_tier(name: &str, priority_tier: u32) -> Partition {
+        Partition {
+            name: name.into(),
+            priority_tier,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn max_priority_tier_picks_highest_among_matched_partitions() {
+        let parts = vec![
+            partition_with_tier("low", 1),
+            partition_with_tier("high", 9),
+        ];
+        assert_eq!(max_priority_tier(Some("low,high"), &parts), 9);
+        assert_eq!(max_priority_tier(Some("high, low"), &parts), 9);
+    }
+
+    #[test]
+    fn max_priority_tier_defaults_to_one_when_unset_or_unmatched() {
+        let parts = vec![partition_with_tier("gpu", 5)];
+        assert_eq!(max_priority_tier(None, &parts), 1);
+        assert_eq!(max_priority_tier(Some("nope"), &parts), 1);
     }
 }

--- a/crates/spur-core/src/qos.rs
+++ b/crates/spur-core/src/qos.rs
@@ -115,10 +115,16 @@ pub fn check_qos_limits(
     QosCheckResult::Allowed
 }
 
-/// Calculate effective priority including QOS priority adjustment.
+/// Add a QOS's priority delta on top of an already-computed priority.
+///
+/// Callers should pass the fully weighted priority (fairshare/age/partition
+/// tier already applied) as `base_priority`, not a job's raw submitted
+/// priority: the QOS delta is a flat addition, so applying it before those
+/// multiplicative factors would let them amplify or dilute it in proportion
+/// to values that have nothing to do with QOS.
 pub fn qos_adjusted_priority(base_priority: u32, qos: &Qos) -> u32 {
     let adjusted = base_priority as i64 + qos.priority as i64;
-    adjusted.max(1) as u32
+    adjusted.clamp(1, u32::MAX as i64) as u32
 }
 
 #[cfg(test)]

--- a/crates/spur-core/src/qos.rs
+++ b/crates/spur-core/src/qos.rs
@@ -27,6 +27,12 @@ impl From<QosPreemptMode> for PreemptMode {
 /// legitimate explicit choice — there is no way to tell them apart — so
 /// `Off` is treated as "no override" here, deferring to whatever the
 /// caller would otherwise resolve (e.g. partition-level `PreemptMode`).
+///
+/// This means a QOS can't express "never preempt this job regardless of
+/// partition" — the most protective use case is exactly the one this
+/// override can't reach. Doing so would need a wire-format change (e.g.
+/// `optional string preempt_mode` in the proto) to distinguish "explicitly
+/// Off" from "unset"; out of scope here.
 pub fn qos_preempt_override(qos: &Qos) -> Option<PreemptMode> {
     match qos.preempt_mode {
         QosPreemptMode::Off => None,

--- a/crates/spur-core/src/qos.rs
+++ b/crates/spur-core/src/qos.rs
@@ -5,8 +5,34 @@
 //!
 //! Checks per-QOS limits before allowing a job to be scheduled.
 
-use crate::accounting::{Qos, TresRecord, TresType};
+use crate::accounting::{Qos, QosPreemptMode, TresRecord, TresType};
 use crate::job::{Job, PendingReason};
+use crate::partition::PreemptMode;
+
+impl From<QosPreemptMode> for PreemptMode {
+    fn from(mode: QosPreemptMode) -> Self {
+        match mode {
+            QosPreemptMode::Off => PreemptMode::Off,
+            QosPreemptMode::Cancel => PreemptMode::Cancel,
+            QosPreemptMode::Requeue => PreemptMode::Requeue,
+            QosPreemptMode::Suspend => PreemptMode::Suspend,
+        }
+    }
+}
+
+/// A QOS-level preempt mode override for a running job, or `None` if the
+/// QOS carries no override.
+///
+/// `QosPreemptMode::Off` is both the wire format's "unset" default and a
+/// legitimate explicit choice — there is no way to tell them apart — so
+/// `Off` is treated as "no override" here, deferring to whatever the
+/// caller would otherwise resolve (e.g. partition-level `PreemptMode`).
+pub fn qos_preempt_override(qos: &Qos) -> Option<PreemptMode> {
+    match qos.preempt_mode {
+        QosPreemptMode::Off => None,
+        other => Some(other.into()),
+    }
+}
 
 /// Result of QOS limit check.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -391,5 +417,35 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(qos_adjusted_priority(1000, &qos), 1); // Floor at 1
+    }
+
+    #[test]
+    fn test_qos_preempt_override_off_is_none() {
+        let qos = Qos {
+            preempt_mode: QosPreemptMode::Off,
+            ..Default::default()
+        };
+        assert_eq!(qos_preempt_override(&qos), None);
+    }
+
+    #[test]
+    fn test_qos_preempt_override_maps_variants() {
+        let requeue = Qos {
+            preempt_mode: QosPreemptMode::Requeue,
+            ..Default::default()
+        };
+        assert_eq!(qos_preempt_override(&requeue), Some(PreemptMode::Requeue));
+
+        let cancel = Qos {
+            preempt_mode: QosPreemptMode::Cancel,
+            ..Default::default()
+        };
+        assert_eq!(qos_preempt_override(&cancel), Some(PreemptMode::Cancel));
+
+        let suspend = Qos {
+            preempt_mode: QosPreemptMode::Suspend,
+            ..Default::default()
+        };
+        assert_eq!(qos_preempt_override(&suspend), Some(PreemptMode::Suspend));
     }
 }

--- a/crates/spur-core/src/qos.rs
+++ b/crates/spur-core/src/qos.rs
@@ -410,6 +410,15 @@ mod tests {
     }
 
     #[test]
+    fn test_qos_priority_saturation() {
+        let qos = Qos {
+            priority: i32::MAX,
+            ..Default::default()
+        };
+        assert_eq!(qos_adjusted_priority(u32::MAX, &qos), u32::MAX); // Saturates instead of wrapping
+    }
+
+    #[test]
     fn test_qos_preempt_override_off_is_none() {
         let qos = Qos {
             preempt_mode: QosPreemptMode::Off,

--- a/crates/spur-core/src/qos.rs
+++ b/crates/spur-core/src/qos.rs
@@ -20,19 +20,8 @@ impl From<QosPreemptMode> for PreemptMode {
     }
 }
 
-/// A QOS-level preempt mode override for a running job, or `None` if the
-/// QOS carries no override.
-///
-/// `QosPreemptMode::Off` is both the wire format's "unset" default and a
-/// legitimate explicit choice — there is no way to tell them apart — so
-/// `Off` is treated as "no override" here, deferring to whatever the
-/// caller would otherwise resolve (e.g. partition-level `PreemptMode`).
-///
-/// This means a QOS can't express "never preempt this job regardless of
-/// partition" — the most protective use case is exactly the one this
-/// override can't reach. Doing so would need a wire-format change (e.g.
-/// `optional string preempt_mode` in the proto) to distinguish "explicitly
-/// Off" from "unset"; out of scope here.
+/// A QOS-level preempt mode override, or `None` if unset. `Off` can't be
+/// told apart from "unset" on the wire, so it's treated as no override.
 pub fn qos_preempt_override(qos: &Qos) -> Option<PreemptMode> {
     match qos.preempt_mode {
         QosPreemptMode::Off => None,
@@ -147,13 +136,8 @@ pub fn check_qos_limits(
     QosCheckResult::Allowed
 }
 
-/// Add a QOS's priority delta on top of an already-computed priority.
-///
-/// Callers should pass the fully weighted priority (fairshare/age/partition
-/// tier already applied) as `base_priority`, not a job's raw submitted
-/// priority: the QOS delta is a flat addition, so applying it before those
-/// multiplicative factors would let them amplify or dilute it in proportion
-/// to values that have nothing to do with QOS.
+/// Add a QOS's flat priority delta on top of an already fairshare/age/tier
+/// weighted priority; applying it earlier would let those factors amplify it.
 pub fn qos_adjusted_priority(base_priority: u32, qos: &Qos) -> u32 {
     let adjusted = base_priority as i64 + qos.priority as i64;
     adjusted.clamp(1, u32::MAX as i64) as u32

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2701,7 +2701,7 @@ impl ClusterManager {
     }
 
     /// Resolve a job's QoS from the cache; unknown/absent name → limitless default.
-    fn resolve_qos(&self, job: &Job) -> Qos {
+    pub(crate) fn resolve_qos(&self, job: &Job) -> Qos {
         match job.spec.qos.as_deref() {
             Some(name) => self.qos_cache.get(name).unwrap_or_default(),
             None => Qos::default(),

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1653,9 +1653,8 @@ impl ClusterManager {
             true
         });
 
-        // Resolve each job's QoS once and reuse it for both the QoS-limit
-        // check below and the priority adjustment further down, instead of
-        // looking it up twice per job per scheduling cycle.
+        // Resolve once, reuse for both the QoS-limit check and the priority
+        // adjustment below, instead of looking it up twice per job.
         let qos_by_job: HashMap<JobId, Qos> = pending
             .iter()
             .map(|job| (job.job_id, self.resolve_qos(job)))
@@ -1683,13 +1682,8 @@ impl ClusterManager {
         let reservations = self.get_reservations();
         for job in &mut pending {
             let age_minutes = (now - job.submit_time).num_minutes().max(0);
-            let partition_tier = job
-                .spec
-                .partition
-                .as_ref()
-                .and_then(|pname| partitions.iter().find(|p| p.name == *pname))
-                .map(|p| p.priority_tier)
-                .unwrap_or(1);
+            let partition_tier =
+                spur_core::partition::max_priority_tier(job.spec.partition.as_deref(), &partitions);
             let fair_share = self
                 .fairshare_cache
                 .get(&job.spec.user, job.spec.account.as_deref().unwrap_or(""));
@@ -1703,9 +1697,8 @@ impl ClusterManager {
         }
         drop(partitions);
 
-        // Priority ties (more likely now that QoS floors low-priority jobs at
-        // 1) break on job_id so ordering is deterministic instead of
-        // depending on HashMap iteration order.
+        // QoS floors priority at 1, making ties more likely; break on job_id
+        // for deterministic ordering.
         pending.sort_by(|a, b| {
             let a_res = reservation::job_has_active_reservation(a, &reservations, now);
             let b_res = reservation::job_has_active_reservation(b, &reservations, now);
@@ -2708,31 +2701,14 @@ impl ClusterManager {
         }
     }
 
-    /// Recompute a job's effective priority (fairshare + age + partition
-    /// tier + QoS) as of right now, given an already-resolved `Qos`.
-    ///
-    /// Running jobs never pass back through `pending_jobs()`, so their
-    /// stored `priority` stays at the raw base value forever. This lets
-    /// callers like the preemption gate compare a running job's *current*
-    /// effective priority against a pending job's fully adjusted one
-    /// instead of comparing raw and adjusted values against each other.
-    ///
-    /// Takes `qos` instead of resolving it internally so callers that also
-    /// need the job's QoS for another decision (e.g. preempt-mode
-    /// resolution) can resolve it once and reuse the same snapshot for
-    /// both, rather than hitting `QosCache` twice for the same job in one
-    /// scheduling pass.
+    /// Recompute a job's live effective priority (a running job's stored
+    /// `priority` is stale). Takes `qos` pre-resolved so it can be reused.
     pub(crate) fn current_effective_priority_with_qos(&self, job: &Job, qos: &Qos) -> u32 {
         let now = Utc::now();
         let age_minutes = (now - job.submit_time).num_minutes().max(0);
         let partition_tier = {
             let partitions = self.partitions.read();
-            job.spec
-                .partition
-                .as_ref()
-                .and_then(|pname| partitions.iter().find(|p| p.name == *pname))
-                .map(|p| p.priority_tier)
-                .unwrap_or(1)
+            spur_core::partition::max_priority_tier(job.spec.partition.as_deref(), &partitions)
         };
         let fair_share = self
             .fairshare_cache
@@ -3818,10 +3794,8 @@ fn reservation_block(
     }
 }
 
-/// Combine fairshare/age/partition-tier and QoS into a job's effective
-/// priority. QoS is added on top of the fairshare/age/tier product rather
-/// than fed into it, so a job's QoS tier is a constant, predictable offset
-/// instead of being amplified or diluted by factors unrelated to QoS.
+/// QoS is added on top of the fairshare/age/tier product rather than fed
+/// into it, so it's a constant offset instead of an amplified/diluted one.
 fn compute_effective_priority(
     base_priority: u32,
     fair_share: f64,
@@ -6747,14 +6721,8 @@ mod tests {
             ..Default::default()
         });
 
-        // Realistic, non-maxed-out fairshare (3x) and age (6 days) on the
-        // low-QoS job; the high-QoS job is left neutral. Before this fix,
-        // applying QoS before the fairshare/age multiplication meant this
-        // exact combination let the low-QoS job's unrelated fairshare/age
-        // boost get multiplied into its QoS delta and outrank the high-QoS
-        // job: (1000 + 100) * 3.0 * ~1.857 ≈ 6128 vs (1000 + 5000) * 1 =
-        // 6000. Applying QoS on top instead keeps the two independent:
-        // 1000 * 3.0 * ~1.857 + 100 ≈ 5671 vs 1000 + 5000 = 6000.
+        // Non-neutral fairshare/age on the low-QoS job would previously let
+        // that unrelated boost amplify its QoS delta and outrank the high-QoS job.
         cm.fairshare_cache().set_for_test("low-user", "", 3.0);
 
         let mut low = basic_spec("low");
@@ -6787,6 +6755,43 @@ mod tests {
             high_priority > low_priority,
             "high-QoS job ({high_priority}) should still outrank low-QoS job ({low_priority}) \
              once fairshare/age no longer amplify the QoS delta"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn current_effective_priority_multi_partition_uses_highest_priority_tier() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        {
+            let mut partitions = cm.partitions.write();
+            partitions.push(Partition {
+                name: "low".into(),
+                priority_tier: 1,
+                ..Default::default()
+            });
+            partitions.push(Partition {
+                name: "high".into(),
+                priority_tier: 9,
+                ..Default::default()
+            });
+        }
+
+        // Built directly (not submitted) to isolate priority resolution from
+        // unrelated eligibility filters like partition_block().
+        let job = Job::new(
+            1,
+            JobSpec {
+                partition: Some("low,high".into()),
+                priority: Some(1000),
+                ..basic_spec("multi")
+            },
+        );
+
+        let priority = cm.current_effective_priority_with_qos(&job, &Qos::default());
+        assert_eq!(
+            priority, 9000,
+            "multi-partition job should use the highest matched priority_tier (9), \
+             not fall back to 1 because \"low,high\" isn't an exact partition name"
         );
     }
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2702,14 +2702,19 @@ impl ClusterManager {
     }
 
     /// Recompute a job's live effective priority (a running job's stored
-    /// `priority` is stale). Takes `qos` pre-resolved so it can be reused.
-    pub(crate) fn current_effective_priority_with_qos(&self, job: &Job, qos: &Qos) -> u32 {
+    /// `priority` is stale). Takes `qos` pre-resolved so it can be reused,
+    /// and `partitions` so callers iterating over multiple jobs don't pay
+    /// for a separate lock acquisition per call.
+    pub(crate) fn current_effective_priority_with_qos(
+        &self,
+        job: &Job,
+        qos: &Qos,
+        partitions: &[Partition],
+    ) -> u32 {
         let now = Utc::now();
         let age_minutes = (now - job.submit_time).num_minutes().max(0);
-        let partition_tier = {
-            let partitions = self.partitions.read();
-            spur_core::partition::max_priority_tier(job.spec.partition.as_deref(), &partitions)
-        };
+        let partition_tier =
+            spur_core::partition::max_priority_tier(job.spec.partition.as_deref(), partitions);
         let fair_share = self
             .fairshare_cache
             .get(&job.spec.user, job.spec.account.as_deref().unwrap_or(""));
@@ -6787,7 +6792,8 @@ mod tests {
             },
         );
 
-        let priority = cm.current_effective_priority_with_qos(&job, &Qos::default());
+        let priority =
+            cm.current_effective_priority_with_qos(&job, &Qos::default(), &cm.get_partitions());
         assert_eq!(
             priority, 9000,
             "multi-partition job should use the highest matched priority_tier (9), \

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -20,7 +20,7 @@ use spur_core::job::{
 };
 use spur_core::node::{Node, NodeEvent, NodeSource, NodeState};
 use spur_core::partition::{Partition, PreemptMode};
-use spur_core::qos::{check_qos_limits, QosCheckResult};
+use spur_core::qos::{check_qos_limits, qos_adjusted_priority, QosCheckResult};
 use spur_core::reservation::{self, normalize_node_list, running_jobs_overlap_start, Reservation};
 use spur_core::resource::{ResourceAllocations, ResourceSet};
 use spur_core::step::{JobStep, StepState, STEP_BATCH, STEP_RESERVED_MIN};
@@ -1572,7 +1572,7 @@ impl ClusterManager {
     }
 
     /// Get pending jobs sorted by priority, filtering out held and dependency-blocked jobs.
-    /// Recomputes effective priority using age and partition tier before sorting.
+    /// Recomputes effective priority using QoS, age, and partition tier before sorting.
     pub fn pending_jobs(&self) -> Vec<Job> {
         let jobs = self.jobs.read();
         let mut pending: Vec<Job> = jobs
@@ -1685,8 +1685,9 @@ impl ClusterManager {
             let fair_share = self
                 .fairshare_cache
                 .get(&job.spec.user, job.spec.account.as_deref().unwrap_or(""));
+            let qos_priority = qos_adjusted_priority(job.priority, &self.resolve_qos(job));
             job.priority = spur_sched::priority::effective_priority(
-                job.priority,
+                qos_priority,
                 fair_share,
                 age_minutes,
                 partition_tier,
@@ -6623,6 +6624,49 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pending_jobs_applies_qos_priority_adjustment() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        cm.qos_cache().insert(Qos {
+            name: "low".into(),
+            priority: -500,
+            ..Default::default()
+        });
+        cm.qos_cache().insert(Qos {
+            name: "high".into(),
+            priority: 5000,
+            ..Default::default()
+        });
+
+        let mut low = basic_spec("low");
+        low.priority = Some(1000);
+        low.qos = Some("low".into());
+        let low_id = submit_and_wait(&cm, low);
+
+        let mut high = basic_spec("high");
+        high.priority = Some(1000);
+        high.qos = Some("high".into());
+        let high_id = submit_and_wait(&cm, high);
+
+        let pending = cm.pending_jobs();
+        let low_priority = pending
+            .iter()
+            .find(|j| j.job_id == low_id)
+            .unwrap()
+            .priority;
+        let high_priority = pending
+            .iter()
+            .find(|j| j.job_id == high_id)
+            .unwrap()
+            .priority;
+        assert!(
+            high_priority > low_priority,
+            "high-QoS job ({high_priority}) should outrank low-QoS job ({low_priority}) \
+             despite identical base priority"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn resv_overrun_grace_delays_cancel() {
         let dir = TempDir::new().unwrap();
         let mut config = test_config();
@@ -6733,6 +6777,48 @@ mod tests {
 
         crate::scheduler_loop::try_preempt(&cm, &partitions, &[&high_job]).await;
         assert_eq!(cm.get_job(low_id).unwrap().state, JobState::Running);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn preempt_triggers_when_qos_priority_differentiates_pending_job() {
+        let dir = TempDir::new().unwrap();
+        let mut config = test_config();
+        config.partitions[0].preempt_mode = "cancel".into();
+        let cm = test_cluster_with_config(&dir, config).await;
+        register_node(&cm, "n1", 8, 16000);
+
+        cm.qos_cache().insert(Qos {
+            name: "high".into(),
+            priority: 5000,
+            ..Default::default()
+        });
+
+        // Same base priority on both jobs; only the QoS adjustment differentiates them.
+        let mut low = basic_spec("low");
+        low.priority = Some(1000);
+        let low_id = submit_and_wait(&cm, low);
+        let res = scalar_alloc(2, 4000);
+        cm.start_job(
+            low_id,
+            vec!["n1".into()],
+            res.clone(),
+            per_node_for(&["n1"], res),
+        )
+        .unwrap();
+        settle(&cm, low_id, JobState::Running);
+
+        let mut high = basic_spec("high");
+        high.priority = Some(1000);
+        high.qos = Some("high".into());
+        submit_and_wait(&cm, high);
+
+        // pending_jobs() applies the QoS adjustment, unlike a synthetic Job.
+        let pending = cm.pending_jobs();
+        let pending_refs: Vec<&Job> = pending.iter().collect();
+        let partitions = cm.get_partitions();
+        crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs).await;
+
+        settle(&cm, low_id, JobState::Cancelled);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2709,14 +2709,20 @@ impl ClusterManager {
     }
 
     /// Recompute a job's effective priority (fairshare + age + partition
-    /// tier + QoS) as of right now.
+    /// tier + QoS) as of right now, given an already-resolved `Qos`.
     ///
     /// Running jobs never pass back through `pending_jobs()`, so their
     /// stored `priority` stays at the raw base value forever. This lets
     /// callers like the preemption gate compare a running job's *current*
     /// effective priority against a pending job's fully adjusted one
     /// instead of comparing raw and adjusted values against each other.
-    pub(crate) fn current_effective_priority(&self, job: &Job) -> u32 {
+    ///
+    /// Takes `qos` instead of resolving it internally so callers that also
+    /// need the job's QoS for another decision (e.g. preempt-mode
+    /// resolution) can resolve it once and reuse the same snapshot for
+    /// both, rather than hitting `QosCache` twice for the same job in one
+    /// scheduling pass.
+    pub(crate) fn current_effective_priority_with_qos(&self, job: &Job, qos: &Qos) -> u32 {
         let now = Utc::now();
         let age_minutes = (now - job.submit_time).num_minutes().max(0);
         let partition_tier = {
@@ -2731,13 +2737,7 @@ impl ClusterManager {
         let fair_share = self
             .fairshare_cache
             .get(&job.spec.user, job.spec.account.as_deref().unwrap_or(""));
-        compute_effective_priority(
-            job.priority,
-            fair_share,
-            age_minutes,
-            partition_tier,
-            &self.resolve_qos(job),
-        )
+        compute_effective_priority(job.priority, fair_share, age_minutes, partition_tier, qos)
     }
 
     /// Persist a mutation via Raft consensus. The apply callback
@@ -6943,6 +6943,48 @@ mod tests {
         crate::scheduler_loop::try_preempt(&cm, &partitions, &pending_refs).await;
 
         settle(&cm, low_id, JobState::Cancelled);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn preempt_uses_candidate_qos_preempt_mode_over_partition() {
+        let dir = TempDir::new().unwrap();
+        let mut config = test_config();
+        // Partition says Cancel; the candidate's QoS overrides it to Suspend.
+        config.partitions[0].preempt_mode = "cancel".into();
+        let cm = test_cluster_with_config(&dir, config).await;
+        register_node(&cm, "n1", 8, 16000);
+
+        cm.qos_cache().insert(Qos {
+            name: "suspend-me".into(),
+            preempt_mode: spur_core::accounting::QosPreemptMode::Suspend,
+            ..Default::default()
+        });
+
+        let mut low = basic_spec("low");
+        low.priority = Some(100);
+        low.qos = Some("suspend-me".into());
+        let low_id = submit_and_wait(&cm, low);
+        let res = scalar_alloc(2, 4000);
+        cm.start_job(
+            low_id,
+            vec!["n1".into()],
+            res.clone(),
+            per_node_for(&["n1"], res),
+        )
+        .unwrap();
+        settle(&cm, low_id, JobState::Running);
+
+        let mut high = basic_spec("high");
+        high.priority = Some(10_000);
+        let high_id = submit_and_wait(&cm, high);
+        let high_job = cm.get_job(high_id).unwrap();
+        let partitions = cm.get_partitions();
+
+        crate::scheduler_loop::try_preempt(&cm, &partitions, &[&high_job]).await;
+
+        // Suspended, not Cancelled: proves the QoS override reached the real
+        // preemption action, not just the pure job_preempt_mode() decision.
+        settle(&cm, low_id, JobState::Suspended);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1653,10 +1653,18 @@ impl ClusterManager {
             true
         });
 
+        // Resolve each job's QoS once and reuse it for both the QoS-limit
+        // check below and the priority adjustment further down, instead of
+        // looking it up twice per job per scheduling cycle.
+        let qos_by_job: HashMap<JobId, Qos> = pending
+            .iter()
+            .map(|job| (job.job_id, self.resolve_qos(job)))
+            .collect();
+
         // QoS enforcement: check per-user limits for jobs with a QoS. Shares
         // the eligibility logic with tag_blocked_pending_reasons() via
         // qos_block_for() so the drop decision and the displayed reason agree.
-        pending.retain(|job| qos_block_for(job, &self.resolve_qos(job), &jobs).is_none());
+        pending.retain(|job| qos_block_for(job, &qos_by_job[&job.job_id], &jobs).is_none());
 
         // License enforcement is applied after the priority sort below, so scarce
         // licenses are reserved highest-priority-first and a single pass cannot
@@ -1685,20 +1693,26 @@ impl ClusterManager {
             let fair_share = self
                 .fairshare_cache
                 .get(&job.spec.user, job.spec.account.as_deref().unwrap_or(""));
-            let qos_priority = qos_adjusted_priority(job.priority, &self.resolve_qos(job));
-            job.priority = spur_sched::priority::effective_priority(
-                qos_priority,
+            job.priority = compute_effective_priority(
+                job.priority,
                 fair_share,
                 age_minutes,
                 partition_tier,
+                &qos_by_job[&job.job_id],
             );
         }
         drop(partitions);
 
+        // Priority ties (more likely now that QoS floors low-priority jobs at
+        // 1) break on job_id so ordering is deterministic instead of
+        // depending on HashMap iteration order.
         pending.sort_by(|a, b| {
             let a_res = reservation::job_has_active_reservation(a, &reservations, now);
             let b_res = reservation::job_has_active_reservation(b, &reservations, now);
-            b_res.cmp(&a_res).then(b.priority.cmp(&a.priority))
+            b_res
+                .cmp(&a_res)
+                .then(b.priority.cmp(&a.priority))
+                .then(a.job_id.cmp(&b.job_id))
         });
 
         // License reservation, in priority order. `remaining` starts from current
@@ -2692,6 +2706,38 @@ impl ClusterManager {
             Some(name) => self.qos_cache.get(name).unwrap_or_default(),
             None => Qos::default(),
         }
+    }
+
+    /// Recompute a job's effective priority (fairshare + age + partition
+    /// tier + QoS) as of right now.
+    ///
+    /// Running jobs never pass back through `pending_jobs()`, so their
+    /// stored `priority` stays at the raw base value forever. This lets
+    /// callers like the preemption gate compare a running job's *current*
+    /// effective priority against a pending job's fully adjusted one
+    /// instead of comparing raw and adjusted values against each other.
+    pub(crate) fn current_effective_priority(&self, job: &Job) -> u32 {
+        let now = Utc::now();
+        let age_minutes = (now - job.submit_time).num_minutes().max(0);
+        let partition_tier = {
+            let partitions = self.partitions.read();
+            job.spec
+                .partition
+                .as_ref()
+                .and_then(|pname| partitions.iter().find(|p| p.name == *pname))
+                .map(|p| p.priority_tier)
+                .unwrap_or(1)
+        };
+        let fair_share = self
+            .fairshare_cache
+            .get(&job.spec.user, job.spec.account.as_deref().unwrap_or(""));
+        compute_effective_priority(
+            job.priority,
+            fair_share,
+            age_minutes,
+            partition_tier,
+            &self.resolve_qos(job),
+        )
     }
 
     /// Persist a mutation via Raft consensus. The apply callback
@@ -3770,6 +3816,26 @@ fn reservation_block(
         }
         _ => Some(PendingReason::Reservation),
     }
+}
+
+/// Combine fairshare/age/partition-tier and QoS into a job's effective
+/// priority. QoS is added on top of the fairshare/age/tier product rather
+/// than fed into it, so a job's QoS tier is a constant, predictable offset
+/// instead of being amplified or diluted by factors unrelated to QoS.
+fn compute_effective_priority(
+    base_priority: u32,
+    fair_share: f64,
+    age_minutes: i64,
+    partition_tier: u32,
+    qos: &Qos,
+) -> u32 {
+    let raw = spur_sched::priority::effective_priority(
+        base_priority,
+        fair_share,
+        age_minutes,
+        partition_tier,
+    );
+    qos_adjusted_priority(raw, qos)
 }
 
 /// Reason a job is ineligible because currently-available licenses cannot satisfy
@@ -6663,6 +6729,64 @@ mod tests {
             high_priority > low_priority,
             "high-QoS job ({high_priority}) should outrank low-QoS job ({low_priority}) \
              despite identical base priority"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pending_jobs_qos_ordering_holds_with_nonneutral_fairshare_and_age() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        cm.qos_cache().insert(Qos {
+            name: "low".into(),
+            priority: 100,
+            ..Default::default()
+        });
+        cm.qos_cache().insert(Qos {
+            name: "high".into(),
+            priority: 5000,
+            ..Default::default()
+        });
+
+        // Realistic, non-maxed-out fairshare (3x) and age (6 days) on the
+        // low-QoS job; the high-QoS job is left neutral. Before this fix,
+        // applying QoS before the fairshare/age multiplication meant this
+        // exact combination let the low-QoS job's unrelated fairshare/age
+        // boost get multiplied into its QoS delta and outrank the high-QoS
+        // job: (1000 + 100) * 3.0 * ~1.857 ≈ 6128 vs (1000 + 5000) * 1 =
+        // 6000. Applying QoS on top instead keeps the two independent:
+        // 1000 * 3.0 * ~1.857 + 100 ≈ 5671 vs 1000 + 5000 = 6000.
+        cm.fairshare_cache().set_for_test("low-user", "", 3.0);
+
+        let mut low = basic_spec("low");
+        low.user = "low-user".into();
+        low.priority = Some(1000);
+        low.qos = Some("low".into());
+        let low_id = submit_and_wait(&cm, low);
+        {
+            let mut jobs = cm.jobs.write();
+            jobs.get_mut(&low_id).unwrap().submit_time = Utc::now() - chrono::Duration::days(6);
+        }
+
+        let mut high = basic_spec("high");
+        high.priority = Some(1000);
+        high.qos = Some("high".into());
+        let high_id = submit_and_wait(&cm, high);
+
+        let pending = cm.pending_jobs();
+        let low_priority = pending
+            .iter()
+            .find(|j| j.job_id == low_id)
+            .unwrap()
+            .priority;
+        let high_priority = pending
+            .iter()
+            .find(|j| j.job_id == high_id)
+            .unwrap()
+            .priority;
+        assert!(
+            high_priority > low_priority,
+            "high-QoS job ({high_priority}) should still outrank low-QoS job ({low_priority}) \
+             once fairshare/age no longer amplify the QoS delta"
         );
     }
 

--- a/crates/spurctld/src/fairshare_cache.rs
+++ b/crates/spurctld/src/fairshare_cache.rs
@@ -38,6 +38,16 @@ impl FairshareCache {
         *self.factors.write() = new_factors;
     }
 
+    /// Set a single user/account's fairshare factor directly, bypassing the
+    /// periodic DB refresh. Scheduling tests need non-neutral fairshare
+    /// without standing up a PostgreSQL-backed refresh loop.
+    #[cfg(test)]
+    pub(crate) fn set_for_test(&self, user: &str, account: &str, factor: f64) {
+        self.factors
+            .write()
+            .insert((user.to_owned(), account.to_owned()), factor);
+    }
+
     pub fn spawn_refresh_loop(
         self: &Arc<Self>,
         pool: PgPool,

--- a/crates/spurctld/src/fairshare_cache.rs
+++ b/crates/spurctld/src/fairshare_cache.rs
@@ -38,9 +38,7 @@ impl FairshareCache {
         *self.factors.write() = new_factors;
     }
 
-    /// Set a single user/account's fairshare factor directly, bypassing the
-    /// periodic DB refresh. Scheduling tests need non-neutral fairshare
-    /// without standing up a PostgreSQL-backed refresh loop.
+    /// Set a factor directly, bypassing the DB refresh loop; for tests only.
     #[cfg(test)]
     pub(crate) fn set_for_test(&self, user: &str, account: &str, factor: f64) {
         self.factors

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -350,15 +350,8 @@ pub(crate) fn compute_job_allocation(
     }
 }
 
-/// Resolve the effective PreemptMode for a job.
-///
-/// The job's QOS `preempt_mode` takes precedence when it carries an explicit
-/// override (anything but `Off` — see `qos_preempt_override`'s doc comment
-/// for why `Off` can't be told apart from "unset"). Otherwise falls back to
-/// the partition config: `job.spec.partition` is a comma-separated OR list
-/// (same convention as the backfill scheduler's node matching), so a job may
-/// span several partitions, and the most aggressive mode among the matched
-/// partitions wins.
+/// Resolve the effective PreemptMode for a job: QoS override wins if set
+/// (see `qos_preempt_override`), else the most aggressive matched partition.
 fn job_preempt_mode(
     job: &spur_core::job::Job,
     partitions: &[spur_core::partition::Partition],
@@ -370,13 +363,8 @@ fn job_preempt_mode(
         return mode;
     }
 
-    let Some(name) = job.spec.partition.as_deref().filter(|p| !p.is_empty()) else {
-        return PreemptMode::Off;
-    };
-    name.split(',')
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .filter_map(|req| partitions.iter().find(|p| p.name == req))
+    spur_core::partition::matched_partitions(job.spec.partition.as_deref(), partitions)
+        .into_iter()
         .map(|p| p.preempt_mode)
         .max_by_key(|m| m.aggressiveness())
         .unwrap_or(PreemptMode::Off)
@@ -399,33 +387,24 @@ pub(crate) async fn try_preempt(
     let cluster_nodes = cluster.get_nodes();
 
     let partition_for = |job: &spur_core::job::Job| -> Option<&Partition> {
-        job.spec.partition.as_deref().and_then(|pname| {
-            pname
-                .split(',')
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .filter_map(|req| partitions.iter().find(|p| p.name == req))
-                .max_by_key(|p| p.preempt_mode.aggressiveness())
-        })
+        spur_core::partition::matched_partitions(job.spec.partition.as_deref(), partitions)
+            .into_iter()
+            .max_by_key(|p| p.preempt_mode.aggressiveness())
     };
 
     let mut running: Vec<spur_core::job::Job> = cluster
         .get_jobs(&[JobState::Running], None, None, None, None, &[])
         .into_iter()
         .collect();
-    // Resolve each running job's QoS once and reuse it for both the priority
-    // recompute below and the preempt-mode decision further down, instead of
-    // hitting QosCache once per candidate for priority and again per
-    // (pending, candidate) pair for preempt-mode.
+    // Resolve once, reuse for both the priority recompute and the
+    // preempt-mode decision below.
     let running_qos: std::collections::HashMap<spur_core::job::JobId, spur_core::accounting::Qos> =
         running
             .iter()
             .map(|j| (j.job_id, cluster.resolve_qos(j)))
             .collect();
-    // Running jobs never pass back through pending_jobs(), so their stored
-    // `priority` is the raw base value, not the fairshare/age/tier/QoS
-    // adjusted value `pending` jobs carry. Recompute a comparable priority
-    // here rather than comparing raw and adjusted values against each other.
+    // Running jobs' stored `priority` is the raw base value, unlike
+    // `pending`'s fully adjusted one; recompute a comparable value.
     let running_priority: std::collections::HashMap<spur_core::job::JobId, u32> = running
         .iter()
         .map(|j| {

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -350,16 +350,26 @@ pub(crate) fn compute_job_allocation(
     }
 }
 
-/// Resolve the effective PreemptMode for a job from its partition config.
+/// Resolve the effective PreemptMode for a job.
 ///
-/// `job.spec.partition` is a comma-separated OR list (same convention as the
-/// backfill scheduler's node matching), so a job may span several partitions.
-/// The most aggressive mode among the matched partitions wins.
+/// The job's QOS `preempt_mode` takes precedence when it carries an explicit
+/// override (anything but `Off` — see `qos_preempt_override`'s doc comment
+/// for why `Off` can't be told apart from "unset"). Otherwise falls back to
+/// the partition config: `job.spec.partition` is a comma-separated OR list
+/// (same convention as the backfill scheduler's node matching), so a job may
+/// span several partitions, and the most aggressive mode among the matched
+/// partitions wins.
 fn job_preempt_mode(
     job: &spur_core::job::Job,
     partitions: &[spur_core::partition::Partition],
+    qos: &spur_core::accounting::Qos,
 ) -> spur_core::partition::PreemptMode {
     use spur_core::partition::PreemptMode;
+
+    if let Some(mode) = spur_core::qos::qos_preempt_override(qos) {
+        return mode;
+    }
+
     let Some(name) = job.spec.partition.as_deref().filter(|p| !p.is_empty()) else {
         return PreemptMode::Off;
     };
@@ -441,7 +451,8 @@ pub(crate) async fn try_preempt(
                 }
             }
 
-            let mode = job_preempt_mode(candidate, partitions);
+            let candidate_qos = cluster.resolve_qos(candidate);
+            let mode = job_preempt_mode(candidate, partitions, &candidate_qos);
             if mode == PreemptMode::Off {
                 continue;
             }
@@ -1581,12 +1592,23 @@ mod tests {
         })
     }
 
+    fn qos_with_mode(mode: spur_core::accounting::QosPreemptMode) -> spur_core::accounting::Qos {
+        spur_core::accounting::Qos {
+            preempt_mode: mode,
+            ..Default::default()
+        }
+    }
+
+    fn no_qos_override() -> spur_core::accounting::Qos {
+        qos_with_mode(spur_core::accounting::QosPreemptMode::Off)
+    }
+
     #[test]
     fn job_preempt_mode_single_partition() {
         use spur_core::partition::PreemptMode;
         let parts = vec![partition_with_mode("gpu", PreemptMode::Requeue)];
         assert_eq!(
-            job_preempt_mode(&job_in_partitions("gpu"), &parts),
+            job_preempt_mode(&job_in_partitions("gpu"), &parts, &no_qos_override()),
             PreemptMode::Requeue
         );
     }
@@ -1596,11 +1618,15 @@ mod tests {
         use spur_core::partition::PreemptMode;
         let parts = vec![partition_with_mode("gpu", PreemptMode::Cancel)];
         assert_eq!(
-            job_preempt_mode(&job_with_spec(JobSpec::default()), &parts),
+            job_preempt_mode(
+                &job_with_spec(JobSpec::default()),
+                &parts,
+                &no_qos_override()
+            ),
             PreemptMode::Off
         );
         assert_eq!(
-            job_preempt_mode(&job_in_partitions("nope"), &parts),
+            job_preempt_mode(&job_in_partitions("nope"), &parts, &no_qos_override()),
             PreemptMode::Off
         );
     }
@@ -1615,7 +1641,7 @@ mod tests {
             partition_with_mode("cpu", PreemptMode::Cancel),
         ];
         assert_eq!(
-            job_preempt_mode(&job_in_partitions("gpu, cpu"), &parts),
+            job_preempt_mode(&job_in_partitions("gpu, cpu"), &parts, &no_qos_override()),
             PreemptMode::Cancel
         );
     }
@@ -1628,7 +1654,7 @@ mod tests {
             partition_with_mode("cpu", PreemptMode::Off),
         ];
         assert_eq!(
-            job_preempt_mode(&job_in_partitions("gpu,cpu"), &parts),
+            job_preempt_mode(&job_in_partitions("gpu,cpu"), &parts, &no_qos_override()),
             PreemptMode::Off
         );
     }
@@ -2011,5 +2037,27 @@ mod tests {
             assert_eq!(job.state, JobState::Pending);
             assert!(job.allocated_nodes.is_empty());
         }
+    }
+
+    #[test]
+    fn job_preempt_mode_qos_override_wins_over_partition() {
+        use spur_core::accounting::QosPreemptMode;
+        use spur_core::partition::PreemptMode;
+        let parts = vec![partition_with_mode("gpu", PreemptMode::Cancel)];
+        let qos = qos_with_mode(QosPreemptMode::Requeue);
+        assert_eq!(
+            job_preempt_mode(&job_in_partitions("gpu"), &parts, &qos),
+            PreemptMode::Requeue
+        );
+    }
+
+    #[test]
+    fn job_preempt_mode_qos_off_falls_back_to_partition() {
+        use spur_core::partition::PreemptMode;
+        let parts = vec![partition_with_mode("gpu", PreemptMode::Cancel)];
+        assert_eq!(
+            job_preempt_mode(&job_in_partitions("gpu"), &parts, &no_qos_override()),
+            PreemptMode::Cancel
+        );
     }
 }

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -413,13 +413,27 @@ pub(crate) async fn try_preempt(
         .get_jobs(&[JobState::Running], None, None, None, None, &[])
         .into_iter()
         .collect();
+    // Resolve each running job's QoS once and reuse it for both the priority
+    // recompute below and the preempt-mode decision further down, instead of
+    // hitting QosCache once per candidate for priority and again per
+    // (pending, candidate) pair for preempt-mode.
+    let running_qos: std::collections::HashMap<spur_core::job::JobId, spur_core::accounting::Qos> =
+        running
+            .iter()
+            .map(|j| (j.job_id, cluster.resolve_qos(j)))
+            .collect();
     // Running jobs never pass back through pending_jobs(), so their stored
     // `priority` is the raw base value, not the fairshare/age/tier/QoS
     // adjusted value `pending` jobs carry. Recompute a comparable priority
     // here rather than comparing raw and adjusted values against each other.
     let running_priority: std::collections::HashMap<spur_core::job::JobId, u32> = running
         .iter()
-        .map(|j| (j.job_id, cluster.current_effective_priority(j)))
+        .map(|j| {
+            (
+                j.job_id,
+                cluster.current_effective_priority_with_qos(j, &running_qos[&j.job_id]),
+            )
+        })
         .collect();
     running.sort_by_key(|j| running_priority[&j.job_id]);
 
@@ -451,8 +465,7 @@ pub(crate) async fn try_preempt(
                 }
             }
 
-            let candidate_qos = cluster.resolve_qos(candidate);
-            let mode = job_preempt_mode(candidate, partitions, &candidate_qos);
+            let mode = job_preempt_mode(candidate, partitions, &running_qos[&candidate.job_id]);
             if mode == PreemptMode::Off {
                 continue;
             }

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -403,7 +403,15 @@ pub(crate) async fn try_preempt(
         .get_jobs(&[JobState::Running], None, None, None, None, &[])
         .into_iter()
         .collect();
-    running.sort_by_key(|j| j.priority);
+    // Running jobs never pass back through pending_jobs(), so their stored
+    // `priority` is the raw base value, not the fairshare/age/tier/QoS
+    // adjusted value `pending` jobs carry. Recompute a comparable priority
+    // here rather than comparing raw and adjusted values against each other.
+    let running_priority: std::collections::HashMap<spur_core::job::JobId, u32> = running
+        .iter()
+        .map(|j| (j.job_id, cluster.current_effective_priority(j)))
+        .collect();
+    running.sort_by_key(|j| running_priority[&j.job_id]);
 
     for pending in unscheduled {
         let Some(pending_part) = partition_for(pending) else {
@@ -415,7 +423,8 @@ pub(crate) async fn try_preempt(
         let pending_tier = pending_part.priority_tier;
 
         for candidate in &running {
-            if candidate.priority >= pending.priority / 2 {
+            let candidate_priority = running_priority[&candidate.job_id];
+            if candidate_priority >= pending.priority / 2 {
                 continue;
             }
 
@@ -438,7 +447,7 @@ pub(crate) async fn try_preempt(
             }
             info!(
                 preempted_job = candidate.job_id,
-                preempted_priority = candidate.priority,
+                preempted_priority = candidate_priority,
                 pending_job = pending.job_id,
                 pending_priority = pending.priority,
                 mode = ?mode,

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -410,7 +410,7 @@ pub(crate) async fn try_preempt(
         .map(|j| {
             (
                 j.job_id,
-                cluster.current_effective_priority_with_qos(j, &running_qos[&j.job_id]),
+                cluster.current_effective_priority_with_qos(j, &running_qos[&j.job_id], partitions),
             )
         })
         .collect();

--- a/tests/native_host/e2e/conftest.py
+++ b/tests/native_host/e2e/conftest.py
@@ -186,7 +186,7 @@ def multi_node_cluster(ssh_nodes, remote_bin_dir, cluster_config_overrides):
 
 
 @pytest.fixture
-def accounting_cluster(ssh_nodes, remote_bin_dir):
+def accounting_cluster(ssh_nodes, remote_bin_dir, cluster_config_overrides):
     """
     Per-test fixture: a running cluster with Postgres on node 0.
 
@@ -206,7 +206,7 @@ def accounting_cluster(ssh_nodes, remote_bin_dir):
     except RuntimeError as e:
         pytest.skip(str(e))
     try:
-        c.deploy()
+        c.deploy(config_overrides=cluster_config_overrides)
     except Exception:
         c.teardown()
         raise

--- a/tests/native_host/e2e/test_qos_preemption.py
+++ b/tests/native_host/e2e/test_qos_preemption.py
@@ -7,7 +7,10 @@ E2E tests for QOS-driven priority and preemption (SPUR-40).
 Covers the fix where a QOS's `priority` delta is wired into a job's
 effective priority and a QOS's `preempt_mode` can override the partition's,
 letting a plain `sacctmgr`-configured QOS (no `scontrol update Priority=`
-trickery, no partition `preempt_mode`) drive real preemption over the wire.
+trickery) drive real preemption over the wire, on top of a partition that
+has already opted into preemption at all (`preempt_mode` != Off, the
+partition-level gate `try_preempt` checks before any QOS override is
+ever consulted).
 
 Requires Postgres on node 0 (the accounting_cluster fixture, which skips
 when Docker is unavailable).
@@ -15,21 +18,47 @@ when Docker is unavailable).
 
 import time
 
+import pytest
+
 from cluster import parse_job_id, wait_job, wait_job_state
 
 
 class TestQosPriorityPreemption:
     """A low-QOS running job must be preempted by a high-QOS pending job
     contending for the same exclusive node, driven purely by the QOS
-    priority delta and the low QOS's preempt_mode override."""
+    priority delta and the low QOS's preempt_mode override, once the
+    partition has opted into preemption at all."""
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        # preempt_mode must be non-Off for the scheduler to attempt
+        # preemption at all (a partition-level gate checked before any
+        # QOS override is consulted). Set to `cancel` here, deliberately
+        # different from `low`'s QOS-level `preemptmode=requeue` below, so
+        # the final assertion (low comes back as R, not cancelled) actually
+        # exercises the QOS override rather than just the partition default.
+        return {
+            "partitions": [
+                {
+                    "name": "default",
+                    "state": "UP",
+                    "default": True,
+                    "nodes": "ALL",
+                    "max_time": "24:00:00",
+                    "default_time": "10:00",
+                    "preempt_mode": "cancel",
+                }
+            ],
+        }
 
     def test_high_qos_preempts_low_qos_job(self, accounting_cluster):
         c = accounting_cluster
         node0 = c.node_names[0]
 
         # `low`'s negative priority delta keeps its effective priority at
-        # the floor, and its preempt_mode override makes it preemptable
-        # without needing a partition-level preempt_mode at all.
+        # the floor, and its preempt_mode override changes the eviction
+        # action from the partition's `cancel` to `requeue` (see
+        # cluster_config_overrides above for the partition-level opt-in).
         c.sacctmgr(["add", "qos", "name=low", "priority=-1000", "preemptmode=requeue"])
         c.sacctmgr(["add", "qos", "name=high", "priority=100000"])
         # Wait past the QoS cache refresh floor (10s) before submitting.

--- a/tests/native_host/e2e/test_qos_preemption.py
+++ b/tests/native_host/e2e/test_qos_preemption.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+E2E tests for QOS-driven priority and preemption (SPUR-40).
+
+Covers the fix where a QOS's `priority` delta is wired into a job's
+effective priority and a QOS's `preempt_mode` can override the partition's,
+letting a plain `sacctmgr`-configured QOS (no `scontrol update Priority=`
+trickery, no partition `preempt_mode`) drive real preemption over the wire.
+
+Requires Postgres on node 0 (the accounting_cluster fixture, which skips
+when Docker is unavailable).
+"""
+
+import time
+
+from cluster import parse_job_id, wait_job, wait_job_state
+
+
+class TestQosPriorityPreemption:
+    """A low-QOS running job must be preempted by a high-QOS pending job
+    contending for the same exclusive node, driven purely by the QOS
+    priority delta and the low QOS's preempt_mode override."""
+
+    def test_high_qos_preempts_low_qos_job(self, accounting_cluster):
+        c = accounting_cluster
+        node0 = c.node_names[0]
+
+        # `low`'s negative priority delta keeps its effective priority at
+        # the floor, and its preempt_mode override makes it preemptable
+        # without needing a partition-level preempt_mode at all.
+        c.sacctmgr(["add", "qos", "name=low", "priority=-1000", "preemptmode=requeue"])
+        c.sacctmgr(["add", "qos", "name=high", "priority=100000"])
+        # Wait past the QoS cache refresh floor (10s) before submitting.
+        time.sleep(15)
+
+        low_id = None
+        try:
+            low_script = c.write_file("qos-preempt-low.sh", "#!/bin/bash\nsleep 600\n")
+            low_out = c.sbatch(
+                ["-J", "qos-low", "-N", "1", f"--nodelist={node0}",
+                 "--exclusive", "-q", "low", low_script]
+            )
+            low_id = parse_job_id(low_out)
+            assert low_id is not None, f"submit failed:\n{low_out}"
+            wait_job_state(c, low_id, "R", timeout=30)
+
+            high_script = c.write_file("qos-preempt-high.sh", "#!/bin/bash\nsleep 2\n")
+            high_out = c.sbatch(
+                ["-J", "qos-high", "-N", "1", f"--nodelist={node0}",
+                 "--exclusive", "-q", "high", high_script]
+            )
+            high_id = parse_job_id(high_out)
+            assert high_id is not None, f"submit failed:\n{high_out}"
+
+            # The node is fully allocated to `low`, so `high` can only start
+            # once the scheduler's preemption pass evicts it.
+            wait_job_state(c, low_id, "PD", timeout=30)
+            high_state = wait_job(c, high_id, timeout=30)
+            assert high_state == "CD", f"high-QoS job did not complete: {high_state}"
+
+            # preempt_mode=requeue: `low` must come back, not stay cancelled.
+            wait_job_state(c, low_id, "R", timeout=30)
+        finally:
+            if low_id is not None:
+                c.cli_allow_fail(["scancel", str(low_id)])


### PR DESCRIPTION
## What

Fixes SPUR-40 completely: a job's QOS priority was never factored into scheduling/preemption, and a QOS's `preempt_mode` setting was never consulted either (only partition-level `preempt_mode` determined how a running job got preempted).

## Approach

QOS priority is applied as a **weighted-additive** term on top of the existing multiplicative `fairshare * age_factor * partition_tier` pipeline (an earlier draft fed it into the multiplicative base directly, which let unrelated fairshare/age amplify or invert the QOS delta by up to ~20x — caught in review, confirmed numerically, fixed).

QOS `preempt_mode` (Off/Cancel/Requeue/Suspend) now overrides the partition-level preempt mode for a running job when explicitly set to something other than `Off` — letting a QOS assert "jobs under me get preempted this specific way" regardless of partition config. `Off` is treated as "no override" since the wire format can't distinguish "explicitly Off" from "never configured."

Also fixes, found during review:
- `try_preempt`'s priority comparison previously compared a running job's raw stored priority against a pending job's fully-adjusted priority — now recomputed consistently.
- A deterministic tie-break (`job_id`) added to pending-job sorting, since the priority floor can now realistically collapse an entire low-priority QOS tier to the same value.
- A wrap-instead-of-saturate cast bug in the priority floor calculation.
- A redundant/inconsistent QOS cache lookup: the candidate job's QOS was being resolved twice per scheduling pass (once for priority, once for preempt-mode, in two temporally-separate reads that could theoretically observe different cache snapshots) — consolidated into a single resolve-once-per-candidate lookup, closing both a performance issue (was O(pending × running) instead of O(running)) and the snapshot-consistency gap.

## Known limitation, documented not fixed

A QOS explicitly set to `preempt_mode=Off` cannot express "never preempt regardless of partition" — the most protective use case is the one this feature can't express, since the wire format can't distinguish that from "never configured." Fixing this would need a wire-format change (e.g. `optional string` in the proto) — out of scope here, documented in code.

## Testing

- Unit tests including one with non-neutral fairshare/age proving QOS-tier priority ordering holds under realistic conditions.
- Unit tests for QOS preempt-mode override vs. partition fallback, plus regression coverage for the 4 pre-existing partition-only tests.
- An integration test through the real `try_preempt` → cache wiring (not just the pure decision function) confirming a QOS's `Suspend` override actually results in the job being suspended, not cancelled.
- Live-verified on the real 2-node cluster: a high-priority-QOS job correctly preempts a low-priority-QOS job, and a QOS with `preempt_mode=suspend` correctly overrides a partition's `cancel` default (confirmed via SIGSTOP at the agent level, not a kill).

## Review

3 rounds of independent adversarial review + cross-validation, which caught: the multiplicative-amplification bug (required a real redesign, not a patch), the raw-vs-adjusted priority mismatch, the missing tie-break, and the redundant/inconsistent QOS lookup described above.