### PR TITLE
feat(spur-cli): add -V/--version support across all binaries and CLI entry points

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,6 +23,7 @@ jobs:
       date: ${{ steps.meta.outputs.date }}
       short_sha: ${{ steps.meta.outputs.short_sha }}
       full_sha: ${{ steps.meta.outputs.full_sha }}
+      git_describe: ${{ steps.meta.outputs.git_describe }}
     steps:
       - uses: actions/checkout@v7
 
@@ -49,6 +50,7 @@ jobs:
           echo "date=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
           echo "short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           echo "full_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "git_describe=$(git describe --always --dirty)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         if: steps.check.outputs.skip != 'true'
@@ -63,6 +65,8 @@ jobs:
           target: dist
           push: false
           outputs: type=local,dest=./dist
+          build-args: |
+            SPUR_GIT_DESCRIBE=${{ steps.meta.outputs.git_describe }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -166,6 +170,8 @@ jobs:
           tags: |
             rocm/spur:nightly
             rocm/spur:nightly-${{ needs.build.outputs.date }}
+          build-args: |
+            SPUR_GIT_DESCRIBE=${{ needs.build.outputs.git_describe }}
           cache-from: type=gha,scope=nightly-docker
           cache-to: type=gha,scope=nightly-docker,mode=max
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,8 @@ jobs:
           target: dist
           push: false
           outputs: type=local,dest=./dist
+          build-args: |
+            SPUR_GIT_DESCRIBE=${{ env.TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -154,6 +156,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            SPUR_GIT_DESCRIBE=${{ env.TAG }}
           cache-from: type=gha,scope=release-docker
           cache-to: type=gha,scope=release-docker,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,9 @@ COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
+ARG SPUR_GIT_DESCRIBE
+ENV SPUR_GIT_DESCRIBE=$SPUR_GIT_DESCRIBE
+
 COPY --from=planner /build/recipe.json recipe.json
 RUN cargo chef cook --release --locked --recipe-path recipe.json
 

--- a/crates/spur-cli/src/main.rs
+++ b/crates/spur-cli/src/main.rs
@@ -65,6 +65,14 @@ fn main() -> anyhow::Result<()> {
         let _ = signal(Signal::SIGPIPE, SigHandler::SigDfl);
     }
 
+    // Applies to every entry point (native `spur` and all Slurm-compatible
+    // symlinks alike), ahead of per-subcommand clap parsing that doesn't
+    // otherwise register -V/--version.
+    if std::env::args().any(|a| a == "-V" || a == "--version") {
+        println!("{}", spur_core::version::version_string());
+        std::process::exit(0);
+    }
+
     load_controller_addr_from_config();
 
     // Multi-call binary: dispatch based on argv[0] (symlink name).
@@ -197,7 +205,7 @@ fn main() -> anyhow::Result<()> {
 
     match args[1].as_str() {
         "version" | "--version" | "-V" => {
-            println!("spur {}", env!("CARGO_PKG_VERSION"));
+            println!("{}", spur_core::version::version_string());
             if args.len() > 2 && args[2] == "--check" {
                 runtime.block_on(async {
                     print!("Checking for updates... ");

--- a/crates/spur-cli/src/main.rs
+++ b/crates/spur-cli/src/main.rs
@@ -70,7 +70,7 @@ fn main() -> anyhow::Result<()> {
     // otherwise register -V/--version. Only the first argument is checked so
     // that trailing args forwarded to a user program (srun, exec, scontrol
     // update, sacctmgr, ...) can't be mistaken for this flag.
-    if matches!(std::env::args().nth(1).as_deref(), Some("-V" | "--version")) {
+    if matches!(std::env::args_os().nth(1).as_deref(), Some(a) if a == "-V" || a == "--version") {
         println!("{}", spur_core::version::version_string());
         std::process::exit(0);
     }

--- a/crates/spur-cli/src/main.rs
+++ b/crates/spur-cli/src/main.rs
@@ -69,8 +69,12 @@ fn main() -> anyhow::Result<()> {
     // symlinks alike), ahead of per-subcommand clap parsing that doesn't
     // otherwise register -V/--version. Only the first argument is checked so
     // that trailing args forwarded to a user program (srun, exec, scontrol
-    // update, sacctmgr, ...) can't be mistaken for this flag.
-    if matches!(std::env::args_os().nth(1).as_deref(), Some(a) if a == "-V" || a == "--version") {
+    // update, sacctmgr, ...) can't be mistaken for this flag. Requiring no
+    // further arguments lets `spur -V --check`/`spur --version --check` fall
+    // through to the native dispatch below, where `--check` is handled.
+    if std::env::args_os().len() <= 2
+        && matches!(std::env::args_os().nth(1).as_deref(), Some(a) if a == "-V" || a == "--version")
+    {
         println!("{}", spur_core::version::version_string());
         std::process::exit(0);
     }

--- a/crates/spur-cli/src/main.rs
+++ b/crates/spur-cli/src/main.rs
@@ -67,8 +67,10 @@ fn main() -> anyhow::Result<()> {
 
     // Applies to every entry point (native `spur` and all Slurm-compatible
     // symlinks alike), ahead of per-subcommand clap parsing that doesn't
-    // otherwise register -V/--version.
-    if std::env::args().any(|a| a == "-V" || a == "--version") {
+    // otherwise register -V/--version. Only the first argument is checked so
+    // that trailing args forwarded to a user program (srun, exec, scontrol
+    // update, sacctmgr, ...) can't be mistaken for this flag.
+    if matches!(std::env::args().nth(1).as_deref(), Some("-V" | "--version")) {
         println!("{}", spur_core::version::version_string());
         std::process::exit(0);
     }

--- a/crates/spur-core/build.rs
+++ b/crates/spur-core/build.rs
@@ -1,51 +1,8 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
-
-/// Walk up from `start` looking for a `.git` entry (directory for a normal
-/// clone, file for a worktree checkout).
-fn find_git_path(start: &Path) -> Option<PathBuf> {
-    let mut dir = start;
-    loop {
-        let candidate = dir.join(".git");
-        if candidate.exists() {
-            return Some(candidate);
-        }
-        dir = dir.parent()?;
-    }
-}
-
-/// Paths whose mtime should invalidate the cached git descriptor: the
-/// current HEAD and the refs that HEAD (or tags) can move to. Worktrees
-/// store HEAD per-worktree but keep refs in the shared "commondir".
-fn watch_paths(git_path: &Path) -> Vec<PathBuf> {
-    if git_path.is_dir() {
-        return vec![
-            git_path.join("HEAD"),
-            git_path.join("refs"),
-            git_path.join("packed-refs"),
-        ];
-    }
-
-    let Ok(contents) = std::fs::read_to_string(git_path) else {
-        return vec![];
-    };
-    let Some(worktree_gitdir) = contents.trim().strip_prefix("gitdir: ") else {
-        return vec![];
-    };
-    let worktree_gitdir = PathBuf::from(worktree_gitdir);
-
-    let mut paths = vec![worktree_gitdir.join("HEAD")];
-    if let Ok(commondir) = std::fs::read_to_string(worktree_gitdir.join("commondir")) {
-        let common_dir = worktree_gitdir.join(commondir.trim());
-        paths.push(common_dir.join("HEAD"));
-        paths.push(common_dir.join("refs"));
-        paths.push(common_dir.join("packed-refs"));
-    }
-    paths
-}
 
 fn git_describe(manifest_dir: &Path) -> String {
     Command::new("git")
@@ -59,15 +16,11 @@ fn git_describe(manifest_dir: &Path) -> String {
         .unwrap_or_default()
 }
 
+// No `rerun-if-changed` is emitted: Cargo's default with none is to rerun
+// every build, which we want since `--dirty` reflects the whole tree, not
+// just this crate's files. Not unit tested; verified manually and in CI.
 fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
-
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    if let Some(git_path) = find_git_path(&manifest_dir) {
-        for path in watch_paths(&git_path) {
-            println!("cargo:rerun-if-changed={}", path.display());
-        }
-    }
+    let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
     // Docker builds don't ship `.git` (see `.dockerignore`), so CI passes the
     // descriptor in directly; only shell out to git for local dev builds.

--- a/crates/spur-core/build.rs
+++ b/crates/spur-core/build.rs
@@ -69,8 +69,10 @@ fn main() {
         }
     }
 
-    println!(
-        "cargo:rustc-env=SPUR_GIT_DESCRIBE={}",
-        git_describe(&manifest_dir)
-    );
+    // Docker builds don't ship `.git` (see `.dockerignore`), so CI passes the
+    // descriptor in directly; only shell out to git for local dev builds.
+    let describe =
+        std::env::var("SPUR_GIT_DESCRIBE").unwrap_or_else(|_| git_describe(&manifest_dir));
+
+    println!("cargo:rustc-env=SPUR_GIT_DESCRIBE={describe}");
 }

--- a/crates/spur-core/build.rs
+++ b/crates/spur-core/build.rs
@@ -16,7 +16,6 @@ fn git_describe(manifest_dir: &Path) -> String {
         .unwrap_or_default()
 }
 
-// Not unit tested; verified manually and in CI.
 fn main() {
     // `--dirty` reflects the whole working tree, not just this crate's
     // files, so no `rerun-if-changed` path can scope this correctly.

--- a/crates/spur-core/build.rs
+++ b/crates/spur-core/build.rs
@@ -16,10 +16,14 @@ fn git_describe(manifest_dir: &Path) -> String {
         .unwrap_or_default()
 }
 
-// No `rerun-if-changed` is emitted: Cargo's default with none is to rerun
-// every build, which we want since `--dirty` reflects the whole tree, not
-// just this crate's files. Not unit tested; verified manually and in CI.
+// Not unit tested; verified manually and in CI.
 fn main() {
+    // `--dirty` reflects the whole working tree, not just this crate's
+    // files, so no `rerun-if-changed` path can scope this correctly.
+    // Watching a path that never exists forces Cargo to treat the build
+    // script as always out of date, so it reruns on every build.
+    println!("cargo:rerun-if-changed=__spur_always_rerun__");
+
     let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
     // Docker builds don't ship `.git` (see `.dockerignore`), so CI passes the

--- a/crates/spur-core/build.rs
+++ b/crates/spur-core/build.rs
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Walk up from `start` looking for a `.git` entry (directory for a normal
+/// clone, file for a worktree checkout).
+fn find_git_path(start: &Path) -> Option<PathBuf> {
+    let mut dir = start;
+    loop {
+        let candidate = dir.join(".git");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+        dir = dir.parent()?;
+    }
+}
+
+/// Paths whose mtime should invalidate the cached git descriptor: the
+/// current HEAD and the refs that HEAD (or tags) can move to. Worktrees
+/// store HEAD per-worktree but keep refs in the shared "commondir".
+fn watch_paths(git_path: &Path) -> Vec<PathBuf> {
+    if git_path.is_dir() {
+        return vec![
+            git_path.join("HEAD"),
+            git_path.join("refs"),
+            git_path.join("packed-refs"),
+        ];
+    }
+
+    let Ok(contents) = std::fs::read_to_string(git_path) else {
+        return vec![];
+    };
+    let Some(worktree_gitdir) = contents.trim().strip_prefix("gitdir: ") else {
+        return vec![];
+    };
+    let worktree_gitdir = PathBuf::from(worktree_gitdir);
+
+    let mut paths = vec![worktree_gitdir.join("HEAD")];
+    if let Ok(commondir) = std::fs::read_to_string(worktree_gitdir.join("commondir")) {
+        let common_dir = worktree_gitdir.join(commondir.trim());
+        paths.push(common_dir.join("HEAD"));
+        paths.push(common_dir.join("refs"));
+        paths.push(common_dir.join("packed-refs"));
+    }
+    paths
+}
+
+fn git_describe(manifest_dir: &Path) -> String {
+    Command::new("git")
+        .args(["describe", "--always", "--dirty"])
+        .current_dir(manifest_dir)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default()
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    if let Some(git_path) = find_git_path(&manifest_dir) {
+        for path in watch_paths(&git_path) {
+            println!("cargo:rerun-if-changed={}", path.display());
+        }
+    }
+
+    println!(
+        "cargo:rustc-env=SPUR_GIT_DESCRIBE={}",
+        git_describe(&manifest_dir)
+    );
+}

--- a/crates/spur-core/src/lib.rs
+++ b/crates/spur-core/src/lib.rs
@@ -19,4 +19,5 @@ pub mod resource;
 pub mod spur_env;
 pub mod step;
 pub mod topology;
+pub mod version;
 pub mod wal;

--- a/crates/spur-core/src/version.rs
+++ b/crates/spur-core/src/version.rs
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Git descriptor captured at build time (`git describe --always --dirty`).
+/// Empty when git was unavailable at build time (e.g. building from a
+/// released source tarball with no `.git` directory).
+pub const GIT_DESCRIBE: &str = env!("SPUR_GIT_DESCRIBE");
+
+fn format_version(pkg_version: &str, git_describe: &str) -> String {
+    let tag = format!("v{pkg_version}");
+    if git_describe.is_empty() || git_describe == tag {
+        format!("spur {pkg_version}")
+    } else {
+        format!("spur {pkg_version} ({git_describe})")
+    }
+}
+
+/// User-facing version string, matching Slurm's `<product> <version>` format
+/// for release builds and appending git metadata for dev builds.
+pub fn version_string() -> String {
+    format_version(env!("CARGO_PKG_VERSION"), GIT_DESCRIBE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_git_describe_yields_plain_version() {
+        assert_eq!(format_version("0.4.1", ""), "spur 0.4.1");
+    }
+
+    #[test]
+    fn exact_tag_match_yields_plain_version() {
+        assert_eq!(format_version("0.4.1", "v0.4.1"), "spur 0.4.1");
+    }
+
+    #[test]
+    fn commits_past_tag_includes_git_describe() {
+        assert_eq!(
+            format_version("0.4.1", "v0.4.1-45-gabc1234"),
+            "spur 0.4.1 (v0.4.1-45-gabc1234)"
+        );
+    }
+
+    #[test]
+    fn dirty_tree_includes_dirty_suffix() {
+        assert_eq!(
+            format_version("0.4.1", "v0.4.1-dirty"),
+            "spur 0.4.1 (v0.4.1-dirty)"
+        );
+    }
+
+    #[test]
+    fn commits_past_tag_and_dirty_includes_full_descriptor() {
+        assert_eq!(
+            format_version("0.4.1", "v0.4.1-45-gabc1234-dirty"),
+            "spur 0.4.1 (v0.4.1-45-gabc1234-dirty)"
+        );
+    }
+
+    #[test]
+    fn descriptor_from_older_tag_is_not_treated_as_exact_match() {
+        assert_eq!(
+            format_version("0.4.1", "v0.3.0-251-g4b85bd7"),
+            "spur 0.4.1 (v0.3.0-251-g4b85bd7)"
+        );
+    }
+}

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -62,7 +62,7 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    if std::env::args().any(|a| a == "-V" || a == "--version") {
+    if matches!(std::env::args().nth(1).as_deref(), Some("-V" | "--version")) {
         println!("{}", spur_core::version::version_string());
         return Ok(());
     }

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -62,6 +62,11 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    if std::env::args().any(|a| a == "-V" || a == "--version") {
+        println!("{}", spur_core::version::version_string());
+        return Ok(());
+    }
+
     let args = Args::parse();
 
     tracing_subscriber::fmt()
@@ -71,7 +76,7 @@ async fn main() -> anyhow::Result<()> {
         )
         .init();
 
-    info!(version = env!("CARGO_PKG_VERSION"), "spurctld starting");
+    info!(version = %spur_core::version::version_string(), "spurctld starting");
 
     // Load config if it exists, otherwise use defaults
     let mut config = if args.config.exists() {

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -62,7 +62,10 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    if matches!(std::env::args().nth(1).as_deref(), Some("-V" | "--version")) {
+    if std::env::args_os()
+        .skip(1)
+        .any(|a| a == "-V" || a == "--version")
+    {
         println!("{}", spur_core::version::version_string());
         return Ok(());
     }

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -79,7 +79,7 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    if std::env::args().any(|a| a == "-V" || a == "--version") {
+    if matches!(std::env::args().nth(1).as_deref(), Some("-V" | "--version")) {
         println!("{}", spur_core::version::version_string());
         return Ok(());
     }

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -79,7 +79,10 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    if matches!(std::env::args().nth(1).as_deref(), Some("-V" | "--version")) {
+    if std::env::args_os()
+        .skip(1)
+        .any(|a| a == "-V" || a == "--version")
+    {
         println!("{}", spur_core::version::version_string());
         return Ok(());
     }

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -79,6 +79,11 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    if std::env::args().any(|a| a == "-V" || a == "--version") {
+        println!("{}", spur_core::version::version_string());
+        return Ok(());
+    }
+
     let args = Args::parse();
 
     tracing_subscriber::fmt()
@@ -103,7 +108,7 @@ async fn main() -> anyhow::Result<()> {
         .unwrap_or(6818);
 
     info!(
-        version = env!("CARGO_PKG_VERSION"),
+        version = %spur_core::version::version_string(),
         hostname = %hostname,
         controller = %args.controller,
         listen = %args.listen,


### PR DESCRIPTION
## What

Fixes SPUR-61: none of Spur's Slurm-compatible CLI tools (`squeue`, `sinfo`, `sbatch`, `srun`, `scontrol`, etc.) or daemons (`spurctld`, `spurd`) supported `-V`/`--version`, unlike every real Slurm binary (`squeue -V` → `slurm 25.11.6`). Only the native `spur` command itself had it.

## Approach

- Added a `crates/spur-core/build.rs` that captures `git describe --always --dirty` at compile time, exposed via `spur_core::version::version_string()`. A clean, exact release build shows the plain `spur 0.4.1` (matching Slurm's format); a build with commits past the last release tag or an uncommitted change shows `spur 0.4.1 (v0.4.1-12-gabc1234[-dirty])`, so nightly/dirty/in-development builds are unambiguously distinguishable from a real release, without any CI/workflow redesign.
- Wired `-V`/`--version` into every Slurm-compatible entry point (the multi-call `spur` binary and all its symlinks) via a single early check scoped to the first CLI argument, plus both daemons.
- Daemon startup logs now include the same richer version string, not just the bare semver, per the ticket's third requirement.

## Bugs found and fixed during review (before this ever reached the point of being reviewable as "done")

- **A naive first draft of the version-flag check scanned the entire argument list**, which silently hijacked commands like `srun python -V` or `spur exec <id> python -V` — spur would print its own version and exit instead of ever running the wrapped command. Fixed by scoping the check to only the first argument.
- **Docker-built nightly/release binaries would never have shown any git metadata at all** — `.dockerignore` excludes `.git` from the build context entirely, so `build.rs` had no way to compute a git descriptor inside a container build. Fixed by threading the descriptor through as a Docker build-arg, computed on the CI runner (which has full git history) and passed to the Docker build step in both `nightly.yml` and `release.yml`.
- **The `--dirty` flag could go stale** on ordinary incremental rebuilds, since the build script was only re-triggered by `.git` metadata changes, not working-tree file edits. Fixed by making the build script always rerun (a standard idiom for this class of tool, matching `vergen`/`git-version`).

## Testing

- Unit tests for the version-string formatting logic across all cases (clean tag, commits-past-tag, dirty, no-git-available).
- Live-verified on the real 2-node cluster: daemon `--version` flags, daemon startup log output, CLI symlinks (`squeue`, `sinfo`, `sbatch`, `scontrol`), the argv-hijack regression fix (confirmed `srun echo hello -V` actually submits and runs the job, passing `-V` through as a literal argument), and a completely ordinary job submission to confirm nothing else broke.
- Manually verified the Docker build-arg wiring with a real `docker build --target dist --build-arg SPUR_GIT_DESCRIBE=...` run.

## Review

2 rounds of independent adversarial review + cross-validation, which caught all 3 bugs described above before this was mergeable.