### PR TITLE
fix(spurctld): raise grpc message-size limits and cap job submission size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3706,6 +3706,7 @@ dependencies = [
  "sqlx",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tonic",
  "tower",
  "tower-http 0.7.0",

--- a/crates/spur-cli/src/exec.rs
+++ b/crates/spur-cli/src/exec.rs
@@ -5,7 +5,6 @@
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::ExecInJobRequest;
 
 /// Execute a command inside a running containerized job.
@@ -41,7 +40,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let channel = spur_client::connect_channel(&args.controller)
         .await
         .context("failed to connect to controller")?;
-    let mut client = SlurmControllerClient::new(channel);
+    let mut client = spur_proto::controller_client(channel);
 
     let resp = client
         .exec_in_job(ExecInJobRequest {

--- a/crates/spur-cli/src/node.rs
+++ b/crates/spur-cli/src/node.rs
@@ -8,7 +8,6 @@ use std::collections::HashMap;
 use anyhow::{bail, Result};
 use clap::{Parser, Subcommand};
 
-use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::UpdateNodeRequest;
 
 /// Node management commands.
@@ -104,7 +103,7 @@ fn parse_label_args(label_args: &[String]) -> Result<(HashMap<String, String>, V
 }
 
 async fn cmd_label(controller: &str, node: String, label_args: Vec<String>) -> Result<()> {
-    let mut client = SlurmControllerClient::new(spur_client::connect_channel(controller).await?);
+    let mut client = spur_proto::controller_client(spur_client::connect_channel(controller).await?);
     let (set_labels, remove_labels) = parse_label_args(&label_args)?;
 
     client
@@ -128,7 +127,7 @@ async fn cmd_label(controller: &str, node: String, label_args: Vec<String>) -> R
 }
 
 async fn cmd_drain(controller: &str, node: String, reason: Option<String>) -> Result<()> {
-    let mut client = SlurmControllerClient::new(spur_client::connect_channel(controller).await?);
+    let mut client = spur_proto::controller_client(spur_client::connect_channel(controller).await?);
     let resp = client
         .drain_node(spur_proto::proto::DrainNodeRequest {
             name: node.clone(),
@@ -158,7 +157,7 @@ async fn cmd_remove(
     force: bool,
     reason: Option<String>,
 ) -> Result<()> {
-    let mut client = SlurmControllerClient::new(spur_client::connect_channel(controller).await?);
+    let mut client = spur_proto::controller_client(spur_client::connect_channel(controller).await?);
     let resp = client
         .deregister_node(spur_proto::proto::DeregisterNodeRequest {
             name: node.clone(),

--- a/crates/spur-cli/src/sacct.rs
+++ b/crates/spur-cli/src/sacct.rs
@@ -3,7 +3,6 @@
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use spur_proto::proto::slurm_accounting_client::SlurmAccountingClient;
 use spur_proto::proto::GetJobHistoryRequest;
 
 use crate::exit_fmt::format_exit;
@@ -156,7 +155,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let channel = spur_client::connect_channel(&args.controller)
         .await
         .context("failed to connect to controller")?;
-    let mut client = SlurmAccountingClient::new(channel);
+    let mut client = spur_proto::accounting_client(channel);
 
     let start_after = args
         .starttime

--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -113,7 +113,7 @@ async fn connect(addr: &str) -> Result<SlurmAccountingClient<tonic::transport::C
     let channel = spur_client::connect_channel(addr)
         .await
         .context("failed to connect to controller")?;
-    Ok(SlurmAccountingClient::new(channel))
+    Ok(spur_proto::accounting_client(channel))
 }
 
 /// Extract the fields shared by `add user` and `modify user` (both upsert

--- a/crates/spur-cli/src/salloc.rs
+++ b/crates/spur-cli/src/salloc.rs
@@ -4,7 +4,6 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use spur_core::spur_env::SpurEnv;
-use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{CancelJobRequest, GetJobRequest, JobSpec, SubmitJobRequest};
 use std::collections::HashMap;
 
@@ -122,7 +121,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let channel = spur_client::connect_channel(&controller)
         .await
         .context("failed to connect to spurctld")?;
-    let mut client = SlurmControllerClient::new(channel);
+    let mut client = spur_proto::controller_client(channel);
 
     // Submit interactive allocation (sleep infinity holds the allocation)
     let job_spec = JobSpec {

--- a/crates/spur-cli/src/sattach.rs
+++ b/crates/spur-cli/src/sattach.rs
@@ -79,7 +79,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         .await
         .context(format!("failed to connect to agent at {}", agent_addr))?
         .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
-        .max_encoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE);
+        .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE);
 
     if args.output_only {
         // Output-only mode: stream stdout/stderr without stdin

--- a/crates/spur-cli/src/sattach.rs
+++ b/crates/spur-cli/src/sattach.rs
@@ -4,7 +4,6 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
-use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{AttachJobInput, GetJobRequest, JobState, StreamJobOutputRequest};
 use std::io::Write;
 
@@ -50,7 +49,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let channel = spur_client::connect_channel(&args.controller)
         .await
         .context("failed to connect to spurctld")?;
-    let mut client = SlurmControllerClient::new(channel);
+    let mut client = spur_proto::controller_client(channel);
 
     // Look up the job to find which node it is running on
     let job = client
@@ -78,7 +77,9 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let agent_addr = format!("http://{}:6818", first_node);
     let mut agent = SlurmAgentClient::connect(agent_addr.clone())
         .await
-        .context(format!("failed to connect to agent at {}", agent_addr))?;
+        .context(format!("failed to connect to agent at {}", agent_addr))?
+        .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
+        .max_encoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE);
 
     if args.output_only {
         // Output-only mode: stream stdout/stderr without stdin

--- a/crates/spur-cli/src/sbatch.rs
+++ b/crates/spur-cli/src/sbatch.rs
@@ -4,7 +4,6 @@
 use anyhow::{bail, Context, Result};
 use clap::parser::ValueSource;
 use clap::{CommandFactory, FromArgMatches, Parser};
-use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{JobSpec, SubmitJobRequest};
 use std::collections::HashMap;
 
@@ -842,7 +841,7 @@ pub async fn main_with_args(cli_args: Vec<String>) -> Result<()> {
     let channel = spur_client::connect_channel(&args.controller)
         .await
         .context("failed to connect to spurctld")?;
-    let mut client = SlurmControllerClient::new(channel);
+    let mut client = spur_proto::controller_client(channel);
 
     let response = client
         .submit_job(SubmitJobRequest {

--- a/crates/spur-cli/src/scancel.rs
+++ b/crates/spur-cli/src/scancel.rs
@@ -3,7 +3,6 @@
 
 use anyhow::{bail, Context, Result};
 use clap::Parser;
-use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::CancelJobRequest;
 
 /// Cancel pending or running jobs.
@@ -78,7 +77,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let channel = spur_client::connect_channel(&args.controller)
         .await
         .context("failed to connect to spurctld")?;
-    let mut client = SlurmControllerClient::new(channel);
+    let mut client = spur_proto::controller_client(channel);
 
     if !args.job_ids.is_empty() {
         // Cancel specific jobs

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -3,9 +3,9 @@
 
 use std::collections::HashMap;
 
+use crate::exit_fmt::{format_exit, render_reason};
 use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand};
-use crate::exit_fmt::{format_exit, render_reason};
 
 /// Administrative control commands.
 #[derive(Parser, Debug)]

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -5,8 +5,6 @@ use std::collections::HashMap;
 
 use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand};
-use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
-
 use crate::exit_fmt::{format_exit, render_reason};
 
 /// Administrative control commands.
@@ -174,7 +172,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             let channel = spur_client::connect_channel(&args.controller)
                 .await
                 .context("failed to connect to spurctld")?;
-            let mut client = SlurmControllerClient::new(channel);
+            let mut client = spur_proto::controller_client(channel);
             client
                 .cancel_job(spur_proto::proto::CancelJobRequest {
                     job_id,
@@ -190,7 +188,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             let channel = spur_client::connect_channel(&args.controller)
                 .await
                 .context("failed to connect to spurctld")?;
-            let mut client = SlurmControllerClient::new(channel);
+            let mut client = spur_proto::controller_client(channel);
             client
                 .suspend_job(spur_proto::proto::SuspendJobRequest {
                     job_id,
@@ -205,7 +203,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             let channel = spur_client::connect_channel(&args.controller)
                 .await
                 .context("failed to connect to spurctld")?;
-            let mut client = SlurmControllerClient::new(channel);
+            let mut client = spur_proto::controller_client(channel);
             client
                 .resume_job(spur_proto::proto::ResumeJobRequest {
                     job_id,
@@ -257,7 +255,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             let channel = spur_client::connect_channel(&args.controller)
                 .await
                 .context("failed to connect to spurctld")?;
-            let mut client = SlurmControllerClient::new(channel);
+            let mut client = spur_proto::controller_client(channel);
             client
                 .update_reservation(spur_proto::proto::UpdateReservationRequest {
                     name: name.clone(),
@@ -284,7 +282,7 @@ async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> 
     let channel = spur_client::connect_channel(controller)
         .await
         .context("failed to connect to spurctld")?;
-    let mut client = SlurmControllerClient::new(channel);
+    let mut client = spur_proto::controller_client(channel);
 
     match entity.to_lowercase().as_str() {
         "job" | "jobs" => {
@@ -531,7 +529,7 @@ async fn ping(controller: &str) -> Result<()> {
     let channel = spur_client::connect_channel(controller)
         .await
         .context("failed to connect to spurctld")?;
-    let mut client = SlurmControllerClient::new(channel);
+    let mut client = spur_proto::controller_client(channel);
 
     let resp = client.ping(()).await.context("ping failed")?;
 
@@ -573,7 +571,7 @@ async fn send_job_update(controller: &str, req: spur_proto::proto::UpdateJobRequ
     let channel = spur_client::connect_channel(controller)
         .await
         .context("failed to connect to spurctld")?;
-    let mut client = SlurmControllerClient::new(channel);
+    let mut client = spur_proto::controller_client(channel);
 
     client.update_job(req).await.context("update failed")?;
 
@@ -661,7 +659,7 @@ async fn update_node(
     let channel = spur_client::connect_channel(controller)
         .await
         .context("failed to connect to spurctld")?;
-    let mut client = SlurmControllerClient::new(channel);
+    let mut client = spur_proto::controller_client(channel);
 
     let proto_state = state.map(|s| match s.to_lowercase().as_str() {
         "idle" | "resume" => spur_proto::proto::NodeState::NodeIdle as i32,
@@ -706,7 +704,7 @@ async fn create_reservation(
     let channel = spur_client::connect_channel(controller)
         .await
         .context("failed to connect to spurctld")?;
-    let mut client = SlurmControllerClient::new(channel);
+    let mut client = spur_proto::controller_client(channel);
 
     let node_list: Vec<String> = nodes
         .split(',')
@@ -751,7 +749,7 @@ async fn delete_reservation(controller: &str, name: &str) -> Result<()> {
     let channel = spur_client::connect_channel(controller)
         .await
         .context("failed to connect to spurctld")?;
-    let mut client = SlurmControllerClient::new(channel);
+    let mut client = spur_proto::controller_client(channel);
 
     client
         .delete_reservation(spur_proto::proto::DeleteReservationRequest {

--- a/crates/spur-cli/src/sdiag.rs
+++ b/crates/spur-cli/src/sdiag.rs
@@ -5,7 +5,6 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use spur_core::job::JobState as CoreJobState;
 use spur_core::node::NodeState as CoreNodeState;
-use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{JobMetrics, NodeMetrics, RpcOperationStats, RpcStats, SchedStats};
 
 /// Display scheduler diagnostics and statistics.
@@ -39,7 +38,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let channel = spur_client::connect_channel(&args.controller)
         .await
         .context("failed to connect to spurctld")?;
-    let mut client = SlurmControllerClient::new(channel);
+    let mut client = spur_proto::controller_client(channel);
 
     if args.reset {
         client

--- a/crates/spur-cli/src/sinfo.rs
+++ b/crates/spur-cli/src/sinfo.rs
@@ -5,7 +5,6 @@ use std::collections::BTreeMap;
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{GetNodesRequest, GetPartitionsRequest, NodeInfo, PartitionInfo};
 
 use crate::format_engine;
@@ -73,7 +72,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let channel = spur_client::connect_channel(&args.controller)
         .await
         .context("failed to connect to spurctld")?;
-    let mut client = SlurmControllerClient::new(channel);
+    let mut client = spur_proto::controller_client(channel);
 
     // Get partitions
     let partitions_resp = client

--- a/crates/spur-cli/src/smd.rs
+++ b/crates/spur-cli/src/smd.rs
@@ -3,7 +3,6 @@
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{GetNodesRequest, NodeInfo, NodeState};
 
 /// Node health monitoring daemon.
@@ -45,7 +44,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         let channel = spur_client::connect_channel(&args.controller)
             .await
             .context("failed to connect to spurctld")?;
-        let mut client = SlurmControllerClient::new(channel);
+        let mut client = spur_proto::controller_client(channel);
 
         let nodes = client
             .get_nodes(GetNodesRequest {

--- a/crates/spur-cli/src/sprio.rs
+++ b/crates/spur-cli/src/sprio.rs
@@ -3,7 +3,6 @@
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{GetJobsRequest, GetPartitionsRequest, JobState};
 
 /// View job priority breakdown for pending jobs.
@@ -56,7 +55,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let channel = spur_client::connect_channel(&args.controller)
         .await
         .context("failed to connect to spurctld")?;
-    let mut client = SlurmControllerClient::new(channel);
+    let mut client = spur_proto::controller_client(channel);
 
     // Get pending jobs only (priority is relevant for pending jobs)
     let response = client

--- a/crates/spur-cli/src/squeue.rs
+++ b/crates/spur-cli/src/squeue.rs
@@ -3,7 +3,6 @@
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::GetJobsRequest;
 
 use crate::format_engine;
@@ -100,7 +99,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let channel = spur_client::connect_channel(&args.controller)
         .await
         .context("failed to connect to spurctld")?;
-    let mut client = SlurmControllerClient::new(channel);
+    let mut client = spur_proto::controller_client(channel);
 
     let response = client
         .get_jobs(GetJobsRequest {

--- a/crates/spur-cli/src/sreport.rs
+++ b/crates/spur-cli/src/sreport.rs
@@ -69,7 +69,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let channel = spur_client::connect_channel(&args.controller)
         .await
         .context("failed to connect to controller")?;
-    let mut client = SlurmAccountingClient::new(channel);
+    let mut client = spur_proto::accounting_client(channel);
 
     match &args.command {
         SreportCommand::Cluster { report_type } => match report_type.to_lowercase().as_str() {

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -415,7 +415,7 @@ async fn try_stream_output(
     let mut agent = match SlurmAgentClient::connect(agent_addr).await {
         Ok(c) => c
             .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
-            .max_encoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE),
+            .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE),
         Err(_) => return false,
     };
 

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -241,7 +241,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let channel = spur_client::connect_channel(&args.controller)
         .await
         .context("failed to connect to spurctld")?;
-    let mut client = SlurmControllerClient::new(channel);
+    let mut client = spur_proto::controller_client(channel);
 
     let job_spec = JobSpec {
         name,
@@ -413,7 +413,9 @@ async fn try_stream_output(
     let agent_addr = format!("http://{}:6818", first_node);
 
     let mut agent = match SlurmAgentClient::connect(agent_addr).await {
-        Ok(c) => c,
+        Ok(c) => c
+            .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
+            .max_encoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE),
         Err(_) => return false,
     };
 
@@ -667,7 +669,7 @@ async fn run_as_step(
     let channel = spur_client::connect_channel(&args.controller)
         .await
         .context("failed to connect to spurctld")?;
-    let mut client = SlurmControllerClient::new(channel);
+    let mut client = spur_proto::controller_client(channel);
 
     // Create a step on the controller for tracking; capture the assigned
     // step_id so the completion (and thus DerivedExitCode) records against it.

--- a/crates/spur-cli/src/sshare.rs
+++ b/crates/spur-cli/src/sshare.rs
@@ -3,7 +3,6 @@
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use spur_proto::proto::slurm_accounting_client::SlurmAccountingClient;
 use spur_proto::proto::{GetUsageRequest, ListAccountsRequest, ListUsersRequest};
 
 /// Display fair-share information by account and user.
@@ -45,7 +44,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let channel = spur_client::connect_channel(&args.controller)
         .await
         .context("failed to connect to controller")?;
-    let mut client = SlurmAccountingClient::new(channel);
+    let mut client = spur_proto::accounting_client(channel);
 
     // Get accounts
     let accounts_resp = client

--- a/crates/spur-cli/src/sstat.rs
+++ b/crates/spur-cli/src/sstat.rs
@@ -3,7 +3,6 @@
 
 use anyhow::{bail, Context, Result};
 use clap::Parser;
-use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::GetJobRequest;
 
 /// Display status information for running jobs.
@@ -56,7 +55,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let channel = spur_client::connect_channel(&args.controller)
         .await
         .context("failed to connect to spurctld")?;
-    let mut client = SlurmControllerClient::new(channel);
+    let mut client = spur_proto::controller_client(channel);
 
     // Determine which fields to show
     let fields = if let Some(ref fmt) = args.format {

--- a/crates/spur-cli/src/token.rs
+++ b/crates/spur-cli/src/token.rs
@@ -6,7 +6,6 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 
-use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{CreateTokenRequest, ListTokensRequest, RevokeTokenRequest};
 
 #[derive(Parser, Debug)]
@@ -73,7 +72,7 @@ fn parse_ttl(s: &str) -> Result<u32> {
 async fn cmd_create(controller: &str, ttl: Option<String>) -> Result<()> {
     let ttl_secs = ttl.map(|t| parse_ttl(&t)).transpose()?;
 
-    let mut client = SlurmControllerClient::new(spur_client::connect_channel(controller).await?);
+    let mut client = spur_proto::controller_client(spur_client::connect_channel(controller).await?);
     let resp = client.create_token(CreateTokenRequest { ttl_secs }).await?;
 
     let inner = resp.into_inner();
@@ -83,7 +82,7 @@ async fn cmd_create(controller: &str, ttl: Option<String>) -> Result<()> {
 }
 
 async fn cmd_list(controller: &str) -> Result<()> {
-    let mut client = SlurmControllerClient::new(spur_client::connect_channel(controller).await?);
+    let mut client = spur_proto::controller_client(spur_client::connect_channel(controller).await?);
     let resp = client.list_tokens(ListTokensRequest {}).await?;
     let tokens = resp.into_inner().tokens;
 
@@ -109,7 +108,7 @@ async fn cmd_list(controller: &str) -> Result<()> {
 }
 
 async fn cmd_revoke(controller: &str, token_id: &str) -> Result<()> {
-    let mut client = SlurmControllerClient::new(spur_client::connect_channel(controller).await?);
+    let mut client = spur_proto::controller_client(spur_client::connect_channel(controller).await?);
     client
         .revoke_token(RevokeTokenRequest {
             token_id: token_id.to_string(),

--- a/crates/spur-client/src/lib.rs
+++ b/crates/spur-client/src/lib.rs
@@ -6,7 +6,8 @@
 //! Establishes a [`tonic::transport::Channel`] from a comma-separated list of
 //! endpoints, rotating to the next endpoint when one is unreachable. The helper
 //! is service-agnostic: callers wrap the returned channel in whatever generated
-//! client they need (e.g. `SlurmControllerClient::new(channel)`).
+//! client they need (e.g. `spur_proto::controller_client(channel)`, which
+//! applies the shared `MAX_GRPC_MESSAGE_SIZE` limit).
 
 use std::time::Duration;
 

--- a/crates/spur-ffi/src/lib.rs
+++ b/crates/spur-ffi/src/lib.rs
@@ -64,11 +64,10 @@ pub extern "C" fn slurm_submit_batch_job(
 
     let desc = unsafe { &*desc };
     let result = runtime().block_on(async {
-        use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
         use spur_proto::proto::{JobSpec, SubmitJobRequest};
 
         let channel = spur_client::connect_channel(controller_addr()).await.ok()?;
-        let mut client = SlurmControllerClient::new(channel);
+        let mut client = spur_proto::controller_client(channel);
 
         let spec = JobSpec {
             name: c_str_to_string(desc.name),
@@ -122,11 +121,10 @@ pub extern "C" fn slurm_load_jobs(
     }
 
     let result = runtime().block_on(async {
-        use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
         use spur_proto::proto::GetJobsRequest;
 
         let channel = spur_client::connect_channel(controller_addr()).await.ok()?;
-        let mut client = SlurmControllerClient::new(channel);
+        let mut client = spur_proto::controller_client(channel);
 
         let resp = client.get_jobs(GetJobsRequest::default()).await.ok()?;
 
@@ -199,11 +197,10 @@ pub extern "C" fn slurm_load_node(
     }
 
     let result = runtime().block_on(async {
-        use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
         use spur_proto::proto::GetNodesRequest;
 
         let channel = spur_client::connect_channel(controller_addr()).await.ok()?;
-        let mut client = SlurmControllerClient::new(channel);
+        let mut client = spur_proto::controller_client(channel);
 
         let resp = client.get_nodes(GetNodesRequest::default()).await.ok()?;
 
@@ -252,11 +249,10 @@ pub extern "C" fn slurm_load_partitions(
     }
 
     let result = runtime().block_on(async {
-        use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
         use spur_proto::proto::GetPartitionsRequest;
 
         let channel = spur_client::connect_channel(controller_addr()).await.ok()?;
-        let mut client = SlurmControllerClient::new(channel);
+        let mut client = spur_proto::controller_client(channel);
 
         let resp = client
             .get_partitions(GetPartitionsRequest::default())
@@ -298,11 +294,10 @@ pub extern "C" fn slurm_load_partitions(
 #[no_mangle]
 pub extern "C" fn slurm_kill_job(job_id: c_uint, signal: u16, _flags: u16) -> c_int {
     let result = runtime().block_on(async {
-        use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
         use spur_proto::proto::CancelJobRequest;
 
         let channel = spur_client::connect_channel(controller_addr()).await.ok()?;
-        let mut client = SlurmControllerClient::new(channel);
+        let mut client = spur_proto::controller_client(channel);
 
         client
             .cancel_job(CancelJobRequest {

--- a/crates/spur-k8s/src/heartbeat.rs
+++ b/crates/spur-k8s/src/heartbeat.rs
@@ -81,7 +81,10 @@ async fn connect(addr: &str) -> anyhow::Result<SlurmControllerClient<tonic::tran
     } else {
         format!("http://{}", addr)
     };
-    Ok(SlurmControllerClient::connect(url).await?)
+    Ok(SlurmControllerClient::connect(url)
+        .await?
+        .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
+        .max_encoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE))
 }
 
 #[cfg(test)]

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -297,7 +297,10 @@ pub async fn run(
     } else {
         format!("http://{}", controller_addr)
     };
-    let ctrl_client = SlurmControllerClient::connect(url).await?;
+    let ctrl_client = SlurmControllerClient::connect(url)
+        .await?
+        .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
+        .max_encoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE);
 
     let ctx = Arc::new(JobControllerCtx {
         client: client.clone(),

--- a/crates/spur-k8s/src/main.rs
+++ b/crates/spur-k8s/src/main.rs
@@ -16,8 +16,6 @@ use clap::{Parser, Subcommand};
 use kube::Client;
 use tracing::info;
 
-use spur_proto::proto::slurm_agent_server::SlurmAgentServer;
-
 #[derive(Parser)]
 #[command(
     name = "spur-k8s-operator",
@@ -176,7 +174,7 @@ async fn main() -> anyhow::Result<()> {
     info!(%listen_addr, "virtual agent gRPC server listening");
 
     tonic::transport::Server::builder()
-        .add_service(SlurmAgentServer::new(virtual_agent))
+        .add_service(spur_proto::agent_server(virtual_agent))
         .serve(listen_addr)
         .await?;
 

--- a/crates/spur-k8s/src/node_watcher.rs
+++ b/crates/spur-k8s/src/node_watcher.rs
@@ -294,7 +294,10 @@ async fn connect_controller(addr: &str) -> anyhow::Result<SlurmControllerClient<
     } else {
         format!("http://{}", addr)
     };
-    let client = SlurmControllerClient::connect(url).await?;
+    let client = SlurmControllerClient::connect(url)
+        .await?
+        .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
+        .max_encoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE);
     Ok(client)
 }
 

--- a/crates/spur-proto/src/lib.rs
+++ b/crates/spur-proto/src/lib.rs
@@ -13,54 +13,62 @@ pub use proto::*;
 
 use tonic::transport::Channel;
 
-/// Maximum size of a single client-facing gRPC message (request or response),
-/// in bytes. tonic defaults both encode and decode limits to 4 MiB, which large
-/// `GetJobs`/`GetNodes` responses and forwarded submissions can exceed on big
-/// clusters. Construct clients and servers through the helpers below so this
-/// limit is applied consistently.
+/// Maximum size of a gRPC *response* (server encode / client decode), in bytes.
+/// Large `GetJobs`/`GetNodes` responses can exceed tonic's default 4 MiB on big
+/// clusters. The Raft-internal service uses a separate constant in `raft.rs`.
 pub const MAX_GRPC_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
 
-/// Controller client with message-size limits raised to `MAX_GRPC_MESSAGE_SIZE`.
+/// Maximum size of a gRPC *request* (client encode / server decode), in bytes.
+/// Sized to the 4 MiB `JobSpec` submission cap plus headroom for proto framing;
+/// no client RPC legitimately needs more. Keeps the inbound decode surface tight
+/// while allowing large outbound responses.
+pub const MAX_GRPC_REQUEST_SIZE: usize = 8 * 1024 * 1024;
+
+/// Controller client with asymmetric size limits: requests capped at
+/// `MAX_GRPC_REQUEST_SIZE`, responses up to `MAX_GRPC_MESSAGE_SIZE`.
 pub fn controller_client(
     channel: Channel,
 ) -> proto::slurm_controller_client::SlurmControllerClient<Channel> {
     proto::slurm_controller_client::SlurmControllerClient::new(channel)
         .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE)
-        .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+        .max_encoding_message_size(MAX_GRPC_REQUEST_SIZE)
 }
 
-/// Accounting client with message-size limits raised to `MAX_GRPC_MESSAGE_SIZE`.
+/// Accounting client with asymmetric size limits.
 pub fn accounting_client(
     channel: Channel,
 ) -> proto::slurm_accounting_client::SlurmAccountingClient<Channel> {
     proto::slurm_accounting_client::SlurmAccountingClient::new(channel)
         .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE)
-        .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+        .max_encoding_message_size(MAX_GRPC_REQUEST_SIZE)
 }
 
-/// Controller server with message-size limits raised to `MAX_GRPC_MESSAGE_SIZE`.
+/// Controller server: inbound requests capped at `MAX_GRPC_REQUEST_SIZE`,
+/// outbound responses up to `MAX_GRPC_MESSAGE_SIZE`.
 pub fn controller_server<T: proto::slurm_controller_server::SlurmController>(
     service: T,
 ) -> proto::slurm_controller_server::SlurmControllerServer<T> {
     proto::slurm_controller_server::SlurmControllerServer::new(service)
-        .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+        .max_decoding_message_size(MAX_GRPC_REQUEST_SIZE)
         .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE)
 }
 
-/// Agent server with message-size limits raised to `MAX_GRPC_MESSAGE_SIZE`.
+/// Agent server: inbound requests capped at `MAX_GRPC_REQUEST_SIZE`,
+/// outbound responses up to `MAX_GRPC_MESSAGE_SIZE`.
 pub fn agent_server<T: proto::slurm_agent_server::SlurmAgent>(
     service: T,
 ) -> proto::slurm_agent_server::SlurmAgentServer<T> {
     proto::slurm_agent_server::SlurmAgentServer::new(service)
-        .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+        .max_decoding_message_size(MAX_GRPC_REQUEST_SIZE)
         .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE)
 }
 
-/// Accounting server with message-size limits raised to `MAX_GRPC_MESSAGE_SIZE`.
+/// Accounting server: inbound requests capped at `MAX_GRPC_REQUEST_SIZE`,
+/// outbound responses up to `MAX_GRPC_MESSAGE_SIZE`.
 pub fn accounting_server<T: proto::slurm_accounting_server::SlurmAccounting>(
     service: T,
 ) -> proto::slurm_accounting_server::SlurmAccountingServer<T> {
     proto::slurm_accounting_server::SlurmAccountingServer::new(service)
-        .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+        .max_decoding_message_size(MAX_GRPC_REQUEST_SIZE)
         .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE)
 }

--- a/crates/spur-proto/src/lib.rs
+++ b/crates/spur-proto/src/lib.rs
@@ -10,3 +10,57 @@ pub mod raft_proto {
 }
 
 pub use proto::*;
+
+use tonic::transport::Channel;
+
+/// Maximum size of a single client-facing gRPC message (request or response),
+/// in bytes. tonic defaults both encode and decode limits to 4 MiB, which large
+/// `GetJobs`/`GetNodes` responses and forwarded submissions can exceed on big
+/// clusters. Construct clients and servers through the helpers below so this
+/// limit is applied consistently.
+pub const MAX_GRPC_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
+
+/// Controller client with message-size limits raised to `MAX_GRPC_MESSAGE_SIZE`.
+pub fn controller_client(
+    channel: Channel,
+) -> proto::slurm_controller_client::SlurmControllerClient<Channel> {
+    proto::slurm_controller_client::SlurmControllerClient::new(channel)
+        .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+        .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+}
+
+/// Accounting client with message-size limits raised to `MAX_GRPC_MESSAGE_SIZE`.
+pub fn accounting_client(
+    channel: Channel,
+) -> proto::slurm_accounting_client::SlurmAccountingClient<Channel> {
+    proto::slurm_accounting_client::SlurmAccountingClient::new(channel)
+        .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+        .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+}
+
+/// Controller server with message-size limits raised to `MAX_GRPC_MESSAGE_SIZE`.
+pub fn controller_server<T: proto::slurm_controller_server::SlurmController>(
+    service: T,
+) -> proto::slurm_controller_server::SlurmControllerServer<T> {
+    proto::slurm_controller_server::SlurmControllerServer::new(service)
+        .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+        .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+}
+
+/// Agent server with message-size limits raised to `MAX_GRPC_MESSAGE_SIZE`.
+pub fn agent_server<T: proto::slurm_agent_server::SlurmAgent>(
+    service: T,
+) -> proto::slurm_agent_server::SlurmAgentServer<T> {
+    proto::slurm_agent_server::SlurmAgentServer::new(service)
+        .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+        .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+}
+
+/// Accounting server with message-size limits raised to `MAX_GRPC_MESSAGE_SIZE`.
+pub fn accounting_server<T: proto::slurm_accounting_server::SlurmAccounting>(
+    service: T,
+) -> proto::slurm_accounting_server::SlurmAccountingServer<T> {
+    proto::slurm_accounting_server::SlurmAccountingServer::new(service)
+        .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+        .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+}

--- a/crates/spurctld/Cargo.toml
+++ b/crates/spurctld/Cargo.toml
@@ -40,6 +40,7 @@ tower-http = { workspace = true }
 tempfile = "3"
 tower = { workspace = true, features = ["util"] }
 http-body-util = "0.1"
+tokio-stream = { version = "0.1", features = ["net"] }
 
 [lints]
 workspace = true

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -22,7 +22,7 @@ impl AccountingService {
 
 /// Build a ready-to-register tonic service for embedding in another server.
 pub fn accounting_server(pool: PgPool) -> SlurmAccountingServer<AccountingService> {
-    SlurmAccountingServer::new(AccountingService::new(pool))
+    spur_proto::accounting_server(AccountingService::new(pool))
 }
 
 #[tonic::async_trait]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -239,12 +239,16 @@ impl ClusterManager {
 
     /// Submit a new job. If it has an array spec, expand into individual tasks.
     pub fn submit_job(&self, mut spec: JobSpec) -> Result<JobId, SubmitError> {
-        check_submission_size(&spec)?;
         apply_default_partition(&mut spec, &self.partitions.read());
         apply_default_account(&mut spec, &self.association_cache);
         validate_user_account(&spec, &self.association_cache)?;
         self.validate_partition(&spec)?;
         apply_default_qos(&mut spec, &self.association_cache, &self.qos_cache)?;
+
+        // Checked after defaults are applied so we measure the final spec.
+        // Array expansion only adds bounded integer metadata per task, so a
+        // single pre-expansion check still bounds each Raft log entry.
+        check_submission_size(&spec)?;
 
         // Reject unknown/malformed dependency types up front so users get a
         // clear error instead of a silently-deadlocked job (e.g. `expand:N`).

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -4287,8 +4287,8 @@ mod tests {
             argv: vec![big],
             ..Default::default()
         };
-        let err = check_submission_size(&spec)
-            .expect_err("env + argv over the cap must be rejected");
+        let err =
+            check_submission_size(&spec).expect_err("env + argv over the cap must be rejected");
         assert!(matches!(err, SubmitError::InvalidArgument(_)));
     }
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -97,6 +97,52 @@ impl SubmitError {
     }
 }
 
+/// Maximum serialized size of a single job submission, in bytes.
+///
+/// A submission becomes one Raft log entry (`WalOperation::JobSubmit`) that is
+/// also retained in every snapshot, so bounding the whole serialized spec keeps
+/// that entry well under `crate::raft::RAFT_MAX_MESSAGE_SIZE`. Measuring the
+/// serialized form rather than individual fields counts every payload the spec
+/// carries (script, environment, argv, container env/mounts, ...), so it cannot
+/// be bypassed by a field the check forgot to sum. Mirrors Slurm, which rejects
+/// oversized batch scripts.
+const MAX_JOB_SPEC_SIZE: usize = 4 * 1024 * 1024;
+
+/// A `std::io::Write` that only tallies byte counts and discards the data. Used
+/// to measure a value's serialized size without allocating the serialized bytes.
+#[derive(Default)]
+struct ByteCounter {
+    len: usize,
+}
+
+impl std::io::Write for ByteCounter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.len += buf.len();
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn check_submission_size(spec: &JobSpec) -> Result<(), SubmitError> {
+    // Count serialized bytes without allocating the output; the entry is
+    // re-serialized by openraft on propose.
+    let mut counter = ByteCounter::default();
+    serde_json::to_writer(&mut counter, spec)
+        .map_err(|e| SubmitError::internal(format!("failed to encode job spec: {e}")))?;
+    let size = counter.len;
+    if size > MAX_JOB_SPEC_SIZE {
+        return Err(SubmitError::invalid(format!(
+            "job submission too large: {:.1} MiB serialized, limit is {} MiB (reduce script, environment, or argv size)",
+            size as f64 / (1024.0 * 1024.0),
+            MAX_JOB_SPEC_SIZE / (1024 * 1024),
+        )));
+    }
+    Ok(())
+}
+
 impl ReservationError {
     pub fn invalid(msg: impl Into<String>) -> Self {
         Self::InvalidArgument(msg.into())
@@ -193,6 +239,7 @@ impl ClusterManager {
 
     /// Submit a new job. If it has an array spec, expand into individual tasks.
     pub fn submit_job(&self, mut spec: JobSpec) -> Result<JobId, SubmitError> {
+        check_submission_size(&spec)?;
         apply_default_partition(&mut spec, &self.partitions.read());
         apply_default_account(&mut spec, &self.association_cache);
         validate_user_account(&spec, &self.association_cache)?;
@@ -4209,6 +4256,41 @@ mod tests {
     use spur_core::resource::{ResourceAllocations, ResourceSet};
     use spur_metrics::job::JobMetricsSnapshot;
     use tempfile::TempDir;
+
+    #[test]
+    fn submission_size_accepts_normal_script() {
+        let spec = JobSpec {
+            script: Some("#!/bin/bash\necho hello\n".into()),
+            ..Default::default()
+        };
+        assert!(check_submission_size(&spec).is_ok());
+    }
+
+    #[test]
+    fn submission_size_rejects_oversized_script() {
+        let spec = JobSpec {
+            script: Some("x".repeat(MAX_JOB_SPEC_SIZE + 1)),
+            ..Default::default()
+        };
+        let err = check_submission_size(&spec).expect_err("oversized script must be rejected");
+        assert!(matches!(err, SubmitError::InvalidArgument(_)));
+        assert!(err.to_string().contains("too large"));
+    }
+
+    #[test]
+    fn submission_size_counts_all_fields() {
+        // Split the payload across environment and argv (not script) to prove the
+        // check bounds the whole serialized spec, not just the script field.
+        let big = "y".repeat(MAX_JOB_SPEC_SIZE / 2 + 1024);
+        let spec = JobSpec {
+            environment: std::iter::once(("BIG".to_string(), big.clone())).collect(),
+            argv: vec![big],
+            ..Default::default()
+        };
+        let err = check_submission_size(&spec)
+            .expect_err("env + argv over the cap must be rejected");
+        assert!(matches!(err, SubmitError::InvalidArgument(_)));
+    }
 
     fn test_config() -> SlurmConfig {
         SlurmConfig {

--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -641,6 +641,13 @@ impl openraft::RaftNetwork<SpurTypeConfig> for SpurNetworkConnection {
             ))
         })?;
 
+        if payload.len() > RAFT_MAX_MESSAGE_SIZE {
+            let hint = (rpc.entries.len() as u64 / 2).max(1);
+            return Err(openraft::error::RPCError::PayloadTooLarge(
+                openraft::error::PayloadTooLarge::new_entries_hint(hint),
+            ));
+        }
+
         let client = self.get_client().await?;
         let resp = client
             .append_entries(spur_proto::raft_proto::RaftRequest { payload })
@@ -1274,5 +1281,95 @@ mod tests {
         // A rejected snapshot must never reach disk: persisting it first would
         // make the next (strict-by-default) startup hard-fail on it forever.
         assert!(!dir.path().join("raft").join("snapshot.json").exists());
+    }
+
+    #[tokio::test]
+    async fn append_entries_rejects_oversized_batch_with_payload_too_large() {
+        use openraft::network::RPCOption;
+        use openraft::RaftNetwork;
+        use spur_core::job::JobSpec;
+
+        let mut conn = SpurNetworkConnection {
+            target: 99,
+            addr: "http://127.0.0.1:1".into(),
+            client: None,
+        };
+
+        let big_spec = JobSpec {
+            script: Some("x".repeat(2 * 1024 * 1024)),
+            ..Default::default()
+        };
+        let entry = Entry::<SpurTypeConfig> {
+            log_id: LogId {
+                leader_id: openraft::LeaderId {
+                    term: 1,
+                    node_id: 1,
+                },
+                index: 1,
+            },
+            payload: EntryPayload::Normal(WalOperation::JobSubmit {
+                job_id: 1,
+                spec: Box::new(big_spec),
+            }),
+        };
+
+        let rpc = openraft::raft::AppendEntriesRequest::<SpurTypeConfig> {
+            vote: Vote::new(1, 1),
+            prev_log_id: None,
+            entries: vec![entry; 20],
+            leader_commit: None,
+        };
+
+        let option = RPCOption::new(std::time::Duration::from_secs(5));
+        let result = conn.append_entries(rpc, option).await;
+
+        let err = result.expect_err("oversized batch should be rejected");
+        match err {
+            openraft::error::RPCError::PayloadTooLarge(too_large) => {
+                assert_eq!(too_large.entries_hint(), 10);
+            }
+            other => panic!("expected PayloadTooLarge, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn append_entries_accepts_small_batch() {
+        use openraft::network::RPCOption;
+        use openraft::RaftNetwork;
+
+        let mut conn = SpurNetworkConnection {
+            target: 99,
+            addr: "http://127.0.0.1:1".into(),
+            client: None,
+        };
+
+        let entry = Entry::<SpurTypeConfig> {
+            log_id: LogId {
+                leader_id: openraft::LeaderId {
+                    term: 1,
+                    node_id: 1,
+                },
+                index: 1,
+            },
+            payload: EntryPayload::Blank,
+        };
+
+        let rpc = openraft::raft::AppendEntriesRequest::<SpurTypeConfig> {
+            vote: Vote::new(1, 1),
+            prev_log_id: None,
+            entries: vec![entry],
+            leader_commit: None,
+        };
+
+        let option = RPCOption::new(std::time::Duration::from_secs(5));
+        let result = conn.append_entries(rpc, option).await;
+
+        // Small batch passes the size guard but fails to connect (bogus address).
+        // The error should be Unreachable (connection failure), NOT PayloadTooLarge.
+        let err = result.expect_err("should fail to connect to bogus address");
+        assert!(
+            matches!(err, openraft::error::RPCError::Unreachable(_)),
+            "expected Unreachable, got: {err:?}"
+        );
     }
 }

--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -35,6 +35,32 @@ openraft::declare_raft_types!(
 
 pub type SpurRaft = Raft<SpurTypeConfig>;
 
+/// Maximum size of a single Raft gRPC message (request or response), in bytes.
+///
+/// tonic defaults both encode and decode limits to 4 MiB. Snapshots ship in
+/// chunks of `RAFT_SNAPSHOT_MAX_CHUNK_SIZE` raw bytes, and `serde_json` inflates
+/// the chunk's `Vec<u8>` payload roughly 3.4x (each byte becomes a decimal
+/// integer plus a comma), so the largest message we ever put on the wire is
+/// about `3.4 * RAFT_SNAPSHOT_MAX_CHUNK_SIZE`. This limit keeps large headroom
+/// over that bound. Invariant: `4 * RAFT_SNAPSHOT_MAX_CHUNK_SIZE < RAFT_MAX_MESSAGE_SIZE`.
+pub const RAFT_MAX_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
+
+/// Raw bytes per `install_snapshot` chunk. Bounded so the JSON-encoded message
+/// stays well under `RAFT_MAX_MESSAGE_SIZE` (see the invariant above). A larger
+/// snapshot simply ships in more chunks.
+pub const RAFT_SNAPSHOT_MAX_CHUNK_SIZE: u64 = 1024 * 1024;
+
+/// Build a Raft gRPC client with message-size limits raised to
+/// `RAFT_MAX_MESSAGE_SIZE`. Used by both the live network path and tests so the
+/// exact transport configuration is covered.
+pub(crate) fn raft_client(
+    channel: tonic::transport::Channel,
+) -> spur_proto::raft_proto::raft_internal_client::RaftInternalClient<tonic::transport::Channel> {
+    spur_proto::raft_proto::raft_internal_client::RaftInternalClient::new(channel)
+        .max_decoding_message_size(RAFT_MAX_MESSAGE_SIZE)
+        .max_encoding_message_size(RAFT_MAX_MESSAGE_SIZE)
+}
+
 /// Set when a committed WAL entry transitions a job to a terminal state.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct JobFinalized {
@@ -594,9 +620,7 @@ impl SpurNetworkConnection {
                         &std::io::Error::new(std::io::ErrorKind::ConnectionRefused, e.to_string()),
                     ))
                 })?;
-            self.client = Some(
-                spur_proto::raft_proto::raft_internal_client::RaftInternalClient::new(channel),
-            );
+            self.client = Some(raft_client(channel));
         }
         Ok(self.client.as_mut().unwrap())
     }
@@ -775,6 +799,7 @@ pub async fn start_raft_with_recovery_mode(
         heartbeat_interval: 500,
         election_timeout_min: 1500,
         election_timeout_max: 3000,
+        snapshot_max_chunk_size: RAFT_SNAPSHOT_MAX_CHUNK_SIZE,
         ..Default::default()
     };
     let config = Arc::new(config.validate().map_err(|e| anyhow::anyhow!("{e}"))?);

--- a/crates/spurctld/src/raft_server.rs
+++ b/crates/spurctld/src/raft_server.rs
@@ -198,8 +198,8 @@ mod tests {
     #[tokio::test]
     async fn default_limits_reject_message_over_4mb() {
         let addr = spawn(RaftInternalServer::new(EchoRaft)).await;
-        let mut client =
-            RaftInternalClient::new(connect(addr).await).max_encoding_message_size(64 * 1024 * 1024);
+        let mut client = RaftInternalClient::new(connect(addr).await)
+            .max_encoding_message_size(64 * 1024 * 1024);
 
         let payload = vec![0u8; 8 * 1024 * 1024];
         let err = client

--- a/crates/spurctld/src/raft_server.rs
+++ b/crates/spurctld/src/raft_server.rs
@@ -209,4 +209,41 @@ mod tests {
 
         assert_eq!(err.code(), tonic::Code::OutOfRange);
     }
+
+    /// The Raft-internal service accepts messages up to `RAFT_MAX_MESSAGE_SIZE`
+    /// (32 MiB) while the client-facing surface caps inbound requests at
+    /// `MAX_GRPC_REQUEST_SIZE` (8 MiB). This test verifies that the raft-internal
+    /// server still accepts a message above the client-facing cap but below the
+    /// raft cap, guarding against accidental re-tightening.
+    #[tokio::test]
+    async fn raft_server_accepts_above_client_cap() {
+        let addr = spawn(raft_server(EchoRaft)).await;
+        let mut client = crate::raft::raft_client(connect(addr).await);
+
+        let payload = vec![0u8; 12 * 1024 * 1024];
+        let resp = client
+            .append_entries(RaftRequest {
+                payload: payload.clone(),
+            })
+            .await
+            .expect("12 MiB should be accepted by raft-internal (32 MiB cap)");
+
+        let echoed = u64::from_le_bytes(resp.into_inner().payload.try_into().unwrap());
+        assert_eq!(echoed as usize, payload.len());
+    }
+
+    /// Verify the constant relationship: client-facing request cap is
+    /// significantly tighter than the raft-internal cap.
+    #[test]
+    #[allow(clippy::assertions_on_constants)]
+    fn request_size_tighter_than_raft_size() {
+        assert!(
+            spur_proto::MAX_GRPC_REQUEST_SIZE < RAFT_MAX_MESSAGE_SIZE,
+            "client-facing request cap must be below raft-internal cap"
+        );
+        assert!(
+            spur_proto::MAX_GRPC_REQUEST_SIZE <= spur_proto::MAX_GRPC_MESSAGE_SIZE / 4,
+            "request cap should be at most 1/4 of the response cap"
+        );
+    }
 }

--- a/crates/spurctld/src/raft_server.rs
+++ b/crates/spurctld/src/raft_server.rs
@@ -14,7 +14,7 @@ use tracing::info;
 use spur_proto::raft_proto::raft_internal_server::{RaftInternal, RaftInternalServer};
 use spur_proto::raft_proto::{RaftRequest, RaftResponse};
 
-use crate::raft::{SpurRaft, SpurTypeConfig};
+use crate::raft::{SpurRaft, SpurTypeConfig, RAFT_MAX_MESSAGE_SIZE};
 
 pub struct RaftInternalService {
     raft: SpurRaft,
@@ -86,15 +86,127 @@ impl RaftInternal for RaftInternalService {
     }
 }
 
+/// Build the Raft gRPC service with message-size limits raised to
+/// `RAFT_MAX_MESSAGE_SIZE`. Shared by `serve_raft` and tests so the exact
+/// transport configuration is covered.
+pub(crate) fn raft_server<T: RaftInternal>(service: T) -> RaftInternalServer<T> {
+    RaftInternalServer::new(service)
+        .max_decoding_message_size(RAFT_MAX_MESSAGE_SIZE)
+        .max_encoding_message_size(RAFT_MAX_MESSAGE_SIZE)
+}
+
 pub async fn serve_raft(addr: SocketAddr, raft: SpurRaft) -> anyhow::Result<()> {
     let service = RaftInternalService::new(raft);
 
     info!(%addr, "raft internal gRPC server listening");
 
     tonic::transport::Server::builder()
-        .add_service(RaftInternalServer::new(service))
+        .add_service(raft_server(service))
         .serve(addr)
         .await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spur_proto::raft_proto::raft_internal_client::RaftInternalClient;
+
+    /// Minimal `RaftInternal` that echoes the received payload length. The unit
+    /// under test is the gRPC transport message-size configuration, not Raft
+    /// logic, so a stub keeps the test deterministic and free of election timing.
+    struct EchoRaft;
+
+    #[tonic::async_trait]
+    impl RaftInternal for EchoRaft {
+        async fn append_entries(
+            &self,
+            request: Request<RaftRequest>,
+        ) -> Result<Response<RaftResponse>, Status> {
+            let len = request.into_inner().payload.len() as u64;
+            Ok(Response::new(RaftResponse {
+                payload: len.to_le_bytes().to_vec(),
+            }))
+        }
+
+        async fn vote(
+            &self,
+            _request: Request<RaftRequest>,
+        ) -> Result<Response<RaftResponse>, Status> {
+            Ok(Response::new(RaftResponse {
+                payload: Vec::new(),
+            }))
+        }
+
+        async fn install_snapshot(
+            &self,
+            request: Request<RaftRequest>,
+        ) -> Result<Response<RaftResponse>, Status> {
+            let len = request.into_inner().payload.len() as u64;
+            Ok(Response::new(RaftResponse {
+                payload: len.to_le_bytes().to_vec(),
+            }))
+        }
+    }
+
+    async fn spawn(service: RaftInternalServer<EchoRaft>) -> SocketAddr {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        tokio::spawn(async move {
+            let _ = tonic::transport::Server::builder()
+                .add_service(service)
+                .serve_with_incoming(incoming)
+                .await;
+        });
+        addr
+    }
+
+    async fn connect(addr: SocketAddr) -> tonic::transport::Channel {
+        tonic::transport::Channel::from_shared(format!("http://{addr}"))
+            .unwrap()
+            .connect()
+            .await
+            .unwrap()
+    }
+
+    /// The customer bug: an `install_snapshot` message larger than tonic's 4 MiB
+    /// default must succeed once the server and client raise their limits. Uses
+    /// the exact production constructors (`raft_server` / `raft_client`).
+    #[tokio::test]
+    async fn install_snapshot_accepts_message_over_4mb() {
+        let addr = spawn(raft_server(EchoRaft)).await;
+        let mut client = crate::raft::raft_client(connect(addr).await);
+
+        let payload = vec![0u8; 8 * 1024 * 1024];
+        let resp = client
+            .install_snapshot(RaftRequest {
+                payload: payload.clone(),
+            })
+            .await
+            .expect("8 MiB install_snapshot should be accepted with raised limits");
+
+        let echoed = u64::from_le_bytes(resp.into_inner().payload.try_into().unwrap());
+        assert_eq!(echoed as usize, payload.len());
+    }
+
+    /// Negative control: with tonic's default 4 MiB decode limit the same
+    /// message is rejected, proving the raised limit is what fixes the bug. The
+    /// client encoding limit is raised so the failure is the server-side decode
+    /// cap (the exact failure seen in the field), not a client encode cap.
+    #[tokio::test]
+    async fn default_limits_reject_message_over_4mb() {
+        let addr = spawn(RaftInternalServer::new(EchoRaft)).await;
+        let mut client =
+            RaftInternalClient::new(connect(addr).await).max_encoding_message_size(64 * 1024 * 1024);
+
+        let payload = vec![0u8; 8 * 1024 * 1024];
+        let err = client
+            .install_snapshot(RaftRequest { payload })
+            .await
+            .expect_err("8 MiB should exceed tonic's default 4 MiB decode limit");
+
+        assert_eq!(err.code(), tonic::Code::OutOfRange);
+    }
 }

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -532,7 +532,7 @@ async fn forward_to_federation(cluster: &ClusterManager, jobs: &[spur_core::job:
                 .await
                 .map(|c| {
                     c.max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
-                        .max_encoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
+                        .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE)
                 }) {
                 Ok(mut client) => {
                     let req = SubmitJobRequest {
@@ -682,7 +682,7 @@ async fn dispatch_to_agent(
     let mut client = SlurmAgentClient::connect(agent_addr.to_string())
         .await?
         .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
-        .max_encoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE);
+        .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE);
 
     let spec = params.spec;
     let proto_spec = ProtoJobSpec {
@@ -1256,7 +1256,7 @@ async fn cancel_one_agent(agent_addr: String, job_id: spur_core::job::JobId, sig
             .await
             .map(|c| {
                 c.max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
-                    .max_encoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
+                    .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE)
             }) {
             Ok(mut client) => {
                 if let Err(e) = client
@@ -1319,7 +1319,7 @@ pub async fn send_suspend_to_agents(
                 .await
                 .map(|c| {
                     c.max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
-                        .max_encoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
+                        .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE)
                 }) {
                 Ok(mut client) => {
                     if let Err(e) = client

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -528,7 +528,12 @@ async fn forward_to_federation(cluster: &ClusterManager, jobs: &[spur_core::job:
     let peers = &cluster.config.federation.clusters;
     for job in jobs {
         for peer in peers {
-            match SlurmControllerClient::connect(peer.address.clone()).await {
+            match SlurmControllerClient::connect(peer.address.clone())
+                .await
+                .map(|c| {
+                    c.max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
+                        .max_encoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
+                }) {
                 Ok(mut client) => {
                     let req = SubmitJobRequest {
                         spec: Some(core_spec_to_proto(&job.spec)),
@@ -674,7 +679,10 @@ async fn dispatch_to_agent(
     agent_addr: &str,
     params: &AgentDispatchParams<'_>,
 ) -> anyhow::Result<()> {
-    let mut client = SlurmAgentClient::connect(agent_addr.to_string()).await?;
+    let mut client = SlurmAgentClient::connect(agent_addr.to_string())
+        .await?
+        .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
+        .max_encoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE);
 
     let spec = params.spec;
     let proto_spec = ProtoJobSpec {
@@ -1244,7 +1252,12 @@ fn cancel_agent_addrs(
 /// must not block the caller past the timeout.
 async fn cancel_one_agent(agent_addr: String, job_id: spur_core::job::JobId, signal: i32) {
     let attempt = async {
-        match SlurmAgentClient::connect(agent_addr.clone()).await {
+        match SlurmAgentClient::connect(agent_addr.clone())
+            .await
+            .map(|c| {
+                c.max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
+                    .max_encoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
+            }) {
             Ok(mut client) => {
                 if let Err(e) = client
                     .cancel_job(AgentCancelJobRequest { job_id, signal })
@@ -1302,7 +1315,12 @@ pub async fn send_suspend_to_agents(
         let agent_addr = format!("http://{}:{}", addr, port);
         let job_id = job.job_id;
         tokio::spawn(async move {
-            match SlurmAgentClient::connect(agent_addr.clone()).await {
+            match SlurmAgentClient::connect(agent_addr.clone())
+                .await
+                .map(|c| {
+                    c.max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
+                        .max_encoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
+                }) {
                 Ok(mut client) => {
                     if let Err(e) = client
                         .suspend_job(AgentSuspendJobRequest { job_id, resume })

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -82,7 +82,7 @@ impl LeaderProxy {
             .await
             .map_err(|e| Status::unavailable(format!("cannot reach leader: {e}")))?
             .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
-            .max_encoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE);
+            .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE);
 
         *cached = Some((leader_id, client.clone()));
         Ok(client)
@@ -1372,7 +1372,7 @@ impl SlurmController for ControllerService {
                 Status::unavailable(format!("cannot reach agent at {}: {}", agent_addr, e))
             })?
             .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
-            .max_encoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE);
+            .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE);
 
         let resp = agent
             .exec_in_job(ExecInJobRequest {
@@ -1434,7 +1434,7 @@ impl SlurmController for ControllerService {
                 Status::unavailable(format!("cannot reach agent at {}: {}", agent_addr, e))
             })?
             .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
-            .max_encoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE);
+            .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE);
 
         let agent_resp = agent
             .run_command(RunCommandRequest {

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -14,7 +14,7 @@ use tracing::warn;
 use spur_core::job::NodeCompleteError;
 use spur_core::reservation::Reservation;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
-use spur_proto::proto::slurm_controller_server::{SlurmController, SlurmControllerServer};
+use spur_proto::proto::slurm_controller_server::SlurmController;
 use spur_proto::proto::*;
 
 use crate::cluster::{ClusterManager, ReservationError};
@@ -80,7 +80,9 @@ impl LeaderProxy {
 
         let client = SlurmControllerClient::connect(url)
             .await
-            .map_err(|e| Status::unavailable(format!("cannot reach leader: {e}")))?;
+            .map_err(|e| Status::unavailable(format!("cannot reach leader: {e}")))?
+            .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
+            .max_encoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE);
 
         *cached = Some((leader_id, client.clone()));
         Ok(client)
@@ -1368,7 +1370,9 @@ impl SlurmController for ControllerService {
             .await
             .map_err(|e| {
                 Status::unavailable(format!("cannot reach agent at {}: {}", agent_addr, e))
-            })?;
+            })?
+            .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
+            .max_encoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE);
 
         let resp = agent
             .exec_in_job(ExecInJobRequest {
@@ -1428,7 +1432,9 @@ impl SlurmController for ControllerService {
             .await
             .map_err(|e| {
                 Status::unavailable(format!("cannot reach agent at {}: {}", agent_addr, e))
-            })?;
+            })?
+            .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
+            .max_encoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE);
 
         let agent_resp = agent
             .run_command(RunCommandRequest {
@@ -1503,7 +1509,7 @@ pub async fn serve(
 
     let mut builder = tonic::transport::Server::builder().layer(stats_layer);
 
-    let mut router = builder.add_service(SlurmControllerServer::new(service));
+    let mut router = builder.add_service(spur_proto::controller_server(service));
     if let Some(pool) = accounting_pool {
         router = router.add_service(crate::accounting::accounting_server(pool));
     }

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -369,8 +369,6 @@ async fn report_completion(
     reporting_node: &str,
     drain: Option<&DrainRequest>,
 ) {
-    use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
-
     // Wire `state` is derived from `exit_code` alone (advisory): a signaled job
     // reports Completed/0 because the controller's validator requires
     // state<->exit_code agreement. The controller rederives the true Failed /
@@ -382,7 +380,7 @@ async fn report_completion(
     for attempt in 1..=3 {
         match spur_client::connect_channel(controller_addr).await {
             Ok(channel) => {
-                let mut client = SlurmControllerClient::new(channel);
+                let mut client = spur_proto::controller_client(channel);
                 let req = ReportJobStatusRequest {
                     job_id,
                     state,

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -220,7 +220,7 @@ async fn main() -> anyhow::Result<()> {
     info!(%addr, "agent gRPC server listening");
 
     let server_future = tonic::transport::Server::builder()
-        .add_service(spur_proto::proto::slurm_agent_server::SlurmAgentServer::new(agent_service))
+        .add_service(spur_proto::agent_server(agent_service))
         .serve(addr);
 
     let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;

--- a/crates/spurd/src/reporter.rs
+++ b/crates/spurd/src/reporter.rs
@@ -8,7 +8,6 @@ use std::sync::RwLock;
 use anyhow::Context;
 use spur_core::resource::{GpuLinkType, GpuResource, ResourceSet};
 use spur_devices::{resolve_link_type, DeviceRegistry, LinkType};
-use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{RegisterAgentRequest, ResourceSet as ProtoResourceSet};
 use tracing::{debug, info, warn};
 
@@ -52,7 +51,7 @@ impl NodeReporter {
         let channel = spur_client::connect_channel(&self.controller_addr)
             .await
             .context("failed to connect to spurctld for registration")?;
-        let mut client = SlurmControllerClient::new(channel);
+        let mut client = spur_proto::controller_client(channel);
 
         let resp = client
             .register_agent(RegisterAgentRequest {
@@ -87,7 +86,7 @@ impl NodeReporter {
         let channel = spur_client::connect_channel(&self.controller_addr)
             .await
             .context("failed to connect to spurctld for deregistration")?;
-        let mut client = SlurmControllerClient::new(channel);
+        let mut client = spur_proto::controller_client(channel);
 
         client
             .deregister_agent(spur_proto::proto::DeregisterAgentRequest {
@@ -116,7 +115,7 @@ impl NodeReporter {
 
             match spur_client::connect_channel(&self.controller_addr).await {
                 Ok(channel) => {
-                    let mut client = SlurmControllerClient::new(channel);
+                    let mut client = spur_proto::controller_client(channel);
                     match client
                         .heartbeat(spur_proto::proto::HeartbeatRequest {
                             hostname: self.hostname.clone(),


### PR DESCRIPTION
## Problem

Large Raft `InstallSnapshot` RPCs failed to decode on bigger clusters. openraft serializes snapshots as JSON (expanding `Vec<u8>` ~3.4x), pushing messages past tonic's default 4 MiB decode limit. The follower rejects the message, so a lagging or rejoining node can never install a snapshot and catch up.

## Fix

**Transport limits.**
- Pin `RAFT_MAX_MESSAGE_SIZE` (32 MiB) for the Raft-internal service. Bound installed snapshot chunks to 1 MiB in the openraft `Config`.
- Add asymmetric limits for the client-facing surface: inbound requests capped at `MAX_GRPC_REQUEST_SIZE` (8 MiB, sized to the 4 MiB `JobSpec` cap + headroom), outbound responses up to `MAX_GRPC_MESSAGE_SIZE` (32 MiB) for large `GetJobs`/`GetNodes` payloads. Route all construction through helpers so the caps stay symmetric across crates.

**AppendEntries size guard.**
- After serializing an `AppendEntries` batch, if it exceeds `RAFT_MAX_MESSAGE_SIZE`, return `PayloadTooLarge` with a halved entries hint. openraft retries immediately with a smaller batch, preventing replication wedge during follower catch-up with large entries.

**Submission cap (defense in depth).**
- Cap the serialized `JobSpec` at 4 MiB at the single chokepoint (`ClusterManager::submit_job`), checked after defaults are applied. Measured with a zero-allocation counting writer. Clear user-facing error on rejection.

## Testing

- `append_entries` PayloadTooLarge unit tests (oversized batch rejected with correct hint, small batch passes through).
- Transport regression tests: >4 MiB `install_snapshot` accepted on raft-internal, 12 MiB raft-internal accepted above client-facing cap, constant invariant assertions.
- Submission size-cap unit tests.
- `clippy` clean; `cargo test` green across changed crates.
- Reproduced the decode failure on a 3-node bare-metal Raft cluster, then confirmed snapshots ship and end-to-end submission works after the fix.

## Rolling upgrade note

An un-upgraded `spur-cli`/`spurd`/`spur-k8s` binary still defaults to tonic's 4 MiB limits. Once `spurctld` is upgraded and starts returning >4 MiB responses (e.g. large `GetJobs`), an old client will fail with an opaque `OutOfRange` decode error. Upgrade clients alongside the controller to avoid this.

Note: the two failing `spur-devices` CDI tests are pre-existing and environment-dependent (they read host `/etc/cdi`, from #262), unrelated to this change.