### PR TITLE
fix(spurctld): stop counting preemption requeues against the failure-requeue hold limit

### DIFF
--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -284,8 +284,8 @@ pub struct ControllerConfig {
     #[serde(default)]
     pub heartbeat_timeout_secs: Option<u64>,
 
-    /// Maximum automatic requeues before a job is held with `JobHoldMaxRequeue`.
-    /// Configured in TOML as `[controller] max_batch_requeue` (default: 5).
+    /// Maximum automatic requeues (excluding preemption) before a job is held
+    /// with `JobHoldMaxRequeue`. Configured in TOML as `[controller] max_batch_requeue` (default: 5).
     #[serde(default = "default_max_batch_requeue")]
     pub max_batch_requeue: u32,
 }

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -544,9 +544,14 @@ pub struct Job {
     #[serde(default)]
     pub derived_exit_code: i32,
 
-    /// Number of times this job has been requeued.
+    /// Number of times this job has been requeued after a dispatch failure
+    /// or Timeout/NodeFail. Capped by `max_batch_requeue`.
     #[serde(default)]
     pub requeue_count: u32,
+    /// Number of times this job has been requeued after preemption; tracked
+    /// separately since it isn't a failure signal and never counts toward `max_batch_requeue`.
+    #[serde(default)]
+    pub preempt_requeue_count: u32,
 
     // Heterogeneous job support
     /// Links het job components to the first component's job ID.
@@ -607,6 +612,7 @@ impl Job {
             exit_signal: 0,
             derived_exit_code: 0,
             requeue_count: 0,
+            preempt_requeue_count: 0,
             het_job_id: None,
             het_group: None,
             node_completions: HashMap::new(),

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2705,15 +2705,29 @@ impl ClusterManager {
         .map_err(|e| anyhow::anyhow!("raft propose failed: {}", e))
     }
 
-    /// Clear a job's run-state so it is schedulable again after requeue.
-    fn reset_job_for_requeue(job: &mut Job) {
-        job.requeue_count += 1;
+    /// Clear a job's run-state fields so it's schedulable again after requeue.
+    /// Does not bump either counter; callers do that based on why they're requeuing.
+    fn clear_run_state_for_requeue(job: &mut Job) {
         job.start_time = None;
         job.exit_code = None;
         job.allocated_nodes.clear();
         job.allocated_resources = None;
         job.per_node_alloc.clear();
         job.pending_reason = PendingReason::None;
+    }
+
+    /// Requeue after a dispatch failure or Timeout/NodeFail: counts against
+    /// `max_batch_requeue`.
+    fn reset_job_for_requeue(job: &mut Job) {
+        job.requeue_count += 1;
+        Self::clear_run_state_for_requeue(job);
+    }
+
+    /// Requeue after preemption: tracked separately since it isn't a failure
+    /// signal and must never contribute to the `max_batch_requeue` hold.
+    fn reset_job_for_preempt_requeue(job: &mut Job) {
+        job.preempt_requeue_count += 1;
+        Self::clear_run_state_for_requeue(job);
     }
 
     /// Evict a single job by ID: transition to NodeFail, then free its
@@ -2851,11 +2865,7 @@ impl ClusterManager {
                         if job.requeue_count < max {
                             Self::reset_job_for_requeue(job);
                         } else {
-                            job.start_time = None;
-                            job.exit_code = None;
-                            job.allocated_nodes.clear();
-                            job.allocated_resources = None;
-                            job.per_node_alloc.clear();
+                            Self::clear_run_state_for_requeue(job);
                         }
                         job.pending_reason = pending_reason.clone().unwrap_or(PendingReason::None);
                         if let Some(priority) = pending_priority {
@@ -2898,7 +2908,7 @@ impl ClusterManager {
                         warn!(job_id = *job_id, error = %e, "invalid requeue transition in WAL apply");
                         return ClientResponse::default();
                     }
-                    Self::reset_job_for_requeue(job);
+                    Self::reset_job_for_preempt_requeue(job);
                     job.spec.begin_time = Some(*begin_time);
                     job.pending_reason = PendingReason::BeginTime;
                 }
@@ -5901,7 +5911,8 @@ mod tests {
         assert_eq!(job.state, JobState::Pending);
         assert_eq!(job.spec.begin_time, Some(begin_time));
         assert_eq!(job.pending_reason, PendingReason::BeginTime);
-        assert_eq!(job.requeue_count, 1);
+        assert_eq!(job.preempt_requeue_count, 1);
+        assert_eq!(job.requeue_count, 0);
         assert!(job.allocated_nodes.is_empty());
         assert_eq!(cm.get_node("worker1").unwrap().alloc_resources.cpus, 0);
 
@@ -5921,7 +5932,7 @@ mod tests {
             "instant must not drift"
         );
         assert_eq!(
-            job.requeue_count, 1,
+            job.preempt_requeue_count, 1,
             "replayed preempt-requeue must not double-count"
         );
         assert_eq!(cm.get_node("worker1").unwrap().alloc_resources.cpus, 0);
@@ -7176,6 +7187,108 @@ mod tests {
         assert_eq!(
             cm.get_job(job_id).unwrap().pending_reason,
             PendingReason::ReservationDeleted
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn preempt_requeue_never_holds_job_regardless_of_repeat_count() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+        let max = cm.config.controller.max_batch_requeue;
+
+        let job_id = run_job_on(&cm, "chronic-preempt", "worker1");
+        for _ in 0..(max + 3) {
+            cm.preempt_job(job_id, PreemptMode::Requeue).unwrap();
+            settle(&cm, job_id, JobState::Pending);
+            {
+                let mut jobs = cm.jobs.write();
+                jobs.get_mut(&job_id).unwrap().spec.begin_time =
+                    Some(Utc::now() - chrono::Duration::seconds(1));
+            }
+            let resources = scalar_alloc(2, 4000);
+            cm.start_job(
+                job_id,
+                vec!["worker1".into()],
+                resources.clone(),
+                per_node_for(&["worker1"], resources),
+            )
+            .unwrap();
+            settle(&cm, job_id, JobState::Running);
+        }
+        cm.preempt_job(job_id, PreemptMode::Requeue).unwrap();
+        settle(&cm, job_id, JobState::Pending);
+
+        let job = cm.get_job(job_id).unwrap();
+        assert!(
+            job.preempt_requeue_count > max,
+            "job must have been preempted more times than max_batch_requeue"
+        );
+        assert_eq!(
+            job.requeue_count, 0,
+            "repeated preemption must not touch the failure-requeue counter"
+        );
+        assert_ne!(
+            job.pending_reason,
+            PendingReason::JobHoldMaxRequeue,
+            "a chronically-preempted but otherwise healthy job must never be held"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn chronic_preemption_does_not_exhaust_failure_requeue_budget() {
+        // A job preempted max_batch_requeue times must still get a full
+        // failure-requeue budget: the two counters are independent.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+        let max = cm.config.controller.max_batch_requeue;
+
+        let mut spec = basic_spec("chronic-then-timeout");
+        spec.requeue = true;
+        let job_id = submit_and_wait(&cm, spec);
+        let resources = scalar_alloc(2, 4000);
+
+        for _ in 0..max {
+            cm.start_job(
+                job_id,
+                vec!["worker1".into()],
+                resources.clone(),
+                per_node_for(&["worker1"], resources.clone()),
+            )
+            .unwrap();
+            settle(&cm, job_id, JobState::Running);
+            cm.preempt_job(job_id, PreemptMode::Requeue).unwrap();
+            settle(&cm, job_id, JobState::Pending);
+            {
+                let mut jobs = cm.jobs.write();
+                jobs.get_mut(&job_id).unwrap().spec.begin_time =
+                    Some(Utc::now() - chrono::Duration::seconds(1));
+            }
+        }
+        assert_eq!(cm.get_job(job_id).unwrap().preempt_requeue_count, max);
+        assert_eq!(cm.get_job(job_id).unwrap().requeue_count, 0);
+
+        cm.start_job(
+            job_id,
+            vec!["worker1".into()],
+            resources.clone(),
+            per_node_for(&["worker1"], resources),
+        )
+        .unwrap();
+        settle(&cm, job_id, JobState::Running);
+        cm.complete_job(job_id, -1, JobState::Timeout).unwrap();
+
+        settle(&cm, job_id, JobState::Pending);
+        let job = cm.get_job(job_id).unwrap();
+        assert_eq!(
+            job.requeue_count, 1,
+            "the first genuine failure must count, unaffected by prior preemptions"
+        );
+        assert_ne!(
+            job.pending_reason,
+            PendingReason::JobHoldMaxRequeue,
+            "one timeout after chronic preemption must not exhaust the failure budget"
         );
     }
 

--- a/tests/native_host/e2e/test_preemption.py
+++ b/tests/native_host/e2e/test_preemption.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+E2E tests for preemption.
+
+Covers the fix where a job repeatedly preempted (PreemptMode=Requeue) must
+never be held with JobHoldMaxRequeue: preemption requeues are tracked
+separately from failure requeues (dispatch failure/Timeout/NodeFail) and are
+never checked against `max_batch_requeue`.
+"""
+
+import time
+
+import pytest
+
+from cluster import parse_job_id, wait_job, wait_job_state
+
+
+class TestChronicPreemption:
+    """A job preempted more times than max_batch_requeue must stay
+    schedulable, never landing in JobHoldMaxRequeue."""
+
+    MAX_BATCH_REQUEUE = 2
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return {
+            "controller": {"max_batch_requeue": self.MAX_BATCH_REQUEUE},
+            "partitions": [
+                {
+                    "name": "default",
+                    "state": "UP",
+                    "default": True,
+                    "nodes": "ALL",
+                    "max_time": "24:00:00",
+                    "default_time": "10:00",
+                    "preempt_mode": "requeue",
+                }
+            ],
+        }
+
+    def test_chronic_preemption_never_holds_job(self, cluster):
+        node0 = cluster.node_names[0]
+        low_id = None
+        try:
+            low_script = cluster.write_file(
+                "chronic-low.sh", "#!/bin/bash\nsleep 600\n"
+            )
+            sb = cluster.sbatch(
+                ["-J", "chronic-low", "-N", "1", f"--nodelist={node0}",
+                 "--exclusive", low_script]
+            )
+            low_id = parse_job_id(sb)
+            assert low_id is not None, f"submit failed:\n{sb}"
+            wait_job_state(cluster, low_id, "R", timeout=30)
+
+            # One more preemption cycle than max_batch_requeue: if preemption
+            # requeues wrongly counted against the failure-requeue budget, the
+            # job would be held with JobHoldMaxRequeue by the last cycle.
+            cycles = self.MAX_BATCH_REQUEUE + 3
+            for i in range(cycles):
+                wait_job_state(cluster, low_id, "R", timeout=30)
+
+                hi_script = cluster.write_file(
+                    f"chronic-high-{i}.sh", "#!/bin/bash\nsleep 2\n"
+                )
+                hb = cluster.sbatch(
+                    ["-J", f"chronic-high-{i}", "-N", "1", f"--nodelist={node0}",
+                     "--exclusive", hi_script]
+                )
+                hi_id = parse_job_id(hb)
+                assert hi_id is not None, f"submit failed:\n{hb}"
+                # A high enough priority guarantees preemption eligibility
+                # (candidate.priority must be < pending.priority / 2).
+                cluster.scontrol("update", f"JobId={hi_id}", "Priority=1000000")
+
+                wait_job_state(cluster, low_id, "PD", timeout=15)
+                show = cluster.scontrol("show", "job", str(low_id))
+                assert "Reason=JobHoldMaxRequeue" not in show, (
+                    f"low-priority job held after preemption cycle {i}:\n{show}"
+                )
+
+                state = wait_job(cluster, hi_id, timeout=30)
+                assert state == "CD", f"high job {hi_id} did not complete: {state}"
+
+            wait_job_state(cluster, low_id, "R", timeout=30)
+            show = cluster.scontrol("show", "job", str(low_id))
+            assert "Reason=JobHoldMaxRequeue" not in show, (
+                f"low-priority job held after {cycles} preemption cycles "
+                f"(max_batch_requeue={self.MAX_BATCH_REQUEUE}):\n{show}"
+            )
+        finally:
+            if low_id is not None:
+                cluster.cli_allow_fail(["scancel", str(low_id)])


### PR DESCRIPTION
## What

Fixes SPUR-41: a job could get permanently stuck in Pending (`JobHoldMaxRequeue`) purely from being preempted repeatedly — a normal, expected occurrence in a busy multi-tenant cluster — because preemption-driven requeues and genuine failure/timeout-driven requeues shared a single `requeue_count` counter and cap.

## Approach

Split the counter into two independently tracked fields: `requeue_count` (failure/timeout/dispatch-failure requeues, capped at `max_batch_requeue` as before) and a new `preempt_requeue_count` (preemption-driven requeues, intentionally uncapped — matching real Slurm semantics, where repeated preemption is rate-limited, not count-limited). Refactored the shared job run-state reset logic into one helper used by both paths, replacing what was previously duplicated inline.

## Testing
- Regression tests proving both halves: a job preempted well past the old shared cap is never held, and a job that genuinely times out/fails repeatedly is still held at the same limit as before (no change to the original intended failure-path behavior).
- Verified WAL/Raft backward compatibility for the new persisted field (old-log replay defaults correctly).
- Live-verified on the real 2-node cluster: a job preempted 5 times in a row (exceeding the configured `max_batch_requeue`) was never held, and completed normally once nothing preempted it.

## Review
2 independent adversarial reviews + cross-validation pass — both came back clean, no blockers.