### PR TITLE
feat(spur-cli): support slurm-buildkite bridge compatibility

### DIFF
--- a/crates/spur-cli/src/format_engine.rs
+++ b/crates/spur-cli/src/format_engine.rs
@@ -6,8 +6,8 @@
 //! Parses format strings like `"%.18i %.9P %.8j %.8u %.2t %10M %6D %R"`
 //! where each specifier is `%[flags][width][.precision]<letter>`.
 //!
-//! The engine is generic: callers provide a mapping from format letter
-//! to field value via a closure.
+//! Non-specifier characters (spaces, commas, etc.) are preserved as literal
+//! tokens so that `%k,%A` emits `comment,jobid` with no extra spacing.
 
 /// A parsed format field.
 #[derive(Debug, Clone)]
@@ -24,24 +24,42 @@ pub struct FormatField {
     pub header: String,
 }
 
-/// Parse a Slurm format string into fields.
+/// A token in a parsed format string: either a field specifier or literal text.
+#[derive(Debug, Clone)]
+pub enum FormatToken {
+    Field(FormatField),
+    Literal(String),
+}
+
+/// Parse a Slurm format string into tokens (fields + literal runs).
 ///
 /// Format: `%[.][width]<spec>` where:
 /// - Leading `.` means truncate to width
 /// - No `.` means pad to width
 /// - Negative width means left-align
-pub fn parse_format(fmt: &str, header_map: &dyn Fn(char) -> &'static str) -> Vec<FormatField> {
-    let mut fields = Vec::new();
+/// - `%%` produces a literal `%`
+/// - Any characters between specifiers are preserved as `Literal` tokens
+pub fn parse_format(fmt: &str, header_map: &dyn Fn(char) -> &'static str) -> Vec<FormatToken> {
+    let mut tokens = Vec::new();
     let mut chars = fmt.chars().peekable();
+    let mut literal_buf = String::new();
 
     while let Some(c) = chars.next() {
         if c != '%' {
+            literal_buf.push(c);
             continue;
         }
+
         // Check for %%
         if chars.peek() == Some(&'%') {
             chars.next();
+            literal_buf.push('%');
             continue;
+        }
+
+        // Flush accumulated literal text before parsing the field
+        if !literal_buf.is_empty() {
+            tokens.push(FormatToken::Literal(std::mem::take(&mut literal_buf)));
         }
 
         let mut truncate = false;
@@ -95,7 +113,7 @@ pub fn parse_format(fmt: &str, header_map: &dyn Fn(char) -> &'static str) -> Vec
         let right_align = if hash_flag { false } else { width >= 0 };
         let header = header_map(spec).to_string();
 
-        fields.push(FormatField {
+        tokens.push(FormatToken::Field(FormatField {
             spec,
             width: abs_width,
             right_align,
@@ -105,10 +123,15 @@ pub fn parse_format(fmt: &str, header_map: &dyn Fn(char) -> &'static str) -> Vec
                 None
             },
             header,
-        });
+        }));
     }
 
-    fields
+    // Flush trailing literal
+    if !literal_buf.is_empty() {
+        tokens.push(FormatToken::Literal(literal_buf));
+    }
+
+    tokens
 }
 
 /// Parse sacct/sreport-style comma-separated field names, unlike squeue/sinfo's `%`-specifiers.
@@ -116,9 +139,10 @@ pub fn parse_named_format(
     fmt: &str,
     name_to_spec: &dyn Fn(&str) -> Option<char>,
     header_map: &dyn Fn(char) -> &'static str,
-) -> Vec<FormatField> {
-    let mut fields = Vec::new();
-    for item in fmt.split(',') {
+) -> Vec<FormatToken> {
+    let mut tokens = Vec::new();
+    let items: Vec<&str> = fmt.split(',').collect();
+    for (i, item) in items.iter().enumerate() {
         let item = item.trim();
         if item.is_empty() {
             continue;
@@ -131,41 +155,51 @@ pub fn parse_named_format(
             continue;
         };
         let abs_width = width.unsigned_abs() as usize;
-        fields.push(FormatField {
+        tokens.push(FormatToken::Field(FormatField {
             spec,
             width: abs_width,
             right_align: width >= 0,
             truncate: if abs_width > 0 { Some(abs_width) } else { None },
             header: header_map(spec).to_string(),
-        });
+        }));
+        if i + 1 < items.len() {
+            tokens.push(FormatToken::Literal(" ".to_string()));
+        }
     }
-    fields
+    tokens
 }
 
-/// Format a single row using parsed fields and a value resolver.
-pub fn format_row(fields: &[FormatField], resolver: &dyn Fn(char) -> String) -> String {
-    let mut parts = Vec::new();
+/// Format a single row using parsed tokens and a value resolver.
+pub fn format_row(tokens: &[FormatToken], resolver: &dyn Fn(char) -> String) -> String {
+    let mut out = String::new();
 
-    for field in fields {
-        let value = resolver(field.spec);
-        let formatted = format_field(&value, field);
-        parts.push(formatted);
+    for token in tokens {
+        match token {
+            FormatToken::Field(field) => {
+                let value = resolver(field.spec);
+                out.push_str(&format_field(&value, field));
+            }
+            FormatToken::Literal(lit) => out.push_str(lit),
+        }
     }
 
-    // Join with space and trim trailing whitespace
-    parts.join(" ").trim_end().to_string()
+    out.trim_end().to_string()
 }
 
 /// Format the header row.
-pub fn format_header(fields: &[FormatField]) -> String {
-    let mut parts = Vec::new();
+pub fn format_header(tokens: &[FormatToken]) -> String {
+    let mut out = String::new();
 
-    for field in fields {
-        let formatted = format_field(&field.header, field);
-        parts.push(formatted);
+    for token in tokens {
+        match token {
+            FormatToken::Field(field) => {
+                out.push_str(&format_field(&field.header, field));
+            }
+            FormatToken::Literal(lit) => out.push_str(lit),
+        }
     }
 
-    parts.join(" ").trim_end().to_string()
+    out.trim_end().to_string()
 }
 
 /// Format a single field value with width/alignment/truncation.
@@ -225,6 +259,8 @@ pub fn squeue_header(spec: char) -> &'static str {
         'b' => "GRES",
         'L' => "TIME_LEFT",
         'v' => "RESERVATION",
+        'k' => "COMMENT",
+        'A' => "ARRAY_JOB_ID",
         _ => "?",
     }
 }
@@ -258,21 +294,26 @@ mod tests {
 
     #[test]
     fn test_parse_default_squeue_format() {
-        let fields = parse_format(SQUEUE_DEFAULT_FORMAT, &squeue_header);
-        assert_eq!(fields.len(), 8);
+        let tokens = parse_format(SQUEUE_DEFAULT_FORMAT, &squeue_header);
+        let field_count = tokens
+            .iter()
+            .filter(|t| matches!(t, FormatToken::Field(_)))
+            .count();
+        assert_eq!(field_count, 8);
 
-        assert_eq!(fields[0].spec, 'i');
-        assert_eq!(fields[0].width, 18);
-        assert!(fields[0].truncate.is_some());
-
-        assert_eq!(fields[1].spec, 'P');
-        assert_eq!(fields[1].width, 9);
+        let first = match &tokens[0] {
+            FormatToken::Field(f) => f,
+            _ => panic!("expected field"),
+        };
+        assert_eq!(first.spec, 'i');
+        assert_eq!(first.width, 18);
+        assert!(first.truncate.is_some());
     }
 
     #[test]
     fn test_format_row() {
-        let fields = parse_format("%.8i %.9P %.8j", &squeue_header);
-        let row = format_row(&fields, &|spec| match spec {
+        let tokens = parse_format("%.8i %.9P %.8j", &squeue_header);
+        let row = format_row(&tokens, &|spec| match spec {
             'i' => "12345".into(),
             'P' => "gpu".into(),
             'j' => "train".into(),
@@ -283,8 +324,8 @@ mod tests {
 
     #[test]
     fn test_truncation() {
-        let fields = parse_format("%.5j", &squeue_header);
-        let row = format_row(&fields, &|spec| match spec {
+        let tokens = parse_format("%.5j", &squeue_header);
+        let row = format_row(&tokens, &|spec| match spec {
             'j' => "very_long_job_name".into(),
             _ => "?".into(),
         });
@@ -293,8 +334,8 @@ mod tests {
 
     #[test]
     fn test_left_align() {
-        let fields = parse_format("%-10j", &squeue_header);
-        let row = format_row(&fields, &|spec| match spec {
+        let tokens = parse_format("%-10j", &squeue_header);
+        let row = format_row(&tokens, &|spec| match spec {
             'j' => "short".into(),
             _ => "?".into(),
         });
@@ -303,11 +344,45 @@ mod tests {
 
     #[test]
     fn test_header() {
-        let fields = parse_format("%.18i %.9P %.8j", &squeue_header);
-        let header = format_header(&fields);
+        let tokens = parse_format("%.18i %.9P %.8j", &squeue_header);
+        let header = format_header(&tokens);
         assert!(header.contains("JOBID"));
         assert!(header.contains("PARTITION"));
         assert!(header.contains("NAME"));
+    }
+
+    #[test]
+    fn test_literal_comma_preserved() {
+        let tokens = parse_format("%k,%A", &squeue_header);
+        assert_eq!(tokens.len(), 3);
+        assert!(matches!(&tokens[0], FormatToken::Field(f) if f.spec == 'k'));
+        assert!(matches!(&tokens[1], FormatToken::Literal(s) if s == ","));
+        assert!(matches!(&tokens[2], FormatToken::Field(f) if f.spec == 'A'));
+
+        let row = format_row(&tokens, &|spec| match spec {
+            'k' => "mycomment".into(),
+            'A' => "42".into(),
+            _ => "?".into(),
+        });
+        assert_eq!(row, "mycomment,42");
+    }
+
+    #[test]
+    fn test_percent_percent_becomes_literal() {
+        let tokens = parse_format("%%done", &squeue_header);
+        assert_eq!(tokens.len(), 1);
+        assert!(matches!(&tokens[0], FormatToken::Literal(s) if s == "%done"));
+    }
+
+    #[test]
+    fn test_default_format_spacing_unchanged() {
+        let tokens = parse_format("%.8i %.9P", &squeue_header);
+        let row = format_row(&tokens, &|spec| match spec {
+            'i' => "1".into(),
+            'P' => "gpu".into(),
+            _ => "?".into(),
+        });
+        assert_eq!(row, "       1       gpu");
     }
 
     fn test_name_to_spec(name: &str) -> Option<char> {
@@ -321,50 +396,70 @@ mod tests {
 
     #[test]
     fn parse_named_format_comma_separated_names() {
-        let fields = parse_named_format(
+        let tokens = parse_named_format(
             "JobID,Partition,JobName",
             &test_name_to_spec,
             &squeue_header,
         );
-        assert_eq!(fields.len(), 3);
-        assert_eq!(fields[0].spec, 'i');
-        assert_eq!(fields[1].spec, 'P');
-        assert_eq!(fields[2].spec, 'j');
-        assert_eq!(fields[0].width, 0);
+        let field_count = tokens
+            .iter()
+            .filter(|t| matches!(t, FormatToken::Field(_)))
+            .count();
+        assert_eq!(field_count, 3);
+        let specs: Vec<char> = tokens
+            .iter()
+            .filter_map(|t| match t {
+                FormatToken::Field(f) => Some(f.spec),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(specs, vec!['i', 'P', 'j']);
     }
 
     #[test]
     fn parse_named_format_applies_percent_width() {
-        let fields = parse_named_format("JobName%20", &test_name_to_spec, &squeue_header);
-        assert_eq!(fields[0].width, 20);
-        assert!(fields[0].right_align);
-        assert_eq!(fields[0].truncate, Some(20));
+        let tokens = parse_named_format("JobName%20", &test_name_to_spec, &squeue_header);
+        let field = match &tokens[0] {
+            FormatToken::Field(f) => f,
+            _ => panic!("expected field"),
+        };
+        assert_eq!(field.width, 20);
+        assert!(field.right_align);
+        assert_eq!(field.truncate, Some(20));
     }
 
     #[test]
     fn parse_named_format_negative_width_left_aligns() {
-        let fields = parse_named_format("JobName%-20", &test_name_to_spec, &squeue_header);
-        assert_eq!(fields[0].width, 20);
-        assert!(!fields[0].right_align);
+        let tokens = parse_named_format("JobName%-20", &test_name_to_spec, &squeue_header);
+        let field = match &tokens[0] {
+            FormatToken::Field(f) => f,
+            _ => panic!("expected field"),
+        };
+        assert_eq!(field.width, 20);
+        assert!(!field.right_align);
     }
 
     #[test]
     fn parse_named_format_skips_unknown_field_names() {
-        let fields = parse_named_format(
+        let tokens = parse_named_format(
             "JobID,NotAField,Partition",
             &test_name_to_spec,
             &squeue_header,
         );
-        assert_eq!(fields.len(), 2);
-        assert_eq!(fields[0].spec, 'i');
-        assert_eq!(fields[1].spec, 'P');
+        let field_count = tokens
+            .iter()
+            .filter(|t| matches!(t, FormatToken::Field(_)))
+            .count();
+        assert_eq!(field_count, 2);
     }
 
     #[test]
     fn parse_named_format_is_case_insensitive() {
-        let fields = parse_named_format("jobid,PARTITION", &test_name_to_spec, &squeue_header);
-        assert_eq!(fields.len(), 2);
-        assert_eq!(fields[0].spec, 'i');
-        assert_eq!(fields[1].spec, 'P');
+        let tokens = parse_named_format("jobid,PARTITION", &test_name_to_spec, &squeue_header);
+        let field_count = tokens
+            .iter()
+            .filter(|t| matches!(t, FormatToken::Field(_)))
+            .count();
+        assert_eq!(field_count, 2);
     }
 }

--- a/crates/spur-cli/src/sacct.rs
+++ b/crates/spur-cli/src/sacct.rs
@@ -407,7 +407,11 @@ mod tests {
             &sacct_field_spec,
             &sacct_header,
         );
-        assert_eq!(fields.len(), 4);
+        let field_count = fields
+            .iter()
+            .filter(|t| matches!(t, format_engine::FormatToken::Field(_)))
+            .count();
+        assert_eq!(field_count, 4);
         let mut j = job(0, 0, 0);
         j.name = "train".into();
         j.partition = "gpu".into();

--- a/crates/spur-cli/src/sbatch.rs
+++ b/crates/spur-cli/src/sbatch.rs
@@ -269,12 +269,20 @@ pub struct SbatchArgs {
     )]
     pub controller: String,
 
+    /// Print only the job ID on success
+    #[arg(long)]
+    pub parsable: bool,
+
     /// Wrap the given command in a minimal shell script (mutually exclusive with a script file)
     #[arg(long, conflicts_with = "script")]
     pub wrap: Option<String>,
 
     /// The batch script file
     pub script: Option<String>,
+
+    /// Arguments passed to the batch script as $1, $2, etc.
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+    pub script_args: Vec<String>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -632,20 +640,16 @@ pub async fn main() -> Result<()> {
     main_with_args(std::env::args().collect()).await
 }
 
-/// The token to treat as a batch script path for `#SBATCH` pre-parsing, if any.
-/// Returns `None` when `--wrap` is used (wrap has no script file) or when the
-/// last token is a flag / the `sbatch` argv[0].
-fn candidate_script_path(cli_args: &[String]) -> Option<&str> {
-    if cli_args
-        .iter()
-        .any(|a| a == "--wrap" || a.starts_with("--wrap="))
-    {
+/// Identify the script file for `#SBATCH` directive pre-parsing.
+///
+/// Uses a lightweight clap pre-parse to extract the `script` positional,
+/// which is reliable even when trailing `script_args` are present.
+fn candidate_script_path(cli_args: &[String]) -> Option<String> {
+    let pre = SbatchArgs::try_parse_from(cli_args).ok()?;
+    if pre.wrap.is_some() {
         return None;
     }
-    match cli_args.last() {
-        Some(last) if !last.starts_with('-') && last != "sbatch" => Some(last.as_str()),
-        _ => None,
-    }
+    pre.script
 }
 
 /// Default job name: explicit `-J`, else `"wrap"` for wrap-mode, else the
@@ -662,7 +666,7 @@ fn default_job_name(job_name: Option<&str>, script: Option<&str>, is_wrap: bool)
 
 pub async fn main_with_args(cli_args: Vec<String>) -> Result<()> {
     let script_content =
-        candidate_script_path(&cli_args).and_then(|p| std::fs::read_to_string(p).ok());
+        candidate_script_path(&cli_args).and_then(|p| std::fs::read_to_string(&p).ok());
 
     let directive_args = script_content
         .as_deref()
@@ -673,6 +677,9 @@ pub async fn main_with_args(cli_args: Vec<String>) -> Result<()> {
 
     // Build the job spec
     let is_wrap = args.wrap.is_some();
+    if is_wrap && !args.script_args.is_empty() {
+        bail!("sbatch: script arguments may not be used with --wrap");
+    }
     let stdin_is_terminal = std::io::IsTerminal::is_terminal(&std::io::stdin());
     let script = match choose_body_source(args.wrap.take(), args.script.clone(), stdin_is_terminal)?
     {
@@ -755,6 +762,7 @@ pub async fn main_with_args(cli_args: Vec<String>) -> Result<()> {
         gres,
         script,
         argv: Vec::new(),
+        script_args: args.script_args.clone(),
         work_dir,
         stdout_path: args.output.unwrap_or_default(),
         stderr_path: args.error.unwrap_or_default(),
@@ -844,7 +852,11 @@ pub async fn main_with_args(cli_args: Vec<String>) -> Result<()> {
         .context("job submission failed")?;
 
     let job_id = response.into_inner().job_id;
-    println!("Submitted batch job {}", job_id);
+    if args.parsable {
+        println!("{}", job_id);
+    } else {
+        println!("Submitted batch job {}", job_id);
+    }
 
     Ok(())
 }
@@ -1165,7 +1177,16 @@ echo "hello world"
             .into_iter()
             .map(Into::into)
             .collect();
-        assert_eq!(candidate_script_path(&args), Some("job.sh"));
+        assert_eq!(candidate_script_path(&args), Some("job.sh".to_string()));
+    }
+
+    #[test]
+    fn test_candidate_script_path_with_trailing_args() {
+        let args: Vec<String> = vec!["sbatch", "job.sh", "arg1", "arg2"]
+            .into_iter()
+            .map(Into::into)
+            .collect();
+        assert_eq!(candidate_script_path(&args), Some("job.sh".to_string()));
     }
 
     #[test]

--- a/crates/spur-cli/src/scancel.rs
+++ b/crates/spur-cli/src/scancel.rs
@@ -121,19 +121,14 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
                 partition: args.partition.unwrap_or_default(),
                 account: args.account.unwrap_or_default(),
                 job_ids: Vec::new(),
+                name: args.name.unwrap_or_default(),
             })
             .await
             .context("failed to get jobs")?;
 
         let jobs = response.into_inner().jobs;
-        let name_filter = args.name.as_deref();
 
         for job in &jobs {
-            if let Some(name) = name_filter {
-                if job.name != name {
-                    continue;
-                }
-            }
             match client
                 .cancel_job(CancelJobRequest {
                     job_id: job.job_id,

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -302,6 +302,9 @@ async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> 
 
             for job in resp.into_inner().jobs {
                 println!("JobId={} JobName={}", job.job_id, job.name);
+                if !job.comment.is_empty() {
+                    println!("   Comment={}", job.comment);
+                }
                 println!("   UserId={} Account={}", job.user, job.account);
                 println!("   Partition={} QOS={}", job.partition, job.qos);
                 println!(

--- a/crates/spur-cli/src/sinfo.rs
+++ b/crates/spur-cli/src/sinfo.rs
@@ -118,7 +118,7 @@ fn group_nodes_by_display_state<'a>(nodes: &[&'a NodeInfo]) -> Vec<(String, Vec<
 }
 
 fn render_sinfo_output(
-    fields: &[format_engine::FormatField],
+    fields: &[format_engine::FormatToken],
     partitions: &[PartitionInfo],
     nodes: &[NodeInfo],
     node_oriented: bool,
@@ -322,7 +322,7 @@ mod tests {
         }
     }
 
-    fn default_fields() -> Vec<format_engine::FormatField> {
+    fn default_fields() -> Vec<format_engine::FormatToken> {
         format_engine::parse_format(
             format_engine::SINFO_DEFAULT_FORMAT,
             &format_engine::sinfo_header,

--- a/crates/spur-cli/src/sprio.rs
+++ b/crates/spur-cli/src/sprio.rs
@@ -66,6 +66,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             partition: String::new(),
             account: String::new(),
             job_ids,
+            name: String::new(),
         })
         .await
         .context("failed to get jobs")?;

--- a/crates/spur-cli/src/squeue.rs
+++ b/crates/spur-cli/src/squeue.rs
@@ -32,6 +32,10 @@ pub struct SqueueArgs {
     #[arg(short = 'A', long)]
     pub account: Option<String>,
 
+    /// Show only jobs with this name
+    #[arg(short = 'n', long)]
+    pub name: Option<String>,
+
     /// Output format string
     #[arg(short = 'o', long)]
     pub format: Option<String>,
@@ -105,6 +109,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             partition: args.partition.unwrap_or_default(),
             account: args.account.unwrap_or_default(),
             job_ids,
+            name: args.name.unwrap_or_default(),
         })
         .await
         .context("failed to get jobs")?;
@@ -155,6 +160,8 @@ fn resolve_job_field(job: &spur_proto::proto::JobInfo, spec: char) -> String {
         'V' => format_timestamp(job.submit_time.as_ref()),
         'v' => job.reservation.clone(),
         'e' => format_timestamp(job.end_time.as_ref()),
+        'k' => job.comment.clone(),
+        'A' => job.job_id.to_string(),
         _ => "?".into(),
     }
 }

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -346,6 +346,8 @@ pub struct JobSpec {
     // Execution
     pub script: Option<String>,
     pub argv: Vec<String>,
+    #[serde(default)]
+    pub script_args: Vec<String>,
     pub work_dir: String,
     pub stdout_path: Option<String>,
     pub stderr_path: Option<String>,
@@ -454,6 +456,7 @@ impl Default for JobSpec {
             gres: Vec::new(),
             script: None,
             argv: Vec::new(),
+            script_args: Vec::new(),
             work_dir: String::from("/tmp"),
             stdout_path: None,
             stderr_path: None,

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -765,6 +765,7 @@ fn core_job_spec_to_proto(spec: &spur_core::job::JobSpec) -> spur_proto::proto::
         gres: spec.gres.clone(),
         script: spec.script.clone().unwrap_or_default(),
         argv: spec.argv.clone(),
+        script_args: spec.script_args.clone(),
         work_dir: spec.work_dir.clone(),
         stdout_path: spec.stdout_path.clone().unwrap_or_default(),
         stderr_path: spec.stderr_path.clone().unwrap_or_default(),

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -201,6 +201,7 @@ impl SlurmAccounting for AccountingService {
                 array_job_id: 0,
                 array_task_id: 0,
                 reservation: r.reservation.clone(),
+                comment: String::new(),
             })
             .collect();
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -393,6 +393,7 @@ impl ClusterManager {
         user: Option<&str>,
         partition: Option<&str>,
         account: Option<&str>,
+        name: Option<&str>,
         job_ids: &[JobId],
     ) -> Vec<Job> {
         let matches = |j: &Job| -> bool {
@@ -411,6 +412,11 @@ impl ClusterManager {
             }
             if let Some(a) = account {
                 if !a.is_empty() && j.spec.account.as_deref() != Some(a) {
+                    return false;
+                }
+            }
+            if let Some(n) = name {
+                if !n.is_empty() && !n.split(',').any(|pat| pat.trim() == j.spec.name) {
                     return false;
                 }
             }
@@ -4641,6 +4647,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             &[],
         );
         assert!(
@@ -5496,7 +5503,8 @@ mod tests {
         assert_eq!(m.running_cpus, 0);
 
         // Snapshot matches a full scan of the job map.
-        let expected = JobMetricsSnapshot::collect(cm.get_jobs(&[], None, None, None, &[]).iter());
+        let expected =
+            JobMetricsSnapshot::collect(cm.get_jobs(&[], None, None, None, None, &[]).iter());
         assert_eq!(cm.job_metrics(), expected);
     }
 
@@ -8879,19 +8887,48 @@ mod tests {
         submit_array_task(&cm, 12, 10, 1);
 
         // Query the parent id explicitly.
-        let got = cm.get_jobs(&[], None, None, None, &[10]);
+        let got = cm.get_jobs(&[], None, None, None, None, &[10]);
         assert_eq!(got.len(), 1, "parent id should synthesize one record");
         assert_eq!(got[0].job_id, 10);
         assert_eq!(got[0].state, JobState::Pending);
         assert_eq!(got[0].spec.array_job_id, Some(10));
 
         // Querying a real task id still returns that task, not the parent.
-        let got_task = cm.get_jobs(&[], None, None, None, &[11]);
+        let got_task = cm.get_jobs(&[], None, None, None, None, &[11]);
         assert_eq!(got_task.len(), 1);
         assert_eq!(got_task[0].job_id, 11);
 
         // Unknown id → empty.
-        assert!(cm.get_jobs(&[], None, None, None, &[999]).is_empty());
+        assert!(cm.get_jobs(&[], None, None, None, None, &[999]).is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn get_jobs_filters_by_name() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        submit_and_wait(&cm, basic_spec("alpha"));
+        submit_and_wait(&cm, basic_spec("beta"));
+        submit_and_wait(&cm, basic_spec("alpha"));
+
+        let all = cm.get_jobs(&[], None, None, None, None, &[]);
+        assert_eq!(all.len(), 3);
+
+        let alphas = cm.get_jobs(&[], None, None, None, Some("alpha"), &[]);
+        assert_eq!(alphas.len(), 2);
+        assert!(alphas.iter().all(|j| j.spec.name == "alpha"));
+
+        let betas = cm.get_jobs(&[], None, None, None, Some("beta"), &[]);
+        assert_eq!(betas.len(), 1);
+
+        let multi = cm.get_jobs(&[], None, None, None, Some("alpha,beta"), &[]);
+        assert_eq!(multi.len(), 3);
+
+        let none = cm.get_jobs(&[], None, None, None, Some("nonexistent"), &[]);
+        assert!(none.is_empty());
+
+        let empty = cm.get_jobs(&[], None, None, None, Some(""), &[]);
+        assert_eq!(empty.len(), 3);
     }
 
     // --- Partition matching tests ---

--- a/crates/spurctld/src/rest/handlers.rs
+++ b/crates/spurctld/src/rest/handlers.rs
@@ -44,10 +44,11 @@ pub async fn get_jobs(
     let user = query.user.as_deref();
     let partition = query.partition.as_deref();
     let account = query.account.as_deref();
+    let name = query.name.as_deref();
 
     let jobs = state
         .cluster
-        .get_jobs(&states, user, partition, account, &[]);
+        .get_jobs(&states, user, partition, account, name, &[]);
     let json_jobs: Vec<serde_json::Value> = jobs.iter().map(job_to_json).collect();
 
     Ok(ApiResponse::ok(JobsData { jobs: json_jobs }))

--- a/crates/spurctld/src/rest/types.rs
+++ b/crates/spurctld/src/rest/types.rs
@@ -121,6 +121,7 @@ pub struct JobsQuery {
     pub partition: Option<String>,
     pub state: Option<String>,
     pub account: Option<String>,
+    pub name: Option<String>,
 }
 
 #[derive(Serialize)]

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -466,7 +466,7 @@ pub(crate) async fn try_preempt(
     };
 
     let mut running: Vec<spur_core::job::Job> = cluster
-        .get_jobs(&[JobState::Running], None, None, None, &[])
+        .get_jobs(&[JobState::Running], None, None, None, None, &[])
         .into_iter()
         .collect();
     running.sort_by_key(|j| j.priority);
@@ -650,6 +650,7 @@ fn core_spec_to_proto(s: &spur_core::job::JobSpec) -> ProtoJobSpec {
         licenses,
         script: s.script.clone().unwrap_or_default(),
         argv: s.argv.clone(),
+        script_args: s.script_args.clone(),
         work_dir: s.work_dir.clone(),
         stdout_path: s.stdout_path.clone().unwrap_or_default(),
         stderr_path: s.stderr_path.clone().unwrap_or_default(),
@@ -746,6 +747,7 @@ async fn dispatch_to_agent(
         gres: spec.gres.clone(),
         script: spec.script.clone().unwrap_or_default(),
         argv: spec.argv.clone(),
+        script_args: spec.script_args.clone(),
         work_dir: spec.work_dir.clone(),
         stdout_path: spec.stdout_path.clone().unwrap_or_default(),
         stderr_path: spec.stderr_path.clone().unwrap_or_default(),
@@ -859,8 +861,14 @@ async fn enforce_time_limits(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>
 
         // Deadline enforcement: mark pending jobs whose deadline has passed
         {
-            let pending =
-                cluster.get_jobs(&[spur_core::job::JobState::Pending], None, None, None, &[]);
+            let pending = cluster.get_jobs(
+                &[spur_core::job::JobState::Pending],
+                None,
+                None,
+                None,
+                None,
+                &[],
+            );
             for job in &pending {
                 if let Some(deadline) = job.spec.deadline {
                     if now > deadline {
@@ -877,6 +885,7 @@ async fn enforce_time_limits(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>
                 spur_core::job::JobState::Running,
                 spur_core::job::JobState::Completing,
             ],
+            None,
             None,
             None,
             None,
@@ -962,6 +971,7 @@ async fn enforce_completing_timeout(cluster: Arc<ClusterManager>, raft: Arc<Raft
 
         let completing = cluster.get_jobs(
             &[spur_core::job::JobState::Completing],
+            None,
             None,
             None,
             None,

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -238,10 +238,15 @@ impl SlurmController for ControllerService {
         } else {
             Some(req.account.as_str())
         };
+        let name = if req.name.is_empty() {
+            None
+        } else {
+            Some(req.name.as_str())
+        };
 
         let jobs = self
             .cluster
-            .get_jobs(&states, user, partition, account, &req.job_ids);
+            .get_jobs(&states, user, partition, account, name, &req.job_ids);
 
         let proto_jobs: Vec<JobInfo> = jobs.iter().map(job_to_proto).collect();
 
@@ -1558,6 +1563,7 @@ fn proto_to_job_spec(spec: JobSpec) -> Result<spur_core::job::JobSpec, Status> {
             Some(spec.script)
         },
         argv: spec.argv,
+        script_args: spec.script_args,
         work_dir: if spec.work_dir.is_empty() {
             "/tmp".into()
         } else {
@@ -1796,6 +1802,7 @@ fn job_to_proto(job: &spur_core::job::Job) -> JobInfo {
         array_job_id: job.spec.array_job_id.unwrap_or(0),
         array_task_id: job.spec.array_task_id.unwrap_or(0),
         reservation: job.spec.reservation.clone().unwrap_or_default(),
+        comment: job.spec.comment.clone().unwrap_or_default(),
     }
 }
 

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -317,9 +317,16 @@ mod completion_report_tests {
 /// argument vector whose elements are shell-escaped, so metacharacters stay
 /// data rather than being interpreted by the wrapper shell (a redirect leaking
 /// to the outer shell would escape an argv-wrapped sandbox).
-fn build_job_script(script: &str, argv: &[String]) -> Result<String, Status> {
+///
+/// When `script_args` is non-empty and a script body is present, a `set --`
+/// line is injected so the script receives positional parameters (`$1`, `$@`).
+fn build_job_script(
+    script: &str,
+    argv: &[String],
+    script_args: &[String],
+) -> Result<String, Status> {
     if !script.is_empty() {
-        return Ok(script.to_string());
+        return inject_script_args(script, script_args);
     }
     if argv.is_empty() {
         return Err(Status::invalid_argument("no script or argv"));
@@ -327,6 +334,31 @@ fn build_job_script(script: &str, argv: &[String]) -> Result<String, Status> {
     let joined = shlex::try_join(argv.iter().map(String::as_str))
         .map_err(|e| Status::invalid_argument(format!("argv is not shell-safe: {e}")))?;
     Ok(format!("#!/bin/bash\n{joined}\n"))
+}
+
+/// Inject `set -- <args>` into a script so it receives positional parameters.
+/// Placed right after the shebang line (if present), otherwise at the top.
+fn inject_script_args(script: &str, args: &[String]) -> Result<String, Status> {
+    if args.is_empty() {
+        return Ok(script.to_string());
+    }
+    let escaped = shlex::try_join(args.iter().map(String::as_str))
+        .map_err(|e| Status::invalid_argument(format!("script args not shell-safe: {e}")))?;
+    let set_line = format!("set -- {escaped}");
+
+    let first_newline = script.find('\n');
+    let has_shebang = script.starts_with("#!");
+
+    if has_shebang {
+        if let Some(pos) = first_newline {
+            let shebang = script[..pos].trim_end_matches('\r');
+            let rest = &script[pos + 1..];
+            return Ok(format!("{shebang}\n{set_line}\n{rest}"));
+        }
+        return Ok(format!("{script}\n{set_line}\n"));
+    }
+
+    Ok(format!("{set_line}\n{script}"))
 }
 
 async fn report_completion(
@@ -445,7 +477,7 @@ impl SlurmAgent for AgentService {
             spec.work_dir.clone()
         };
 
-        let script = build_job_script(&spec.script, &spec.argv)?;
+        let script = build_job_script(&spec.script, &spec.argv, &spec.script_args)?;
 
         // Compute tasks_per_node for both single- and multi-node jobs
         let tasks_per_node = if spec.tasks_per_node > 0 {
@@ -1543,23 +1575,17 @@ mod tests {
 
     #[test]
     fn build_job_script_uses_explicit_script_verbatim() {
-        let s = build_job_script("#!/bin/sh\nmake -j4\n", &[]).unwrap();
+        let s = build_job_script("#!/bin/sh\nmake -j4\n", &[], &[]).unwrap();
         assert_eq!(s, "#!/bin/sh\nmake -j4\n");
     }
 
     #[test]
     fn build_job_script_errors_on_empty() {
-        assert!(build_job_script("", &[]).is_err());
+        assert!(build_job_script("", &[], &[]).is_err());
     }
 
     #[test]
     fn build_job_script_escapes_argv_so_redirect_stays_in_arg() {
-        // A sandbox wrapper whose final argv element carries shell syntax. The
-        // redirection must remain *inside* the `bash -c` argument, never leak to
-        // the outer wrapper script (which would escape the sandbox). Shell-split
-        // the generated command and assert it round-trips back to the original
-        // argv: were `>` left unquoted it would split into its own token and the
-        // equality would fail, independent of the quoting style shlex chooses.
         let argv: Vec<String> = [
             "axis",
             "run",
@@ -1573,7 +1599,7 @@ mod tests {
         .iter()
         .map(|s| s.to_string())
         .collect();
-        let s = build_job_script("", &argv).unwrap();
+        let s = build_job_script("", &argv, &[]).unwrap();
         let cmd = s.strip_prefix("#!/bin/bash\n").unwrap().trim_end();
         let reparsed = shlex::split(cmd).expect("generated command must be shell-parseable");
         assert_eq!(reparsed, argv);
@@ -1582,8 +1608,39 @@ mod tests {
     #[test]
     fn build_job_script_simple_argv_round_trips() {
         let argv: Vec<String> = ["echo", "hello"].iter().map(|s| s.to_string()).collect();
-        let s = build_job_script("", &argv).unwrap();
+        let s = build_job_script("", &argv, &[]).unwrap();
         assert_eq!(s, "#!/bin/bash\necho hello\n");
+    }
+
+    #[test]
+    fn build_job_script_injects_args_after_shebang() {
+        let args: Vec<String> = ["uuid-123", "--flag"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let s = build_job_script("#!/bin/bash\necho hello\n", &[], &args).unwrap();
+        assert_eq!(s, "#!/bin/bash\nset -- uuid-123 --flag\necho hello\n");
+    }
+
+    #[test]
+    fn build_job_script_injects_args_no_shebang() {
+        let args: Vec<String> = ["arg1"].iter().map(|s| s.to_string()).collect();
+        let s = build_job_script("echo $1\n", &[], &args).unwrap();
+        assert_eq!(s, "set -- arg1\necho $1\n");
+    }
+
+    #[test]
+    fn build_job_script_injects_args_with_env_shebang() {
+        let args: Vec<String> = ["a", "b c"].iter().map(|s| s.to_string()).collect();
+        let s = build_job_script("#!/usr/bin/env bash\necho $@\n", &[], &args).unwrap();
+        assert_eq!(s, "#!/usr/bin/env bash\nset -- a 'b c'\necho $@\n");
+    }
+
+    #[test]
+    fn build_job_script_injects_args_crlf_shebang() {
+        let args: Vec<String> = ["x"].iter().map(|s| s.to_string()).collect();
+        let s = build_job_script("#!/bin/bash\r\necho hi\n", &[], &args).unwrap();
+        assert_eq!(s, "#!/bin/bash\nset -- x\necho hi\n");
     }
 
     async fn run_command_test_setup() -> (AgentService, u32) {

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -148,6 +148,7 @@ message JobSpec {
   bool host_ipc = 68;              // Share host IPC namespace
   string shm_size = 69;            // Shared memory size (e.g., "64Gi")
   map<string, string> extra_resources = 80; // Custom device plugin resources
+  repeated string script_args = 81;          // Positional args for the batch script ($1, $2, ...)
 
   // Container
   string container_image = 70;     // OCI image ref or squashfs path
@@ -201,6 +202,8 @@ message JobInfo {
 
   // Reservation
   string reservation = 52;
+
+  string comment = 53;
 }
 
 message NodeInfo {
@@ -389,6 +392,7 @@ message GetJobsRequest {
   string partition = 3;
   string account = 4;
   repeated uint32 job_ids = 5;
+  string name = 6;
 }
 
 message GetJobsResponse {


### PR DESCRIPTION
## Summary

Adds the missing Slurm CLI features required by [CliMA/slurm-buildkite](https://github.com/CliMA/slurm-buildkite) and similar CI bridges that script against Slurm's CLI surface.

- **`sbatch --parsable`**: prints bare job ID on stdout (no header/decoration)
- **`sbatch` positional script args**: trailing arguments after the script path are forwarded as `$1`, `$2`, etc. via `set --` injection
- **`--comment` readback**: new `comment` field on `JobInfo` proto, surfaced in `squeue %k` and `scontrol show`
- **`squeue --format` literals**: refactored format engine to preserve literal characters between specifiers (`%k,%A` emits `comment,42` with no extra spacing), added `%%` escape support
- **`squeue %A`**: resolves to per-element job ID (matches Slurm semantics)
- **`squeue --name`**: client-side filter by job name

## Approach

- Proto: `script_args` (field 81) on `JobSpec`, `comment` (field 53) on `JobInfo`. Both default to empty, backward-compatible with existing Raft state via `#[serde(default)]`.
- Format engine: introduced `FormatToken` enum (`Field | Literal`) replacing the old `Vec<FormatField>` + `join(" ")` pattern. All callers (`squeue`, `sinfo`, `sacct`) updated. Named-format path (`sacct`) emits literal space separators between fields.
- Agent: `build_job_script` injects `set -- <args>` after the shebang line (or at top if no shebang) when script args are present. Handles CRLF shebangs and shell-escapes args via `shlex`.

## Test plan

- [x] 123 spur-cli unit tests pass (format engine, sbatch, squeue, sacct)
- [x] spurd `build_job_script` / `inject_script_args` tests (shebang, no-shebang, CRLF, quoting)
- [x] Full workspace `cargo test` and `cargo clippy` clean
- [x] Smoke tested on 4-node bare-metal cluster: `sbatch --parsable`, `--comment` readback via `squeue %k,%A`, `scontrol show`, `squeue --name`, positional script args

Closes #434