### PR TITLE
docs: Kubernetes quota-enforcement design (RFC)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3700,6 +3700,7 @@ dependencies = [
  "serde_json",
  "spur-core",
  "spur-metrics",
+ "spur-net",
  "spur-proto",
  "spur-sched",
  "spur-update",

--- a/crates/spur-cli/src/k8s.rs
+++ b/crates/spur-cli/src/k8s.rs
@@ -35,9 +35,6 @@ pub enum K8sCommand {
         /// Control-plane node (default: picked from inventory / [cluster] config).
         #[arg(long)]
         control_plane_node: Option<String>,
-        /// Also install the ARC CI runner scale sets.
-        #[arg(long)]
-        install_arc: bool,
     },
     /// Tear the k0s cluster down.
     Down {
@@ -72,10 +69,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let parsed = K8sArgs::try_parse_from(args)?;
     let controller = parsed.controller;
     match parsed.command {
-        K8sCommand::Up {
-            control_plane_node,
-            install_arc,
-        } => cmd_up(&controller, control_plane_node, install_arc).await,
+        K8sCommand::Up { control_plane_node } => cmd_up(&controller, control_plane_node).await,
         K8sCommand::Down { reset } => cmd_down(&controller, reset).await,
         K8sCommand::Status => cmd_status(&controller).await,
         K8sCommand::Kubeconfig => cmd_kubeconfig(&controller).await,
@@ -105,17 +99,10 @@ async fn cmd_install_k0s(version: &str, path: &str, force: bool) -> Result<()> {
     Ok(())
 }
 
-async fn cmd_up(
-    controller: &str,
-    control_plane_node: Option<String>,
-    install_arc: bool,
-) -> Result<()> {
+async fn cmd_up(controller: &str, control_plane_node: Option<String>) -> Result<()> {
     let mut client = SlurmControllerClient::new(spur_client::connect_channel(controller).await?);
     let resp = client
-        .cluster_up(ClusterUpRequest {
-            control_plane_node,
-            install_arc,
-        })
+        .cluster_up(ClusterUpRequest { control_plane_node })
         .await?
         .into_inner();
     if resp.accepted {
@@ -179,21 +166,11 @@ mod tests {
 
     #[test]
     fn parses_up_with_control_plane() {
-        let args = K8sArgs::try_parse_from([
-            "k8s",
-            "up",
-            "--control-plane-node",
-            "head-node",
-            "--install-arc",
-        ])
-        .unwrap();
+        let args =
+            K8sArgs::try_parse_from(["k8s", "up", "--control-plane-node", "head-node"]).unwrap();
         match args.command {
-            K8sCommand::Up {
-                control_plane_node,
-                install_arc,
-            } => {
+            K8sCommand::Up { control_plane_node } => {
                 assert_eq!(control_plane_node.as_deref(), Some("head-node"));
-                assert!(install_arc);
             }
             _ => panic!("wrong command"),
         }

--- a/crates/spur-cli/src/k8s.rs
+++ b/crates/spur-cli/src/k8s.rs
@@ -1,0 +1,215 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `spur k8s` subcommands: drive the SPUR-managed k0s cluster.
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
+use spur_proto::proto::{
+    ClusterDownRequest, ClusterKubeconfigRequest, ClusterStatusRequest, ClusterUpRequest,
+};
+
+/// Manage the SPUR-provisioned k0s cluster.
+#[derive(Parser, Debug)]
+#[command(name = "k8s", about = "Manage the SPUR-provisioned k0s cluster")]
+pub struct K8sArgs {
+    /// Controller address
+    #[arg(
+        long,
+        env = "SPUR_CONTROLLER_ADDR",
+        default_value = "http://localhost:6817",
+        global = true
+    )]
+    controller: String,
+
+    #[command(subcommand)]
+    pub command: K8sCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum K8sCommand {
+    /// Bring the k0s cluster up (assign roles/IPs, then start each node's component).
+    Up {
+        /// Control-plane node (default: picked from inventory / [cluster] config).
+        #[arg(long)]
+        control_plane_node: Option<String>,
+        /// Also install the ARC CI runner scale sets.
+        #[arg(long)]
+        install_arc: bool,
+    },
+    /// Tear the k0s cluster down.
+    Down {
+        /// Also `k0s reset` each node (destructive: wipes cluster state).
+        #[arg(long)]
+        reset: bool,
+    },
+    /// Show cluster phase + per-node component status.
+    Status,
+    /// Print the admin kubeconfig to stdout.
+    Kubeconfig,
+    /// Download + install the k0s binary on THIS node (local; no controller needed).
+    /// Run as root for the default /usr/local/bin path.
+    InstallK0s {
+        /// k0s release tag to install, or "latest". Defaults to spur's pinned version.
+        #[arg(long, default_value_t = String::from(spur_core::k0s::K0S_PINNED_VERSION))]
+        version: String,
+        /// Install path for the k0s binary.
+        #[arg(long, default_value_t = String::from(spur_core::k0s::K0S_DEFAULT_BINARY))]
+        path: String,
+        /// Reinstall even if a k0s binary already exists at --path.
+        #[arg(long)]
+        force: bool,
+    },
+}
+
+pub async fn main() -> Result<()> {
+    main_with_args(std::env::args().collect()).await
+}
+
+pub async fn main_with_args(args: Vec<String>) -> Result<()> {
+    let parsed = K8sArgs::try_parse_from(args)?;
+    let controller = parsed.controller;
+    match parsed.command {
+        K8sCommand::Up {
+            control_plane_node,
+            install_arc,
+        } => cmd_up(&controller, control_plane_node, install_arc).await,
+        K8sCommand::Down { reset } => cmd_down(&controller, reset).await,
+        K8sCommand::Status => cmd_status(&controller).await,
+        K8sCommand::Kubeconfig => cmd_kubeconfig(&controller).await,
+        K8sCommand::InstallK0s {
+            version,
+            path,
+            force,
+        } => cmd_install_k0s(&version, &path, force).await,
+    }
+}
+
+async fn cmd_install_k0s(version: &str, path: &str, force: bool) -> Result<()> {
+    let dest = std::path::Path::new(path);
+    if dest.exists() && !force {
+        eprintln!("k0s already present at {path} (use --force to reinstall)");
+        return Ok(());
+    }
+    eprintln!("Installing k0s {version} -> {path} ...");
+    let info = spur_update::k0s::install_k0s(version, dest).await?;
+    let short = &info.sha256[..info.sha256.len().min(16)];
+    eprintln!(
+        "Installed k0s {} to {} (sha256 {}…)",
+        info.version,
+        info.path.display(),
+        short
+    );
+    Ok(())
+}
+
+async fn cmd_up(
+    controller: &str,
+    control_plane_node: Option<String>,
+    install_arc: bool,
+) -> Result<()> {
+    let mut client = SlurmControllerClient::new(spur_client::connect_channel(controller).await?);
+    let resp = client
+        .cluster_up(ClusterUpRequest {
+            control_plane_node,
+            install_arc,
+        })
+        .await?
+        .into_inner();
+    if resp.accepted {
+        println!("k0s cluster up requested: {}", resp.message);
+    } else {
+        eprintln!("k0s cluster up NOT accepted: {}", resp.message);
+    }
+    for n in resp.nodes {
+        println!("  {} [{}] {}", n.node, n.role, n.component_state);
+    }
+    Ok(())
+}
+
+async fn cmd_down(controller: &str, reset: bool) -> Result<()> {
+    let mut client = SlurmControllerClient::new(spur_client::connect_channel(controller).await?);
+    let resp = client
+        .cluster_down(ClusterDownRequest { reset })
+        .await?
+        .into_inner();
+    if resp.accepted {
+        println!("k0s cluster down requested: {}", resp.message);
+    } else {
+        eprintln!("k0s cluster down NOT accepted: {}", resp.message);
+    }
+    Ok(())
+}
+
+async fn cmd_status(controller: &str) -> Result<()> {
+    let mut client = SlurmControllerClient::new(spur_client::connect_channel(controller).await?);
+    let resp = client
+        .cluster_status(ClusterStatusRequest {})
+        .await?
+        .into_inner();
+    println!("phase: {}", resp.phase);
+    if !resp.control_plane_node.is_empty() {
+        println!("control-plane: {}", resp.control_plane_node);
+    }
+    for n in resp.nodes {
+        println!(
+            "  {:<24} {:<11} {:<11} enabled={}",
+            n.node, n.role, n.component_state, n.enabled
+        );
+    }
+    Ok(())
+}
+
+async fn cmd_kubeconfig(controller: &str) -> Result<()> {
+    let mut client = SlurmControllerClient::new(spur_client::connect_channel(controller).await?);
+    let resp = client
+        .cluster_kubeconfig(ClusterKubeconfigRequest {})
+        .await?
+        .into_inner();
+    // stdout = data (the YAML), so it can be redirected to a kubeconfig file.
+    print!("{}", resp.kubeconfig);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_up_with_control_plane() {
+        let args = K8sArgs::try_parse_from([
+            "k8s",
+            "up",
+            "--control-plane-node",
+            "head-node",
+            "--install-arc",
+        ])
+        .unwrap();
+        match args.command {
+            K8sCommand::Up {
+                control_plane_node,
+                install_arc,
+            } => {
+                assert_eq!(control_plane_node.as_deref(), Some("head-node"));
+                assert!(install_arc);
+            }
+            _ => panic!("wrong command"),
+        }
+    }
+
+    #[test]
+    fn parses_down_reset_and_status() {
+        let args = K8sArgs::try_parse_from(["k8s", "down", "--reset"]).unwrap();
+        assert!(matches!(args.command, K8sCommand::Down { reset: true }));
+        let args = K8sArgs::try_parse_from(["k8s", "status"]).unwrap();
+        assert!(matches!(args.command, K8sCommand::Status));
+    }
+
+    #[test]
+    fn controller_defaults_and_env() {
+        let args = K8sArgs::try_parse_from(["k8s", "status"]).unwrap();
+        assert_eq!(args.controller, "http://localhost:6817");
+    }
+}

--- a/crates/spur-cli/src/main.rs
+++ b/crates/spur-cli/src/main.rs
@@ -5,6 +5,7 @@ mod exec;
 mod exit_fmt;
 mod format_engine;
 mod image;
+mod k8s;
 mod net;
 mod node;
 mod sacct;
@@ -98,6 +99,7 @@ fn main() -> anyhow::Result<()> {
         "smd" => return runtime.block_on(smd::main()),
         "net" => return runtime.block_on(net::main()),
         "node" => return runtime.block_on(node::main()),
+        "k8s" => return runtime.block_on(k8s::main()),
         "image" => return runtime.block_on(image::main()),
         "exec" => return runtime.block_on(exec::main()),
         "token" => return runtime.block_on(token::main()),
@@ -137,7 +139,7 @@ fn main() -> anyhow::Result<()> {
         "sbatch" | "srun" | "squeue" | "scancel" | "sinfo" | "sacct" | "sacctmgr" | "scontrol"
         | "sprio" | "sshare" | "sstat" | "sdiag" | "sreport" | "strigger" | "sattach"
         | "scrontab" | "smd" => Some(args[1].as_str()),
-        "net" | "node" | "image" | "exec" | "token" => Some(args[1].as_str()),
+        "net" | "node" | "k8s" | "image" | "exec" | "token" => Some(args[1].as_str()),
         _ => None,
     };
 
@@ -187,6 +189,7 @@ fn main() -> anyhow::Result<()> {
             "smd" | "health" | "monitor" => runtime.block_on(smd::main_with_args(rewritten)),
             "net" => runtime.block_on(net::main_with_args(rewritten)),
             "node" => runtime.block_on(node::main_with_args(rewritten)),
+            "k8s" => runtime.block_on(k8s::main_with_args(rewritten)),
             "image" => runtime.block_on(image::main_with_args(rewritten)),
             "exec" => runtime.block_on(exec::main_with_args(rewritten)),
             "token" => runtime.block_on(token::main_with_args(rewritten)),
@@ -258,6 +261,7 @@ fn print_usage() {
     eprintln!();
     eprintln!("Commands:");
     eprintln!("  net         Manage WireGuard mesh network (init/join/status)");
+    eprintln!("  k8s         Manage the SPUR-provisioned k0s cluster (up/down/status/kubeconfig)");
     eprintln!("  image       Manage container images (import/list/remove)");
     eprintln!("  exec        Execute a command inside a running container job");
     eprintln!("  submit      Submit a batch job script");

--- a/crates/spur-cli/src/net.rs
+++ b/crates/spur-cli/src/net.rs
@@ -10,6 +10,7 @@ use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand};
 
 use spur_net::address::AddressPool;
+use spur_net::mesh::{self, MeshMembership};
 use spur_net::wireguard::{self, WgConfig, WgPeer};
 
 /// Network mesh management.
@@ -45,7 +46,7 @@ pub enum NetCommand {
     /// Generates a local keypair, connects to the controller to exchange
     /// keys, and brings up the interface.
     Join {
-        /// Controller's real IP and WireGuard port (e.g. 192.168.1.100:51820)
+        /// Controller's real IP and WireGuard port (e.g. 203.0.113.1:51820)
         #[arg(long)]
         endpoint: String,
         /// Controller's WireGuard public key
@@ -78,12 +79,51 @@ pub enum NetCommand {
         /// Peer's allowed IP (e.g. 10.44.0.3/32)
         #[arg(long)]
         allowed_ip: String,
-        /// Peer's endpoint (e.g. 192.168.1.11:51820)
+        /// Peer's pod CIDR (e.g. 10.42.3.0/24), folded into AllowedIPs so
+        /// WireGuard forwards the peer's pod traffic. Required for a
+        /// native-routing CNI (Calico `bird`) over the mesh.
+        #[arg(long)]
+        pod_cidr: Option<String>,
+        /// Also install a kernel route (`<pod-cidr> dev <iface>`). OFF by
+        /// default: a native-routing CNI owns the FIB routes and spur must not
+        /// fight it. Use only when NO CNI manages routes (e.g. bare-mesh test).
+        #[arg(long)]
+        program_routes: bool,
+        /// Peer's endpoint (e.g. 203.0.113.2:51820)
         #[arg(long)]
         endpoint: Option<String>,
         /// WireGuard interface name
         #[arg(long, default_value = "spur0")]
         interface: String,
+    },
+    /// Apply a full-mesh peering from a membership file on the local node.
+    ///
+    /// Adds every other node as a direct peer with pod-CIDR-aware AllowedIPs,
+    /// turning the default hub-and-spoke into a full mesh a native-routing CNI
+    /// can ride. Run on each node (e.g. SSH fan-out from the head) with the
+    /// SAME membership file.
+    ///
+    /// This REPLACES the hub-and-spoke fallback: the membership file MUST list
+    /// every live mesh node (nodes it omits lose the controller's catch-all
+    /// route and become unreachable). It is additive — it does not remove peers
+    /// or routes for nodes dropped from the file.
+    Mesh {
+        /// Path to the membership file (JSON: {"nodes":[{public_key, mesh_ip, endpoint, pod_cidr?}, ...]}).
+        #[arg(long)]
+        config: PathBuf,
+        /// This node's mesh IP (the entry to skip), e.g. 10.44.0.2.
+        #[arg(long = "self")]
+        self_ip: String,
+        /// Also install kernel pod-CIDR routes. OFF by default (the CNI owns
+        /// FIB routes; see `add-peer --program-routes`).
+        #[arg(long)]
+        program_routes: bool,
+        /// WireGuard interface name
+        #[arg(long, default_value = "spur0")]
+        interface: String,
+        /// Print the computed peers/routes without applying them.
+        #[arg(long)]
+        dry_run: bool,
     },
 }
 
@@ -120,9 +160,25 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         NetCommand::AddPeer {
             key,
             allowed_ip,
+            pod_cidr,
+            program_routes,
             endpoint,
             interface,
-        } => cmd_add_peer(&key, &allowed_ip, endpoint.as_deref(), &interface),
+        } => cmd_add_peer(
+            &key,
+            &allowed_ip,
+            pod_cidr.as_deref(),
+            program_routes,
+            endpoint.as_deref(),
+            &interface,
+        ),
+        NetCommand::Mesh {
+            config,
+            self_ip,
+            program_routes,
+            interface,
+            dry_run,
+        } => cmd_mesh(&config, &self_ip, &interface, program_routes, dry_run),
     }
 }
 
@@ -247,24 +303,150 @@ fn cmd_status(interface: &str) -> Result<()> {
 fn cmd_add_peer(
     key: &str,
     allowed_ip: &str,
+    pod_cidr: Option<&str>,
+    program_routes: bool,
     endpoint: Option<&str>,
     interface: &str,
 ) -> Result<()> {
+    // Validate CIDRs before shelling out to `wg`/`ip` so bad input fails fast.
+    mesh::validate_cidr(allowed_ip).context("--allowed-ip")?;
+    let pod_cidr = pod_cidr.map(str::trim).filter(|s| !s.is_empty());
+    if let Some(pod) = pod_cidr {
+        mesh::validate_cidr(pod).context("--pod-cidr")?;
+    }
+
+    // When a pod CIDR is given, fold it into AllowedIPs so WireGuard forwards
+    // the peer's pod traffic (native-routing CNI over the mesh).
+    let allowed_ips = match pod_cidr {
+        Some(pod) => format!("{},{}", allowed_ip, pod),
+        None => allowed_ip.to_string(),
+    };
+
     let peer = WgPeer {
         public_key: key.to_string(),
-        allowed_ips: allowed_ip.to_string(),
+        allowed_ips: allowed_ips.clone(),
         endpoint: endpoint.map(|s| s.to_string()),
         persistent_keepalive: Some(25),
     };
 
     wireguard::add_peer(interface, &peer)?;
+
+    // AllowedIPs (above) is all WireGuard needs. The kernel FIB route is the
+    // CNI's job in native-routing mode; only program it when asked (no CNI).
+    if program_routes {
+        if let Some(pod) = pod_cidr {
+            wireguard::add_route(interface, pod)?;
+        }
+    }
+
     eprintln!("Peer added to {}:", interface);
     eprintln!("  Public key:  {}", key);
-    eprintln!("  Allowed IPs: {}", allowed_ip);
+    eprintln!("  Allowed IPs: {}", allowed_ips);
     if let Some(ep) = endpoint {
         eprintln!("  Endpoint:    {}", ep);
     }
+    if let Some(pod) = pod_cidr {
+        if program_routes {
+            eprintln!("  Pod route:   {} dev {}", pod, interface);
+        } else {
+            eprintln!(
+                "  Pod CIDR:    {} (AllowedIPs only; CNI owns the route)",
+                pod
+            );
+        }
+    }
 
+    Ok(())
+}
+
+fn cmd_mesh(
+    config: &Path,
+    self_ip: &str,
+    interface: &str,
+    program_routes: bool,
+    dry_run: bool,
+) -> Result<()> {
+    let self_ip = self_ip.trim();
+    let raw = std::fs::read_to_string(config)
+        .with_context(|| format!("failed to read mesh membership file {}", config.display()))?;
+    let membership: MeshMembership = serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse mesh membership file {}", config.display()))?;
+
+    // Validate the membership up front: self must be listed, every mesh_ip is an
+    // IP, and every pod_cidr is a CIDR (fail fast before touching `wg`/`ip`).
+    if !membership.nodes.iter().any(|n| n.mesh_ip.trim() == self_ip) {
+        bail!(
+            "--self {} is not present in {} (nodes: {})",
+            self_ip,
+            config.display(),
+            membership
+                .nodes
+                .iter()
+                .map(|n| n.mesh_ip.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+    for n in &membership.nodes {
+        n.mesh_ip
+            .trim()
+            .parse::<Ipv4Addr>()
+            .with_context(|| format!("invalid mesh_ip in membership: {:?}", n.mesh_ip))?;
+        if let Some(pod) = n
+            .pod_cidr
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            mesh::validate_cidr(pod)
+                .with_context(|| format!("invalid pod_cidr for node {}", n.mesh_ip))?;
+        }
+    }
+
+    let peers = mesh::mesh_peers_for(self_ip, &membership.nodes);
+    let routes = mesh::mesh_pod_routes(self_ip, &membership.nodes);
+
+    if dry_run {
+        eprintln!("Mesh apply (dry run) for {} on {}:", self_ip, interface);
+        for p in &peers {
+            eprintln!(
+                "  peer {}  allowed-ips {}  endpoint {}",
+                p.public_key,
+                p.allowed_ips,
+                p.endpoint.as_deref().unwrap_or("-")
+            );
+        }
+        if program_routes {
+            for r in &routes {
+                eprintln!("  route {} dev {}", r, interface);
+            }
+        } else if !routes.is_empty() {
+            eprintln!(
+                "  (routes not programmed — CNI owns them; pass --program-routes to install)"
+            );
+        }
+        return Ok(());
+    }
+
+    // This replaces the hub-and-spoke fallback (each peer's AllowedIPs is set,
+    // not appended), so an omitted node loses reachability. Warn loudly.
+    eprintln!(
+        "note: applying full mesh — this replaces the hub-and-spoke fallback; \
+         the membership file must list every live node."
+    );
+
+    let applied = mesh::apply_mesh(interface, self_ip, &membership.nodes, program_routes)?;
+    eprintln!(
+        "Mesh applied on {}: {} peer(s){} for {}.",
+        interface,
+        applied,
+        if program_routes {
+            format!(", {} pod route(s)", routes.len())
+        } else {
+            " (AllowedIPs only; CNI owns routes)".to_string()
+        },
+        self_ip
+    );
     Ok(())
 }
 

--- a/crates/spur-core/src/assets/local-path-provisioner.yaml
+++ b/crates/spur-core/src/assets/local-path-provisioner.yaml
@@ -1,0 +1,169 @@
+# Vendored from rancher/local-path-provisioner v0.0.31 (deploy/local-path-storage.yaml).
+# SPUR-local edits: (1) the StorageClass is annotated default; (2) the ConfigMap nodePathMap path is
+# a `__LOCAL_PATH_DIR__` placeholder substituted by `spur_core::k0s::k0s_local_path_manifest`.
+# spurd's controller agent writes the rendered result into k0s's manifest-deployer dir so k0s applies
+# it automatically — there is no in-cluster kube client. Bump this file + the version note together.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: local-path-storage
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-path-provisioner-service-account
+  namespace: local-path-storage
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: local-path-provisioner-role
+  namespace: local-path-storage
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-path-provisioner-role
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "persistentvolumeclaims", "configmaps", "pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: local-path-provisioner-bind
+  namespace: local-path-storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: local-path-provisioner-role
+subjects:
+  - kind: ServiceAccount
+    name: local-path-provisioner-service-account
+    namespace: local-path-storage
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-path-provisioner-bind
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: local-path-provisioner-role
+subjects:
+  - kind: ServiceAccount
+    name: local-path-provisioner-service-account
+    namespace: local-path-storage
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: local-path-provisioner
+  namespace: local-path-storage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: local-path-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-path-provisioner
+    spec:
+      serviceAccountName: local-path-provisioner-service-account
+      containers:
+        - name: local-path-provisioner
+          image: rancher/local-path-provisioner:v0.0.31
+          imagePullPolicy: IfNotPresent
+          command:
+            - local-path-provisioner
+            - --debug
+            - start
+            - --config
+            - /etc/config/config.json
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config/
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_MOUNT_PATH
+              value: /etc/config/
+      volumes:
+        - name: config-volume
+          configMap:
+            name: local-path-config
+
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-path
+  annotations:
+    # SPUR ships this as the cluster's default StorageClass so PVCs without an explicit class bind.
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: rancher.io/local-path
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: local-path-config
+  namespace: local-path-storage
+data:
+  config.json: |-
+    {
+            "nodePathMap":[
+            {
+                    "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
+                    "paths":["__LOCAL_PATH_DIR__"]
+            }
+            ]
+    }
+  setup: |-
+    #!/bin/sh
+    set -eu
+    mkdir -m 0777 -p "$VOL_DIR"
+  teardown: |-
+    #!/bin/sh
+    set -eu
+    rm -rf "$VOL_DIR"
+  helperPod.yaml: |-
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: helper-pod
+    spec:
+      priorityClassName: system-node-critical
+      tolerations:
+        - key: node.kubernetes.io/disk-pressure
+          operator: Exists
+          effect: NoSchedule
+      containers:
+      - name: helper-pod
+        image: busybox
+        imagePullPolicy: IfNotPresent

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -645,6 +645,15 @@ pub struct ClusterConfig {
     /// worker's kubelet `--node-ip` to its mesh IP.
     #[serde(default = "default_cni")]
     pub cni: String,
+    /// Storage provisioner SPUR ships so PVC workloads work out of the box (k0s bundles none).
+    /// "local-path" (default — RWO node-local, set as the default StorageClass) or "none" (bring your
+    /// own). Applied via k0s's manifest deployer on the control-plane node.
+    #[serde(default = "default_storage_provisioner")]
+    pub storage_provisioner: String,
+    /// On-node directory the local-path provisioner stores PersistentVolumes in. Point this at a
+    /// large scratch disk if PVCs will hold much data — the default lives under `/var/lib` (root fs).
+    #[serde(default = "default_local_path_dir")]
+    pub local_path_dir: String,
 }
 
 fn default_cluster_distro() -> String {
@@ -668,6 +677,12 @@ fn default_service_cidr() -> String {
 fn default_cni_mtu() -> u16 {
     1450
 }
+fn default_storage_provisioner() -> String {
+    "local-path".into()
+}
+fn default_local_path_dir() -> String {
+    crate::k0s::DEFAULT_LOCAL_PATH_DIR.into()
+}
 
 impl Default for ClusterConfig {
     fn default() -> Self {
@@ -681,6 +696,8 @@ impl Default for ClusterConfig {
             k0s_version: default_k0s_version(),
             k0s_binary: default_k0s_binary(),
             cni: default_cni(),
+            storage_provisioner: default_storage_provisioner(),
+            local_path_dir: default_local_path_dir(),
         }
     }
 }
@@ -962,6 +979,35 @@ impl SlurmConfig {
                     ),
                 });
             }
+            if !matches!(
+                self.cluster.storage_provisioner.as_str(),
+                "local-path" | "none"
+            ) {
+                return Err(ConfigError::InvalidValue {
+                    field: "cluster.storage_provisioner".into(),
+                    value: format!(
+                        "{} (expected \"local-path\" or \"none\")",
+                        self.cluster.storage_provisioner
+                    ),
+                });
+            }
+            // local_path_dir is interpolated verbatim into a JSON string in the generated manifest,
+            // so an absolute path free of quotes/backslashes/whitespace/control chars keeps the JSON
+            // valid and can't inject. Only meaningful when local-path is the chosen provisioner.
+            if self.cluster.storage_provisioner == "local-path" {
+                let d = &self.cluster.local_path_dir;
+                if !d.starts_with('/')
+                    || d.chars()
+                        .any(|c| c == '"' || c == '\\' || c.is_whitespace() || c.is_control())
+                {
+                    return Err(ConfigError::InvalidValue {
+                        field: "cluster.local_path_dir".into(),
+                        value: format!(
+                            "{d} (must be an absolute path with no quotes, backslashes, or whitespace)"
+                        ),
+                    });
+                }
+            }
         }
         Ok(())
     }
@@ -1137,6 +1183,8 @@ mod tests {
         assert_eq!(c.service_cidr, "10.43.0.0/16");
         assert_eq!(c.cni_mtu, 1450);
         assert_eq!(c.cni, "kuberouter");
+        assert_eq!(c.storage_provisioner, "local-path");
+        assert_eq!(c.local_path_dir, "/var/lib/local-path-provisioner");
     }
 
     #[test]
@@ -1173,6 +1221,29 @@ cni_mtu = 1400
             "cluster_name=\"t\"\n[cluster]\nenabled=true\ndistro=\"k3s\"\n"
         )
         .is_err());
+        // Unknown storage provisioner is rejected; "none" and "local-path" are accepted.
+        assert!(SlurmConfig::load_from_str(
+            "cluster_name=\"t\"\n[cluster]\nenabled=true\nstorage_provisioner=\"nfs\"\n"
+        )
+        .is_err());
+        assert!(SlurmConfig::load_from_str(
+            "cluster_name=\"t\"\n[cluster]\nenabled=true\nstorage_provisioner=\"none\"\n"
+        )
+        .is_ok());
+        // A local_path_dir that would break the JSON it is interpolated into is rejected.
+        assert!(SlurmConfig::load_from_str(
+            "cluster_name=\"t\"\n[cluster]\nenabled=true\nlocal_path_dir=\"/mnt/a\\\"b\"\n"
+        )
+        .is_err());
+        assert!(SlurmConfig::load_from_str(
+            "cluster_name=\"t\"\n[cluster]\nenabled=true\nlocal_path_dir=\"relative/path\"\n"
+        )
+        .is_err());
+        // A local_path_dir only matters for local-path; junk is ignored when storage is "none".
+        assert!(SlurmConfig::load_from_str(
+            "cluster_name=\"t\"\n[cluster]\nenabled=true\nstorage_provisioner=\"none\"\nlocal_path_dir=\"bad path\"\n"
+        )
+        .is_ok());
         // Disabled cluster: no cluster validation applied even with junk values.
         assert!(SlurmConfig::load_from_str(
             "cluster_name=\"t\"\n[cluster]\nenabled=false\npod_cidr=\"whatever\"\n"

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -55,6 +55,10 @@ pub struct SlurmConfig {
     #[serde(default)]
     pub kubernetes: KubernetesConfig,
 
+    /// Native cluster (k0s) that SPUR provisions and owns. Inverse of `[kubernetes]`.
+    #[serde(default)]
+    pub cluster: ClusterConfig,
+
     #[serde(default)]
     pub notifications: NotificationConfig,
 
@@ -603,6 +607,184 @@ impl Default for KubernetesConfig {
     }
 }
 
+/// Native cluster (k0s) integration — SPUR OWNS the Kubernetes cluster lifecycle
+/// (`spur k8s up/down`, spurd-owned k0s systemd units, GPU CDI on join). This is the
+/// inverse of `[kubernetes]` above (which lets SPUR run *inside* an existing k8s and accept
+/// SpurJob CRDs); the two are intentionally distinct sections.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClusterConfig {
+    /// Enable SPUR-managed k0s. When false, spurd never touches systemd/k0s.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Kubernetes distribution SPUR manages. Only "k0s" is supported today.
+    #[serde(default = "default_cluster_distro")]
+    pub distro: String,
+    /// Pod network CIDR. Calico bird native routing over the mesh carves per-node /24s from this.
+    #[serde(default = "default_pod_cidr")]
+    pub pod_cidr: String,
+    /// Service network CIDR.
+    #[serde(default = "default_service_cidr")]
+    pub service_cidr: String,
+    /// CNI MTU. Defaults to 1450 to leave headroom for WireGuard's ~50-byte overhead over the mesh;
+    /// set explicitly if your underlay differs.
+    #[serde(default = "default_cni_mtu")]
+    pub cni_mtu: u16,
+    /// Interface k0s/Calico use for node-IP autodetection (the SPUR mesh interface).
+    #[serde(default = "default_flannel_iface")]
+    pub flannel_iface: String,
+    /// Hostname of the node that runs the k0s control plane. Empty = pick from inventory.
+    #[serde(default)]
+    pub control_plane_node: Option<String>,
+    /// Node label selector that marks GPU workers.
+    #[serde(default = "default_gpu_worker_selector")]
+    pub gpu_worker_selector: String,
+    /// GPU device plugin advertising `amd.com/gpu` ("rocm" = ROCm/k8s-device-plugin;
+    /// "spur" = native spur-device-plugin, a later milestone).
+    #[serde(default = "default_device_plugin")]
+    pub device_plugin: String,
+    /// ARC (actions-runner-controller) settings for CI runner scale sets.
+    #[serde(default)]
+    pub arc: ClusterArcConfig,
+    /// k0s release to install/run (e.g. "v1.36.2+k0s.0", or "latest"). Pinned to a known-good
+    /// version by default; bumped per spur release. spurd installs this if the binary is missing.
+    #[serde(default = "default_k0s_version")]
+    pub k0s_version: String,
+    /// Filesystem path to the k0s binary (install target + what the systemd unit runs).
+    #[serde(default = "default_k0s_binary")]
+    pub k0s_binary: String,
+    /// CNI / network mode. "kuberouter" (k0s default — no custom config) or "calico" (Calico in
+    /// bird native-routing mode with the API advertised on the mesh IP, so pods route over the
+    /// WireGuard mesh). Selecting "calico" makes `spur k8s up` generate the k0s config + set each
+    /// worker's kubelet `--node-ip` to its mesh IP.
+    #[serde(default = "default_cni")]
+    pub cni: String,
+}
+
+fn default_cluster_distro() -> String {
+    "k0s".into()
+}
+fn default_k0s_version() -> String {
+    crate::k0s::K0S_PINNED_VERSION.into()
+}
+fn default_k0s_binary() -> String {
+    crate::k0s::K0S_DEFAULT_BINARY.into()
+}
+fn default_cni() -> String {
+    "kuberouter".into()
+}
+fn default_pod_cidr() -> String {
+    "10.42.0.0/16".into()
+}
+fn default_service_cidr() -> String {
+    "10.43.0.0/16".into()
+}
+fn default_cni_mtu() -> u16 {
+    1450
+}
+fn default_flannel_iface() -> String {
+    "spur0".into()
+}
+fn default_gpu_worker_selector() -> String {
+    "spur.amd.com/compute=true".into()
+}
+fn default_device_plugin() -> String {
+    "rocm".into()
+}
+
+impl Default for ClusterConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            distro: default_cluster_distro(),
+            pod_cidr: default_pod_cidr(),
+            service_cidr: default_service_cidr(),
+            cni_mtu: default_cni_mtu(),
+            flannel_iface: default_flannel_iface(),
+            control_plane_node: None,
+            gpu_worker_selector: default_gpu_worker_selector(),
+            device_plugin: default_device_plugin(),
+            arc: ClusterArcConfig::default(),
+            k0s_version: default_k0s_version(),
+            k0s_binary: default_k0s_binary(),
+            cni: default_cni(),
+        }
+    }
+}
+
+/// ARC (actions-runner-controller) settings for CI runner scale sets on the SPUR-managed cluster.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClusterArcConfig {
+    /// Install ARC as part of `spur k8s up`.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Helm release / runner scale-set name.
+    #[serde(default = "default_arc_installation_name")]
+    pub installation_name: String,
+    /// GitHub org/repo URL the runners register to (required when arc.enabled).
+    #[serde(default)]
+    pub github_config_url: String,
+    /// ARC container mode ("dind", "kubernetes", or empty for a hand-authored pod spec).
+    #[serde(default)]
+    pub container_mode: String,
+    /// Runner image.
+    #[serde(default = "default_arc_runner_image")]
+    pub runner_image: String,
+}
+
+fn default_arc_installation_name() -> String {
+    "spur-gpu-runners".into()
+}
+fn default_arc_runner_image() -> String {
+    "ghcr.io/actions/actions-runner:latest".into()
+}
+
+impl Default for ClusterArcConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            installation_name: default_arc_installation_name(),
+            github_config_url: String::new(),
+            container_mode: String::new(),
+            runner_image: default_arc_runner_image(),
+        }
+    }
+}
+
+/// Basic dependency-free CIDR sanity check (`<ip>/<prefix>`), used by config validation.
+fn is_valid_cidr(s: &str) -> bool {
+    match s.split_once('/') {
+        Some((ip, prefix)) => {
+            ip.parse::<std::net::IpAddr>().is_ok()
+                && prefix.parse::<u8>().map(|p| p <= 128).unwrap_or(false)
+        }
+        None => false,
+    }
+}
+
+/// True if two IPv4 CIDRs overlap (share any address). Non-IPv4 / malformed inputs return false
+/// (they are rejected separately by `is_valid_cidr`).
+fn cidrs_overlap(a: &str, b: &str) -> bool {
+    fn parse_v4(s: &str) -> Option<(u32, u8)> {
+        let (ip, prefix) = s.split_once('/')?;
+        let ip: std::net::Ipv4Addr = ip.parse().ok()?;
+        let prefix: u8 = prefix.parse().ok()?;
+        if prefix > 32 {
+            return None;
+        }
+        Some((u32::from(ip), prefix))
+    }
+    let (Some((a_ip, a_pfx)), Some((b_ip, b_pfx))) = (parse_v4(a), parse_v4(b)) else {
+        return false;
+    };
+    let shorter = a_pfx.min(b_pfx);
+    let mask = if shorter == 0 {
+        0
+    } else {
+        u32::MAX << (32 - shorter)
+    };
+    (a_ip & mask) == (b_ip & mask)
+}
+
 /// Power management configuration for suspending/resuming idle nodes.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct PowerConfig {
@@ -816,6 +998,39 @@ impl SlurmConfig {
                 value: "0 (must be at least 1)".into(),
             });
         }
+        if self.cluster.enabled {
+            if self.cluster.distro != "k0s" {
+                return Err(ConfigError::InvalidValue {
+                    field: "cluster.distro".into(),
+                    value: format!("{} (only \"k0s\" is supported)", self.cluster.distro),
+                });
+            }
+            for (field, cidr) in [
+                ("cluster.pod_cidr", &self.cluster.pod_cidr),
+                ("cluster.service_cidr", &self.cluster.service_cidr),
+            ] {
+                if !is_valid_cidr(cidr) {
+                    return Err(ConfigError::InvalidValue {
+                        field: field.into(),
+                        value: cidr.clone(),
+                    });
+                }
+            }
+            if cidrs_overlap(&self.cluster.pod_cidr, &self.cluster.service_cidr) {
+                return Err(ConfigError::InvalidValue {
+                    field: "cluster.pod_cidr/service_cidr".into(),
+                    value: format!(
+                        "{} overlaps {}",
+                        self.cluster.pod_cidr, self.cluster.service_cidr
+                    ),
+                });
+            }
+            if self.cluster.arc.enabled && self.cluster.arc.github_config_url.is_empty() {
+                return Err(ConfigError::MissingField(
+                    "cluster.arc.github_config_url".into(),
+                ));
+            }
+        }
         Ok(())
     }
 
@@ -979,6 +1194,87 @@ mod tests {
     fn test_controller_endpoints_single_host() {
         let cfg = ControllerConfig::default();
         assert_eq!(cfg.endpoints(), vec!["http://localhost:6817"]);
+    }
+
+    #[test]
+    fn cluster_config_defaults_are_disabled_and_sane() {
+        let c = ClusterConfig::default();
+        assert!(!c.enabled);
+        assert_eq!(c.distro, "k0s");
+        assert_eq!(c.pod_cidr, "10.42.0.0/16");
+        assert_eq!(c.service_cidr, "10.43.0.0/16");
+        assert_eq!(c.cni_mtu, 1450);
+        assert_eq!(c.flannel_iface, "spur0");
+        assert!(!c.arc.enabled);
+    }
+
+    #[test]
+    fn cluster_config_round_trips_from_toml() {
+        let toml = r#"
+cluster_name = "test"
+
+[cluster]
+enabled = true
+pod_cidr = "10.60.0.0/16"
+control_plane_node = "head-node"
+
+[cluster.arc]
+enabled = true
+github_config_url = "https://github.com/org/repo"
+"#;
+        let cfg = SlurmConfig::load_from_str(toml).expect("valid cluster config");
+        assert!(cfg.cluster.enabled);
+        assert_eq!(cfg.cluster.distro, "k0s"); // default fills in
+        assert_eq!(cfg.cluster.pod_cidr, "10.60.0.0/16");
+        assert_eq!(cfg.cluster.control_plane_node.as_deref(), Some("head-node"));
+        assert_eq!(cfg.cluster.service_cidr, "10.43.0.0/16"); // default
+        assert!(cfg.cluster.arc.enabled);
+    }
+
+    #[test]
+    fn cluster_validation_gates_on_enabled() {
+        // Bad pod_cidr is rejected when enabled.
+        assert!(SlurmConfig::load_from_str(
+            "cluster_name=\"t\"\n[cluster]\nenabled=true\npod_cidr=\"not-a-cidr\"\n"
+        )
+        .is_err());
+        // Unsupported distro is rejected.
+        assert!(SlurmConfig::load_from_str(
+            "cluster_name=\"t\"\n[cluster]\nenabled=true\ndistro=\"k3s\"\n"
+        )
+        .is_err());
+        // ARC enabled without a github_config_url is rejected.
+        assert!(SlurmConfig::load_from_str(
+            "cluster_name=\"t\"\n[cluster]\nenabled=true\n[cluster.arc]\nenabled=true\n"
+        )
+        .is_err());
+        // Disabled cluster: no cluster validation applied even with junk values.
+        assert!(SlurmConfig::load_from_str(
+            "cluster_name=\"t\"\n[cluster]\nenabled=false\npod_cidr=\"whatever\"\n"
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn cidr_overlap_detection() {
+        assert!(cidrs_overlap("10.42.0.0/16", "10.42.5.0/24")); // /24 inside /16
+        assert!(cidrs_overlap("10.42.0.0/16", "10.42.0.0/16")); // identical
+        assert!(!cidrs_overlap("10.42.0.0/16", "10.43.0.0/16")); // adjacent, disjoint
+        assert!(!cidrs_overlap("10.42.0.0/16", "10.96.0.0/12")); // pod vs default service
+        assert!(!cidrs_overlap("bad", "10.42.0.0/16")); // malformed -> false
+    }
+
+    #[test]
+    fn cluster_validation_rejects_overlapping_cidrs() {
+        // pod_cidr overlapping service_cidr is rejected when enabled.
+        assert!(SlurmConfig::load_from_str(
+            "cluster_name=\"t\"\n[cluster]\nenabled=true\npod_cidr=\"10.42.0.0/16\"\nservice_cidr=\"10.42.5.0/24\"\n"
+        )
+        .is_err());
+        // The defaults (10.42/16 pod vs 10.43/16 service) do NOT overlap.
+        assert!(
+            SlurmConfig::load_from_str("cluster_name=\"t\"\n[cluster]\nenabled=true\n").is_ok()
+        );
     }
 
     #[test]

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -752,10 +752,12 @@ impl Default for ClusterArcConfig {
 
 /// Basic dependency-free CIDR sanity check (`<ip>/<prefix>`), used by config validation.
 fn is_valid_cidr(s: &str) -> bool {
+    // IPv4 only: the native k0s provisioning paths (cluster_k8s IPAM, pod-CIDR carving, AddressPool)
+    // are all `Ipv4Addr`, so an IPv6 CIDR would validate here and then fail later at runtime.
     match s.split_once('/') {
         Some((ip, prefix)) => {
-            ip.parse::<std::net::IpAddr>().is_ok()
-                && prefix.parse::<u8>().map(|p| p <= 128).unwrap_or(false)
+            ip.parse::<std::net::Ipv4Addr>().is_ok()
+                && prefix.parse::<u8>().map(|p| p <= 32).unwrap_or(false)
         }
         None => false,
     }

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -625,26 +625,13 @@ pub struct ClusterConfig {
     /// Service network CIDR.
     #[serde(default = "default_service_cidr")]
     pub service_cidr: String,
-    /// CNI MTU. Defaults to 1450 to leave headroom for WireGuard's ~50-byte overhead over the mesh;
-    /// set explicitly if your underlay differs.
+    /// CNI MTU (Calico only). Defaults to 1450 to leave headroom for WireGuard's ~50-byte overhead
+    /// over the mesh; set explicitly if your underlay differs. Emitted into the generated k0s config.
     #[serde(default = "default_cni_mtu")]
     pub cni_mtu: u16,
-    /// Interface k0s/Calico use for node-IP autodetection (the SPUR mesh interface).
-    #[serde(default = "default_flannel_iface")]
-    pub flannel_iface: String,
     /// Hostname of the node that runs the k0s control plane. Empty = pick from inventory.
     #[serde(default)]
     pub control_plane_node: Option<String>,
-    /// Node label selector that marks GPU workers.
-    #[serde(default = "default_gpu_worker_selector")]
-    pub gpu_worker_selector: String,
-    /// GPU device plugin advertising `amd.com/gpu` ("rocm" = ROCm/k8s-device-plugin;
-    /// "spur" = native spur-device-plugin, a later milestone).
-    #[serde(default = "default_device_plugin")]
-    pub device_plugin: String,
-    /// ARC (actions-runner-controller) settings for CI runner scale sets.
-    #[serde(default)]
-    pub arc: ClusterArcConfig,
     /// k0s release to install/run (e.g. "v1.36.2+k0s.0", or "latest"). Pinned to a known-good
     /// version by default; bumped per spur release. spurd installs this if the binary is missing.
     #[serde(default = "default_k0s_version")]
@@ -681,15 +668,6 @@ fn default_service_cidr() -> String {
 fn default_cni_mtu() -> u16 {
     1450
 }
-fn default_flannel_iface() -> String {
-    "spur0".into()
-}
-fn default_gpu_worker_selector() -> String {
-    "spur.amd.com/compute=true".into()
-}
-fn default_device_plugin() -> String {
-    "rocm".into()
-}
 
 impl Default for ClusterConfig {
     fn default() -> Self {
@@ -699,53 +677,10 @@ impl Default for ClusterConfig {
             pod_cidr: default_pod_cidr(),
             service_cidr: default_service_cidr(),
             cni_mtu: default_cni_mtu(),
-            flannel_iface: default_flannel_iface(),
             control_plane_node: None,
-            gpu_worker_selector: default_gpu_worker_selector(),
-            device_plugin: default_device_plugin(),
-            arc: ClusterArcConfig::default(),
             k0s_version: default_k0s_version(),
             k0s_binary: default_k0s_binary(),
             cni: default_cni(),
-        }
-    }
-}
-
-/// ARC (actions-runner-controller) settings for CI runner scale sets on the SPUR-managed cluster.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ClusterArcConfig {
-    /// Install ARC as part of `spur k8s up`.
-    #[serde(default)]
-    pub enabled: bool,
-    /// Helm release / runner scale-set name.
-    #[serde(default = "default_arc_installation_name")]
-    pub installation_name: String,
-    /// GitHub org/repo URL the runners register to (required when arc.enabled).
-    #[serde(default)]
-    pub github_config_url: String,
-    /// ARC container mode ("dind", "kubernetes", or empty for a hand-authored pod spec).
-    #[serde(default)]
-    pub container_mode: String,
-    /// Runner image.
-    #[serde(default = "default_arc_runner_image")]
-    pub runner_image: String,
-}
-
-fn default_arc_installation_name() -> String {
-    "spur-gpu-runners".into()
-}
-fn default_arc_runner_image() -> String {
-    "ghcr.io/actions/actions-runner:latest".into()
-}
-
-impl Default for ClusterArcConfig {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            installation_name: default_arc_installation_name(),
-            github_config_url: String::new(),
-            container_mode: String::new(),
-            runner_image: default_arc_runner_image(),
         }
     }
 }
@@ -1027,11 +962,6 @@ impl SlurmConfig {
                     ),
                 });
             }
-            if self.cluster.arc.enabled && self.cluster.arc.github_config_url.is_empty() {
-                return Err(ConfigError::MissingField(
-                    "cluster.arc.github_config_url".into(),
-                ));
-            }
         }
         Ok(())
     }
@@ -1206,8 +1136,7 @@ mod tests {
         assert_eq!(c.pod_cidr, "10.42.0.0/16");
         assert_eq!(c.service_cidr, "10.43.0.0/16");
         assert_eq!(c.cni_mtu, 1450);
-        assert_eq!(c.flannel_iface, "spur0");
-        assert!(!c.arc.enabled);
+        assert_eq!(c.cni, "kuberouter");
     }
 
     #[test]
@@ -1219,10 +1148,8 @@ cluster_name = "test"
 enabled = true
 pod_cidr = "10.60.0.0/16"
 control_plane_node = "head-node"
-
-[cluster.arc]
-enabled = true
-github_config_url = "https://github.com/org/repo"
+cni = "calico"
+cni_mtu = 1400
 "#;
         let cfg = SlurmConfig::load_from_str(toml).expect("valid cluster config");
         assert!(cfg.cluster.enabled);
@@ -1230,7 +1157,8 @@ github_config_url = "https://github.com/org/repo"
         assert_eq!(cfg.cluster.pod_cidr, "10.60.0.0/16");
         assert_eq!(cfg.cluster.control_plane_node.as_deref(), Some("head-node"));
         assert_eq!(cfg.cluster.service_cidr, "10.43.0.0/16"); // default
-        assert!(cfg.cluster.arc.enabled);
+        assert_eq!(cfg.cluster.cni, "calico");
+        assert_eq!(cfg.cluster.cni_mtu, 1400);
     }
 
     #[test]
@@ -1243,11 +1171,6 @@ github_config_url = "https://github.com/org/repo"
         // Unsupported distro is rejected.
         assert!(SlurmConfig::load_from_str(
             "cluster_name=\"t\"\n[cluster]\nenabled=true\ndistro=\"k3s\"\n"
-        )
-        .is_err());
-        // ARC enabled without a github_config_url is rejected.
-        assert!(SlurmConfig::load_from_str(
-            "cluster_name=\"t\"\n[cluster]\nenabled=true\n[cluster.arc]\nenabled=true\n"
         )
         .is_err());
         // Disabled cluster: no cluster validation applied even with junk values.

--- a/crates/spur-core/src/k0s.rs
+++ b/crates/spur-core/src/k0s.rs
@@ -1,0 +1,144 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared types for native k0s cluster integration (SPUR owns the k0s lifecycle).
+//!
+//! Named here so both the WAL (`spur_core::wal`) and node inventory (`spur_core::node`) can
+//! reference them, and the spurctld raft state machine can persist them across failover.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// k0s release SPUR installs/runs by default — pinned to a known-good version and bumped with each
+/// spur release. Override per node via `[cluster] k0s_version` (accepts a tag or "latest").
+pub const K0S_PINNED_VERSION: &str = "v1.36.2+k0s.0";
+
+/// Default filesystem path for the k0s binary (install target + what the spurd-owned unit runs).
+pub const K0S_DEFAULT_BINARY: &str = "/usr/local/bin/k0s";
+
+/// The GitHub repo k0s releases come from.
+pub const K0S_REPO: &str = "k0sproject/k0s";
+
+/// Generate a k0s controller config (YAML) for a mesh-native cluster: the API server is advertised
+/// on `api_address` (the control-plane's WireGuard mesh IP) and Calico runs in `bird` mode (native
+/// routing, no overlay) so pod traffic rides the mesh. Returns `None` for any `cni` other than
+/// `"calico"` (the k0s default, kube-router, needs no config file). `sans` are extra API-server
+/// certificate SANs (e.g. the control-plane's mesh + underlay IPs).
+pub fn k0s_controller_config_yaml(
+    cni: &str,
+    pod_cidr: &str,
+    service_cidr: &str,
+    api_address: &str,
+    sans: &[String],
+) -> Option<String> {
+    if cni != "calico" {
+        return None;
+    }
+    let mut y = String::new();
+    y.push_str("apiVersion: k0s.k0sproject.io/v1beta1\n");
+    y.push_str("kind: ClusterConfig\n");
+    y.push_str("metadata:\n");
+    y.push_str("  name: k0s\n");
+    y.push_str("spec:\n");
+    y.push_str("  api:\n");
+    y.push_str(&format!("    address: {api_address}\n"));
+    if !sans.is_empty() {
+        y.push_str("    sans:\n");
+        for san in sans {
+            y.push_str(&format!("      - {san}\n"));
+        }
+    }
+    y.push_str("  network:\n");
+    y.push_str("    provider: calico\n");
+    y.push_str(&format!("    podCIDR: {pod_cidr}\n"));
+    y.push_str(&format!("    serviceCIDR: {service_cidr}\n"));
+    y.push_str("    calico:\n");
+    y.push_str("      mode: bird\n");
+    Some(y)
+}
+
+#[cfg(test)]
+mod k0s_config_tests {
+    use super::k0s_controller_config_yaml;
+
+    #[test]
+    fn calico_config_has_mesh_api_and_bird() {
+        // Documentation-range addresses only (RFC 5737 TEST-NET); no real infrastructure IPs.
+        let y = k0s_controller_config_yaml(
+            "calico",
+            "192.0.2.0/24",
+            "198.51.100.0/24",
+            "192.0.2.1",
+            &["192.0.2.1".to_string(), "203.0.113.9".to_string()],
+        )
+        .unwrap();
+        assert!(y.contains("address: 192.0.2.1"));
+        assert!(y.contains("      - 203.0.113.9"));
+        assert!(y.contains("provider: calico"));
+        assert!(y.contains("mode: bird"));
+        assert!(y.contains("podCIDR: 192.0.2.0/24"));
+        assert!(y.contains("serviceCIDR: 198.51.100.0/24"));
+    }
+
+    #[test]
+    fn kuberouter_default_generates_no_config() {
+        assert!(k0s_controller_config_yaml(
+            "kuberouter",
+            "192.0.2.0/24",
+            "198.51.100.0/24",
+            "192.0.2.1",
+            &[]
+        )
+        .is_none());
+    }
+}
+
+/// Which k0s role a node's spurd-owned systemd unit runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum K0sRole {
+    Controller,
+    Worker,
+    Single,
+}
+
+/// Lifecycle phase of the SPUR-managed k0s cluster.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum K0sPhase {
+    #[default]
+    Down,
+    Provisioning,
+    Ready,
+    Degraded,
+}
+
+/// Metadata for a minted k0s join token. Deliberately holds NO plaintext secret: k0s tokens are
+/// opaque bearer secrets from `k0s token create` and are handed to an agent only as the
+/// return-once value of a StartClusterComponent call — never persisted, snapshotted, or logged.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct K0sJoinTokenRecord {
+    pub id: String,
+    pub role: K0sRole,
+    pub created_at: DateTime<Utc>,
+    #[serde(default)]
+    pub expires_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub revoked: bool,
+}
+
+/// Cluster-wide k0s state held in the replicated raft state machine.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct K0sClusterState {
+    #[serde(default)]
+    pub phase: K0sPhase,
+    #[serde(default)]
+    pub control_plane_node: Option<String>,
+    #[serde(default)]
+    pub reset_requested: bool,
+    /// Minted join-token metadata by id (never the plaintext secret).
+    #[serde(default)]
+    pub join_tokens: HashMap<String, K0sJoinTokenRecord>,
+}

--- a/crates/spur-core/src/k0s.rs
+++ b/crates/spur-core/src/k0s.rs
@@ -6,9 +6,6 @@
 //! Named here so both the WAL (`spur_core::wal`) and node inventory (`spur_core::node`) can
 //! reference them, and the spurctld raft state machine can persist them across failover.
 
-use std::collections::HashMap;
-
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 /// k0s release SPUR installs/runs by default — pinned to a known-good version and bumped with each
@@ -23,13 +20,15 @@ pub const K0S_REPO: &str = "k0sproject/k0s";
 
 /// Generate a k0s controller config (YAML) for a mesh-native cluster: the API server is advertised
 /// on `api_address` (the control-plane's WireGuard mesh IP) and Calico runs in `bird` mode (native
-/// routing, no overlay) so pod traffic rides the mesh. Returns `None` for any `cni` other than
-/// `"calico"` (the k0s default, kube-router, needs no config file). `sans` are extra API-server
-/// certificate SANs (e.g. the control-plane's mesh + underlay IPs).
+/// routing, no overlay) so pod traffic rides the mesh. `cni_mtu` sets Calico's MTU (typically below
+/// the underlay to leave room for WireGuard's ~50-byte overhead, avoiding fragmentation). Returns
+/// `None` for any `cni` other than `"calico"` (the k0s default, kube-router, needs no config file).
+/// `sans` are extra API-server certificate SANs (e.g. the control-plane's mesh + underlay IPs).
 pub fn k0s_controller_config_yaml(
     cni: &str,
     pod_cidr: &str,
     service_cidr: &str,
+    cni_mtu: u16,
     api_address: &str,
     sans: &[String],
 ) -> Option<String> {
@@ -56,6 +55,7 @@ pub fn k0s_controller_config_yaml(
     y.push_str(&format!("    serviceCIDR: {service_cidr}\n"));
     y.push_str("    calico:\n");
     y.push_str("      mode: bird\n");
+    y.push_str(&format!("      mtu: {cni_mtu}\n"));
     Some(y)
 }
 
@@ -70,6 +70,7 @@ mod k0s_config_tests {
             "calico",
             "192.0.2.0/24",
             "198.51.100.0/24",
+            1450,
             "192.0.2.1",
             &["192.0.2.1".to_string(), "203.0.113.9".to_string()],
         )
@@ -78,6 +79,7 @@ mod k0s_config_tests {
         assert!(y.contains("      - 203.0.113.9"));
         assert!(y.contains("provider: calico"));
         assert!(y.contains("mode: bird"));
+        assert!(y.contains("mtu: 1450"));
         assert!(y.contains("podCIDR: 192.0.2.0/24"));
         assert!(y.contains("serviceCIDR: 198.51.100.0/24"));
     }
@@ -88,6 +90,7 @@ mod k0s_config_tests {
             "kuberouter",
             "192.0.2.0/24",
             "198.51.100.0/24",
+            1450,
             "192.0.2.1",
             &[]
         )
@@ -115,20 +118,6 @@ pub enum K0sPhase {
     Degraded,
 }
 
-/// Metadata for a minted k0s join token. Deliberately holds NO plaintext secret: k0s tokens are
-/// opaque bearer secrets from `k0s token create` and are handed to an agent only as the
-/// return-once value of a StartClusterComponent call — never persisted, snapshotted, or logged.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct K0sJoinTokenRecord {
-    pub id: String,
-    pub role: K0sRole,
-    pub created_at: DateTime<Utc>,
-    #[serde(default)]
-    pub expires_at: Option<DateTime<Utc>>,
-    #[serde(default)]
-    pub revoked: bool,
-}
-
 /// Cluster-wide k0s state held in the replicated raft state machine.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct K0sClusterState {
@@ -138,7 +127,4 @@ pub struct K0sClusterState {
     pub control_plane_node: Option<String>,
     #[serde(default)]
     pub reset_requested: bool,
-    /// Minted join-token metadata by id (never the plaintext secret).
-    #[serde(default)]
-    pub join_tokens: HashMap<String, K0sJoinTokenRecord>,
 }

--- a/crates/spur-core/src/k0s.rs
+++ b/crates/spur-core/src/k0s.rs
@@ -18,6 +18,47 @@ pub const K0S_DEFAULT_BINARY: &str = "/usr/local/bin/k0s";
 /// The GitHub repo k0s releases come from.
 pub const K0S_REPO: &str = "k0sproject/k0s";
 
+/// k0s's manifest-deployer directory (under the default data-dir). Any manifest written to a
+/// `<stack>/` subdirectory here is applied + reconciled by the k0s controller automatically, so SPUR
+/// ships cluster addons (e.g. local-path storage) by writing files here — no in-cluster kube client.
+pub const K0S_MANIFESTS_DIR: &str = "/var/lib/k0s/manifests";
+
+/// Vendored local-path-provisioner release (see `assets/local-path-provisioner.yaml`).
+pub const LOCAL_PATH_VERSION: &str = "v0.0.31";
+
+/// Default node directory the local-path provisioner stores PersistentVolumes in. Override via
+/// `[cluster] local_path_dir` — point it at a large scratch disk if PVCs will hold much data (the
+/// default lives under `/var/lib`, i.e. the root filesystem).
+pub const DEFAULT_LOCAL_PATH_DIR: &str = "/var/lib/local-path-provisioner";
+
+/// Render the local-path-provisioner manifest with `data_dir` as the on-node PV storage path. The
+/// result is a full k8s manifest (Namespace, RBAC, Deployment, default StorageClass, ConfigMap) that
+/// SPUR writes into k0s's manifest-deployer dir on the control-plane node; k0s applies it.
+///
+/// `data_dir` is interpolated verbatim into a JSON string in the ConfigMap, so it must be free of
+/// quotes/backslashes/whitespace — [`ClusterConfig::validate`](crate::config) enforces that for
+/// `[cluster] local_path_dir`, so callers pass a validated value.
+pub fn k0s_local_path_manifest(data_dir: &str) -> String {
+    include_str!("assets/local-path-provisioner.yaml").replace("__LOCAL_PATH_DIR__", data_dir)
+}
+
+#[cfg(test)]
+mod local_path_tests {
+    use super::k0s_local_path_manifest;
+
+    #[test]
+    fn renders_data_dir_and_default_storageclass() {
+        let m = k0s_local_path_manifest("/mnt/scratch/local-path");
+        // The placeholder is substituted and no literal placeholder survives.
+        assert!(m.contains("\"paths\":[\"/mnt/scratch/local-path\"]"));
+        assert!(!m.contains("__LOCAL_PATH_DIR__"));
+        // Shipped as the cluster default so unclassed PVCs bind.
+        assert!(m.contains("storageclass.kubernetes.io/is-default-class: \"true\""));
+        assert!(m.contains("kind: StorageClass"));
+        assert!(m.contains("provisioner: rancher.io/local-path"));
+    }
+}
+
 /// Generate a k0s controller config (YAML) for a mesh-native cluster: the API server is advertised
 /// on `api_address` (the control-plane's WireGuard mesh IP) and Calico runs in `bird` mode (native
 /// routing, no overlay) so pod traffic rides the mesh. `cni_mtu` sets Calico's MTU (typically below

--- a/crates/spur-core/src/lib.rs
+++ b/crates/spur-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod dependency;
 pub mod hooks;
 pub mod hostlist;
 pub mod job;
+pub mod k0s;
 pub mod node;
 pub mod partition;
 pub mod qos;

--- a/crates/spur-core/src/node.rs
+++ b/crates/spur-core/src/node.rs
@@ -265,6 +265,15 @@ pub struct Node {
     /// Leaf switch this node belongs to (from topology config).
     #[serde(default)]
     pub switch_name: Option<String>,
+    /// Native k0s: role assigned to this node's spurd-owned unit.
+    #[serde(default)]
+    pub k0s_role: Option<crate::k0s::K0sRole>,
+    /// mesh IP allocated to this node for k0s (--node-ip / advertise address).
+    #[serde(default)]
+    pub k0s_mesh_ip: Option<String>,
+    /// per-node pod /24 carved from the cluster pod_cidr.
+    #[serde(default)]
+    pub k0s_pod_cidr: Option<String>,
 }
 
 fn default_weight() -> u32 {
@@ -298,6 +307,9 @@ impl Node {
             version: None,
             weight: 1,
             switch_name: None,
+            k0s_role: None,
+            k0s_mesh_ip: None,
+            k0s_pod_cidr: None,
         }
     }
 

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::admission::AdmissionToken;
 use crate::job::{JobId, JobSpec, JobState, PendingReason};
-use crate::k0s::{K0sJoinTokenRecord, K0sPhase, K0sRole};
+use crate::k0s::{K0sPhase, K0sRole};
 use crate::node::NodeState;
 use crate::reservation::Reservation;
 use std::collections::HashMap;
@@ -179,12 +179,6 @@ pub enum WalOperation {
         control_plane_node: Option<String>,
         #[serde(default)]
         reset_requested: bool,
-    },
-    K0sJoinTokenCreate {
-        token: K0sJoinTokenRecord,
-    },
-    K0sJoinTokenRevoke {
-        token_id: String,
     },
 }
 

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::admission::AdmissionToken;
 use crate::job::{JobId, JobSpec, JobState, PendingReason};
+use crate::k0s::{K0sJoinTokenRecord, K0sPhase, K0sRole};
 use crate::node::NodeState;
 use crate::reservation::Reservation;
 use std::collections::HashMap;
@@ -162,6 +163,28 @@ pub enum WalOperation {
     },
     ReservationDelete {
         name: String,
+    },
+
+    // Native k0s cluster operations. Appended at the end to keep externally-tagged
+    // WAL replay backward-compatible.
+    NodeK0sAssign {
+        name: String,
+        role: K0sRole,
+        mesh_ip: String,
+        pod_cidr: String,
+    },
+    K0sSetPhase {
+        phase: K0sPhase,
+        #[serde(default)]
+        control_plane_node: Option<String>,
+        #[serde(default)]
+        reset_requested: bool,
+    },
+    K0sJoinTokenCreate {
+        token: K0sJoinTokenRecord,
+    },
+    K0sJoinTokenRevoke {
+        token_id: String,
     },
 }
 
@@ -336,6 +359,52 @@ mod deregistration_wal_tests {
             WalOperation::NodeRemove { name, reason } => {
                 assert_eq!(name, "gpu01");
                 assert_eq!(reason.as_deref(), Some("decommission"));
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn k0s_wal_variants_round_trip() {
+        let op = WalOperation::NodeK0sAssign {
+            name: "gpu-node-1".into(),
+            role: K0sRole::Worker,
+            mesh_ip: "10.44.0.2".into(),
+            pod_cidr: "10.42.2.0/24".into(),
+        };
+        let back: WalOperation =
+            serde_json::from_str(&serde_json::to_string(&op).unwrap()).unwrap();
+        match back {
+            WalOperation::NodeK0sAssign {
+                name,
+                role,
+                mesh_ip,
+                pod_cidr,
+            } => {
+                assert_eq!(name, "gpu-node-1");
+                assert_eq!(role, K0sRole::Worker);
+                assert_eq!(mesh_ip, "10.44.0.2");
+                assert_eq!(pod_cidr, "10.42.2.0/24");
+            }
+            _ => panic!("wrong variant"),
+        }
+
+        let op = WalOperation::K0sSetPhase {
+            phase: K0sPhase::Ready,
+            control_plane_node: Some("head-node".into()),
+            reset_requested: false,
+        };
+        let back: WalOperation =
+            serde_json::from_str(&serde_json::to_string(&op).unwrap()).unwrap();
+        match back {
+            WalOperation::K0sSetPhase {
+                phase,
+                control_plane_node,
+                reset_requested,
+            } => {
+                assert_eq!(phase, K0sPhase::Ready);
+                assert_eq!(control_plane_node.as_deref(), Some("head-node"));
+                assert!(!reset_requested);
             }
             _ => panic!("wrong variant"),
         }

--- a/crates/spur-k8s/src/agent.rs
+++ b/crates/spur-k8s/src/agent.rs
@@ -678,6 +678,60 @@ impl SlurmAgent for VirtualAgent {
             "interactive attach not supported for K8s agent",
         ))
     }
+
+    // -- Native cluster component control. The virtual K8s agent does not run k0s
+    //    systemd units, so these are permanently unsupported here. --
+    async fn start_cluster_component(
+        &self,
+        _request: Request<StartClusterComponentRequest>,
+    ) -> Result<Response<StartClusterComponentResponse>, Status> {
+        Err(Status::unimplemented(
+            "cluster components not supported for K8s agent",
+        ))
+    }
+
+    async fn stop_cluster_component(
+        &self,
+        _request: Request<StopClusterComponentRequest>,
+    ) -> Result<Response<StopClusterComponentResponse>, Status> {
+        Err(Status::unimplemented(
+            "cluster components not supported for K8s agent",
+        ))
+    }
+
+    async fn get_cluster_component_status(
+        &self,
+        _request: Request<GetClusterComponentStatusRequest>,
+    ) -> Result<Response<GetClusterComponentStatusResponse>, Status> {
+        Err(Status::unimplemented(
+            "cluster components not supported for K8s agent",
+        ))
+    }
+
+    async fn create_k0s_join_token(
+        &self,
+        _request: Request<CreateK0sJoinTokenRequest>,
+    ) -> Result<Response<CreateK0sJoinTokenResponse>, Status> {
+        Err(Status::unimplemented(
+            "cluster components not supported for K8s agent",
+        ))
+    }
+
+    async fn get_admin_kubeconfig(
+        &self,
+        _request: Request<GetAdminKubeconfigRequest>,
+    ) -> Result<Response<GetAdminKubeconfigResponse>, Status> {
+        Err(Status::unimplemented(
+            "cluster components not supported for K8s agent",
+        ))
+    }
+
+    async fn apply_mesh(
+        &self,
+        _request: Request<MeshMembership>,
+    ) -> Result<Response<ApplyMeshResponse>, Status> {
+        Err(Status::unimplemented("mesh not supported for K8s agent"))
+    }
 }
 
 impl VirtualAgent {

--- a/crates/spur-k8s/src/heartbeat.rs
+++ b/crates/spur-k8s/src/heartbeat.rs
@@ -62,6 +62,7 @@ impl HeartbeatManager {
                             free_memory_mb: 0,
                             running_jobs: vec![],
                             node_token: String::new(),
+                            wg_pubkey: String::new(), // virtual agents are not on the mesh
                         };
                         match client.heartbeat(req).await {
                             Ok(_) => debug!(node = %name, "heartbeat sent"),

--- a/crates/spur-net/src/lib.rs
+++ b/crates/spur-net/src/lib.rs
@@ -3,10 +3,12 @@
 
 pub mod address;
 pub mod detect;
+pub mod mesh;
 pub mod oci;
 pub mod wireguard;
 
 pub use address::{AddressPool, AddressSource, NodeAddress};
 pub use detect::detect_node_address;
+pub use mesh::{MeshMembership, MeshNode};
 pub use oci::{pull_image, ImageRef};
 pub use wireguard::{WgConfig, WgPeer};

--- a/crates/spur-net/src/mesh.rs
+++ b/crates/spur-net/src/mesh.rs
@@ -1,0 +1,299 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Full-mesh WireGuard peering with pod-CIDR routing.
+//!
+//! The default `spur net join` sets up a hub-and-spoke topology: each worker
+//! peers only the controller (with `AllowedIPs` covering the whole mesh CIDR).
+//! That is enough for control-plane traffic, but a CNI running in
+//! native-routing mode (e.g. Calico `bird`/BGP, no VXLAN/IPIP overlay) on top
+//! of the mesh needs two more things:
+//!
+//! 1. **Full mesh** — every node must peer every other node directly, so raw
+//!    pod packets can flow worker↔worker without hairpinning through the hub.
+//! 2. **Pod CIDRs in `AllowedIPs`** — WireGuard is a cryptokey router; it only
+//!    forwards a packet whose destination is in some peer's `AllowedIPs`. A
+//!    native-routed pod packet has a pod-IP destination, so each peer's
+//!    `AllowedIPs` must include that node's pod CIDR (in addition to its `/32`
+//!    mesh address), and a matching kernel route must exist over the interface.
+//!
+//! This module computes the per-node peer set (pure, tested) and applies it to
+//! a running interface via `wg set`. `AllowedIPs` is all WireGuard needs to
+//! forward pod traffic; the kernel FIB routes are owned by the CNI in
+//! native-routing mode, so spur only programs them on request (`program_routes`,
+//! for the no-CNI case). Applying is **additive** — it does not prune peers for
+//! nodes removed from the membership.
+
+use serde::{Deserialize, Serialize};
+
+use crate::wireguard::{self, WgPeer};
+
+/// A member of the WireGuard mesh, as known to the controller/operator.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MeshNode {
+    /// Node hostname (informational).
+    #[serde(default)]
+    pub hostname: String,
+    /// WireGuard public key.
+    pub public_key: String,
+    /// Mesh address on `spur0`, e.g. `10.44.0.2` (no prefix).
+    pub mesh_ip: String,
+    /// Underlay endpoint for the WireGuard tunnel, e.g. `203.0.113.9:51820`.
+    pub endpoint: String,
+    /// Optional pod CIDR routed to this node for native-routing CNIs,
+    /// e.g. `10.42.1.0/24`.
+    #[serde(default)]
+    pub pod_cidr: Option<String>,
+}
+
+/// A mesh membership document (what `spur net mesh --config` parses).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct MeshMembership {
+    #[serde(default)]
+    pub nodes: Vec<MeshNode>,
+}
+
+/// The `AllowedIPs` string for a peer: its `/32` mesh address, plus its pod
+/// CIDR when set (comma-separated, as `wg` accepts).
+pub fn peer_allowed_ips(node: &MeshNode) -> String {
+    match &node.pod_cidr {
+        Some(pod) if !pod.trim().is_empty() => format!("{}/32,{}", node.mesh_ip, pod.trim()),
+        _ => format!("{}/32", node.mesh_ip),
+    }
+}
+
+/// Validate that `cidr` is an IPv4 CIDR like `10.42.1.0/24`, so bad user input
+/// fails fast instead of reaching `wg`/`ip` as an opaque stderr.
+pub fn validate_cidr(cidr: &str) -> anyhow::Result<()> {
+    let (addr, prefix) = cidr
+        .split_once('/')
+        .ok_or_else(|| anyhow::anyhow!("invalid CIDR (missing /prefix): {cidr}"))?;
+    addr.parse::<std::net::Ipv4Addr>()
+        .map_err(|_| anyhow::anyhow!("invalid CIDR address: {cidr}"))?;
+    let prefix: u8 = prefix
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid CIDR prefix: {cidr}"))?;
+    if prefix > 32 {
+        anyhow::bail!("invalid CIDR prefix (>32): {cidr}");
+    }
+    Ok(())
+}
+
+/// Build the WireGuard peer set for `self_mesh_ip`'s view of a full mesh:
+/// every member except itself, each with pod-CIDR-aware `AllowedIPs`.
+pub fn mesh_peers_for(self_mesh_ip: &str, members: &[MeshNode]) -> Vec<WgPeer> {
+    let self_mesh_ip = self_mesh_ip.trim();
+    members
+        .iter()
+        .filter(|n| n.mesh_ip.trim() != self_mesh_ip)
+        .map(|n| WgPeer {
+            public_key: n.public_key.clone(),
+            allowed_ips: peer_allowed_ips(n),
+            endpoint: Some(n.endpoint.clone()),
+            persistent_keepalive: Some(25),
+        })
+        .collect()
+}
+
+/// The pod-CIDR routes for `self_mesh_ip`'s node (one per remote member that
+/// advertises a pod CIDR). Only relevant when spur programs routes directly
+/// (no native-routing CNI — see `apply_mesh`'s `program_routes`).
+pub fn mesh_pod_routes<'a>(self_mesh_ip: &str, members: &'a [MeshNode]) -> Vec<&'a str> {
+    let self_mesh_ip = self_mesh_ip.trim();
+    members
+        .iter()
+        .filter(|n| n.mesh_ip.trim() != self_mesh_ip)
+        .filter_map(|n| n.pod_cidr.as_deref())
+        .map(str::trim)
+        .filter(|c| !c.is_empty())
+        .collect()
+}
+
+/// Apply the full mesh on the local node: add every remote peer (with
+/// pod-CIDR-aware `AllowedIPs`). Returns the number of peers applied.
+///
+/// **Additive**, not a full reconcile: it never removes peers/routes for nodes
+/// dropped from `members` (re-run with the complete membership to converge). It
+/// is idempotent for a fixed membership (`wg set` is add-or-update).
+///
+/// `program_routes` also installs kernel routes (`<pod>/24 dev <iface>`). Leave
+/// it **false** whenever a native-routing CNI (Calico `bird`) is present — the
+/// CNI owns the FIB routes and spur programming them would fight its reconcile
+/// loop. `AllowedIPs` (always set) is all WireGuard itself needs.
+pub fn apply_mesh(
+    interface: &str,
+    self_mesh_ip: &str,
+    members: &[MeshNode],
+    program_routes: bool,
+) -> anyhow::Result<usize> {
+    let peers = mesh_peers_for(self_mesh_ip, members);
+    for peer in &peers {
+        wireguard::add_peer(interface, peer)?;
+    }
+    if program_routes {
+        for cidr in mesh_pod_routes(self_mesh_ip, members) {
+            wireguard::add_route(interface, cidr)?;
+        }
+    }
+    Ok(peers.len())
+}
+
+/// Of the interface's `current` peer public keys, those NOT in the desired member set (self
+/// excluded) — i.e. peers for nodes that have left the mesh and should be removed. Pure + tested.
+pub fn peers_to_prune<'a>(
+    current: &'a [String],
+    self_mesh_ip: &str,
+    members: &[MeshNode],
+) -> Vec<&'a str> {
+    let desired: std::collections::HashSet<String> = mesh_peers_for(self_mesh_ip, members)
+        .into_iter()
+        .map(|p| p.public_key)
+        .collect();
+    current
+        .iter()
+        .filter(|k| !desired.contains(k.as_str()))
+        .map(String::as_str)
+        .collect()
+}
+
+/// Reconcile the full mesh: prune peers no longer in `members`, then add/update the desired peers.
+/// Unlike [`apply_mesh`] (additive only), this converges — a node dropped from `members` has its
+/// WireGuard peer removed. `current_peers` is the interface's live peer keys (from
+/// [`wireguard::list_peers`]). Returns `(added, pruned)`. `program_routes` as in [`apply_mesh`].
+pub fn reconcile_mesh(
+    interface: &str,
+    self_mesh_ip: &str,
+    members: &[MeshNode],
+    current_peers: &[String],
+    program_routes: bool,
+) -> anyhow::Result<(usize, usize)> {
+    let mut pruned = 0;
+    for key in peers_to_prune(current_peers, self_mesh_ip, members) {
+        wireguard::remove_peer(interface, key)?;
+        pruned += 1;
+    }
+    let added = apply_mesh(interface, self_mesh_ip, members, program_routes)?;
+    Ok((added, pruned))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(ip: &str, pod: Option<&str>) -> MeshNode {
+        MeshNode {
+            hostname: format!("n{ip}"),
+            public_key: format!("pk-{ip}"),
+            mesh_ip: ip.to_string(),
+            endpoint: format!("{ip}:51820"),
+            pod_cidr: pod.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn allowed_ips_with_and_without_pod_cidr() {
+        assert_eq!(
+            peer_allowed_ips(&node("10.44.0.2", Some("10.42.1.0/24"))),
+            "10.44.0.2/32,10.42.1.0/24"
+        );
+        assert_eq!(peer_allowed_ips(&node("10.44.0.2", None)), "10.44.0.2/32");
+        // whitespace-only pod cidr is treated as absent
+        assert_eq!(
+            peer_allowed_ips(&node("10.44.0.2", Some("  "))),
+            "10.44.0.2/32"
+        );
+    }
+
+    #[test]
+    fn mesh_peers_exclude_self_and_carry_pod_cidr() {
+        let members = vec![
+            node("10.44.0.1", None),                 // controller, no pods
+            node("10.44.0.2", Some("10.42.1.0/24")), // self
+            node("10.44.0.3", Some("10.42.2.0/24")),
+            node("10.44.0.4", Some("10.42.3.0/24")),
+        ];
+        let peers = mesh_peers_for("10.44.0.2", &members);
+        assert_eq!(peers.len(), 3, "self excluded");
+        assert!(peers.iter().all(|p| p.public_key != "pk-10.44.0.2"));
+        let p3 = peers
+            .iter()
+            .find(|p| p.public_key == "pk-10.44.0.3")
+            .unwrap();
+        assert_eq!(p3.allowed_ips, "10.44.0.3/32,10.42.2.0/24");
+        assert_eq!(p3.endpoint.as_deref(), Some("10.44.0.3:51820"));
+        assert_eq!(p3.persistent_keepalive, Some(25));
+        let p1 = peers
+            .iter()
+            .find(|p| p.public_key == "pk-10.44.0.1")
+            .unwrap();
+        assert_eq!(p1.allowed_ips, "10.44.0.1/32", "hub with no pod cidr");
+    }
+
+    #[test]
+    fn pod_routes_skip_self_and_empty() {
+        let members = vec![
+            node("10.44.0.1", None),
+            node("10.44.0.2", Some("10.42.1.0/24")), // self, must be skipped
+            node("10.44.0.3", Some("10.42.2.0/24")),
+            node("10.44.0.4", Some("")), // empty pod cidr skipped
+        ];
+        let routes = mesh_pod_routes("10.44.0.2", &members);
+        assert_eq!(routes, vec!["10.42.2.0/24"]);
+    }
+
+    #[test]
+    fn validate_cidr_accepts_and_rejects() {
+        assert!(validate_cidr("10.42.1.0/24").is_ok());
+        assert!(validate_cidr("10.44.0.2/32").is_ok());
+        assert!(validate_cidr("10.42.1.0").is_err()); // missing /prefix
+        assert!(validate_cidr("10.42.1.0/33").is_err()); // prefix > 32
+        assert!(validate_cidr("not-an-ip/24").is_err());
+        assert!(validate_cidr("10.42.1.0/xx").is_err());
+    }
+
+    #[test]
+    fn mesh_peers_trims_self_ip() {
+        let members = vec![
+            node("10.44.0.2", Some("10.42.1.0/24")),
+            node("10.44.0.3", None),
+        ];
+        // trailing space on self must still exclude the matching member
+        let peers = mesh_peers_for("10.44.0.2 ", &members);
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0].public_key, "pk-10.44.0.3");
+    }
+
+    #[test]
+    fn membership_parses_from_json() {
+        let json = r#"{"nodes":[
+            {"public_key":"a","mesh_ip":"10.44.0.2","endpoint":"1.2.3.4:51820","pod_cidr":"10.42.1.0/24"},
+            {"public_key":"b","mesh_ip":"10.44.0.3","endpoint":"1.2.3.5:51820"}
+        ]}"#;
+        let m: MeshMembership = serde_json::from_str(json).unwrap();
+        assert_eq!(m.nodes.len(), 2);
+        assert_eq!(m.nodes[0].pod_cidr.as_deref(), Some("10.42.1.0/24"));
+        assert_eq!(m.nodes[1].pod_cidr, None);
+    }
+
+    #[test]
+    fn peers_to_prune_removes_departed_and_self_keeps_members() {
+        let members = vec![
+            node("10.44.0.1", None),                 // controller
+            node("10.44.0.2", Some("10.42.1.0/24")), // self
+            node("10.44.0.3", Some("10.42.2.0/24")),
+        ];
+        // Live peers on the interface: two current members, a departed node, and self's own key.
+        let current = vec![
+            "pk-10.44.0.1".to_string(),
+            "pk-10.44.0.3".to_string(),
+            "pk-10.44.0.4".to_string(), // departed -> prune
+            "pk-10.44.0.2".to_string(), // self (never a desired peer) -> prune
+        ];
+        let prune = peers_to_prune(&current, "10.44.0.2", &members);
+        assert_eq!(prune.len(), 2);
+        assert!(prune.contains(&"pk-10.44.0.4"));
+        assert!(prune.contains(&"pk-10.44.0.2"));
+        assert!(!prune.contains(&"pk-10.44.0.1"));
+        assert!(!prune.contains(&"pk-10.44.0.3"));
+    }
+}

--- a/crates/spur-net/src/mesh.rs
+++ b/crates/spur-net/src/mesh.rs
@@ -89,7 +89,9 @@ pub fn mesh_peers_for(self_mesh_ip: &str, members: &[MeshNode]) -> Vec<WgPeer> {
         .map(|n| WgPeer {
             public_key: n.public_key.clone(),
             allowed_ips: peer_allowed_ips(n),
-            endpoint: Some(n.endpoint.clone()),
+            // Empty endpoint => leave the peer's endpoint untouched (`wg set` omits it), preserving
+            // the underlay tunnel `spur net join` established. Only override when one is supplied.
+            endpoint: Some(n.endpoint.clone()).filter(|e| !e.trim().is_empty()),
             persistent_keepalive: Some(25),
         })
         .collect()

--- a/crates/spur-net/src/wireguard.rs
+++ b/crates/spur-net/src/wireguard.rs
@@ -198,6 +198,81 @@ pub fn add_peer(interface: &str, peer: &WgPeer) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Remove a peer from the mesh interface by its public key (the counterpart to `add_peer`, used
+/// when a node leaves the cluster: `wg set <iface> peer <key> remove`). Idempotent.
+pub fn remove_peer(interface: &str, public_key: &str) -> anyhow::Result<()> {
+    let output = Command::new("wg")
+        .args(["set", interface, "peer", public_key, "remove"])
+        .output()
+        .context("failed to run `wg set peer remove`")?;
+    if !output.status.success() {
+        bail!(
+            "wg set peer remove failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(())
+}
+
+/// Add (or replace) a kernel route for `cidr` via the WireGuard interface.
+///
+/// Used to route a peer's pod CIDR over the mesh when a CNI runs in
+/// native-routing mode (no overlay) on top of WireGuard. `wg set allowed-ips`
+/// only updates the cryptokey routing table — it does not install a kernel
+/// route — so this is required alongside it. Uses `ip route replace` so it is
+/// idempotent (add-or-update).
+pub fn add_route(interface: &str, cidr: &str) -> anyhow::Result<()> {
+    let output = Command::new("ip")
+        .args(["route", "replace", cidr, "dev", interface])
+        .output()
+        .context("failed to run `ip route replace` — is iproute2 installed?")?;
+    if !output.status.success() {
+        bail!(
+            "ip route replace {} dev {} failed: {}",
+            cidr,
+            interface,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    info!(cidr, interface, "route programmed over WireGuard");
+    Ok(())
+}
+
+/// List the public keys of the interface's current WireGuard peers (`wg show <iface> peers`), so a
+/// reconcile can prune peers no longer in the desired membership.
+pub fn list_peers(interface: &str) -> anyhow::Result<Vec<String>> {
+    let output = Command::new("wg")
+        .args(["show", interface, "peers"])
+        .output()
+        .context("failed to run `wg show peers`")?;
+    if !output.status.success() {
+        bail!(
+            "wg show {interface} peers failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|l| l.trim().to_string())
+        .filter(|l| !l.is_empty())
+        .collect())
+}
+
+/// The public key of an existing WireGuard interface (`wg show <iface> public-key`).
+pub fn interface_public_key(interface: &str) -> anyhow::Result<String> {
+    let output = Command::new("wg")
+        .args(["show", interface, "public-key"])
+        .output()
+        .context("failed to run `wg show public-key`")?;
+    if !output.status.success() {
+        bail!(
+            "wg show {interface} public-key failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -211,7 +286,7 @@ mod tests {
             peers: vec![WgPeer {
                 public_key: "peerPubKeyBase64=".into(),
                 allowed_ips: "10.44.0.2/32".into(),
-                endpoint: Some("192.168.1.10:51820".into()),
+                endpoint: Some("203.0.113.10:51820".into()),
                 persistent_keepalive: Some(25),
             }],
         };
@@ -220,7 +295,7 @@ mod tests {
         assert!(ini.contains("PrivateKey = aPrivateKeyBase64="));
         assert!(ini.contains("ListenPort = 51820"));
         assert!(ini.contains("[Peer]"));
-        assert!(ini.contains("Endpoint = 192.168.1.10:51820"));
+        assert!(ini.contains("Endpoint = 203.0.113.10:51820"));
         assert!(ini.contains("PersistentKeepalive = 25"));
     }
 

--- a/crates/spur-update/src/k0s.rs
+++ b/crates/spur-update/src/k0s.rs
@@ -1,0 +1,215 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Download + install a pinned k0s release binary from GitHub so `spur k8s up` is self-contained
+//! on bare-metal nodes.
+//!
+//! k0s ships one raw binary per arch (`k0s-<version>-<arch>`, e.g. `k0s-v1.36.2+k0s.0-amd64`) plus a
+//! combined `sha256sums.txt` (lines are `<hex>  <name>` or `<hex> *<name>` in binary mode). This
+//! fetches the binary for the host arch, verifies its SHA-256 against that manifest, and installs
+//! it atomically (write temp -> chmod 0755 -> rename over dest). Version-agnostic: the caller
+//! supplies the tag; the pin (`spur_core::k0s::K0S_PINNED_VERSION`) lives in spur-core.
+//!
+//! Only SHA-256 is verified (matching the rest of `spur-update`); the `.sig` cosign signatures k0s
+//! also publishes are not checked.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use sha2::{Digest, Sha256};
+
+/// GitHub repo k0s releases come from.
+const K0S_REPO: &str = "k0sproject/k0s";
+const GITHUB_API: &str = "https://api.github.com";
+/// Generous ceiling for the ~260 MB binary download.
+const DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// k0s asset arch suffix for the host (`amd64`/`arm64`).
+fn host_arch() -> Result<&'static str> {
+    match std::env::consts::ARCH {
+        "x86_64" => Ok("amd64"),
+        "aarch64" => Ok("arm64"),
+        other => bail!("no k0s build for host arch {other} (supported: x86_64, aarch64)"),
+    }
+}
+
+/// The k0s asset filename for `version` on the host arch, e.g. `k0s-v1.36.2+k0s.0-amd64`.
+pub fn asset_name(version: &str) -> Result<String> {
+    Ok(format!("k0s-{version}-{}", host_arch()?))
+}
+
+fn http_client(user_agent: &str) -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .user_agent(user_agent)
+        .timeout(DOWNLOAD_TIMEOUT)
+        .build()
+        .context("failed to build HTTP client")
+}
+
+/// Resolve `"latest"` to the newest k0s release tag via the GitHub API.
+pub async fn resolve_latest_version() -> Result<String> {
+    let url = format!("{GITHUB_API}/repos/{K0S_REPO}/releases/latest");
+    let resp = http_client("spur")?
+        .get(&url)
+        .send()
+        .await
+        .context("GitHub API request for the latest k0s release failed")?
+        .error_for_status()
+        .context("GitHub API returned an error for the latest k0s release")?;
+    let json: serde_json::Value = resp.json().await.context("parse GitHub release JSON")?;
+    let tag = json
+        .get("tag_name")
+        .and_then(|t| t.as_str())
+        .context("latest k0s release JSON has no tag_name")?;
+    if tag.is_empty() {
+        bail!("GitHub returned an empty latest k0s tag");
+    }
+    Ok(tag.to_string())
+}
+
+/// Summary of a completed install.
+#[derive(Debug, Clone)]
+pub struct InstalledK0s {
+    pub version: String,
+    pub path: PathBuf,
+    pub sha256: String,
+}
+
+/// The SHA-256 hex of `asset` from a `sha256sums.txt` body. Lines are `<hex>  <name>` or, in
+/// sha256sum binary mode, `<hex> *<name>`.
+fn expected_hash(sums: &str, asset: &str) -> Result<String> {
+    for line in sums.lines() {
+        let mut it = line.split_whitespace();
+        let (Some(hash), Some(name)) = (it.next(), it.next()) else {
+            continue;
+        };
+        let name = name.strip_prefix('*').unwrap_or(name);
+        if name == asset {
+            return Ok(hash.to_lowercase());
+        }
+    }
+    bail!("no sha256 entry for {asset} in sha256sums.txt");
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    use std::fmt::Write;
+    let digest = Sha256::digest(data);
+    let mut hex = String::with_capacity(64);
+    for b in digest.iter() {
+        write!(hex, "{b:02x}").unwrap();
+    }
+    hex
+}
+
+/// Download k0s `version` for the host arch, verify its SHA-256, and install it to `dest`
+/// atomically (temp file -> `chmod 0755` -> rename over `dest`). `version` may be `"latest"`.
+pub async fn install_k0s(version: &str, dest: &Path) -> Result<InstalledK0s> {
+    let version = if version == "latest" {
+        resolve_latest_version().await?
+    } else {
+        version.to_string()
+    };
+    let asset = asset_name(&version)?;
+    let base = format!("https://github.com/{K0S_REPO}/releases/download/{version}");
+    let client = http_client("spur-update")?;
+
+    // Checksum manifest first, so a bad/nonexistent version fails before the big download.
+    let sums = client
+        .get(format!("{base}/sha256sums.txt"))
+        .send()
+        .await
+        .context("download k0s sha256sums.txt")?
+        .error_for_status()
+        .with_context(|| format!("sha256sums.txt not found for k0s {version}"))?
+        .text()
+        .await
+        .context("read k0s sha256sums.txt")?;
+    let want = expected_hash(&sums, &asset)?;
+
+    let bytes = client
+        .get(format!("{base}/{asset}"))
+        .send()
+        .await
+        .with_context(|| format!("download {asset}"))?
+        .error_for_status()
+        .with_context(|| format!("{asset} not found (unknown k0s version {version}?)"))?
+        .bytes()
+        .await
+        .context("read k0s binary body")?;
+    let got = sha256_hex(&bytes);
+    if got != want {
+        bail!("k0s {asset} sha256 mismatch: expected {want}, got {got}");
+    }
+
+    if let Some(parent) = dest.parent() {
+        tokio::fs::create_dir_all(parent).await.ok();
+    }
+    // Temp sibling on the same filesystem so the final rename is atomic.
+    let tmp = dest.with_extension("k0s-download");
+    tokio::fs::write(&tmp, &bytes)
+        .await
+        .with_context(|| format!("write {}", tmp.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        tokio::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o755))
+            .await
+            .context("chmod k0s 0755")?;
+    }
+    tokio::fs::rename(&tmp, dest)
+        .await
+        .with_context(|| format!("install k0s to {}", dest.display()))?;
+
+    Ok(InstalledK0s {
+        version,
+        path: dest.to_path_buf(),
+        sha256: got,
+    })
+}
+
+/// Ensure a k0s binary exists at `dest`; install `version` if it is missing. Returns `Some(info)`
+/// when it installed, `None` when k0s was already present (no network use).
+pub async fn ensure_k0s(version: &str, dest: &Path) -> Result<Option<InstalledK0s>> {
+    if dest.exists() {
+        return Ok(None);
+    }
+    Ok(Some(install_k0s(version, dest).await?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn asset_name_is_k0s_version_arch() {
+        let n = asset_name("v1.36.2+k0s.0").unwrap();
+        assert!(n.starts_with("k0s-v1.36.2+k0s.0-"), "got {n}");
+        assert!(n.ends_with("amd64") || n.ends_with("arm64"), "got {n}");
+    }
+
+    #[test]
+    fn expected_hash_binary_mode() {
+        let sums = "8b5d985f *k0s-v1.36.2+k0s.0-amd64\nb00b425a *k0s-v1.36.2+k0s.0-arm64\n";
+        assert_eq!(
+            expected_hash(sums, "k0s-v1.36.2+k0s.0-amd64").unwrap(),
+            "8b5d985f"
+        );
+        assert_eq!(
+            expected_hash(sums, "k0s-v1.36.2+k0s.0-arm64").unwrap(),
+            "b00b425a"
+        );
+    }
+
+    #[test]
+    fn expected_hash_two_space_mode_and_lowercases() {
+        let sums = "ABC123  k0s-v1-amd64\n";
+        assert_eq!(expected_hash(sums, "k0s-v1-amd64").unwrap(), "abc123");
+    }
+
+    #[test]
+    fn expected_hash_missing_asset_errors() {
+        let sums = "abc  k0s-v1-amd64\n";
+        assert!(expected_hash(sums, "k0s-v1-arm64").is_err());
+    }
+}

--- a/crates/spur-update/src/lib.rs
+++ b/crates/spur-update/src/lib.rs
@@ -13,6 +13,7 @@ pub mod cache;
 pub mod check;
 pub mod download;
 pub mod install;
+pub mod k0s;
 
 use std::path::PathBuf;
 

--- a/crates/spurctld/Cargo.toml
+++ b/crates/spurctld/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 spur-proto = { path = "../spur-proto" }
 spur-core = { path = "../spur-core" }
 spur-sched = { path = "../spur-sched" }
+spur-net = { path = "../spur-net" }
 spur-metrics = { path = "../spur-metrics" }
 spur-update = { path = "../spur-update" }
 sqlx = { workspace = true }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -8118,6 +8118,96 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn provision_reassigns_a_readded_node() {
+        // The Ready-phase self-heal: a spurd restart deregisters on SIGTERM (the node is REMOVED),
+        // then re-registers as a fresh node with no k0s role. Re-running provisioning (which the
+        // reconcile loop now does in Ready, not only Provisioning) must re-assign the un-roled node
+        // its role + mesh IP + pod CIDR so it rejoins the mesh — without disturbing the others.
+        use spur_core::k0s::K0sRole;
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "node-a", 4, 8000);
+        register_node(&cm, "node-b", 4, 8000);
+        wait_for("both registered", || {
+            cm.get_node("node-a").is_some() && cm.get_node("node-b").is_some()
+        });
+        let net = crate::cluster_k8s::ClusterNetworking {
+            mesh_cidr: "10.44.0.0/16".into(),
+            pod_cidr: "10.42.0.0/16".into(),
+            service_cidr: "10.43.0.0/16".into(),
+            cni_mtu: 1450,
+            cni: "kuberouter".into(),
+            control_plane_node: None,
+        };
+        crate::cluster_k8s::provision_assignments(&cm, &net, &cm.k0s_state()).unwrap();
+        wait_for("both assigned", || {
+            cm.get_node("node-a").and_then(|n| n.k0s_role).is_some()
+                && cm.get_node("node-b").and_then(|n| n.k0s_role).is_some()
+        });
+        let b_role = cm.get_node("node-b").unwrap().k0s_role;
+        let b_ip = cm.get_node("node-b").unwrap().k0s_mesh_ip.clone();
+        let b_cidr = cm.get_node("node-b").unwrap().k0s_pod_cidr.clone();
+        assert!(b_ip.is_some() && b_cidr.is_some());
+
+        // spurd restart: deregister (remove) then re-register as a fresh, un-roled node.
+        cm.remove_node("node-b", true, Some("test restart".into()))
+            .unwrap();
+        wait_for("node-b removed", || cm.get_node("node-b").is_none());
+        register_node(&cm, "node-b", 4, 8000);
+        wait_for("node-b re-registered without a role", || {
+            cm.get_node("node-b")
+                .map(|n| n.k0s_role.is_none())
+                .unwrap_or(false)
+        });
+
+        // The Ready-phase reconcile re-runs provisioning and heals the un-roled node.
+        crate::cluster_k8s::provision_assignments(&cm, &net, &cm.k0s_state()).unwrap();
+        wait_for("node-b re-assigned", || {
+            cm.get_node("node-b").and_then(|n| n.k0s_role).is_some()
+        });
+        let b = cm.get_node("node-b").unwrap();
+        assert_eq!(b.k0s_role, b_role, "same role after re-add");
+        assert_eq!(b.k0s_mesh_ip, b_ip, "same mesh IP reclaimed after re-add");
+        assert_eq!(b.k0s_pod_cidr, b_cidr, "same pod CIDR after re-add");
+        // The untouched node keeps its assignment (provisioning is idempotent).
+        assert!(cm.get_node("node-a").and_then(|n| n.k0s_role).is_some());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn ready_phase_reconcile_assigns_unroled_node() {
+        // The loop wiring: reconcile_phase must run provisioning in the Ready phase, not only
+        // Provisioning. An un-roled node present while Ready (e.g. re-added after a spurd restart)
+        // must be assigned by a Ready-phase reconcile tick. If Ready were a no-op it would stay
+        // un-roled forever (out of the mesh) — the bug this fixes.
+        use spur_core::k0s::K0sPhase;
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "node-a", 4, 8000);
+        wait_for("registered", || cm.get_node("node-a").is_some());
+        // Cluster is Ready with the control plane already recorded, but node-a has no k0s role.
+        cm.set_k0s_phase(K0sPhase::Ready, Some("node-a".into()), false)
+            .unwrap();
+        wait_for("phase ready", || cm.k0s_state().phase == K0sPhase::Ready);
+        assert!(cm.get_node("node-a").and_then(|n| n.k0s_role).is_none());
+
+        let net = crate::cluster_k8s::ClusterNetworking {
+            mesh_cidr: "10.44.0.0/16".into(),
+            pod_cidr: "10.42.0.0/16".into(),
+            service_cidr: "10.43.0.0/16".into(),
+            cni_mtu: 1450,
+            cni: "kuberouter".into(),
+            control_plane_node: Some("node-a".into()),
+        };
+        let mut tokens = std::collections::HashMap::new();
+        crate::cluster_k8s::reconcile_phase(&cm, &net, &cm.k0s_state(), &mut tokens).await;
+
+        wait_for("un-roled node assigned by a Ready-phase tick", || {
+            cm.get_node("node-a").and_then(|n| n.k0s_role).is_some()
+        });
+        assert!(cm.get_node("node-a").and_then(|n| n.k0s_mesh_ip).is_some());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn provision_assigns_controller_and_worker_for_two_nodes() {
         use spur_core::k0s::K0sRole;
         let dir = TempDir::new().unwrap();

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -8123,7 +8123,6 @@ mod tests {
         // then re-registers as a fresh node with no k0s role. Re-running provisioning (which the
         // reconcile loop now does in Ready, not only Provisioning) must re-assign the un-roled node
         // its role + mesh IP + pod CIDR so it rejoins the mesh — without disturbing the others.
-        use spur_core::k0s::K0sRole;
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         register_node(&cm, "node-a", 4, 8000);

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1081,6 +1081,24 @@ impl ClusterManager {
         }
     }
 
+    /// Update a node's WireGuard mesh public key from a heartbeat when it appears or changes (mesh
+    /// came up after registration, or `spur0` was recreated). In-memory like `update_heartbeat` —
+    /// the mesh reconcile loop reads live inventory, so this is enough to include the node in
+    /// ApplyMesh without a spurd restart. Returns true if the stored key changed.
+    pub fn update_node_wg_pubkey(&self, name: &str, pubkey: &str) -> bool {
+        if pubkey.is_empty() {
+            return false;
+        }
+        let mut nodes = self.nodes.write();
+        if let Some(node) = nodes.get_mut(name) {
+            if node.wg_pubkey.as_deref() != Some(pubkey) {
+                node.wg_pubkey = Some(pubkey.to_string());
+                return true;
+            }
+        }
+        false
+    }
+
     /// Create an admission token and persist via Raft.
     pub fn create_token(
         &self,
@@ -1415,26 +1433,6 @@ impl ClusterManager {
             reset_requested,
         })?;
         info!(?phase, "k0s cluster phase set");
-        Ok(())
-    }
-
-    /// record minted join-token METADATA (never the plaintext secret) via Raft.
-    /// Consumer is the deferred worker join-token mint on the control-plane agent.
-    #[allow(dead_code)]
-    pub fn create_k0s_join_token(
-        &self,
-        token: spur_core::k0s::K0sJoinTokenRecord,
-    ) -> anyhow::Result<()> {
-        self.propose(WalOperation::K0sJoinTokenCreate { token })?;
-        Ok(())
-    }
-
-    /// mark a k0s join token revoked.
-    #[allow(dead_code)]
-    pub fn revoke_k0s_join_token(&self, token_id: &str) -> anyhow::Result<()> {
-        self.propose(WalOperation::K0sJoinTokenRevoke {
-            token_id: token_id.to_string(),
-        })?;
         Ok(())
     }
 
@@ -3558,17 +3556,6 @@ impl ClusterManager {
                     k0s.control_plane_node = control_plane_node.clone();
                 }
                 k0s.reset_requested = *reset_requested;
-            }
-            WalOperation::K0sJoinTokenCreate { token } => {
-                self.k0s
-                    .write()
-                    .join_tokens
-                    .insert(token.id.clone(), token.clone());
-            }
-            WalOperation::K0sJoinTokenRevoke { token_id } => {
-                if let Some(t) = self.k0s.write().join_tokens.get_mut(token_id) {
-                    t.revoked = true;
-                }
             }
         }
         self.next_job_id.store(next_id, Ordering::Relaxed);
@@ -8100,7 +8087,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn k0s_state_survives_snapshot() {
-        use spur_core::k0s::{K0sJoinTokenRecord, K0sPhase, K0sRole};
+        use spur_core::k0s::{K0sPhase, K0sRole};
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
 
@@ -8109,14 +8096,6 @@ mod tests {
             .unwrap();
         cm.set_k0s_phase(K0sPhase::Ready, Some("head-node".into()), false)
             .unwrap();
-        cm.create_k0s_join_token(K0sJoinTokenRecord {
-            id: "tok-1".into(),
-            role: K0sRole::Worker,
-            created_at: chrono::Utc::now(),
-            expires_at: None,
-            revoked: false,
-        })
-        .unwrap();
         wait_for("k0s state applied", || {
             cm.k0s_state().phase == K0sPhase::Ready
                 && cm.get_node("n1").and_then(|n| n.k0s_role).is_some()
@@ -8132,7 +8111,6 @@ mod tests {
         let st = cm2.k0s_state();
         assert_eq!(st.phase, K0sPhase::Ready);
         assert_eq!(st.control_plane_node.as_deref(), Some("head-node"));
-        assert!(st.join_tokens.contains_key("tok-1"));
         // Per-node k0s fields ride snap.nodes.
         let n1 = cm2.get_node("n1").unwrap();
         assert_eq!(n1.k0s_role, Some(K0sRole::Worker));
@@ -8154,6 +8132,7 @@ mod tests {
             mesh_cidr: "10.44.0.0/16".into(),
             pod_cidr: "10.42.0.0/16".into(),
             service_cidr: "10.43.0.0/16".into(),
+            cni_mtu: 1450,
             cni: "kuberouter".into(),
             control_plane_node: None,
         };

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -146,6 +146,8 @@ pub struct ClusterManager {
     /// `available_bb_with`), so it cannot drift from config.
     burst_buffer_total_gb: RwLock<u64>,
     tokens: RwLock<HashMap<String, spur_core::admission::AdmissionToken>>,
+    /// Native k0s cluster state (phase, control-plane node, join-token metadata).
+    k0s: RwLock<spur_core::k0s::K0sClusterState>,
     raft: RwLock<Option<SpurRaft>>,
     accounting: RwLock<Option<AccountingNotifier>>,
     fairshare_cache: Arc<FairshareCache>,
@@ -177,6 +179,7 @@ impl ClusterManager {
             license_pool: RwLock::new(license_pool),
             burst_buffer_total_gb: RwLock::new(burst_buffer_total_gb),
             tokens: RwLock::new(HashMap::new()),
+            k0s: RwLock::new(spur_core::k0s::K0sClusterState::default()),
             raft: RwLock::new(None),
             accounting: RwLock::new(None),
             fairshare_cache,
@@ -1372,6 +1375,72 @@ impl ClusterManager {
         })?;
         info!(node = %name, "node labels updated");
         Ok(())
+    }
+
+    /// assign a k0s role + allocated mesh IP + pod /24 to a node (replicated via Raft).
+    /// Callers never touch `self.nodes`/`self.k0s` directly — that would bypass Raft.
+    pub fn assign_node_k0s(
+        &self,
+        name: &str,
+        role: spur_core::k0s::K0sRole,
+        mesh_ip: &str,
+        pod_cidr: &str,
+    ) -> anyhow::Result<()> {
+        {
+            let nodes = self.nodes.read();
+            if !nodes.contains_key(name) {
+                anyhow::bail!("node {} not found", name);
+            }
+        }
+        self.propose(WalOperation::NodeK0sAssign {
+            name: name.to_string(),
+            role,
+            mesh_ip: mesh_ip.to_string(),
+            pod_cidr: pod_cidr.to_string(),
+        })?;
+        info!(node = %name, ?role, "node k0s role assigned");
+        Ok(())
+    }
+
+    /// set the cluster-wide k0s phase (+ optional control-plane node / reset flag).
+    pub fn set_k0s_phase(
+        &self,
+        phase: spur_core::k0s::K0sPhase,
+        control_plane_node: Option<String>,
+        reset_requested: bool,
+    ) -> anyhow::Result<()> {
+        self.propose(WalOperation::K0sSetPhase {
+            phase,
+            control_plane_node,
+            reset_requested,
+        })?;
+        info!(?phase, "k0s cluster phase set");
+        Ok(())
+    }
+
+    /// record minted join-token METADATA (never the plaintext secret) via Raft.
+    /// Consumer is the deferred worker join-token mint on the control-plane agent.
+    #[allow(dead_code)]
+    pub fn create_k0s_join_token(
+        &self,
+        token: spur_core::k0s::K0sJoinTokenRecord,
+    ) -> anyhow::Result<()> {
+        self.propose(WalOperation::K0sJoinTokenCreate { token })?;
+        Ok(())
+    }
+
+    /// mark a k0s join token revoked.
+    #[allow(dead_code)]
+    pub fn revoke_k0s_join_token(&self, token_id: &str) -> anyhow::Result<()> {
+        self.propose(WalOperation::K0sJoinTokenRevoke {
+            token_id: token_id.to_string(),
+        })?;
+        Ok(())
+    }
+
+    /// snapshot of the current cluster-wide k0s state.
+    pub fn k0s_state(&self) -> spur_core::k0s::K0sClusterState {
+        self.k0s.read().clone()
     }
 
     /// Reconcile node liveness state with heartbeat data.
@@ -3462,6 +3531,45 @@ impl ClusterManager {
                     }
                 }
             }
+
+            // Native k0s cluster operations. All idempotent/replay-safe: NodeK0sAssign is
+            // keyed by node name, token insert/revoke are keyed by id, phase is a last-write set.
+            WalOperation::NodeK0sAssign {
+                name,
+                role,
+                mesh_ip,
+                pod_cidr,
+            } => {
+                // Reuses the `nodes` write guard from the top of this fn.
+                if let Some(node) = nodes.get_mut(name) {
+                    node.k0s_role = Some(*role);
+                    node.k0s_mesh_ip = Some(mesh_ip.clone());
+                    node.k0s_pod_cidr = Some(pod_cidr.clone());
+                }
+            }
+            WalOperation::K0sSetPhase {
+                phase,
+                control_plane_node,
+                reset_requested,
+            } => {
+                let mut k0s = self.k0s.write();
+                k0s.phase = *phase;
+                if control_plane_node.is_some() {
+                    k0s.control_plane_node = control_plane_node.clone();
+                }
+                k0s.reset_requested = *reset_requested;
+            }
+            WalOperation::K0sJoinTokenCreate { token } => {
+                self.k0s
+                    .write()
+                    .join_tokens
+                    .insert(token.id.clone(), token.clone());
+            }
+            WalOperation::K0sJoinTokenRevoke { token_id } => {
+                if let Some(t) = self.k0s.write().join_tokens.get_mut(token_id) {
+                    t.revoked = true;
+                }
+            }
         }
         self.next_job_id.store(next_id, Ordering::Relaxed);
         response
@@ -3484,6 +3592,11 @@ struct ClusterSnapshot {
     /// staging phase rides along on each `Job`.
     #[serde(default)]
     burst_buffer_total_gb: u64,
+    /// cluster-wide k0s state (phase, control-plane node, join-token metadata). Unlike
+    /// license_pool/burst_buffer this is runtime-authoritative allocated state and MUST be
+    /// restored (see restore_from_snapshot).
+    #[serde(default)]
+    k0s: spur_core::k0s::K0sClusterState,
 }
 
 impl ClusterManager {
@@ -3533,6 +3646,7 @@ impl StateMachineApply for ClusterManager {
             license_pool: self.license_pool.read().clone(),
             tokens: self.tokens.read().values().cloned().collect(),
             burst_buffer_total_gb: *self.burst_buffer_total_gb.read(),
+            k0s: self.k0s.read().clone(),
         };
         serde_json::to_vec(&snap).map_err(Into::into)
     }
@@ -3573,6 +3687,10 @@ impl StateMachineApply for ClusterManager {
         for token in snap.tokens {
             tokens.insert(token.id.clone(), token);
         }
+
+        // k0s phase + join-token metadata are runtime-authoritative allocated state
+        // (NOT config-derived like license_pool/burst_buffer) — restore them.
+        *self.k0s.write() = snap.k0s;
 
         self.next_job_id.store(next_id, Ordering::Relaxed);
 
@@ -4133,6 +4251,7 @@ mod tests {
             network: Default::default(),
             logging: Default::default(),
             kubernetes: Default::default(),
+            cluster: Default::default(),
             notifications: Default::default(),
             power: Default::default(),
             federation: Default::default(),
@@ -7977,6 +8096,84 @@ mod tests {
 
         assert!(cm2.get_job(1).is_some());
         assert!(cm2.get_node("n1").is_some());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn k0s_state_survives_snapshot() {
+        use spur_core::k0s::{K0sJoinTokenRecord, K0sPhase, K0sRole};
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        register_node(&cm, "n1", 4, 8000);
+        cm.assign_node_k0s("n1", K0sRole::Worker, "10.44.0.2", "10.42.2.0/24")
+            .unwrap();
+        cm.set_k0s_phase(K0sPhase::Ready, Some("head-node".into()), false)
+            .unwrap();
+        cm.create_k0s_join_token(K0sJoinTokenRecord {
+            id: "tok-1".into(),
+            role: K0sRole::Worker,
+            created_at: chrono::Utc::now(),
+            expires_at: None,
+            revoked: false,
+        })
+        .unwrap();
+        wait_for("k0s state applied", || {
+            cm.k0s_state().phase == K0sPhase::Ready
+                && cm.get_node("n1").and_then(|n| n.k0s_role).is_some()
+        });
+
+        // snapshot -> restore into a fresh cluster (log-compaction / HA follower path)
+        let data = cm.snapshot_state().unwrap();
+        let dir2 = TempDir::new().unwrap();
+        let cm2 = test_cluster(&dir2).await;
+        cm2.restore_from_snapshot(&data).unwrap();
+
+        // Cluster-wide k0s state must be restored (it is runtime-authoritative).
+        let st = cm2.k0s_state();
+        assert_eq!(st.phase, K0sPhase::Ready);
+        assert_eq!(st.control_plane_node.as_deref(), Some("head-node"));
+        assert!(st.join_tokens.contains_key("tok-1"));
+        // Per-node k0s fields ride snap.nodes.
+        let n1 = cm2.get_node("n1").unwrap();
+        assert_eq!(n1.k0s_role, Some(K0sRole::Worker));
+        assert_eq!(n1.k0s_mesh_ip.as_deref(), Some("10.44.0.2"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn provision_assigns_controller_and_worker_for_two_nodes() {
+        use spur_core::k0s::K0sRole;
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "node-a", 4, 8000);
+        register_node(&cm, "node-b", 4, 8000);
+        wait_for("both nodes registered", || {
+            cm.get_node("node-a").is_some() && cm.get_node("node-b").is_some()
+        });
+
+        let net = crate::cluster_k8s::ClusterNetworking {
+            mesh_cidr: "10.44.0.0/16".into(),
+            pod_cidr: "10.42.0.0/16".into(),
+            service_cidr: "10.43.0.0/16".into(),
+            cni: "kuberouter".into(),
+            control_plane_node: None,
+        };
+        crate::cluster_k8s::provision_assignments(&cm, &net, &cm.k0s_state()).unwrap();
+        wait_for("both nodes assigned k0s roles", || {
+            cm.get_node("node-a").and_then(|n| n.k0s_role).is_some()
+                && cm.get_node("node-b").and_then(|n| n.k0s_role).is_some()
+        });
+
+        // Two nodes -> the deterministic control-plane (lexically-first, node-a) is a Controller
+        // (NOT Single, which would never exercise the worker token-mint/join path); node-b is a
+        // Worker. Each gets a distinct mesh IP + pod /24, and the control-plane choice is recorded.
+        let a = cm.get_node("node-a").unwrap();
+        let b = cm.get_node("node-b").unwrap();
+        assert_eq!(a.k0s_role, Some(K0sRole::Controller));
+        assert_eq!(b.k0s_role, Some(K0sRole::Worker));
+        assert!(a.k0s_mesh_ip.is_some() && b.k0s_mesh_ip.is_some());
+        assert_ne!(a.k0s_mesh_ip, b.k0s_mesh_ip);
+        assert_ne!(a.k0s_pod_cidr, b.k0s_pod_cidr);
+        assert_eq!(cm.k0s_state().control_plane_node.as_deref(), Some("node-a"));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -34,9 +34,6 @@ const AGENT_TIMEOUT: Duration = Duration::from_secs(5);
 
 const RECONCILE_INTERVAL: Duration = Duration::from_secs(30);
 
-/// WireGuard listen port every node's mesh endpoint uses (the `spur net join` default).
-const WG_LISTEN_PORT: u16 = 51820;
-
 /// Network CIDRs the reconcile loop needs (from `[network]` + `[cluster]` config).
 #[derive(Clone, Debug)]
 pub struct ClusterNetworking {
@@ -284,21 +281,29 @@ fn mesh_from_nodes(nodes: Vec<spur_core::node::Node>) -> MeshMembership {
         .filter_map(|n| {
             let mesh_ip = n.k0s_mesh_ip.clone()?;
             let public_key = n.wg_pubkey.clone().filter(|k| !k.is_empty())?;
-            let endpoint = n
-                .address
-                .clone()
-                .map(|a| format!("{a}:{WG_LISTEN_PORT}"))
-                .unwrap_or_default();
             Some(MeshNode {
                 hostname: n.name,
                 public_key,
                 mesh_ip,
-                endpoint,
+                // No endpoint: Node.address is the agent's advertised address, which
+                // `detect_node_address` makes the *mesh* IP when WireGuard is up — not a valid WG
+                // underlay endpoint (using it would clobber the working tunnel). Empty makes
+                // apply_mesh preserve the endpoint `spur net join` already established; membership
+                // reconciliation only maintains peers + AllowedIPs, not the underlay tunnel.
+                endpoint: String::new(),
                 pod_cidr: n.k0s_pod_cidr.clone(),
             })
         })
         .collect();
-    nodes.sort_by(|a, b| a.mesh_ip.cmp(&b.mesh_ip)); // deterministic ordering
+    // Sort numerically by IPv4 — a string sort orders "10.44.0.10" before "10.44.0.2", producing
+    // spurious membership diffs (and unnecessary ApplyMesh pushes) between ticks.
+    nodes.sort_by(|a, b| {
+        a.mesh_ip
+            .parse::<std::net::Ipv4Addr>()
+            .ok()
+            .cmp(&b.mesh_ip.parse::<std::net::Ipv4Addr>().ok())
+            .then_with(|| a.mesh_ip.cmp(&b.mesh_ip))
+    });
     MeshMembership { nodes }
 }
 
@@ -353,7 +358,7 @@ pub async fn fetch_admin_kubeconfig(cluster: &ClusterManager) -> anyhow::Result<
 
 /// Query a node's live k0s component state via its agent, with a timeout. Returns None if the node
 /// is unreachable or has no component yet.
-async fn fetch_component_state(cluster: &ClusterManager, node: &str) -> Option<String> {
+async fn fetch_component_status(cluster: &ClusterManager, node: &str) -> Option<(String, bool)> {
     let endpoint = agent_endpoint(cluster, node)?;
     let fut = async {
         let mut client = SlurmAgentClient::connect(endpoint).await.ok()?;
@@ -361,12 +366,19 @@ async fn fetch_component_state(cluster: &ClusterManager, node: &str) -> Option<S
             .get_cluster_component_status(GetClusterComponentStatusRequest {})
             .await
             .ok()?;
-        Some(resp.into_inner().component_state)
+        let r = resp.into_inner();
+        Some((r.component_state, r.enabled))
     };
     tokio::time::timeout(AGENT_TIMEOUT, fut)
         .await
         .ok()
         .flatten()
+}
+
+async fn fetch_component_state(cluster: &ClusterManager, node: &str) -> Option<String> {
+    fetch_component_status(cluster, node)
+        .await
+        .map(|(state, _)| state)
 }
 
 /// The mesh-native k0s controller config for `node` (api on its mesh IP + Calico bird), or None for
@@ -549,17 +561,23 @@ fn spawn_apply_mesh(cluster: &ClusterManager, node: &str, mesh: &MeshMembership)
     let node = node.to_string();
     let proto = to_proto_membership(mesh);
     tokio::spawn(async move {
-        match SlurmAgentClient::connect(endpoint).await {
-            Ok(mut client) => match client.apply_mesh(proto).await {
-                Ok(resp) => {
-                    let r = resp.into_inner();
-                    if !r.applied {
-                        warn!(node = %node, message = %r.message, "apply_mesh not applied");
-                    }
+        // Bound connect + RPC so a hung/blackholed agent can't leak accumulating detached tasks
+        // (this fires every reconcile tick).
+        let fut = async {
+            let mut client = SlurmAgentClient::connect(endpoint)
+                .await
+                .map_err(|e| tonic::Status::unavailable(e.to_string()))?;
+            client.apply_mesh(proto).await
+        };
+        match tokio::time::timeout(AGENT_TIMEOUT, fut).await {
+            Ok(Ok(resp)) => {
+                let r = resp.into_inner();
+                if !r.applied {
+                    warn!(node = %node, message = %r.message, "apply_mesh not applied");
                 }
-                Err(e) => warn!(node = %node, error = %e, "apply_mesh RPC failed"),
-            },
-            Err(e) => warn!(node = %node, error = %e, "connect to agent for apply_mesh failed"),
+            }
+            Ok(Err(e)) => warn!(node = %node, error = %e, "apply_mesh RPC failed"),
+            Err(_) => warn!(node = %node, "apply_mesh timed out"),
         }
     });
 }
@@ -569,14 +587,15 @@ pub async fn live_node_statuses(cluster: &ClusterManager) -> Vec<ClusterNodeStat
     let mut out = Vec::new();
     for n in cluster.get_nodes() {
         let Some(role) = n.k0s_role else { continue };
-        let component_state = fetch_component_state(cluster, &n.name)
+        // Report the agent's real (state, enabled) — not a hard-coded enabled=true.
+        let (component_state, enabled) = fetch_component_status(cluster, &n.name)
             .await
-            .unwrap_or_else(|| "unknown".to_string());
+            .unwrap_or_else(|| ("unknown".to_string(), false));
         out.push(ClusterNodeStatus {
             node: n.name,
             role: role_str(role),
             component_state,
-            enabled: true,
+            enabled,
         });
     }
     out
@@ -676,7 +695,8 @@ mod tests {
         // sorted by mesh_ip
         assert_eq!(m.nodes[0].mesh_ip, "10.44.0.1");
         assert_eq!(m.nodes[0].public_key, "pk-cp");
-        assert_eq!(m.nodes[0].endpoint, "198.51.100.1:51820");
+        // endpoint is left empty on purpose — apply_mesh preserves the tunnel `spur net join` set.
+        assert_eq!(m.nodes[0].endpoint, "");
         assert_eq!(m.nodes[0].pod_cidr.as_deref(), Some("10.42.0.0/24"));
         assert_eq!(m.nodes[1].mesh_ip, "10.44.0.2");
         // the resulting membership feeds apply_mesh: pod CIDR folds into AllowedIPs

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -1,0 +1,688 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Native k0s cluster controller (leader-gated).
+//!
+//! Distinct from `crate::cluster` (the raft-backed `ClusterManager` state machine): this drives
+//! the SPUR-managed k0s cluster — role selection, IP/CIDR allocation, and the
+//! per-node `SlurmAgent` StartClusterComponent/StopClusterComponent fan-out — all
+//! gated on Raft leadership. Phase transitions go through `ClusterManager::set_k0s_phase`
+//! (WAL-replicated) so a leadership change mid-provision is safe.
+
+use std::collections::HashSet;
+use std::net::Ipv4Addr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use tracing::{info, warn};
+
+use spur_core::k0s::{K0sClusterState, K0sPhase, K0sRole};
+use spur_net::address::AddressPool;
+use spur_net::mesh::{MeshMembership, MeshNode};
+use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
+use spur_proto::proto::{
+    ClusterNodeStatus, CreateK0sJoinTokenRequest, GetAdminKubeconfigRequest,
+    GetClusterComponentStatusRequest, StartClusterComponentRequest, StopClusterComponentRequest,
+};
+
+use crate::cluster::ClusterManager;
+use crate::raft::RaftHandle;
+
+/// Per-agent RPC dial timeout.
+const AGENT_TIMEOUT: Duration = Duration::from_secs(5);
+
+const RECONCILE_INTERVAL: Duration = Duration::from_secs(30);
+
+/// WireGuard listen port every node's mesh endpoint uses (the `spur net join` default).
+const WG_LISTEN_PORT: u16 = 51820;
+
+/// Network CIDRs the reconcile loop needs (from `[network]` + `[cluster]` config).
+#[derive(Clone, Debug)]
+pub struct ClusterNetworking {
+    /// WireGuard mesh CIDR (network.wg_cidr) — node mesh IPs are allocated from here.
+    pub mesh_cidr: String,
+    /// Pod CIDR (cluster.pod_cidr) — per-node /24s are carved from here.
+    pub pod_cidr: String,
+    /// Service CIDR (cluster.service_cidr) — for the generated k0s config.
+    pub service_cidr: String,
+    /// CNI mode (cluster.cni): "kuberouter" (default) or "calico" (mesh-native config + node-ip).
+    pub cni: String,
+    /// Operator-pinned control-plane node (cluster.control_plane_node), if any.
+    pub control_plane_node: Option<String>,
+}
+
+/// Leader-gated k0s reconcile loop. Spawned from `main.rs` when `[cluster].enabled`; it still
+/// re-checks leadership every tick because leadership can flip at any time.
+pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>, net: ClusterNetworking) {
+    info!(mesh = %net.mesh_cidr, pod = %net.pod_cidr, "k0s cluster reconcile loop started");
+    let mut interval = tokio::time::interval(RECONCILE_INTERVAL);
+    let mut last_mesh: Vec<MeshNode> = Vec::new();
+    loop {
+        interval.tick().await;
+        if !raft.is_leader() {
+            last_mesh.clear(); // forget on leadership loss so a new term re-logs the membership
+            continue; // only the leader reconciles
+        }
+        let state = cluster.k0s_state();
+
+        // Mesh: derive the authoritative full-mesh membership (pubkey + mesh IP + pod /24) from
+        // live inventory and push it to every meshed node's agent (ApplyMesh) so a native-routing
+        // CNI can ride the WireGuard mesh. Level-triggered: re-push EVERY tick (the agent's
+        // reconcile_mesh is idempotent + prunes) so node-local drift (reboot, wg restart), a failed
+        // push, and controller failover all self-heal. Only meaningful with ≥2 meshed nodes; the
+        // membership diff gates only the log line, not the push.
+        let mesh = build_mesh_membership(&cluster);
+        if mesh.nodes.len() >= 2 {
+            if mesh.nodes != last_mesh {
+                info!(
+                    members = mesh.nodes.len(),
+                    "k0s full-mesh membership changed"
+                );
+            }
+            for node in &mesh.nodes {
+                spawn_apply_mesh(&cluster, &node.hostname, &mesh);
+            }
+        }
+        last_mesh = mesh.nodes.clone();
+
+        match state.phase {
+            // Converged; ClusterStatus reports live component state on demand.
+            K0sPhase::Ready => {}
+            K0sPhase::Provisioning => {
+                // 5b assigns role/IP/CIDR; 5c starts each component and converges to Ready.
+                if let Err(e) = provision_assignments(&cluster, &net, &state) {
+                    warn!(error = %e, "k0s provisioning assignment failed; will retry next tick");
+                    continue;
+                }
+                converge_provisioning(&cluster, &net).await;
+            }
+            K0sPhase::Down => stop_all_components(&cluster, state.reset_requested).await,
+            K0sPhase::Degraded => warn!("k0s cluster degraded"),
+        }
+    }
+}
+
+/// Assign role + mesh IP + pod /24 to any node that lacks one. Idempotent: a node's persisted
+/// `k0s_role`/`k0s_mesh_ip`/`k0s_pod_cidr` IS the allocation record, so assigned nodes are skipped
+/// and never re-allocated. The (in-memory) AddressPool is re-seeded from persisted inventory on
+/// every call — skipping that would hand out IPs already in use after a controller restart.
+pub(crate) fn provision_assignments(
+    cluster: &ClusterManager,
+    net: &ClusterNetworking,
+    state: &K0sClusterState,
+) -> anyhow::Result<()> {
+    let mut nodes = cluster.get_nodes();
+    if nodes.is_empty() {
+        return Ok(());
+    }
+    nodes.sort_by(|a, b| a.name.cmp(&b.name)); // deterministic
+
+    // Control-plane node: existing choice -> config override -> lexically-first node.
+    let cp_node = state
+        .control_plane_node
+        .clone()
+        .or_else(|| net.control_plane_node.clone())
+        .unwrap_or_else(|| nodes[0].name.clone());
+
+    // Re-seed the mesh pool from persisted assignments + reserve .1 for the controller.
+    let mut pool = AddressPool::new(&net.mesh_cidr)?;
+    let controller_ip = first_host(&net.mesh_cidr)?;
+    let _ = pool.allocate_specific(controller_ip); // reserve .1 (ignore if already reserved)
+    for n in &nodes {
+        if let Some(ip) = &n.k0s_mesh_ip {
+            let parsed: Ipv4Addr = ip
+                .parse()
+                .with_context(|| format!("persisted k0s_mesh_ip {ip} for {}", n.name))?;
+            pool.mark_allocated(parsed);
+        }
+    }
+
+    // Pod-/24 ordinals already in use (so a new node never collides).
+    let pod_base = cidr_base(&net.pod_cidr)?;
+    let mut used_ordinals: HashSet<u32> = nodes
+        .iter()
+        .filter_map(|n| n.k0s_pod_cidr.as_deref())
+        .filter_map(|c| pod_ordinal(c, pod_base))
+        .collect();
+
+    let single = nodes.len() == 1;
+    for node in &nodes {
+        if node.k0s_role.is_some() {
+            continue; // already assigned
+        }
+        let is_cp = node.name == cp_node;
+        let role = if is_cp {
+            if single {
+                K0sRole::Single
+            } else {
+                K0sRole::Controller
+            }
+        } else {
+            K0sRole::Worker
+        };
+        let mesh_ip = if is_cp {
+            controller_ip
+        } else {
+            pool.allocate()?
+        };
+        let ordinal = next_free_ordinal(&used_ordinals);
+        used_ordinals.insert(ordinal);
+        let pod_cidr = carve_pod_cidr(&net.pod_cidr, ordinal)?;
+        cluster.assign_node_k0s(&node.name, role, &mesh_ip.to_string(), &pod_cidr)?;
+    }
+
+    // Persist the control-plane choice if not already recorded.
+    if state.control_plane_node.as_deref() != Some(cp_node.as_str()) {
+        cluster.set_k0s_phase(K0sPhase::Provisioning, Some(cp_node), false)?;
+    }
+    Ok(())
+}
+
+/// The `.1` host of a CIDR (mesh controller IP).
+fn first_host(cidr: &str) -> anyhow::Result<Ipv4Addr> {
+    Ok(Ipv4Addr::from(u32::from(cidr_base(cidr)?) + 1))
+}
+
+/// The base address of a CIDR string.
+fn cidr_base(cidr: &str) -> anyhow::Result<Ipv4Addr> {
+    let (base, _) = cidr
+        .split_once('/')
+        .ok_or_else(|| anyhow::anyhow!("{cidr} is not a CIDR"))?;
+    base.parse().with_context(|| format!("CIDR base in {cidr}"))
+}
+
+/// Carve a per-node pod /24 out of `pod_cidr` by ordinal, e.g. ("10.42.0.0/16", 2) -> "10.42.2.0/24".
+fn carve_pod_cidr(pod_cidr: &str, ordinal: u32) -> anyhow::Result<String> {
+    let (base, prefix) = pod_cidr
+        .split_once('/')
+        .ok_or_else(|| anyhow::anyhow!("{pod_cidr} is not a CIDR"))?;
+    let prefix: u8 = prefix
+        .parse()
+        .with_context(|| format!("pod_cidr prefix in {pod_cidr}"))?;
+    if prefix > 24 {
+        anyhow::bail!("pod_cidr {pod_cidr} must be /24 or larger to carve per-node /24s");
+    }
+    let base: Ipv4Addr = base
+        .parse()
+        .with_context(|| format!("pod_cidr base in {pod_cidr}"))?;
+    let num_24s = 1u32 << (24 - prefix);
+    if ordinal >= num_24s {
+        anyhow::bail!("pod ordinal {ordinal} exceeds {num_24s} /24s in {pod_cidr}");
+    }
+    let carved = u32::from(base) + (ordinal << 8);
+    Ok(format!("{}/24", Ipv4Addr::from(carved)))
+}
+
+/// Inverse of `carve_pod_cidr`: the ordinal of a per-node /24 within `pod_base`.
+fn pod_ordinal(node_cidr: &str, pod_base: Ipv4Addr) -> Option<u32> {
+    let (b, _) = node_cidr.split_once('/')?;
+    let nb: Ipv4Addr = b.parse().ok()?;
+    Some(u32::from(nb).checked_sub(u32::from(pod_base))? >> 8)
+}
+
+/// Smallest non-negative ordinal not already in use.
+fn next_free_ordinal(used: &HashSet<u32>) -> u32 {
+    let mut o = 0;
+    while used.contains(&o) {
+        o += 1;
+    }
+    o
+}
+
+/// Proto status string for a cluster phase.
+pub fn phase_str(p: K0sPhase) -> String {
+    match p {
+        K0sPhase::Down => "down",
+        K0sPhase::Provisioning => "provisioning",
+        K0sPhase::Ready => "ready",
+        K0sPhase::Degraded => "degraded",
+    }
+    .to_string()
+}
+
+fn role_str(r: K0sRole) -> String {
+    match r {
+        K0sRole::Controller => "controller",
+        K0sRole::Worker => "worker",
+        K0sRole::Single => "single",
+    }
+    .to_string()
+}
+
+/// Per-node status list from persisted (Raft-replicated) k0s state only (no agent round-trip).
+pub fn node_statuses(cluster: &ClusterManager) -> Vec<ClusterNodeStatus> {
+    cluster
+        .get_nodes()
+        .into_iter()
+        .filter_map(|n| {
+            let role = n.k0s_role?;
+            Some(ClusterNodeStatus {
+                node: n.name,
+                role: role_str(role),
+                component_state: "unknown".to_string(),
+                enabled: true,
+            })
+        })
+        .collect()
+}
+
+/// Build the authoritative full-mesh membership from live node inventory: every node that has both
+/// joined the WireGuard mesh (non-empty `wg_pubkey`, reported at registration) and been assigned a
+/// mesh IP. Each entry carries the node's pod /24, so a native-routing CNI (Calico `bird`) can ride
+/// the mesh — the controller is the source of truth for `MeshNode.public_key`/`pod_cidr`, which an
+/// operator feeds to `apply_mesh` on each node via `spur net mesh --config`. Nodes not yet on the
+/// mesh (no pubkey) are skipped rather than fabricated, so an incomplete membership is never emitted.
+pub fn build_mesh_membership(cluster: &ClusterManager) -> MeshMembership {
+    mesh_from_nodes(cluster.get_nodes())
+}
+
+/// Pure core of [`build_mesh_membership`] (testable without a `ClusterManager`).
+fn mesh_from_nodes(nodes: Vec<spur_core::node::Node>) -> MeshMembership {
+    let mut nodes: Vec<MeshNode> = nodes
+        .into_iter()
+        .filter_map(|n| {
+            let mesh_ip = n.k0s_mesh_ip.clone()?;
+            let public_key = n.wg_pubkey.clone().filter(|k| !k.is_empty())?;
+            let endpoint = n
+                .address
+                .clone()
+                .map(|a| format!("{a}:{WG_LISTEN_PORT}"))
+                .unwrap_or_default();
+            Some(MeshNode {
+                hostname: n.name,
+                public_key,
+                mesh_ip,
+                endpoint,
+                pod_cidr: n.k0s_pod_cidr.clone(),
+            })
+        })
+        .collect();
+    nodes.sort_by(|a, b| a.mesh_ip.cmp(&b.mesh_ip)); // deterministic ordering
+    MeshMembership { nodes }
+}
+
+/// Resolve a node's agent endpoint (`http://addr:port`), or None if it has no address.
+fn agent_endpoint(cluster: &ClusterManager, node: &str) -> Option<String> {
+    let n = cluster.get_node(node)?;
+    let addr = n.address?;
+    Some(format!("http://{}:{}", addr, n.port))
+}
+
+/// Dial the control-plane node's agent, timing out per `AGENT_TIMEOUT`. Errors if no control-plane
+/// node is assigned yet or it has no reachable address.
+async fn connect_control_plane(
+    cluster: &ClusterManager,
+) -> anyhow::Result<SlurmAgentClient<tonic::transport::Channel>> {
+    let cp = cluster
+        .k0s_state()
+        .control_plane_node
+        .ok_or_else(|| anyhow::anyhow!("no control-plane node assigned yet"))?;
+    let endpoint = agent_endpoint(cluster, &cp)
+        .ok_or_else(|| anyhow::anyhow!("control-plane node {cp} has no agent address"))?;
+    tokio::time::timeout(AGENT_TIMEOUT, SlurmAgentClient::connect(endpoint))
+        .await
+        .map_err(|_| anyhow::anyhow!("connect to control-plane agent timed out"))?
+        .map_err(|e| anyhow::anyhow!("connect to control-plane agent failed: {e}"))
+}
+
+/// Mint a worker join token from the control-plane node's agent (`k0s token create --role worker`).
+/// Errors until the control-plane component is up (its k0s API must answer); the caller retries.
+async fn mint_worker_token(cluster: &ClusterManager) -> anyhow::Result<String> {
+    let mut client = connect_control_plane(cluster).await?;
+    let resp = client
+        .create_k0s_join_token(CreateK0sJoinTokenRequest {
+            role: "worker".to_string(),
+            expiry_seconds: 0, // k0s default lifetime
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("create_k0s_join_token RPC failed: {e}"))?;
+    Ok(resp.into_inner().join_token)
+}
+
+/// Fetch the admin kubeconfig from the control-plane node's agent (`k0s kubeconfig admin`), for the
+/// ClusterKubeconfig RPC. Errors if there is no control-plane node yet or it is unreachable.
+pub async fn fetch_admin_kubeconfig(cluster: &ClusterManager) -> anyhow::Result<String> {
+    let mut client = connect_control_plane(cluster).await?;
+    let resp = client
+        .get_admin_kubeconfig(GetAdminKubeconfigRequest {})
+        .await
+        .map_err(|e| anyhow::anyhow!("get_admin_kubeconfig RPC failed: {e}"))?;
+    Ok(resp.into_inner().kubeconfig)
+}
+
+/// Query a node's live k0s component state via its agent, with a timeout. Returns None if the node
+/// is unreachable or has no component yet.
+async fn fetch_component_state(cluster: &ClusterManager, node: &str) -> Option<String> {
+    let endpoint = agent_endpoint(cluster, node)?;
+    let fut = async {
+        let mut client = SlurmAgentClient::connect(endpoint).await.ok()?;
+        let resp = client
+            .get_cluster_component_status(GetClusterComponentStatusRequest {})
+            .await
+            .ok()?;
+        Some(resp.into_inner().component_state)
+    };
+    tokio::time::timeout(AGENT_TIMEOUT, fut)
+        .await
+        .ok()
+        .flatten()
+}
+
+/// The mesh-native k0s controller config for `node` (api on its mesh IP + Calico bird), or None for
+/// the default kube-router mode (`cni != "calico"`) / a node without a mesh IP.
+fn controller_k0s_config(net: &ClusterNetworking, node: &spur_core::node::Node) -> Option<String> {
+    let api = node.k0s_mesh_ip.as_deref()?;
+    // SANs: the mesh IP (advertised) + the underlay address (so `kubectl` over either works).
+    let mut sans = vec![api.to_string()];
+    if let Some(addr) = &node.address {
+        if addr != api {
+            sans.push(addr.clone());
+        }
+    }
+    spur_core::k0s::k0s_controller_config_yaml(
+        &net.cni,
+        &net.pod_cidr,
+        &net.service_cidr,
+        api,
+        &sans,
+    )
+}
+
+/// Start any assigned component that is not yet active; when all are active, mark the cluster Ready.
+async fn converge_provisioning(cluster: &ClusterManager, net: &ClusterNetworking) {
+    let assigned: Vec<_> = cluster
+        .get_nodes()
+        .into_iter()
+        .filter(|n| n.k0s_role.is_some())
+        .collect();
+    if assigned.is_empty() {
+        return;
+    }
+    let mut all_active = true;
+    // Control-plane (controller/single) first: a worker needs the control-plane's k0s API up to
+    // mint its join token, so the control-plane must be started before we try any worker.
+    for node in &assigned {
+        let role = node.k0s_role.expect("assigned above");
+        if role == K0sRole::Worker {
+            continue;
+        }
+        if fetch_component_state(cluster, &node.name).await.as_deref() == Some("active") {
+            continue;
+        }
+        all_active = false;
+        // Mesh-native cluster: generate the k0s config (api on the mesh IP + Calico bird) when
+        // cni=calico; None keeps the default kube-router. Control-plane needs no join token.
+        let k0s_config = controller_k0s_config(net, node);
+        spawn_start_component(cluster, &node.name, role, None, k0s_config, None);
+    }
+    // Workers: mint a fresh join token from the control-plane agent, then start with it.
+    // Minting errors until the control-plane's k0s API is reachable — treated as "retry next tick".
+    for node in &assigned {
+        if node.k0s_role != Some(K0sRole::Worker) {
+            continue;
+        }
+        if fetch_component_state(cluster, &node.name).await.as_deref() == Some("active") {
+            continue;
+        }
+        all_active = false;
+        // For a native-routing CNI, pin the worker's kubelet node-ip to its mesh IP.
+        let node_ip = if net.cni == "calico" {
+            node.k0s_mesh_ip.clone()
+        } else {
+            None
+        };
+        match mint_worker_token(cluster).await {
+            Ok(token) => spawn_start_component(
+                cluster,
+                &node.name,
+                K0sRole::Worker,
+                Some(token),
+                None,
+                node_ip,
+            ),
+            Err(e) => {
+                warn!(node = %node.name, error = %e, "could not mint worker join token yet; will retry")
+            }
+        }
+    }
+    if all_active {
+        match cluster.set_k0s_phase(K0sPhase::Ready, None, false) {
+            Ok(()) => info!("k0s cluster converged: all components active -> Ready"),
+            Err(e) => warn!(error = %e, "failed to mark k0s cluster Ready"),
+        }
+    }
+}
+
+/// Stop every assigned component that is still running (cluster teardown).
+async fn stop_all_components(cluster: &ClusterManager, reset: bool) {
+    for node in cluster.get_nodes() {
+        if node.k0s_role.is_none() {
+            continue;
+        }
+        if fetch_component_state(cluster, &node.name).await.as_deref() == Some("inactive") {
+            continue;
+        }
+        spawn_stop_component(cluster, &node.name, reset);
+    }
+}
+
+/// Fire-and-forget StartClusterComponent to a node's agent (off the reconcile thread).
+fn spawn_start_component(
+    cluster: &ClusterManager,
+    node: &str,
+    role: K0sRole,
+    join_token: Option<String>,
+    k0s_config: Option<String>,
+    node_ip: Option<String>,
+) {
+    let Some(endpoint) = agent_endpoint(cluster, node) else {
+        warn!(node = %node, "no agent address; cannot start k0s component");
+        return;
+    };
+    let node = node.to_string();
+    let role = role_str(role);
+    tokio::spawn(async move {
+        match SlurmAgentClient::connect(endpoint).await {
+            Ok(mut client) => {
+                let req = StartClusterComponentRequest {
+                    role,
+                    join_token,
+                    k0s_config,
+                    node_ip,
+                };
+                if let Err(e) = client.start_cluster_component(req).await {
+                    warn!(node = %node, error = %e, "start_cluster_component failed");
+                }
+            }
+            Err(e) => warn!(node = %node, error = %e, "connect to agent failed"),
+        }
+    });
+}
+
+/// Fire-and-forget StopClusterComponent to a node's agent.
+fn spawn_stop_component(cluster: &ClusterManager, node: &str, reset: bool) {
+    let Some(endpoint) = agent_endpoint(cluster, node) else {
+        return;
+    };
+    let node = node.to_string();
+    tokio::spawn(async move {
+        match SlurmAgentClient::connect(endpoint).await {
+            Ok(mut client) => {
+                if let Err(e) = client
+                    .stop_cluster_component(StopClusterComponentRequest { reset })
+                    .await
+                {
+                    warn!(node = %node, error = %e, "stop_cluster_component failed");
+                }
+            }
+            Err(e) => warn!(node = %node, error = %e, "connect to agent failed"),
+        }
+    });
+}
+
+/// Convert the spur-net mesh membership to its proto mirror for the wire.
+fn to_proto_membership(mesh: &MeshMembership) -> spur_proto::proto::MeshMembership {
+    spur_proto::proto::MeshMembership {
+        nodes: mesh
+            .nodes
+            .iter()
+            .map(|n| spur_proto::proto::MeshNode {
+                hostname: n.hostname.clone(),
+                public_key: n.public_key.clone(),
+                mesh_ip: n.mesh_ip.clone(),
+                endpoint: n.endpoint.clone(),
+                pod_cidr: n.pod_cidr.clone(),
+            })
+            .collect(),
+    }
+}
+
+/// Fire-and-forget ApplyMesh to a node's agent: the agent reconciles the full mesh locally
+/// (prune departed peers + add/update the desired set via `wg set`). Idempotent, so the
+/// level-triggered per-tick re-push is safe.
+fn spawn_apply_mesh(cluster: &ClusterManager, node: &str, mesh: &MeshMembership) {
+    let Some(endpoint) = agent_endpoint(cluster, node) else {
+        warn!(node = %node, "no agent address; cannot push mesh");
+        return;
+    };
+    let node = node.to_string();
+    let proto = to_proto_membership(mesh);
+    tokio::spawn(async move {
+        match SlurmAgentClient::connect(endpoint).await {
+            Ok(mut client) => match client.apply_mesh(proto).await {
+                Ok(resp) => {
+                    let r = resp.into_inner();
+                    if !r.applied {
+                        warn!(node = %node, message = %r.message, "apply_mesh not applied");
+                    }
+                }
+                Err(e) => warn!(node = %node, error = %e, "apply_mesh RPC failed"),
+            },
+            Err(e) => warn!(node = %node, error = %e, "connect to agent for apply_mesh failed"),
+        }
+    });
+}
+
+/// Per-node status with LIVE component_state fetched from each agent (for the ClusterStatus RPC).
+pub async fn live_node_statuses(cluster: &ClusterManager) -> Vec<ClusterNodeStatus> {
+    let mut out = Vec::new();
+    for n in cluster.get_nodes() {
+        let Some(role) = n.k0s_role else { continue };
+        let component_state = fetch_component_state(cluster, &n.name)
+            .await
+            .unwrap_or_else(|| "unknown".to_string());
+        out.push(ClusterNodeStatus {
+            node: n.name,
+            role: role_str(role),
+            component_state,
+            enabled: true,
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn carve_pod_cidr_from_16() {
+        assert_eq!(carve_pod_cidr("10.42.0.0/16", 0).unwrap(), "10.42.0.0/24");
+        assert_eq!(carve_pod_cidr("10.42.0.0/16", 2).unwrap(), "10.42.2.0/24");
+        assert_eq!(
+            carve_pod_cidr("10.42.0.0/16", 255).unwrap(),
+            "10.42.255.0/24"
+        );
+        // /16 has exactly 256 /24s -> ordinal 256 overflows.
+        assert!(carve_pod_cidr("10.42.0.0/16", 256).is_err());
+        // /25 is too small to carve a /24.
+        assert!(carve_pod_cidr("10.42.0.0/25", 0).is_err());
+    }
+
+    #[test]
+    fn pod_ordinal_inverts_carve() {
+        let base: Ipv4Addr = "10.42.0.0".parse().unwrap();
+        assert_eq!(pod_ordinal("10.42.0.0/24", base), Some(0));
+        assert_eq!(pod_ordinal("10.42.7.0/24", base), Some(7));
+        // below the pod base -> None (not one of ours)
+        assert_eq!(pod_ordinal("10.41.0.0/24", base), None);
+    }
+
+    #[test]
+    fn next_free_ordinal_skips_used() {
+        let used: HashSet<u32> = [0, 1, 3].into_iter().collect();
+        assert_eq!(next_free_ordinal(&used), 2);
+        assert_eq!(next_free_ordinal(&HashSet::new()), 0);
+    }
+
+    #[test]
+    fn first_host_is_dot_one() {
+        assert_eq!(
+            first_host("10.44.0.0/16").unwrap(),
+            "10.44.0.1".parse::<Ipv4Addr>().unwrap()
+        );
+    }
+
+    fn mesh_node(
+        name: &str,
+        mesh_ip: Option<&str>,
+        pubkey: Option<&str>,
+        addr: Option<&str>,
+        pod: Option<&str>,
+    ) -> spur_core::node::Node {
+        let mut n = spur_core::node::Node::new(name.to_string(), Default::default());
+        n.k0s_mesh_ip = mesh_ip.map(String::from);
+        n.wg_pubkey = pubkey.map(String::from);
+        n.address = addr.map(String::from);
+        n.k0s_pod_cidr = pod.map(String::from);
+        n
+    }
+
+    #[test]
+    fn mesh_membership_skips_unmeshed_and_carries_pod_cidr() {
+        let nodes = vec![
+            // controller: meshed, pod CIDR set
+            mesh_node(
+                "cp",
+                Some("10.44.0.1"),
+                Some("pk-cp"),
+                Some("198.51.100.1"),
+                Some("10.42.0.0/24"),
+            ),
+            // worker: meshed
+            mesh_node(
+                "w2",
+                Some("10.44.0.2"),
+                Some("pk-w2"),
+                Some("198.51.100.2"),
+                Some("10.42.1.0/24"),
+            ),
+            // assigned a mesh IP but hasn't reported a pubkey yet -> not on the mesh, skip
+            mesh_node("w3", Some("10.44.0.3"), None, Some("198.51.100.3"), None),
+            // empty pubkey is treated as absent -> skip
+            mesh_node(
+                "w4",
+                Some("10.44.0.4"),
+                Some(""),
+                Some("198.51.100.4"),
+                None,
+            ),
+            // no mesh IP (not assigned) -> skip
+            mesh_node("w5", None, Some("pk-w5"), Some("198.51.100.5"), None),
+        ];
+        let m = mesh_from_nodes(nodes);
+        assert_eq!(m.nodes.len(), 2, "only fully-meshed nodes included");
+        // sorted by mesh_ip
+        assert_eq!(m.nodes[0].mesh_ip, "10.44.0.1");
+        assert_eq!(m.nodes[0].public_key, "pk-cp");
+        assert_eq!(m.nodes[0].endpoint, "198.51.100.1:51820");
+        assert_eq!(m.nodes[0].pod_cidr.as_deref(), Some("10.42.0.0/24"));
+        assert_eq!(m.nodes[1].mesh_ip, "10.44.0.2");
+        // the resulting membership feeds apply_mesh: pod CIDR folds into AllowedIPs
+        assert_eq!(
+            spur_net::mesh::peer_allowed_ips(&m.nodes[1]),
+            "10.44.0.2/32,10.42.1.0/24"
+        );
+    }
+}

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -9,7 +9,7 @@
 //! gated on Raft leadership. Phase transitions go through `ClusterManager::set_k0s_phase`
 //! (WAL-replicated) so a leadership change mid-provision is safe.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::net::Ipv4Addr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -43,6 +43,8 @@ pub struct ClusterNetworking {
     pub pod_cidr: String,
     /// Service CIDR (cluster.service_cidr) — for the generated k0s config.
     pub service_cidr: String,
+    /// CNI MTU (cluster.cni_mtu) — emitted into the generated Calico config.
+    pub cni_mtu: u16,
     /// CNI mode (cluster.cni): "kuberouter" (default) or "calico" (mesh-native config + node-ip).
     pub cni: String,
     /// Operator-pinned control-plane node (cluster.control_plane_node), if any.
@@ -55,6 +57,10 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>, net: Clust
     info!(mesh = %net.mesh_cidr, pod = %net.pod_cidr, "k0s cluster reconcile loop started");
     let mut interval = tokio::time::interval(RECONCILE_INTERVAL);
     let mut last_mesh: Vec<MeshNode> = Vec::new();
+    // Cache of the worker join token minted per node, so we mint once (not every tick) while a
+    // worker joins — re-minting each tick churns k0s server tokens and races the join. Cleared when
+    // the worker's component reports active.
+    let mut worker_tokens: HashMap<String, String> = HashMap::new();
     loop {
         interval.tick().await;
         if !raft.is_leader() {
@@ -92,7 +98,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>, net: Clust
                     warn!(error = %e, "k0s provisioning assignment failed; will retry next tick");
                     continue;
                 }
-                converge_provisioning(&cluster, &net).await;
+                converge_provisioning(&cluster, &net, &mut worker_tokens).await;
             }
             K0sPhase::Down => stop_all_components(&cluster, state.reset_requested).await,
             K0sPhase::Degraded => warn!("k0s cluster degraded"),
@@ -396,19 +402,26 @@ fn controller_k0s_config(net: &ClusterNetworking, node: &spur_core::node::Node) 
         &net.cni,
         &net.pod_cidr,
         &net.service_cidr,
+        net.cni_mtu,
         api,
         &sans,
     )
 }
 
 /// Start any assigned component that is not yet active; when all are active, mark the cluster Ready.
-async fn converge_provisioning(cluster: &ClusterManager, net: &ClusterNetworking) {
+/// `worker_tokens` caches each worker's minted join token across ticks so we mint once per join.
+async fn converge_provisioning(
+    cluster: &ClusterManager,
+    net: &ClusterNetworking,
+    worker_tokens: &mut HashMap<String, String>,
+) {
     let assigned: Vec<_> = cluster
         .get_nodes()
         .into_iter()
         .filter(|n| n.k0s_role.is_some())
         .collect();
     if assigned.is_empty() {
+        worker_tokens.clear();
         return;
     }
     let mut all_active = true;
@@ -435,6 +448,7 @@ async fn converge_provisioning(cluster: &ClusterManager, net: &ClusterNetworking
             continue;
         }
         if fetch_component_state(cluster, &node.name).await.as_deref() == Some("active") {
+            worker_tokens.remove(&node.name); // joined — drop the cached token
             continue;
         }
         all_active = false;
@@ -444,19 +458,29 @@ async fn converge_provisioning(cluster: &ClusterManager, net: &ClusterNetworking
         } else {
             None
         };
-        match mint_worker_token(cluster).await {
-            Ok(token) => spawn_start_component(
-                cluster,
-                &node.name,
-                K0sRole::Worker,
-                Some(token),
-                None,
-                node_ip,
-            ),
-            Err(e) => {
-                warn!(node = %node.name, error = %e, "could not mint worker join token yet; will retry")
-            }
-        }
+        // Mint the worker's join token once and cache it: re-minting every tick churns k0s server
+        // tokens and races the join. Reuse the cached token on later ticks until the worker joins.
+        let token = match worker_tokens.get(&node.name) {
+            Some(cached) => cached.clone(),
+            None => match mint_worker_token(cluster).await {
+                Ok(token) => {
+                    worker_tokens.insert(node.name.clone(), token.clone());
+                    token
+                }
+                Err(e) => {
+                    warn!(node = %node.name, error = %e, "could not mint worker join token yet; will retry");
+                    continue;
+                }
+            },
+        };
+        spawn_start_component(
+            cluster,
+            &node.name,
+            K0sRole::Worker,
+            Some(token),
+            None,
+            node_ip,
+        );
     }
     if all_active {
         match cluster.set_k0s_phase(K0sPhase::Ready, None, false) {
@@ -521,11 +545,24 @@ fn spawn_stop_component(cluster: &ClusterManager, node: &str, reset: bool) {
     tokio::spawn(async move {
         match SlurmAgentClient::connect(endpoint).await {
             Ok(mut client) => {
-                if let Err(e) = client
+                match client
                     .stop_cluster_component(StopClusterComponentRequest { reset })
                     .await
                 {
-                    warn!(node = %node, error = %e, "stop_cluster_component failed");
+                    Ok(resp) => {
+                        // The agent reports a failed stop/reset in-band (stopped=false): surface it
+                        // so `down --reset` isn't a false success. The component stays active, so the
+                        // reconcile loop retries and `spur k8s status` still shows the node.
+                        let r = resp.into_inner();
+                        if !r.stopped {
+                            warn!(
+                                node = %node,
+                                detail = %r.message,
+                                "k0s component stop/reset failed; teardown is partial — retrying"
+                            );
+                        }
+                    }
+                    Err(e) => warn!(node = %node, error = %e, "stop_cluster_component failed"),
                 }
             }
             Err(e) => warn!(node = %node, error = %e, "connect to agent failed"),

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -89,20 +89,34 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>, net: Clust
         }
         last_mesh = mesh.nodes.clone();
 
-        match state.phase {
-            // Converged; ClusterStatus reports live component state on demand.
-            K0sPhase::Ready => {}
-            K0sPhase::Provisioning => {
-                // 5b assigns role/IP/CIDR; 5c starts each component and converges to Ready.
-                if let Err(e) = provision_assignments(&cluster, &net, &state) {
-                    warn!(error = %e, "k0s provisioning assignment failed; will retry next tick");
-                    continue;
-                }
-                converge_provisioning(&cluster, &net, &mut worker_tokens).await;
+        reconcile_phase(&cluster, &net, &state, &mut worker_tokens).await;
+    }
+}
+
+/// Run one reconcile tick for the current phase. Extracted from `run` so it is testable.
+///
+/// Ready and Provisioning both run the assignment + converge reconcile so the cluster self-heals: a
+/// node that is removed then re-added (a spurd restart deregisters on SIGTERM, dropping the node +
+/// its k0s assignment) or a node added while Ready gets (re)assigned a role/IP/CIDR, (re)joined, and
+/// rejoins the mesh membership on the next ApplyMesh tick. Idempotent — assigned + active nodes are
+/// skipped — so a converged cluster does no work beyond the per-node status probes. Without running
+/// this in Ready, a re-added node stays un-roled (out of the mesh) until the next manual `spur k8s up`.
+pub(crate) async fn reconcile_phase(
+    cluster: &ClusterManager,
+    net: &ClusterNetworking,
+    state: &K0sClusterState,
+    worker_tokens: &mut HashMap<String, String>,
+) {
+    match state.phase {
+        K0sPhase::Ready | K0sPhase::Provisioning => {
+            if let Err(e) = provision_assignments(cluster, net, state) {
+                warn!(error = %e, "k0s provisioning assignment failed; will retry next tick");
+                return;
             }
-            K0sPhase::Down => stop_all_components(&cluster, state.reset_requested).await,
-            K0sPhase::Degraded => warn!("k0s cluster degraded"),
+            converge_provisioning(cluster, net, worker_tokens).await;
         }
+        K0sPhase::Down => stop_all_components(cluster, state.reset_requested).await,
+        K0sPhase::Degraded => warn!("k0s cluster degraded"),
     }
 }
 
@@ -482,7 +496,9 @@ async fn converge_provisioning(
             node_ip,
         );
     }
-    if all_active {
+    // Only transition on the edge — this reconcile also runs every tick while already Ready (to
+    // heal re-added nodes), so an unconditional set would churn a WAL write + log line each tick.
+    if all_active && cluster.k0s_state().phase != K0sPhase::Ready {
         match cluster.set_k0s_phase(K0sPhase::Ready, None, false) {
             Ok(()) => info!("k0s cluster converged: all components active -> Ready"),
             Err(e) => warn!(error = %e, "failed to mark k0s cluster Ready"),

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -4,6 +4,7 @@
 mod accounting;
 mod association_cache;
 mod cluster;
+mod cluster_k8s;
 mod fairshare_cache;
 mod limits_cache;
 mod metrics_proto;
@@ -218,6 +219,22 @@ async fn main() -> anyhow::Result<()> {
         scheduler_loop::run(sched_cluster, sched_raft).await;
     });
 
+    // Start the k0s cluster reconcile loop (leader-gated; only when [cluster].enabled).
+    if config.cluster.enabled {
+        let k8s_cluster = cluster.clone();
+        let k8s_raft = raft_handle.clone();
+        let k8s_net = cluster_k8s::ClusterNetworking {
+            mesh_cidr: config.network.wg_cidr.clone(),
+            pod_cidr: config.cluster.pod_cidr.clone(),
+            service_cidr: config.cluster.service_cidr.clone(),
+            cni: config.cluster.cni.clone(),
+            control_plane_node: config.cluster.control_plane_node.clone(),
+        };
+        tokio::spawn(async move {
+            cluster_k8s::run(k8s_cluster, k8s_raft, k8s_net).await;
+        });
+    }
+
     // Start node health checker (only on leader).
     let hb_timeout = config.controller.heartbeat_timeout_secs.unwrap_or(90);
     let health_cluster = cluster.clone();
@@ -323,6 +340,7 @@ fn default_config() -> spur_core::config::SlurmConfig {
         network: Default::default(),
         logging: Default::default(),
         kubernetes: Default::default(),
+        cluster: Default::default(),
         notifications: Default::default(),
         power: Default::default(),
         federation: Default::default(),

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -227,6 +227,7 @@ async fn main() -> anyhow::Result<()> {
             mesh_cidr: config.network.wg_cidr.clone(),
             pod_cidr: config.cluster.pod_cidr.clone(),
             service_cidr: config.cluster.service_cidr.clone(),
+            cni_mtu: config.cluster.cni_mtu,
             cni: config.cluster.cni.clone(),
             control_plane_node: config.cluster.control_plane_node.clone(),
         };

--- a/crates/spurctld/src/metrics_server.rs
+++ b/crates/spurctld/src/metrics_server.rs
@@ -168,6 +168,7 @@ mod tests {
             network: Default::default(),
             logging: Default::default(),
             kubernetes: Default::default(),
+            cluster: Default::default(),
             notifications: Default::default(),
             power: Default::default(),
             federation: Default::default(),

--- a/crates/spurctld/src/rpc_middleware.rs
+++ b/crates/spurctld/src/rpc_middleware.rs
@@ -189,6 +189,7 @@ mod tests {
                 network: Default::default(),
                 logging: Default::default(),
                 kubernetes: Default::default(),
+                cluster: Default::default(),
                 notifications: Default::default(),
                 power: Default::default(),
                 federation: Default::default(),

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -9,7 +9,7 @@ use chrono::{DateTime, Utc};
 use tokio::sync::Mutex;
 use tonic::metadata::MetadataValue;
 use tonic::{Code, Request, Response, Status};
-use tracing::warn;
+use tracing::{info, warn};
 
 use spur_core::job::NodeCompleteError;
 use spur_core::reservation::Reservation;
@@ -992,6 +992,14 @@ impl SlurmController for ControllerService {
             .cluster
             .update_heartbeat(&req.hostname, req.cpu_load, req.free_memory_mb)
         {
+            // Learn a mesh key that appeared/changed after registration so the node joins ApplyMesh
+            // without a restart. Only meaningful once the node is known (heartbeat accepted).
+            if self
+                .cluster
+                .update_node_wg_pubkey(&req.hostname, &req.wg_pubkey)
+            {
+                info!(node = %req.hostname, "learned updated WireGuard mesh key from heartbeat");
+            }
             Ok(Response::new(HeartbeatResponse {}))
         } else {
             Err(Status::not_found(format!(
@@ -1481,6 +1489,25 @@ impl SlurmController for ControllerService {
             }
         }
         let req = request.into_inner();
+        // Reject a control-plane change once roles are assigned: provisioning skips already-assigned
+        // nodes, so moving the control plane here would only rewrite the recorded CP and leave the
+        // old controller a Controller and the new node a Worker (inconsistent topology). Tear the
+        // cluster down (`spur k8s down --reset`) to re-elect a control plane.
+        if let Some(new_cp) = req.control_plane_node.as_deref() {
+            let state = self.cluster.k0s_state();
+            let assigned = self
+                .cluster
+                .get_nodes()
+                .iter()
+                .any(|n| n.k0s_role.is_some());
+            if assigned && state.control_plane_node.as_deref() != Some(new_cp) {
+                return Err(Status::failed_precondition(format!(
+                    "control-plane node is already assigned ({}); tear the cluster down \
+                     (spur k8s down --reset) before changing it to {new_cp}",
+                    state.control_plane_node.as_deref().unwrap_or("<none>"),
+                )));
+            }
+        }
         self.cluster
             .set_k0s_phase(
                 spur_core::k0s::K0sPhase::Provisioning,
@@ -1488,18 +1515,9 @@ impl SlurmController for ControllerService {
                 false,
             )
             .map_err(|e| Status::internal(format!("set k0s phase: {e}")))?;
-        // ARC (actions-runner-controller) provisioning is not wired yet — don't silently drop the
-        // request: warn and tell the caller so `--install-arc` isn't a confusing no-op.
-        let mut message = "k0s cluster provisioning requested".to_string();
-        if req.install_arc {
-            warn!(
-                "cluster_up: --install-arc requested but ARC provisioning is not yet implemented"
-            );
-            message.push_str(" (note: --install-arc is not yet implemented and was ignored)");
-        }
         Ok(Response::new(ClusterUpResponse {
             accepted: true,
-            message,
+            message: "k0s cluster provisioning requested".to_string(),
             nodes: crate::cluster_k8s::node_statuses(&self.cluster),
         }))
     }

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1488,9 +1488,18 @@ impl SlurmController for ControllerService {
                 false,
             )
             .map_err(|e| Status::internal(format!("set k0s phase: {e}")))?;
+        // ARC (actions-runner-controller) provisioning is not wired yet — don't silently drop the
+        // request: warn and tell the caller so `--install-arc` isn't a confusing no-op.
+        let mut message = "k0s cluster provisioning requested".to_string();
+        if req.install_arc {
+            warn!(
+                "cluster_up: --install-arc requested but ARC provisioning is not yet implemented"
+            );
+            message.push_str(" (note: --install-arc is not yet implemented and was ignored)");
+        }
         Ok(Response::new(ClusterUpResponse {
             accepted: true,
-            message: "k0s cluster provisioning requested".to_string(),
+            message,
             nodes: crate::cluster_k8s::node_statuses(&self.cluster),
         }))
     }

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1460,6 +1460,104 @@ impl SlurmController for ControllerService {
             node: node_name,
         }))
     }
+
+    // -- Native cluster (k0s) lifecycle. Leader-gated; record intent in the
+    //    replicated k0s state and let the reconcile loop (cluster_k8s.rs) converge in 5b/5c. --
+    async fn cluster_up(
+        &self,
+        request: Request<ClusterUpRequest>,
+    ) -> Result<Response<ClusterUpResponse>, Status> {
+        if let Err(status) = self.check_leader(&request) {
+            match self.leader_proxy.get_leader_client().await {
+                Ok(mut client) => {
+                    let mut fwd = Request::new(request.into_inner());
+                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    return client.cluster_up(fwd).await;
+                }
+                Err(e) => {
+                    warn!("failed to forward cluster_up to leader: {e}");
+                    return Err(status);
+                }
+            }
+        }
+        let req = request.into_inner();
+        self.cluster
+            .set_k0s_phase(
+                spur_core::k0s::K0sPhase::Provisioning,
+                req.control_plane_node.clone(),
+                false,
+            )
+            .map_err(|e| Status::internal(format!("set k0s phase: {e}")))?;
+        Ok(Response::new(ClusterUpResponse {
+            accepted: true,
+            message: "k0s cluster provisioning requested".to_string(),
+            nodes: crate::cluster_k8s::node_statuses(&self.cluster),
+        }))
+    }
+
+    async fn cluster_down(
+        &self,
+        request: Request<ClusterDownRequest>,
+    ) -> Result<Response<ClusterDownResponse>, Status> {
+        if let Err(status) = self.check_leader(&request) {
+            match self.leader_proxy.get_leader_client().await {
+                Ok(mut client) => {
+                    let mut fwd = Request::new(request.into_inner());
+                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    return client.cluster_down(fwd).await;
+                }
+                Err(e) => {
+                    warn!("failed to forward cluster_down to leader: {e}");
+                    return Err(status);
+                }
+            }
+        }
+        let req = request.into_inner();
+        self.cluster
+            .set_k0s_phase(spur_core::k0s::K0sPhase::Down, None, req.reset)
+            .map_err(|e| Status::internal(format!("set k0s phase: {e}")))?;
+        Ok(Response::new(ClusterDownResponse {
+            accepted: true,
+            message: "k0s cluster teardown requested".to_string(),
+        }))
+    }
+
+    async fn cluster_status(
+        &self,
+        request: Request<ClusterStatusRequest>,
+    ) -> Result<Response<ClusterStatusResponse>, Status> {
+        if self.check_leader(&request).is_err() {
+            let mut client = self.leader_proxy.get_leader_client().await?;
+            let mut fwd = Request::new(request.into_inner());
+            *fwd.metadata_mut() = Self::forwarded_metadata();
+            return client.cluster_status(fwd).await;
+        }
+        let state = self.cluster.k0s_state();
+        Ok(Response::new(ClusterStatusResponse {
+            phase: crate::cluster_k8s::phase_str(state.phase),
+            control_plane_node: state.control_plane_node.unwrap_or_default(),
+            nodes: crate::cluster_k8s::live_node_statuses(&self.cluster).await,
+        }))
+    }
+
+    async fn cluster_kubeconfig(
+        &self,
+        request: Request<ClusterKubeconfigRequest>,
+    ) -> Result<Response<ClusterKubeconfigResponse>, Status> {
+        if self.check_leader(&request).is_err() {
+            let mut client = self.leader_proxy.get_leader_client().await?;
+            let mut fwd = Request::new(request.into_inner());
+            *fwd.metadata_mut() = Self::forwarded_metadata();
+            return client.cluster_kubeconfig(fwd).await;
+        }
+        // Ask the control-plane node's agent to run `k0s kubeconfig admin`.
+        match crate::cluster_k8s::fetch_admin_kubeconfig(&self.cluster).await {
+            Ok(kubeconfig) => Ok(Response::new(ClusterKubeconfigResponse { kubeconfig })),
+            Err(e) => Err(Status::unavailable(format!(
+                "could not fetch admin kubeconfig from the control-plane agent: {e}"
+            ))),
+        }
+    }
 }
 
 pub async fn serve(

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -71,13 +71,34 @@ pub struct AgentService {
     hooks: Arc<HooksConfig>,
     #[allow(dead_code)]
     device_registry: Arc<Mutex<DeviceRegistry>>,
+    /// RPC-driven owner of this node's k0s systemd unit.
+    k0s: Arc<crate::cluster::K0sAgent>,
 }
 
 impl AgentService {
+    /// Construct with default k0s settings (pinned version, `/usr/local/bin/k0s`). Test-only; the
+    /// binary uses `with_cluster_config` to honor the operator's `[cluster]` settings.
+    #[cfg(test)]
     pub fn new(
         reporter: Arc<NodeReporter>,
         hooks: HooksConfig,
         device_registry: Arc<Mutex<DeviceRegistry>>,
+    ) -> Self {
+        Self::with_cluster_config(
+            reporter,
+            hooks,
+            device_registry,
+            &spur_core::config::ClusterConfig::default(),
+        )
+    }
+
+    /// Construct with the `[cluster]` config so this node's K0sAgent honors the operator's k0s
+    /// version + install path.
+    pub fn with_cluster_config(
+        reporter: Arc<NodeReporter>,
+        hooks: HooksConfig,
+        device_registry: Arc<Mutex<DeviceRegistry>>,
+        cluster: &spur_core::config::ClusterConfig,
     ) -> Self {
         let allocation = NodeAllocation::new(
             hostname::get()
@@ -138,7 +159,13 @@ impl AgentService {
             pmi_servers: Arc::new(Mutex::new(HashMap::new())),
             hooks: Arc::new(hooks),
             device_registry,
+            k0s: Arc::new(crate::cluster::K0sAgent::from_config(cluster)),
         }
+    }
+
+    /// Handle to the RPC-driven k0s component owner. spurd `main()` spawns its supervise loop.
+    pub fn k0s(&self) -> Arc<crate::cluster::K0sAgent> {
+        self.k0s.clone()
     }
 
     /// Spawn a background task to monitor running jobs and report completions.
@@ -1365,6 +1392,167 @@ impl SlurmAgent for AgentService {
 
         Ok(Response::new(ReceiverStream::new(rx)))
     }
+
+    // -- Native cluster component control: drive this node's k0s systemd unit. --
+    async fn start_cluster_component(
+        &self,
+        request: Request<StartClusterComponentRequest>,
+    ) -> Result<Response<StartClusterComponentResponse>, Status> {
+        let req = request.into_inner();
+        let role = crate::cluster::ClusterRole::from_str(&req.role)
+            .ok_or_else(|| Status::invalid_argument(format!("unknown role: {}", req.role)))?;
+        match self
+            .k0s
+            .start(role, req.join_token, req.k0s_config, req.node_ip)
+            .await
+        {
+            Ok(state) => Ok(Response::new(StartClusterComponentResponse {
+                started: true,
+                component_state: state,
+                message: String::new(),
+            })),
+            Err(e) => Ok(Response::new(StartClusterComponentResponse {
+                started: false,
+                component_state: "failed".to_string(),
+                message: e.to_string(),
+            })),
+        }
+    }
+
+    async fn stop_cluster_component(
+        &self,
+        request: Request<StopClusterComponentRequest>,
+    ) -> Result<Response<StopClusterComponentResponse>, Status> {
+        match self.k0s.stop(request.into_inner().reset).await {
+            Ok(()) => Ok(Response::new(StopClusterComponentResponse {
+                stopped: true,
+                message: String::new(),
+            })),
+            Err(e) => Ok(Response::new(StopClusterComponentResponse {
+                stopped: false,
+                message: e.to_string(),
+            })),
+        }
+    }
+
+    async fn get_cluster_component_status(
+        &self,
+        _request: Request<GetClusterComponentStatusRequest>,
+    ) -> Result<Response<GetClusterComponentStatusResponse>, Status> {
+        let (role, component_state, enabled) = self.k0s.status().await;
+        Ok(Response::new(GetClusterComponentStatusResponse {
+            role,
+            component_state,
+            enabled,
+        }))
+    }
+
+    async fn create_k0s_join_token(
+        &self,
+        request: Request<CreateK0sJoinTokenRequest>,
+    ) -> Result<Response<CreateK0sJoinTokenResponse>, Status> {
+        let req = request.into_inner();
+        match self
+            .k0s
+            .create_join_token(&req.role, req.expiry_seconds)
+            .await
+        {
+            Ok(join_token) => Ok(Response::new(CreateK0sJoinTokenResponse { join_token })),
+            Err(e) => Err(Status::internal(format!("k0s token create failed: {e}"))),
+        }
+    }
+
+    async fn get_admin_kubeconfig(
+        &self,
+        _request: Request<GetAdminKubeconfigRequest>,
+    ) -> Result<Response<GetAdminKubeconfigResponse>, Status> {
+        match self.k0s.admin_kubeconfig().await {
+            Ok(kubeconfig) => Ok(Response::new(GetAdminKubeconfigResponse { kubeconfig })),
+            Err(e) => Err(Status::internal(format!(
+                "k0s kubeconfig admin failed: {e}"
+            ))),
+        }
+    }
+
+    async fn apply_mesh(
+        &self,
+        request: Request<MeshMembership>,
+    ) -> Result<Response<ApplyMeshResponse>, Status> {
+        let iface = std::env::var("SPUR_WG_INTERFACE").unwrap_or_else(|_| "spur0".into());
+        // proto -> spur-net mesh types.
+        let members: Vec<spur_net::mesh::MeshNode> = request
+            .into_inner()
+            .nodes
+            .into_iter()
+            .map(|n| spur_net::mesh::MeshNode {
+                hostname: n.hostname,
+                public_key: n.public_key,
+                mesh_ip: n.mesh_ip,
+                endpoint: n.endpoint,
+                pod_cidr: n.pod_cidr,
+            })
+            .collect();
+        let self_host = self.reporter.hostname.clone();
+
+        // All of this shells out to `wg` (blocking) — run it off the async runtime. Native-routing
+        // CNI owns the FIB routes, so program_routes = false.
+        let result =
+            tokio::task::spawn_blocking(move || -> anyhow::Result<(bool, usize, String)> {
+                // Identify self in the membership (so it's excluded from the peer set): prefer the local
+                // WireGuard public key, fall back to hostname.
+                let self_pubkey = spur_net::wireguard::interface_public_key(&iface).ok();
+                let self_mesh_ip = members
+                    .iter()
+                    .find(|n| {
+                        self_pubkey.as_deref() == Some(n.public_key.as_str())
+                            || n.hostname == self_host
+                    })
+                    .map(|n| n.mesh_ip.clone());
+                let Some(self_mesh_ip) = self_mesh_ip else {
+                    return Ok((
+                        false,
+                        0,
+                        "this node is not in the pushed mesh membership".to_string(),
+                    ));
+                };
+                // Reconcile: prune peers no longer in the membership, then add/update the desired peers.
+                let current = spur_net::wireguard::list_peers(&iface).unwrap_or_default();
+                let (added, pruned) = spur_net::mesh::reconcile_mesh(
+                    &iface,
+                    &self_mesh_ip,
+                    &members,
+                    &current,
+                    false,
+                )?;
+                Ok((
+                    true,
+                    added,
+                    format!("reconciled mesh: {added} peers, {pruned} pruned"),
+                ))
+            })
+            .await
+            .map_err(|e| Status::internal(format!("apply_mesh task panicked: {e}")))?;
+
+        match result {
+            Ok((applied, peers, message)) => {
+                if applied {
+                    info!(peers, message = %message, "applied WireGuard mesh");
+                } else {
+                    warn!(message = %message, "mesh not applied");
+                }
+                Ok(Response::new(ApplyMeshResponse {
+                    applied,
+                    peers: peers as u32,
+                    message,
+                }))
+            }
+            Err(e) => Ok(Response::new(ApplyMeshResponse {
+                applied: false,
+                peers: 0,
+                message: e.to_string(),
+            })),
+        }
+    }
 }
 
 impl AgentService {
@@ -1631,6 +1819,7 @@ mod tests {
                 source: spur_net::AddressSource::Static,
             },
             std::collections::HashMap::new(),
+            String::new(),
             String::new(),
         ))
     }

--- a/crates/spurd/src/cluster.rs
+++ b/crates/spurd/src/cluster.rs
@@ -433,6 +433,10 @@ pub struct K0sAgent {
     k0s_version: String,
     /// Directory k0s config + the join-token file are written to (`/etc/k0s`).
     config_dir: PathBuf,
+    /// Storage provisioner SPUR ships ("local-path" or "none"); [`ClusterConfig::storage_provisioner`].
+    storage_provisioner: String,
+    /// On-node PV directory for local-path; [`ClusterConfig::local_path_dir`].
+    local_path_dir: String,
     active: Mutex<Option<ClusterSupervisor>>,
 }
 
@@ -444,6 +448,8 @@ impl K0sAgent {
             k0s_binary: PathBuf::from(&cfg.k0s_binary),
             k0s_version: cfg.k0s_version.clone(),
             config_dir: PathBuf::from("/etc/k0s"),
+            storage_provisioner: cfg.storage_provisioner.clone(),
+            local_path_dir: cfg.local_path_dir.clone(),
             active: Mutex::new(None),
         }
     }
@@ -550,12 +556,43 @@ impl K0sAgent {
                 warn!(error = %e, "failed to write GPU CDI spec (continuing)");
             }
         }
+        // Control-plane nodes (controller/single) run k0s's manifest deployer, so ship the storage
+        // addon by writing its manifest there for k0s to apply (best-effort — a bad write must not
+        // block the control plane). k0s bundles no storage, so without this a PVC workload hangs.
+        if matches!(role, ClusterRole::Controller | ClusterRole::Single)
+            && self.storage_provisioner == "local-path"
+        {
+            if let Err(e) = self.write_local_path_manifest().await {
+                warn!(error = %e, "failed to write local-path storage manifest (continuing)");
+            }
+        }
         let sup = ClusterSupervisor::new(cfg);
         sup.reconcile_once().await?;
         let state = sup.component_state().await;
         *self.active.lock().await = Some(sup);
         info!(role = role.as_str(), state = %state, "k0s component started");
         Ok(state)
+    }
+
+    /// Ship the local-path storage provisioner: render the manifest with the configured PV directory
+    /// and write it into k0s's manifest-deployer dir, which the k0s controller applies + reconciles.
+    /// Control-plane only (that is where the manifest deployer runs). Idempotent — overwrites.
+    async fn write_local_path_manifest(&self) -> anyhow::Result<()> {
+        let dir = Path::new(spur_core::k0s::K0S_MANIFESTS_DIR).join("local-path");
+        tokio::fs::create_dir_all(&dir)
+            .await
+            .with_context(|| format!("create k0s manifests dir {}", dir.display()))?;
+        let manifest = spur_core::k0s::k0s_local_path_manifest(&self.local_path_dir);
+        let path = dir.join("local-path.yaml");
+        tokio::fs::write(&path, manifest)
+            .await
+            .with_context(|| format!("write {}", path.display()))?;
+        info!(
+            path = %path.display(),
+            data_dir = %self.local_path_dir,
+            "shipped local-path storage manifest to k0s manifest deployer"
+        );
+        Ok(())
     }
 
     /// Stop + disable this node's component (optionally `k0s reset`). If there is no tracked

--- a/crates/spurd/src/cluster.rs
+++ b/crates/spurd/src/cluster.rs
@@ -125,9 +125,11 @@ impl ClusterSupervisor {
     }
 
     /// Render the unit file. Mirrors k0s's own installer directives (see module docs for why
-    /// `Type=simple` / `KillMode=process` and not `notify` / `mixed`). `StartLimitIntervalSec=0`
-    /// disables systemd's restart rate-limit because this supervisor is the higher-level recovery
-    /// authority and must never be locked out by a burst limit.
+    /// `Type=simple` / `KillMode=process` and not `notify` / `mixed`). A finite
+    /// `StartLimitIntervalSec`/`StartLimitBurst` bounds a hard crash-loop (a genuinely broken node
+    /// stops hammering every `RestartSec`); the reconcile supervisor is the higher-level recovery
+    /// authority and re-enables the unit on its next tick, so the limit adds backoff without a
+    /// permanent lockout.
     fn render_unit(&self) -> String {
         let mut exec = format!(
             "{} {}",
@@ -156,7 +158,8 @@ impl ClusterSupervisor {
              ExecStart={exec}\n\
              Restart=always\n\
              RestartSec=10\n\
-             StartLimitIntervalSec=0\n\
+             StartLimitIntervalSec=300\n\
+             StartLimitBurst=5\n\
              Delegate=yes\n\
              KillMode=process\n\
              LimitCORE=infinity\n\
@@ -300,7 +303,7 @@ impl ClusterSupervisor {
         }
         self.disable_unit().await;
         if reset {
-            self.k0s_reset().await;
+            self.k0s_reset().await?;
         }
         Ok(())
     }
@@ -312,20 +315,22 @@ impl ClusterSupervisor {
         let _ = self.systemctl(&["disable", "--now", &unit]).await;
     }
 
-    /// `k0s reset` (destructive host-wide cleanup). Best-effort — logs, never fails the caller.
-    async fn k0s_reset(&self) {
-        match Command::new(&self.cfg.k0s_binary)
+    /// `k0s reset` (destructive host-wide cleanup). Returns an error if the reset fails so the
+    /// caller can report a partial teardown instead of a false success.
+    async fn k0s_reset(&self) -> anyhow::Result<()> {
+        let out = Command::new(&self.cfg.k0s_binary)
             .arg("reset")
             .output()
             .await
-        {
-            Ok(out) if !out.status.success() => warn!(
-                stderr = %String::from_utf8_lossy(&out.stderr).trim(),
-                "k0s reset reported an error"
-            ),
-            Err(e) => warn!(error = %e, "failed to run `k0s reset`"),
-            _ => {}
+            .context("failed to run `k0s reset`")?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "`k0s reset` failed ({}): {}",
+                out.status,
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
         }
+        Ok(())
     }
 }
 
@@ -562,7 +567,7 @@ impl K0sAgent {
         let taken = self.active.lock().await.take();
         match taken {
             Some(sup) => sup.stop(reset).await?,
-            None => self.stop_untracked(reset).await,
+            None => self.stop_untracked(reset).await?,
         }
         remove_cdi_spec().await;
         info!(reset, "k0s component stopped");
@@ -571,16 +576,18 @@ impl K0sAgent {
 
     /// Stop/disable any spurd-owned k0s unit present on the host (a node runs at most one, but both
     /// names are disabled idempotently), then `k0s reset` once if requested. Used when `active` is
-    /// empty so a lost in-memory state can't leave a running k0s unit behind.
-    async fn stop_untracked(&self, reset: bool) {
+    /// empty so a lost in-memory state can't leave a running k0s unit behind. A failed reset is
+    /// surfaced so `down --reset` reports the partial teardown rather than a false success.
+    async fn stop_untracked(&self, reset: bool) -> anyhow::Result<()> {
         for role in [ClusterRole::Controller, ClusterRole::Worker] {
             self.probe_supervisor(role).disable_unit().await;
         }
         if reset {
             self.probe_supervisor(ClusterRole::Controller)
                 .k0s_reset()
-                .await;
+                .await?;
         }
+        Ok(())
     }
 
     /// Mint a k0s join token on this (control-plane) node via `k0s token create`. Returns the

--- a/crates/spurd/src/cluster.rs
+++ b/crates/spurd/src/cluster.rs
@@ -97,6 +97,11 @@ pub struct ClusterConfig {
 }
 
 /// Owns and reconciles a single spurd-managed k0s systemd unit.
+///
+/// `Clone` so `K0sAgent` can snapshot the current supervisor out from under its `active` mutex and
+/// then do the (blocking, seconds-long) systemctl/k0s IO WITHOUT holding the lock — otherwise a
+/// stop/reconcile would serialize concurrent status/start RPCs behind it.
+#[derive(Clone)]
 pub struct ClusterSupervisor {
     cfg: ClusterConfig,
     /// systemd unit directory (overridable in tests; `/etc/systemd/system` in production).
@@ -357,12 +362,23 @@ fn parse_execstart(exec: &str) -> anyhow::Result<ClusterConfig> {
 
 /// Write a bearer-secret file (0600). Content is never logged.
 async fn write_secret_file(path: &Path, content: &[u8]) -> anyhow::Result<()> {
-    tokio::fs::write(path, content).await?;
+    use tokio::io::AsyncWriteExt;
+    let mut opts = tokio::fs::OpenOptions::new();
+    opts.write(true).create(true).truncate(true);
+    // Create with 0600 from the start so a bearer token is never briefly world-readable through
+    // the umask-dependent default (the previous write-then-chmod left such a window).
+    #[cfg(unix)]
+    opts.mode(0o600);
+    let mut f = opts.open(path).await?;
     #[cfg(unix)]
     {
+        // Also tighten an already-existing file (mode() only applies on create).
         use std::os::unix::fs::PermissionsExt;
-        tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).await?;
+        f.set_permissions(std::fs::Permissions::from_mode(0o600))
+            .await?;
     }
+    f.write_all(content).await?;
+    f.flush().await?;
     Ok(())
 }
 
@@ -497,7 +513,9 @@ impl K0sAgent {
             ),
         }
 
-        tokio::fs::create_dir_all(&self.config_dir).await.ok();
+        tokio::fs::create_dir_all(&self.config_dir)
+            .await
+            .with_context(|| format!("create k0s config dir {}", self.config_dir.display()))?;
         let join_token_file = match join_token {
             Some(tok) => {
                 let p = self.config_dir.join("token");
@@ -539,12 +557,13 @@ impl K0sAgent {
     /// component (e.g. spurd restarted and adoption found/parsed nothing), it still stops/resets any
     /// spurd-owned k0s unit present on the host — so `down --reset` is never silently a no-op.
     pub async fn stop(&self, reset: bool) -> anyhow::Result<()> {
-        let mut guard = self.active.lock().await;
-        match guard.as_ref() {
+        // Take the supervisor out under the lock, then do the (blocking) stop OUTSIDE it so
+        // concurrent status/start RPCs aren't serialized behind the seconds-long systemctl/k0s IO.
+        let taken = self.active.lock().await.take();
+        match taken {
             Some(sup) => sup.stop(reset).await?,
             None => self.stop_untracked(reset).await,
         }
-        *guard = None;
         remove_cdi_spec().await;
         info!(reset, "k0s component stopped");
         Ok(())
@@ -616,16 +635,15 @@ impl K0sAgent {
     /// it probes the actual spurd-owned units so a restarted spurd (before/without adoption) still
     /// reports the truth instead of a false `inactive`.
     pub async fn status(&self) -> (String, String, bool) {
-        {
-            let guard = self.active.lock().await;
-            if let Some(sup) = guard.as_ref() {
-                let enabled = sup.unit_status_is(&["is-enabled"], "enabled").await;
-                return (
-                    sup.role().as_str().to_string(),
-                    sup.component_state().await,
-                    enabled,
-                );
-            }
+        // Snapshot out of the lock, then query systemctl OUTSIDE it (avoids serializing RPCs).
+        let tracked = self.active.lock().await.clone();
+        if let Some(sup) = tracked {
+            let enabled = sup.unit_status_is(&["is-enabled"], "enabled").await;
+            return (
+                sup.role().as_str().to_string(),
+                sup.component_state().await,
+                enabled,
+            );
         }
         // Untracked: report a running spurd-owned unit if there is one (Controller/Single share a
         // unit name — reported as "controller").
@@ -646,8 +664,10 @@ impl K0sAgent {
         let mut interval = tokio::time::interval(Duration::from_secs(30));
         loop {
             interval.tick().await;
-            let guard = self.active.lock().await;
-            if let Some(sup) = guard.as_ref() {
+            // Snapshot the supervisor, then reconcile OUTSIDE the lock (reconcile shells out + does
+            // filesystem IO; holding the lock would serialize concurrent start/stop/status RPCs).
+            let sup = self.active.lock().await.clone();
+            if let Some(sup) = sup {
                 if let Err(e) = sup.reconcile_once().await {
                     warn!(error = %e, "k0s component reconcile failed");
                 }

--- a/crates/spurd/src/cluster.rs
+++ b/crates/spurd/src/cluster.rs
@@ -1,0 +1,824 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Spurd-owned k0s systemd unit supervisor.
+//!
+//! SPUR owns the k0s lifecycle by OWNING a systemd unit for `k0s controller` / `k0s worker`
+//! rather than forking k0s as a spurd child job. As a consequence k0s:
+//!   * survives a spurd restart (it is not a spurd-parented process, so its delegated
+//!     containerd/kubelet/pod cgroup is not orphaned when spurd exits), and
+//!   * stays entirely out of the executor / `start_monitor` (2s reaper) / `enforce_time_limits`
+//!     (SIGTERM->SIGKILL) job path, which would otherwise drop or kill a long-running cluster.
+//!
+//! Recovery is split between systemd and this supervisor (validated on a real host):
+//!   * process crash / `systemctl kill`     -> systemd's own `Restart=always` re-spawns it.
+//!   * unit deleted / disabled / stopped / config-drifted -> this supervisor's reconcile loop
+//!     re-writes + re-enables + re-starts the unit.
+//!
+//! The unit uses the same directives k0s's own installer emits: `Type=simple` (k0s does NOT
+//! `sd_notify`, so `Type=notify` would hang forever in `activating`), `KillMode=process`
+//! (deliberately leaves the delegated containerd/kubelet/pod cgroup alone on stop, unlike
+//! `KillMode=mixed` which would SIGKILL it), `Delegate=yes`, and `Restart=always`.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use tokio::process::Command;
+use tokio::sync::Mutex;
+use tracing::{info, warn};
+
+/// Which k0s role this node's spurd-owned unit runs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ClusterRole {
+    /// `k0s controller` — control-plane only (head node).
+    Controller,
+    /// `k0s worker` — GPU worker; requires a join token.
+    Worker,
+    /// `k0s controller --single` — all-in-one control-plane+worker (dev / single-node).
+    Single,
+}
+
+impl ClusterRole {
+    /// systemd unit base name (matches k0s's own convention).
+    fn unit_name(self) -> &'static str {
+        match self {
+            ClusterRole::Worker => "k0sworker",
+            ClusterRole::Controller | ClusterRole::Single => "k0scontroller",
+        }
+    }
+
+    /// `k0s` subcommand + role flags for `ExecStart`.
+    fn exec_args(self) -> &'static str {
+        match self {
+            ClusterRole::Controller => "controller",
+            ClusterRole::Worker => "worker",
+            ClusterRole::Single => "controller --single=true",
+        }
+    }
+
+    /// Wire string for the role (matches the controller's `StartClusterComponentRequest.role`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ClusterRole::Controller => "controller",
+            ClusterRole::Worker => "worker",
+            ClusterRole::Single => "single",
+        }
+    }
+
+    /// Parse the controller-supplied role string.
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "controller" => Some(ClusterRole::Controller),
+            "worker" => Some(ClusterRole::Worker),
+            "single" => Some(ClusterRole::Single),
+            _ => None,
+        }
+    }
+}
+
+/// Inputs the supervisor needs to own a k0s unit.
+///
+/// Increment-2 prototype: sourced from env (`from_env`). Later increments populate this from
+/// `spur_core` `ClusterConfig` + a controller-supplied role/join-token over the agent RPC.
+#[derive(Clone, Debug)]
+pub struct ClusterConfig {
+    pub role: ClusterRole,
+    /// Path to the `k0s` binary (`ConditionFileIsExecutable` + `ExecStart`).
+    pub k0s_binary: PathBuf,
+    /// `--config` path the unit passes to k0s (None for `--single` dev).
+    pub k0s_config: Option<PathBuf>,
+    /// `--token-file` for a worker join (None for a controller).
+    pub join_token_file: Option<PathBuf>,
+    /// Worker kubelet `--node-ip` (its mesh IP) for a native-routing CNI. None = k0s default.
+    pub node_ip: Option<String>,
+}
+
+/// Owns and reconciles a single spurd-managed k0s systemd unit.
+pub struct ClusterSupervisor {
+    cfg: ClusterConfig,
+    /// systemd unit directory (overridable in tests; `/etc/systemd/system` in production).
+    unit_dir: PathBuf,
+}
+
+impl ClusterSupervisor {
+    pub fn new(cfg: ClusterConfig) -> Self {
+        Self {
+            cfg,
+            unit_dir: PathBuf::from("/etc/systemd/system"),
+        }
+    }
+
+    fn unit_file_name(&self) -> String {
+        format!("{}.service", self.cfg.role.unit_name())
+    }
+
+    fn unit_path(&self) -> PathBuf {
+        self.unit_dir.join(self.unit_file_name())
+    }
+
+    /// Render the unit file. Mirrors k0s's own installer directives (see module docs for why
+    /// `Type=simple` / `KillMode=process` and not `notify` / `mixed`). `StartLimitIntervalSec=0`
+    /// disables systemd's restart rate-limit because this supervisor is the higher-level recovery
+    /// authority and must never be locked out by a burst limit.
+    fn render_unit(&self) -> String {
+        let mut exec = format!(
+            "{} {}",
+            self.cfg.k0s_binary.display(),
+            self.cfg.role.exec_args()
+        );
+        if let Some(cfg) = &self.cfg.k0s_config {
+            exec.push_str(&format!(" --config={}", cfg.display()));
+        }
+        if let Some(tok) = &self.cfg.join_token_file {
+            exec.push_str(&format!(" --token-file={}", tok.display()));
+        }
+        if let Some(ip) = &self.cfg.node_ip {
+            // Pin kubelet's node IP to the mesh IP so a native-routing CNI peers over the mesh.
+            exec.push_str(&format!(" --kubelet-extra-args=--node-ip={ip}"));
+        }
+        format!(
+            "[Unit]\n\
+             Description=k0s {role} (managed by spurd)\n\
+             Documentation=https://docs.k0sproject.io\n\
+             ConditionFileIsExecutable={bin}\n\
+             After=network-online.target\n\
+             Wants=network-online.target\n\
+             \n\
+             [Service]\n\
+             ExecStart={exec}\n\
+             Restart=always\n\
+             RestartSec=10\n\
+             StartLimitIntervalSec=0\n\
+             Delegate=yes\n\
+             KillMode=process\n\
+             LimitCORE=infinity\n\
+             LimitNOFILE=999999\n\
+             TasksMax=infinity\n\
+             TimeoutStartSec=0\n\
+             \n\
+             [Install]\n\
+             WantedBy=multi-user.target\n",
+            role = self.cfg.role.unit_name(),
+            bin = self.cfg.k0s_binary.display(),
+            exec = exec,
+        )
+    }
+
+    /// One reconcile pass. Returns `Ok(true)` if it changed anything (wrote/enabled/started).
+    /// Idempotent: a steady-state healthy unit is a no-op.
+    pub async fn reconcile_once(&self) -> anyhow::Result<bool> {
+        // Distinguish "cannot reach systemd" (transient/environment) from "k0s degraded".
+        if !self.systemd_available().await {
+            warn!("systemctl unavailable; skipping cluster reconcile this tick");
+            return Ok(false);
+        }
+
+        let mut changed = false;
+
+        // 1. Ensure the unit file exists and matches desired content.
+        let desired = self.render_unit();
+        let path = self.unit_path();
+        let needs_write = match tokio::fs::read_to_string(&path).await {
+            Ok(current) => current != desired,
+            Err(_) => true,
+        };
+        if needs_write {
+            info!(unit = %path.display(), "writing/updating spurd-owned k0s unit file");
+            self.write_unit_atomic(&path, &desired).await?;
+            self.systemctl(&["daemon-reload"]).await?;
+            changed = true;
+        }
+
+        // 2. Ensure enabled (survives reboot).
+        if !self.unit_status_is(&["is-enabled"], "enabled").await {
+            info!(unit = %self.unit_file_name(), "enabling unit");
+            self.systemctl(&["enable", &self.unit_file_name()]).await?;
+            changed = true;
+        }
+
+        // 3. Ensure active. systemd `Restart=always` handles process crashes; this catches a unit
+        //    that was stopped/disabled out-of-band (which Restart= does not cover).
+        if !self.unit_status_is(&["is-active"], "active").await {
+            info!(unit = %self.unit_file_name(), "unit not active; starting");
+            self.systemctl(&["start", &self.unit_file_name()]).await?;
+            changed = true;
+        }
+
+        Ok(changed)
+    }
+
+    async fn systemd_available(&self) -> bool {
+        Command::new("systemctl")
+            .arg("--version")
+            .output()
+            .await
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    /// Atomic write: temp file in the same dir, then rename (containerd/systemd never see a
+    /// partial unit file).
+    async fn write_unit_atomic(&self, path: &Path, content: &str) -> anyhow::Result<()> {
+        let mut tmp = OsString::from(path.as_os_str());
+        tmp.push(".tmp");
+        let tmp = PathBuf::from(tmp);
+        tokio::fs::write(&tmp, content).await?;
+        tokio::fs::rename(&tmp, path).await?;
+        Ok(())
+    }
+
+    async fn systemctl(&self, args: &[&str]) -> anyhow::Result<()> {
+        let out = Command::new("systemctl").args(args).output().await?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "systemctl {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
+        }
+        Ok(())
+    }
+
+    /// `systemctl <verb> <unit>` and compare the trimmed stdout to `expect`
+    /// (e.g. is-active -> "active", is-enabled -> "enabled").
+    async fn unit_status_is(&self, verb: &[&str], expect: &str) -> bool {
+        let unit = self.unit_file_name();
+        let mut args: Vec<&str> = verb.to_vec();
+        args.push(&unit);
+        Command::new("systemctl")
+            .args(&args)
+            .output()
+            .await
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim() == expect)
+            .unwrap_or(false)
+    }
+
+    /// systemd active-state of the unit ("active"/"inactive"/"failed"/"activating"/"unknown").
+    async fn component_state(&self) -> String {
+        let unit = self.unit_file_name();
+        Command::new("systemctl")
+            .args(["show", &unit, "-p", "ActiveState", "--value"])
+            .output()
+            .await
+            .ok()
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "unknown".to_string())
+    }
+
+    fn role(&self) -> ClusterRole {
+        self.cfg.role
+    }
+
+    /// Parse this unit's rendered `ExecStart` back into a `ClusterConfig` (recovering the exact
+    /// role — incl. `Single` via `--single` — the k0s binary, and any `--config`/`--token-file`
+    /// paths), so a rebuilt supervisor re-renders an identical unit and reconcile stays a no-op.
+    async fn read_cfg_from_unit(&self) -> anyhow::Result<ClusterConfig> {
+        let path = self.unit_path();
+        let content = tokio::fs::read_to_string(&path)
+            .await
+            .with_context(|| format!("read unit file {}", path.display()))?;
+        let exec = content
+            .lines()
+            .find_map(|l| l.trim().strip_prefix("ExecStart="))
+            .context("unit file has no ExecStart= line")?;
+        parse_execstart(exec)
+    }
+
+    /// Stop + disable the unit; optionally `k0s reset` (destructive). Idempotent.
+    async fn stop(&self, reset: bool) -> anyhow::Result<()> {
+        if !self.systemd_available().await {
+            anyhow::bail!("systemctl unavailable");
+        }
+        self.disable_unit().await;
+        if reset {
+            self.k0s_reset().await;
+        }
+        Ok(())
+    }
+
+    /// `systemctl disable --now <unit>` — stop + remove the enable symlink. Idempotent (ignores an
+    /// absent unit).
+    async fn disable_unit(&self) {
+        let unit = self.unit_file_name();
+        let _ = self.systemctl(&["disable", "--now", &unit]).await;
+    }
+
+    /// `k0s reset` (destructive host-wide cleanup). Best-effort — logs, never fails the caller.
+    async fn k0s_reset(&self) {
+        match Command::new(&self.cfg.k0s_binary)
+            .arg("reset")
+            .output()
+            .await
+        {
+            Ok(out) if !out.status.success() => warn!(
+                stderr = %String::from_utf8_lossy(&out.stderr).trim(),
+                "k0s reset reported an error"
+            ),
+            Err(e) => warn!(error = %e, "failed to run `k0s reset`"),
+            _ => {}
+        }
+    }
+}
+
+/// Parse a spurd-rendered k0s `ExecStart` value — `<bin> (controller|worker) [--single=true]
+/// [--config=P] [--token-file=P]` — back into a [`ClusterConfig`]. Used to re-adopt a running unit
+/// after a spurd restart (the unit file is the authoritative record of what spurd started).
+fn parse_execstart(exec: &str) -> anyhow::Result<ClusterConfig> {
+    let mut parts = exec.split_whitespace();
+    let bin = parts.next().context("empty ExecStart")?;
+    let subcmd = parts.next().context("ExecStart missing k0s subcommand")?;
+    let rest: Vec<&str> = parts.collect();
+    let role = match subcmd {
+        "worker" => ClusterRole::Worker,
+        "controller" if rest.iter().any(|a| a.starts_with("--single")) => ClusterRole::Single,
+        "controller" => ClusterRole::Controller,
+        other => anyhow::bail!("unexpected k0s subcommand in ExecStart: {other}"),
+    };
+    let flag_value = |name: &str| {
+        rest.iter()
+            .find_map(|a| a.strip_prefix(name).map(PathBuf::from))
+    };
+    let node_ip = rest.iter().find_map(|a| {
+        a.strip_prefix("--kubelet-extra-args=--node-ip=")
+            .map(String::from)
+    });
+    Ok(ClusterConfig {
+        role,
+        k0s_binary: PathBuf::from(bin),
+        k0s_config: flag_value("--config="),
+        join_token_file: flag_value("--token-file="),
+        node_ip,
+    })
+}
+
+/// Write a bearer-secret file (0600). Content is never logged.
+async fn write_secret_file(path: &Path, content: &[u8]) -> anyhow::Result<()> {
+    tokio::fs::write(path, content).await?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).await?;
+    }
+    Ok(())
+}
+
+/// Path of the AMD GPU CDI spec written for k0s's containerd.
+const CDI_SPEC_PATH: &str = "/etc/cdi/amd.json";
+
+/// Discover local AMD GPUs and write a CDI spec to `/etc/cdi` so k0s's containerd can inject
+/// `amd.com/gpu` into pods. No-op when the node has no GPUs — containerd rejects
+/// a device-empty spec. Atomic (temp + rename). NOTE: `amd.com/gpu` is also claimed by the ROCm
+/// k8s-device-plugin; acceptable for Phase-2 containerd injection — a native spur-device-plugin is
+/// a later milestone.
+async fn write_cdi_spec() -> anyhow::Result<()> {
+    let specs = spur_devices::cdi::discovery::discover_to_cdi();
+    if specs.is_empty() {
+        info!("no AMD GPUs discovered; not writing a CDI spec");
+        return Ok(());
+    }
+    tokio::fs::create_dir_all("/etc/cdi").await?;
+    for (i, spec) in specs.iter().enumerate() {
+        spec.validate()
+            .map_err(|e| anyhow::anyhow!("invalid CDI spec: {e}"))?;
+        let final_path = if i == 0 {
+            CDI_SPEC_PATH.to_string()
+        } else {
+            format!("/etc/cdi/amd-{i}.json")
+        };
+        let tmp = format!("{final_path}.tmp");
+        spec.write_json(Path::new(&tmp))
+            .map_err(|e| anyhow::anyhow!("write CDI spec: {e}"))?;
+        tokio::fs::rename(&tmp, &final_path).await?;
+    }
+    info!(count = specs.len(), "wrote AMD GPU CDI spec(s) to /etc/cdi");
+    Ok(())
+}
+
+/// Remove the CDI spec on teardown (best-effort).
+async fn remove_cdi_spec() {
+    let _ = tokio::fs::remove_file(CDI_SPEC_PATH).await;
+}
+
+/// RPC-driven owner of this node's k0s component. The spurctld controller
+/// (`cluster_k8s`) drives it via the SlurmAgent Start/Stop/GetClusterComponentStatus RPCs. It
+/// holds the currently-desired `ClusterSupervisor` and heals its unit from a background loop.
+pub struct K0sAgent {
+    k0s_binary: PathBuf,
+    /// k0s release to install if the binary is missing (a tag or "latest").
+    k0s_version: String,
+    /// Directory k0s config + the join-token file are written to (`/etc/k0s`).
+    config_dir: PathBuf,
+    active: Mutex<Option<ClusterSupervisor>>,
+}
+
+impl K0sAgent {
+    /// Build from the `[cluster]` config so operators can override the k0s version + install path.
+    /// (`ClusterConfig::default()` yields the pinned version + `/usr/local/bin/k0s`.)
+    pub fn from_config(cfg: &spur_core::config::ClusterConfig) -> Self {
+        Self {
+            k0s_binary: PathBuf::from(&cfg.k0s_binary),
+            k0s_version: cfg.k0s_version.clone(),
+            config_dir: PathBuf::from("/etc/k0s"),
+            active: Mutex::new(None),
+        }
+    }
+
+    /// Re-adopt an already-running spurd-owned k0s unit at startup. A spurd restart leaves the k0s
+    /// systemd unit running (by design) but `active` empty, so `status()` would report `inactive`
+    /// and `supervise()` would idle for a unit it owns. This probes the two unit names, and on the
+    /// active one rebuilds the `ClusterSupervisor` from the unit's `ExecStart`. No-op (best-effort)
+    /// when neither unit is active; call before spawning `supervise()`.
+    /// A bare `ClusterSupervisor` for `role` (no config/token) — used to probe/stop the actual
+    /// spurd-owned units by name when there is no tracked component.
+    fn probe_supervisor(&self, role: ClusterRole) -> ClusterSupervisor {
+        ClusterSupervisor::new(ClusterConfig {
+            role,
+            k0s_binary: self.k0s_binary.clone(),
+            k0s_config: None,
+            join_token_file: None,
+            node_ip: None,
+        })
+    }
+
+    pub async fn adopt_running_unit(&self) {
+        // Controller & Single share k0scontroller.service; the ExecStart disambiguates them.
+        for probe_role in [ClusterRole::Controller, ClusterRole::Worker] {
+            let probe = self.probe_supervisor(probe_role);
+            if !probe.unit_status_is(&["is-active"], "active").await {
+                continue;
+            }
+            match probe.read_cfg_from_unit().await {
+                Ok(cfg) => {
+                    let role = cfg.role;
+                    *self.active.lock().await = Some(ClusterSupervisor::new(cfg));
+                    info!(
+                        role = role.as_str(),
+                        "adopted already-running k0s unit on startup"
+                    );
+                }
+                Err(e) => warn!(
+                    unit = probe_role.unit_name(),
+                    error = %e,
+                    "found an active k0s unit but could not parse its ExecStart; not adopting"
+                ),
+            }
+            return; // at most one k0s unit runs per node
+        }
+    }
+
+    /// Start (or update) this node's k0s component. Writes the join token (0600) + k0s config to
+    /// files, then reconciles the spurd-owned unit. Returns the resulting systemd active-state.
+    /// The plaintext `join_token` is never logged.
+    pub async fn start(
+        &self,
+        role: ClusterRole,
+        join_token: Option<String>,
+        k0s_config: Option<String>,
+        node_ip: Option<String>,
+    ) -> anyhow::Result<String> {
+        // Make a fresh bare-metal node self-contained: install the pinned/configured k0s if the
+        // binary is missing. No-op (no network) when it is already present. A failure here is fatal
+        // to start — the systemd unit's ConditionFileIsExecutable would otherwise silently skip.
+        match spur_update::k0s::ensure_k0s(&self.k0s_version, &self.k0s_binary).await {
+            Ok(Some(info)) => info!(
+                version = %info.version,
+                path = %info.path.display(),
+                "installed k0s"
+            ),
+            Ok(None) => {}
+            Err(e) => anyhow::bail!(
+                "k0s not present at {} and auto-install (version {}) failed: {e}",
+                self.k0s_binary.display(),
+                self.k0s_version
+            ),
+        }
+
+        tokio::fs::create_dir_all(&self.config_dir).await.ok();
+        let join_token_file = match join_token {
+            Some(tok) => {
+                let p = self.config_dir.join("token");
+                write_secret_file(&p, tok.as_bytes()).await?;
+                Some(p)
+            }
+            None => None,
+        };
+        let k0s_config = match k0s_config {
+            Some(yaml) => {
+                let p = self.config_dir.join("k0s.yaml");
+                tokio::fs::write(&p, yaml).await?;
+                Some(p)
+            }
+            None => None,
+        };
+        let cfg = ClusterConfig {
+            role,
+            k0s_binary: self.k0s_binary.clone(),
+            k0s_config,
+            join_token_file,
+            node_ip,
+        };
+        // Worker/single nodes run pods, so write the GPU CDI spec before k0s starts (best-effort).
+        if role != ClusterRole::Controller {
+            if let Err(e) = write_cdi_spec().await {
+                warn!(error = %e, "failed to write GPU CDI spec (continuing)");
+            }
+        }
+        let sup = ClusterSupervisor::new(cfg);
+        sup.reconcile_once().await?;
+        let state = sup.component_state().await;
+        *self.active.lock().await = Some(sup);
+        info!(role = role.as_str(), state = %state, "k0s component started");
+        Ok(state)
+    }
+
+    /// Stop + disable this node's component (optionally `k0s reset`). If there is no tracked
+    /// component (e.g. spurd restarted and adoption found/parsed nothing), it still stops/resets any
+    /// spurd-owned k0s unit present on the host — so `down --reset` is never silently a no-op.
+    pub async fn stop(&self, reset: bool) -> anyhow::Result<()> {
+        let mut guard = self.active.lock().await;
+        match guard.as_ref() {
+            Some(sup) => sup.stop(reset).await?,
+            None => self.stop_untracked(reset).await,
+        }
+        *guard = None;
+        remove_cdi_spec().await;
+        info!(reset, "k0s component stopped");
+        Ok(())
+    }
+
+    /// Stop/disable any spurd-owned k0s unit present on the host (a node runs at most one, but both
+    /// names are disabled idempotently), then `k0s reset` once if requested. Used when `active` is
+    /// empty so a lost in-memory state can't leave a running k0s unit behind.
+    async fn stop_untracked(&self, reset: bool) {
+        for role in [ClusterRole::Controller, ClusterRole::Worker] {
+            self.probe_supervisor(role).disable_unit().await;
+        }
+        if reset {
+            self.probe_supervisor(ClusterRole::Controller)
+                .k0s_reset()
+                .await;
+        }
+    }
+
+    /// Mint a k0s join token on this (control-plane) node via `k0s token create`. Returns the
+    /// plaintext token (bearer secret — never logged). Errors on a non-control-plane node or before
+    /// the k0s controller API is reachable; the controller retries on the next reconcile tick.
+    pub async fn create_join_token(
+        &self,
+        role: &str,
+        expiry_seconds: u64,
+    ) -> anyhow::Result<String> {
+        let mut cmd = Command::new(&self.k0s_binary);
+        cmd.args(["token", "create", "--role", role]);
+        if expiry_seconds > 0 {
+            cmd.args(["--expiry", &format!("{expiry_seconds}s")]);
+        }
+        let out = cmd.output().await?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "k0s token create --role {role} failed: {}",
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
+        }
+        let token = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        if token.is_empty() {
+            anyhow::bail!("k0s token create returned an empty token");
+        }
+        info!(role, "minted k0s join token"); // token value never logged
+        Ok(token)
+    }
+
+    /// Read the admin kubeconfig on this (control-plane) node via `k0s kubeconfig admin`. Returns
+    /// the YAML. Errors on a non-control-plane node (no local admin credentials).
+    pub async fn admin_kubeconfig(&self) -> anyhow::Result<String> {
+        let out = Command::new(&self.k0s_binary)
+            .args(["kubeconfig", "admin"])
+            .output()
+            .await?;
+        if !out.status.success() {
+            anyhow::bail!(
+                "k0s kubeconfig admin failed: {}",
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
+        }
+        let kubeconfig = String::from_utf8_lossy(&out.stdout).to_string();
+        if kubeconfig.trim().is_empty() {
+            anyhow::bail!("k0s kubeconfig admin returned empty output");
+        }
+        Ok(kubeconfig)
+    }
+
+    /// (role, active_state, enabled) for the node's component. When there is no tracked component,
+    /// it probes the actual spurd-owned units so a restarted spurd (before/without adoption) still
+    /// reports the truth instead of a false `inactive`.
+    pub async fn status(&self) -> (String, String, bool) {
+        {
+            let guard = self.active.lock().await;
+            if let Some(sup) = guard.as_ref() {
+                let enabled = sup.unit_status_is(&["is-enabled"], "enabled").await;
+                return (
+                    sup.role().as_str().to_string(),
+                    sup.component_state().await,
+                    enabled,
+                );
+            }
+        }
+        // Untracked: report a running spurd-owned unit if there is one (Controller/Single share a
+        // unit name — reported as "controller").
+        for role in [ClusterRole::Worker, ClusterRole::Controller] {
+            let probe = self.probe_supervisor(role);
+            let state = probe.component_state().await;
+            if state != "inactive" && state != "unknown" {
+                let enabled = probe.unit_status_is(&["is-enabled"], "enabled").await;
+                return (role.as_str().to_string(), state, enabled);
+            }
+        }
+        (String::new(), "inactive".to_string(), false)
+    }
+
+    /// Background heal loop: keep the active component's unit reconciled. Spawned from spurd
+    /// `main()`; idle (no-op) until a `start` sets an active component.
+    pub async fn supervise(self: Arc<Self>) {
+        let mut interval = tokio::time::interval(Duration::from_secs(30));
+        loop {
+            interval.tick().await;
+            let guard = self.active.lock().await;
+            if let Some(sup) = guard.as_ref() {
+                if let Err(e) = sup.reconcile_once().await {
+                    warn!(error = %e, "k0s component reconcile failed");
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_controller_unit_with_validated_directives() {
+        let sup = ClusterSupervisor::new(ClusterConfig {
+            role: ClusterRole::Single,
+            k0s_binary: PathBuf::from("/usr/local/bin/k0s"),
+            k0s_config: None,
+            join_token_file: None,
+            node_ip: None,
+        });
+        let unit = sup.render_unit();
+        assert!(unit.contains("ExecStart=/usr/local/bin/k0s controller --single=true"));
+        // The directives that make a spurd-owned k0s unit behave correctly.
+        assert!(unit.contains("KillMode=process"));
+        assert!(unit.contains("Delegate=yes"));
+        assert!(unit.contains("Restart=always"));
+        // k0s does not sd_notify: the unit must NOT be Type=notify (default simple is correct).
+        assert!(!unit.contains("Type=notify"));
+        assert_eq!(sup.unit_file_name(), "k0scontroller.service");
+    }
+
+    #[test]
+    fn worker_unit_carries_config_and_token() {
+        let sup = ClusterSupervisor::new(ClusterConfig {
+            role: ClusterRole::Worker,
+            k0s_binary: PathBuf::from("/usr/local/bin/k0s"),
+            k0s_config: Some(PathBuf::from("/etc/k0s/k0s.yaml")),
+            join_token_file: Some(PathBuf::from("/etc/k0s/token")),
+            node_ip: Some("10.44.0.2".to_string()),
+        });
+        let unit = sup.render_unit();
+        assert!(unit.contains("k0s worker"));
+        assert!(unit.contains("--config=/etc/k0s/k0s.yaml"));
+        assert!(unit.contains("--token-file=/etc/k0s/token"));
+        assert!(unit.contains("--kubelet-extra-args=--node-ip=10.44.0.2"));
+        assert_eq!(sup.unit_file_name(), "k0sworker.service");
+    }
+
+    #[test]
+    fn parse_execstart_recovers_role_and_paths() {
+        let single = parse_execstart("/usr/local/bin/k0s controller --single=true").unwrap();
+        assert_eq!(single.role, ClusterRole::Single);
+        assert_eq!(single.k0s_binary, PathBuf::from("/usr/local/bin/k0s"));
+        assert!(single.k0s_config.is_none() && single.join_token_file.is_none());
+
+        let ctrl = parse_execstart("/opt/k0s controller --config=/etc/k0s/k0s.yaml").unwrap();
+        assert_eq!(ctrl.role, ClusterRole::Controller);
+        assert_eq!(ctrl.k0s_binary, PathBuf::from("/opt/k0s"));
+        assert_eq!(ctrl.k0s_config, Some(PathBuf::from("/etc/k0s/k0s.yaml")));
+
+        let worker = parse_execstart(
+            "/usr/local/bin/k0s worker --token-file=/etc/k0s/token --kubelet-extra-args=--node-ip=10.44.0.2",
+        )
+        .unwrap();
+        assert_eq!(worker.role, ClusterRole::Worker);
+        assert_eq!(
+            worker.join_token_file,
+            Some(PathBuf::from("/etc/k0s/token"))
+        );
+        assert_eq!(worker.node_ip.as_deref(), Some("10.44.0.2"));
+
+        assert!(parse_execstart("").is_err());
+        assert!(parse_execstart("/usr/local/bin/k0s bogus").is_err());
+    }
+
+    /// The adopt path must re-render an *identical* unit, so a rendered ExecStart must parse back
+    /// into a cfg whose re-render matches (otherwise reconcile_once would rewrite the file).
+    #[test]
+    fn execstart_render_parse_roundtrip() {
+        for cfg in [
+            ClusterConfig {
+                role: ClusterRole::Single,
+                k0s_binary: PathBuf::from("/usr/local/bin/k0s"),
+                k0s_config: None,
+                join_token_file: None,
+                node_ip: None,
+            },
+            ClusterConfig {
+                role: ClusterRole::Worker,
+                k0s_binary: PathBuf::from("/usr/local/bin/k0s"),
+                k0s_config: Some(PathBuf::from("/etc/k0s/k0s.yaml")),
+                join_token_file: Some(PathBuf::from("/etc/k0s/token")),
+                node_ip: Some("10.44.0.2".to_string()),
+            },
+        ] {
+            let unit = ClusterSupervisor::new(cfg.clone()).render_unit();
+            let exec = unit
+                .lines()
+                .find_map(|l| l.trim().strip_prefix("ExecStart="))
+                .unwrap();
+            let parsed = parse_execstart(exec).unwrap();
+            assert_eq!(parsed.role, cfg.role);
+            assert_eq!(parsed.k0s_binary, cfg.k0s_binary);
+            assert_eq!(parsed.k0s_config, cfg.k0s_config);
+            assert_eq!(parsed.join_token_file, cfg.join_token_file);
+            assert_eq!(parsed.node_ip, cfg.node_ip);
+            // Re-rendered unit is byte-identical -> reconcile stays a no-op.
+            assert_eq!(ClusterSupervisor::new(parsed).render_unit(), unit);
+        }
+    }
+
+    /// Live de-risk: exercises the real reconcile against systemd + k0s. Gated behind
+    /// `SPUR_CLUSTER_DERISK=1` and requires root on a Linux host with systemd + k0s installed
+    /// (single-node). Run on shark-a:
+    ///   sudo -E ~/.cargo/bin/cargo test -p spurd cluster::tests::derisk -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore = "requires root + systemd + k0s; run explicitly on a Linux host"]
+    async fn derisk_supervise_recovers_unit() {
+        if std::env::var_os("SPUR_CLUSTER_DERISK").is_none() {
+            eprintln!("skip: set SPUR_CLUSTER_DERISK=1 and run as root to exercise this");
+            return;
+        }
+        let sup = ClusterSupervisor::new(ClusterConfig {
+            role: ClusterRole::Single,
+            k0s_binary: PathBuf::from("/usr/local/bin/k0s"),
+            k0s_config: None,
+            join_token_file: None,
+            node_ip: None,
+        });
+
+        // 1. Fresh apply: unit written, enabled, active.
+        sup.reconcile_once().await.expect("initial reconcile");
+        assert!(
+            sup.unit_status_is(&["is-active"], "active").await,
+            "active after reconcile"
+        );
+        assert!(
+            sup.unit_status_is(&["is-enabled"], "enabled").await,
+            "enabled after reconcile"
+        );
+
+        // 2. Out-of-band disable+stop -> reconcile must restore (Restart= does NOT cover this).
+        sup.systemctl(&["disable", "--now", &sup.unit_file_name()])
+            .await
+            .expect("disable");
+        assert!(
+            !sup.unit_status_is(&["is-active"], "active").await,
+            "stopped after disable --now"
+        );
+        sup.reconcile_once().await.expect("reconcile after disable");
+        assert!(
+            sup.unit_status_is(&["is-active"], "active").await,
+            "reconcile restarts a stopped unit"
+        );
+        assert!(
+            sup.unit_status_is(&["is-enabled"], "enabled").await,
+            "reconcile re-enables"
+        );
+
+        // 3. Delete the unit file -> reconcile must re-write it.
+        tokio::fs::remove_file(sup.unit_path()).await.ok();
+        sup.systemctl(&["daemon-reload"]).await.ok();
+        sup.reconcile_once().await.expect("reconcile after delete");
+        assert!(
+            sup.unit_path().exists(),
+            "reconcile re-writes a deleted unit file"
+        );
+        assert!(
+            sup.unit_status_is(&["is-active"], "active").await,
+            "active again after re-write"
+        );
+    }
+}

--- a/crates/spurd/src/container.rs
+++ b/crates/spurd/src/container.rs
@@ -1652,7 +1652,7 @@ mod tests {
         assert!(is_loopback_nameserver("::1"));
         assert!(!is_loopback_nameserver("8.8.8.8"));
         assert!(!is_loopback_nameserver("1.1.1.1"));
-        assert!(!is_loopback_nameserver("192.168.1.1"));
+        assert!(!is_loopback_nameserver("203.0.113.1"));
     }
 
     #[test]

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -185,9 +185,9 @@ async fn main() -> anyhow::Result<()> {
         })
         .collect();
 
-    // this node's WireGuard public key (best-effort) so the controller can reconcile mesh peers.
+    // The WireGuard interface this node's mesh key is read from; the reporter re-reads the key on
+    // every register/heartbeat so the controller learns a key that appears/changes after startup.
     let wg_iface = std::env::var("SPUR_WG_INTERFACE").unwrap_or_else(|_| "spur0".into());
-    let wg_pubkey = spur_net::wireguard::interface_public_key(&wg_iface).unwrap_or_default();
 
     // Create the node reporter
     let reporter = Arc::new(NodeReporter::new(
@@ -197,7 +197,7 @@ async fn main() -> anyhow::Result<()> {
         node_address,
         labels,
         args.token.unwrap_or_default(),
-        wg_pubkey,
+        wg_iface,
     ));
 
     // Register with controller

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod agent_server;
+mod cluster;
 pub mod container;
 mod executor;
 mod landlock;
@@ -184,6 +185,10 @@ async fn main() -> anyhow::Result<()> {
         })
         .collect();
 
+    // this node's WireGuard public key (best-effort) so the controller can reconcile mesh peers.
+    let wg_iface = std::env::var("SPUR_WG_INTERFACE").unwrap_or_else(|_| "spur0".into());
+    let wg_pubkey = spur_net::wireguard::interface_public_key(&wg_iface).unwrap_or_default();
+
     // Create the node reporter
     let reporter = Arc::new(NodeReporter::new(
         hostname.clone(),
@@ -192,6 +197,7 @@ async fn main() -> anyhow::Result<()> {
         node_address,
         labels,
         args.token.unwrap_or_default(),
+        wg_pubkey,
     ));
 
     // Register with controller
@@ -203,9 +209,29 @@ async fn main() -> anyhow::Result<()> {
         hb_reporter.heartbeat_loop().await;
     });
 
-    // Start agent gRPC server (receives job launches from spurctld)
-    let agent_service =
-        agent_server::AgentService::new(reporter.clone(), hooks_config, registry.clone());
+    // Start agent gRPC server (receives job launches + cluster-component RPCs from spurctld).
+    // Pass the [cluster] config so the K0sAgent uses the operator's k0s version + install path.
+    let cluster_config = config
+        .as_ref()
+        .map(|c| c.cluster.clone())
+        .unwrap_or_default();
+    let agent_service = agent_server::AgentService::with_cluster_config(
+        reporter.clone(),
+        hooks_config,
+        registry.clone(),
+        &cluster_config,
+    );
+
+    // the RPC-driven k0s component owner is idle until the controller sends
+    // StartClusterComponent; k0s then runs under its OWN systemd unit — never as a spurd job/child —
+    // so it survives spurd restart and stays out of the executor/monitor/time-limit job path. The
+    // background loop heals the unit; the SlurmAgent start/stop/status RPCs drive it.
+    // Re-adopt an already-running k0s unit (spurd restart leaves it running) so status/heal are
+    // correct immediately, then spawn the heal loop.
+    let k0s = agent_service.k0s();
+    k0s.adopt_running_unit().await;
+    tokio::spawn(k0s.supervise());
+
     agent_service.start_monitor(args.controller.clone());
 
     let addr = args.listen.parse()?;

--- a/crates/spurd/src/reporter.rs
+++ b/crates/spurd/src/reporter.rs
@@ -22,9 +22,10 @@ pub struct NodeReporter {
     pub free_memory_mb: AtomicU64,
     pub cpu_load: AtomicU64,
     pub join_token: String,
-    /// This node's WireGuard public key (empty if not on a mesh). The controller uses it to
-    /// reconcile mesh peers.
-    pub wg_pubkey: String,
+    /// The WireGuard interface this node's mesh key is read from (e.g. "spur0"). The public key is
+    /// re-read on every register/heartbeat via [`wg_pubkey`](Self::wg_pubkey) so a key that appears
+    /// or changes after startup (late mesh join, `spur0` recreated) reaches the controller.
+    pub wg_iface: String,
     node_token: RwLock<String>,
 }
 
@@ -36,7 +37,7 @@ impl NodeReporter {
         node_address: spur_net::NodeAddress,
         labels: HashMap<String, String>,
         join_token: String,
-        wg_pubkey: String,
+        wg_iface: String,
     ) -> Self {
         Self {
             hostname,
@@ -47,9 +48,15 @@ impl NodeReporter {
             free_memory_mb: AtomicU64::new(0),
             cpu_load: AtomicU64::new(0),
             join_token,
-            wg_pubkey,
+            wg_iface,
             node_token: RwLock::new(String::new()),
         }
+    }
+
+    /// This node's current WireGuard mesh public key (empty if the interface has no key / no mesh).
+    /// Read live from the interface so a key that appears or changes after startup is picked up.
+    fn wg_pubkey(&self) -> String {
+        spur_net::wireguard::interface_public_key(&self.wg_iface).unwrap_or_default()
     }
 
     /// Register with the controller.
@@ -66,7 +73,7 @@ impl NodeReporter {
                 version: env!("CARGO_PKG_VERSION").into(),
                 address: self.node_address.ip.clone(),
                 port: self.node_address.port as u32,
-                wg_pubkey: self.wg_pubkey.clone(),
+                wg_pubkey: self.wg_pubkey(),
                 labels: self.labels.clone(),
                 join_token: self.join_token.clone(),
             })
@@ -129,6 +136,7 @@ impl NodeReporter {
                             free_memory_mb: free_mem,
                             running_jobs: vec![],
                             node_token: current_token,
+                            wg_pubkey: self.wg_pubkey(),
                         })
                         .await
                     {

--- a/crates/spurd/src/reporter.rs
+++ b/crates/spurd/src/reporter.rs
@@ -22,6 +22,9 @@ pub struct NodeReporter {
     pub free_memory_mb: AtomicU64,
     pub cpu_load: AtomicU64,
     pub join_token: String,
+    /// This node's WireGuard public key (empty if not on a mesh). The controller uses it to
+    /// reconcile mesh peers.
+    pub wg_pubkey: String,
     node_token: RwLock<String>,
 }
 
@@ -33,6 +36,7 @@ impl NodeReporter {
         node_address: spur_net::NodeAddress,
         labels: HashMap<String, String>,
         join_token: String,
+        wg_pubkey: String,
     ) -> Self {
         Self {
             hostname,
@@ -43,6 +47,7 @@ impl NodeReporter {
             free_memory_mb: AtomicU64::new(0),
             cpu_load: AtomicU64::new(0),
             join_token,
+            wg_pubkey,
             node_token: RwLock::new(String::new()),
         }
     }
@@ -61,7 +66,7 @@ impl NodeReporter {
                 version: env!("CARGO_PKG_VERSION").into(),
                 address: self.node_address.ip.clone(),
                 port: self.node_address.port as u32,
-                wg_pubkey: String::new(),
+                wg_pubkey: self.wg_pubkey.clone(),
                 labels: self.labels.clone(),
                 join_token: self.join_token.clone(),
             })

--- a/docs/deployment/index.rst
+++ b/docs/deployment/index.rst
@@ -8,3 +8,4 @@ Guides for deploying Spur in production across multiple nodes.
 
    native-host
    kubernetes
+   managed-kubernetes

--- a/docs/deployment/managed-kubernetes.rst
+++ b/docs/deployment/managed-kubernetes.rst
@@ -61,6 +61,8 @@ choice):
    service_cidr = "10.43.0.0/16"
    cni = "kuberouter"                # "kuberouter" (default) or "calico" (see Networking)
    cni_mtu = 1450                    # Calico MTU; headroom for WireGuard overhead on the mesh
+   storage_provisioner = "local-path"  # default StorageClass for PVCs; or "none"
+   # local_path_dir = "/mnt/scratch/local-path"  # point local-path at a big disk (default /var/lib)
    k0s_version = "v1.36.2+k0s.0"     # pinned; or "latest"
 
 Installing k0s
@@ -125,6 +127,28 @@ the tunnel.
 The controller continuously reconciles the full-mesh membership to every node
 (pruning peers for departed nodes), so a reboot, a WireGuard restart, or a
 control-plane failover self-heals.
+
+Storage
+~~~~~~~
+
+k0s bundles no storage, so a plain cluster has no ``StorageClass`` and any
+``PersistentVolumeClaim`` stays ``Pending``. By default SPUR ships the
+`local-path-provisioner <https://github.com/rancher/local-path-provisioner>`_
+(``storage_provisioner = "local-path"``) as the cluster's **default**
+StorageClass — RWO, node-local — so PVC workloads bind out of the box. The
+control-plane agent writes the manifest into k0s's manifest-deployer directory,
+which k0s applies automatically (no in-cluster client).
+
+Local-path stores volumes under ``local_path_dir`` (default
+``/var/lib/local-path-provisioner``, on the root filesystem). If PVCs will hold
+much data — model caches, datasets — point it at a large scratch disk:
+
+.. code-block:: ini
+
+   [cluster]
+   local_path_dir = "/mnt/scratch/local-path"
+
+Set ``storage_provisioner = "none"`` to bring your own storage.
 
 Adding a node later
 ~~~~~~~~~~~~~~~~~~~~~
@@ -246,6 +270,12 @@ Configuration reference (``[cluster]``)
    * - ``cni_mtu``
      - ``1450``
      - Calico MTU emitted into the generated k0s config (leaves WireGuard headroom).
+   * - ``storage_provisioner``
+     - ``local-path``
+     - Storage SPUR ships as the default StorageClass (``local-path`` or ``none``).
+   * - ``local_path_dir``
+     - ``/var/lib/local-path-provisioner``
+     - On-node directory local-path stores PVs in; point at a big disk for data-heavy PVCs.
    * - ``k0s_version``
      - pinned
      - k0s release to install/run (a tag or ``latest``).

--- a/docs/deployment/managed-kubernetes.rst
+++ b/docs/deployment/managed-kubernetes.rst
@@ -1,0 +1,254 @@
+SPUR-Managed Kubernetes (k0s)
+=============================
+
+SPUR can **provision and own** a Kubernetes cluster across its own nodes using
+`k0s <https://k0sproject.io>`_. This is the inverse of :doc:`kubernetes` (running
+SPUR *inside* an existing cluster): here ``spur k8s up`` builds the cluster and a
+spurd-owned systemd unit keeps k0s running on each node.
+
+One command assigns roles, mesh IPs and pod CIDRs, installs a pinned k0s on every
+node, brings up the control plane, mints join tokens, joins the workers, and
+(optionally) programs a WireGuard-native CNI — all driven by the existing
+spurctld/spurd control plane.
+
+.. note::
+
+   This feature is gated on ``[cluster].enabled``. With it off (the default),
+   spurd never touches systemd or k0s, and nothing here applies.
+
+Overview
+--------
+
+- **spurctld** (on the head node) owns the cluster lifecycle: role/IP/CIDR
+  assignment and phase, replicated through Raft so it survives a restart.
+- **spurd** (on every node) owns that node's k0s systemd unit: it installs k0s if
+  missing, writes the config/join-token, and reconciles the unit. k0s is never a
+  SPUR job, so it survives a spurd restart (spurd re-adopts it on startup).
+- **Roles** are assigned automatically: a single node becomes an all-in-one
+  ``controller --single``; with two or more nodes the control-plane node becomes a
+  ``controller`` and the rest become ``worker`` s.
+
+For Administrators
+------------------
+
+Prerequisites
+~~~~~~~~~~~~~~
+
+- A working native-host SPUR deployment — ``spurctld`` on the head node and
+  ``spurd`` on every node, all registered. See :doc:`native-host`.
+- ``spurd`` must run as root (it manages systemd units).
+- Outbound HTTPS to ``github.com`` on each node for the k0s download (or
+  pre-stage the binary — see `Installing k0s`_).
+- For the mesh-native CNI only: a WireGuard mesh (``spur0``) already established
+  across the nodes via ``spur net join`` / ``spur net mesh``.
+
+Configure the cluster
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Add a ``[cluster]`` section to ``spur.conf`` on every node (spurd reads
+``k0s_version`` / ``cni`` from it; spurctld reads the CIDRs and control-plane
+choice):
+
+.. code-block:: toml
+
+   [network]
+   wg_cidr = "10.44.0.0/16"          # mesh CIDR; node mesh IPs are allocated from here
+
+   [cluster]
+   enabled = true
+   control_plane_node = "head-node"  # hostname of the k0s control plane (else: first node)
+   pod_cidr = "10.42.0.0/16"         # per-node /24s are carved from this
+   service_cidr = "10.43.0.0/16"
+   flannel_iface = "spur0"           # interface k0s/Calico use for node-IP autodetection
+   k0s_version = "v1.36.2+k0s.0"     # pinned; or "latest"
+   cni = "kuberouter"                # "kuberouter" (default) or "calico" (see Networking)
+
+Installing k0s
+~~~~~~~~~~~~~~~
+
+``spur k8s up`` auto-installs the pinned k0s on any node that is missing it, so
+usually you do nothing. To pre-stage it (e.g. for an air-gapped or
+network-restricted node), run on that node **as root**:
+
+.. code-block:: bash
+
+   sudo spur k8s install-k0s                     # the pinned version -> /usr/local/bin/k0s
+   sudo spur k8s install-k0s --version latest    # newest k0s release
+   sudo spur k8s install-k0s --version v1.36.2+k0s.0 --path /opt/bin/k0s --force
+
+The binary is downloaded from the official k0s GitHub release and SHA-256
+verified before it is installed.
+
+Bring the cluster up
+~~~~~~~~~~~~~~~~~~~~~~
+
+From the head node (or any host that can reach ``spurctld``):
+
+.. code-block:: bash
+
+   spur k8s up --controller http://localhost:6817
+
+This is idempotent and asynchronous — spurctld reconciles toward ``Ready``:
+control plane first, then workers join with freshly minted tokens. A fresh
+cluster typically reaches ``Ready`` in one to two minutes (mostly the k0s
+download + control-plane bootstrap).
+
+Check status
+~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   spur k8s status
+   # phase: ready
+   # control-plane: head-node
+   #   head-node   controller  active   enabled=true
+   #   node-2      worker      active   enabled=true
+   #   ...
+
+``phase`` moves ``down -> provisioning -> ready``. Per-node ``component_state`` is
+queried live from each agent.
+
+Networking / CNI
+~~~~~~~~~~~~~~~~~
+
+**kuberouter** (default) — k0s's built-in CNI. The control-plane API is advertised
+on the node's primary interface and workers join over it. No mesh required.
+
+**calico** (``cni = "calico"``) — mesh-native routing. ``spur k8s up`` generates a
+k0s config that advertises the API on the control-plane's **mesh IP** and runs
+Calico in ``bird`` (BGP, no overlay) mode, and sets each worker's kubelet
+``--node-ip`` to its mesh IP. Pod traffic then routes over the WireGuard mesh.
+This requires the ``spur0`` mesh to be up first (``spur net join``); membership
+reconciliation only maintains the peer set + ``AllowedIPs``, it does not create
+the tunnel.
+
+The controller continuously reconciles the full-mesh membership to every node
+(pruning peers for departed nodes), so a reboot, a WireGuard restart, or a
+control-plane failover self-heals.
+
+Adding a node later
+~~~~~~~~~~~~~~~~~~~~~
+
+Start ``spurd`` on the new node (registered to the same controller) and, if using
+the mesh CNI, join it to the mesh first. On the next ``spur k8s up`` (or the next
+reconcile tick) it is assigned a role + mesh IP + pod CIDR and joins.
+
+Tear down
+~~~~~~~~~
+
+.. code-block:: bash
+
+   spur k8s down            # stop + disable the k0s unit on every node
+   spur k8s down --reset    # also `k0s reset` (destructive: wipes cluster state)
+
+``--reset`` removes ``/var/lib/k0s`` on every node but leaves the WireGuard mesh
+(``spur0``) intact. To switch the CNI, tear down with ``--reset`` and bring the
+cluster back up with the new ``cni`` setting.
+
+For Users
+---------
+
+Users do not need SPUR access — they interact with the cluster through the
+standard Kubernetes tooling.
+
+Get a kubeconfig
+~~~~~~~~~~~~~~~~~
+
+Ask an administrator (or run, if you have controller access):
+
+.. code-block:: bash
+
+   spur k8s kubeconfig > admin.conf
+   export KUBECONFIG=$PWD/admin.conf
+   kubectl get nodes
+
+``spur k8s kubeconfig`` prints the admin kubeconfig to stdout so it can be
+redirected to a file.
+
+Run a workload
+~~~~~~~~~~~~~~~
+
+Use ``kubectl`` normally:
+
+.. code-block:: bash
+
+   kubectl get nodes -o wide
+   kubectl create deployment web --image=nginx
+   kubectl run -it --rm probe --image=busybox -- sh
+
+Request GPUs
+~~~~~~~~~~~~~
+
+GPU worker nodes advertise ``amd.com/gpu`` (containerd injects the devices from a
+CDI spec spurd writes on join). Request them in a pod spec:
+
+.. code-block:: yaml
+
+   apiVersion: v1
+   kind: Pod
+   metadata:
+     name: gpu-probe
+   spec:
+     restartPolicy: Never
+     containers:
+       - name: rocm
+         image: rocm/dev-ubuntu-24.04:latest
+         command: ["rocm-smi"]
+         resources:
+           limits:
+             amd.com/gpu: 1
+
+Command reference
+-----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 36 64
+
+   * - Command
+     - Purpose
+   * - ``spur k8s up [--control-plane-node <h>]``
+     - Provision + start the cluster (idempotent).
+   * - ``spur k8s status``
+     - Cluster phase + per-node component state.
+   * - ``spur k8s kubeconfig``
+     - Print the admin kubeconfig (redirect to a file).
+   * - ``spur k8s down [--reset]``
+     - Stop the cluster; ``--reset`` also wipes k0s state.
+   * - ``spur k8s install-k0s [--version <tag>|latest] [--path <p>] [--force]``
+     - Install the k0s binary on this node (local; run as root).
+
+Configuration reference (``[cluster]``)
+---------------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 22 52
+
+   * - Key
+     - Default
+     - Meaning
+   * - ``enabled``
+     - ``false``
+     - Enable SPUR-managed k0s. When off, spurd never touches systemd/k0s.
+   * - ``control_plane_node``
+     - (first node)
+     - Hostname of the k0s control plane.
+   * - ``pod_cidr``
+     - ``10.42.0.0/16``
+     - Pod network; per-node /24s are carved from it.
+   * - ``service_cidr``
+     - ``10.43.0.0/16``
+     - Service network.
+   * - ``cni``
+     - ``kuberouter``
+     - ``kuberouter`` or ``calico`` (mesh-native bird routing).
+   * - ``flannel_iface``
+     - ``spur0``
+     - Interface k0s/Calico use for node-IP autodetection.
+   * - ``k0s_version``
+     - pinned
+     - k0s release to install/run (a tag or ``latest``).
+   * - ``k0s_binary``
+     - ``/usr/local/bin/k0s``
+     - Install path for the k0s binary.

--- a/docs/deployment/managed-kubernetes.rst
+++ b/docs/deployment/managed-kubernetes.rst
@@ -59,9 +59,9 @@ choice):
    control_plane_node = "head-node"  # hostname of the k0s control plane (else: first node)
    pod_cidr = "10.42.0.0/16"         # per-node /24s are carved from this
    service_cidr = "10.43.0.0/16"
-   flannel_iface = "spur0"           # interface k0s/Calico use for node-IP autodetection
-   k0s_version = "v1.36.2+k0s.0"     # pinned; or "latest"
    cni = "kuberouter"                # "kuberouter" (default) or "calico" (see Networking)
+   cni_mtu = 1450                    # Calico MTU; headroom for WireGuard overhead on the mesh
+   k0s_version = "v1.36.2+k0s.0"     # pinned; or "latest"
 
 Installing k0s
 ~~~~~~~~~~~~~~~
@@ -243,9 +243,9 @@ Configuration reference (``[cluster]``)
    * - ``cni``
      - ``kuberouter``
      - ``kuberouter`` or ``calico`` (mesh-native bird routing).
-   * - ``flannel_iface``
-     - ``spur0``
-     - Interface k0s/Calico use for node-IP autodetection.
+   * - ``cni_mtu``
+     - ``1450``
+     - Calico MTU emitted into the generated k0s config (leaves WireGuard headroom).
    * - ``k0s_version``
      - pinned
      - k0s release to install/run (a tag or ``latest``).

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -8,3 +8,4 @@ Everything you need to build, test, and contribute to Spur.
 
    building
    contributing
+   k8s-quota-enforcement

--- a/docs/developer/k8s-quota-enforcement.rst
+++ b/docs/developer/k8s-quota-enforcement.rst
@@ -1,0 +1,383 @@
+Quota Enforcement for SPUR-Managed Kubernetes (Design)
+======================================================
+
+.. note::
+
+   This is a design document for a planned capability, not yet implemented. It
+   describes how SPUR would enforce its resource model on workloads running in a
+   SPUR-managed k0s cluster. Feedback welcome.
+
+Goal
+----
+
+Let SPUR **seamlessly manage cluster resources** (accounts, QoS, fair-share,
+partitions, GRES/GPU limits) while the k0s cluster remains **a completely normal
+Kubernetes deployment** to its users. A user with a kubeconfig runs ``kubectl``
+against vanilla k8s objects and never touches a SPUR CLI; SPUR is the *invisible
+policy plane* that makes those workloads obey SPUR's resource model.
+
+Principles
+----------
+
+1. **SPUR is the source of truth + reconciler.** SPUR's account/partition/QoS
+   model is authoritative; a controller projects it onto k8s objects and corrects
+   drift (GitOps-style).
+2. **k8s enforces natively.** Enforcement rides on standard primitives
+   (Namespace, ResourceQuota, LimitRange, RBAC, PriorityClass, node
+   labels/taints, and — for batch fairness — Kueue). No proprietary API sits in a
+   user's path.
+3. **SPUR observes usage back.** A watch controller feeds real k8s consumption
+   into SPUR's accounting/fair-share, so SpurJobs and raw pods draw on **one**
+   unified quota/fair-share view.
+4. **No hard dependency in the hot path.** Pod creation must not block on a SPUR
+   RPC; enforcement is declarative (admission/quota) or asynchronous (queueing),
+   not a synchronous call to spurctld.
+
+Architecture
+------------
+
+.. code-block:: text
+
+                   SPUR control plane (source of truth)
+      accounts · associations · QoS · partitions · GRES · fair-share
+                             │
+                 ┌───────────┴────────────┐
+                 ▼                         ▲
+      (1) Policy Reconciler        (3) Usage Watcher
+      projects SPUR model →        watches k8s pods/metrics →
+      native k8s objects           feeds accounting + fair-share
+                 │                         ▲
+                 ▼                         │
+      ┌────────────────────── k0s (vanilla k8s) ──────────────────────┐
+      │ Namespace/ResourceQuota/LimitRange/RBAC/PriorityClass/labels   │
+      │ [Kueue ClusterQueue/LocalQueue/ResourceFlavor]  kube-scheduler │
+      └────────────────────────────────────────────────────────────────┘
+                 ▲
+                 │ scoped kubeconfig (SA token, namespace-bound RBAC)
+             user `kubectl`  (thinks it's a regular cluster)
+
+Concept mapping (SPUR → native k8s)
+-----------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 38 40
+
+   * - SPUR
+     - Native k8s enforcement
+     - Notes
+   * - Account / association
+     - **Namespace** + **RBAC**
+     - tenancy + who-can-submit-where
+   * - Account/QoS resource cap
+     - **ResourceQuota**
+     - CPU, memory, ``amd.com/gpu``, GRES as extended resources, pod/PVC counts
+   * - Default/min/max requests
+     - **LimitRange**
+     - stops request-gaming (unset requests get defaulted)
+   * - QoS priority
+     - **PriorityClass**
+     - native priority + kube-scheduler preemption
+   * - Partition (node group)
+     - **node labels + taints**; per-ns default ``nodeSelector`` (PodNodeSelector admission)
+     - pods land only on the account's partition
+   * - GRES type (``gpu:mi300x:N``)
+     - **extended resource** in quota + ``ResourceFlavor``
+     - typed device accounting
+   * - Time limit
+     - ``activeDeadlineSeconds`` (injected) / Kueue ``maximumExecutionTime``
+     -
+   * - Fair-share / borrowing / preemption
+     - **pluggable backend**: Kueue ``ClusterQueue`` + cohort (default) *or* SPUR-native gating
+     - the one thing ResourceQuota can't do; both impls behind one interface
+   * - User identity
+     - **ServiceAccount token** (or OIDC) scoped by RBAC
+     - ``spur k8s kubeconfig --user``
+   * - Accounting/usage
+     - SPUR usage watcher ← k8s metrics/pod lifecycle
+     - closes the fair-share loop
+
+Layered plan
+------------
+
+**Layer 0 — Cluster ownership.** Done: SPUR provisions/owns k0s.
+
+**Layer 1 — Tenancy + hard quotas (native, no SPUR in the hot path).**
+A reconciler creates, per account, a Namespace + ResourceQuota + LimitRange +
+RBAC, and ``spur k8s kubeconfig --user <u>`` mints a namespace-scoped
+ServiceAccount kubeconfig. Native admission enforces hard caps + isolation
+immediately. Covers "SPUR quotas enforced" for the static dimensions.
+
+**Layer 2 — Partitions + priority.** Reconcile node labels/taints from SPUR
+partitions; set a default ``nodeSelector`` per namespace (PodNodeSelector
+admission plugin, built into the API server) so an account's pods stick to its
+partition; map QoS priority → PriorityClass.
+
+**Layer 3 — Usage feedback.** A watch controller mirrors running pods
+(per-namespace resource use over time) back into SPUR accounting/fair-share so the
+two worlds share one view.
+
+**Layer 4 — Dynamic fairness / queueing.** The part ResourceQuota can't express.
+Built as a **pluggable** ``FairnessBackend`` **interface with two
+implementations**, selected by config (``[cluster] fairness = "kueue" | "native"``):
+
+- **kueue (default, recommended):** SPUR reconciles Kueue ``ClusterQueue`` /
+  cohort / ``ResourceFlavor`` / ``LocalQueue`` objects from
+  accounts/partitions/QoS; Kueue suspends/admits Workloads with borrowing +
+  preemption + fair sharing. The k8s-native batch-quota system; least custom code.
+- **native:** no extra cluster component — SPUR adjusts ResourceQuota hard caps on
+  a fair-share loop and gates pods with ``schedulingGates``, releasing them when
+  the account is within its fair share.
+
+Both back the same internal interface (``admit(account, workload) -> Decision``,
+``reconcile(accounts, partitions)``), so the rest of the system is
+engine-agnostic. **Tests for both** backends are part of the milestone (unit
+tests over the mapping/decision logic + an end-to-end run per backend on a real
+cluster).
+
+**Layer 5 — Polish.** Time-limit injection, licenses/reservations (map to a CRD
+or a semaphore), multi-tenant network policy, dashboards, ``spur k8s quota``
+visibility commands.
+
+Where it lives (code)
+---------------------
+
+- The **spur-k8s operator** grows a *policy reconciler* controller (it already
+  watches ``SpurJob`` + creates pods, so it has kube-client plumbing + namespace
+  logic to build on).
+- **spurctld** exposes account/partition/QoS *reconcile intent* (it already holds
+  associations/QoS/partitions + a Raft state machine + accounting DB).
+- **spur-cli** gains ``spur k8s kubeconfig --user <u>`` and ``spur k8s quota``
+  (show the projected quotas).
+- A **usage watcher** — a controller (in the operator) that reconciles k8s usage
+  → spurctld accounting.
+
+Milestones (implementable increments)
+-------------------------------------
+
+1. **M1** — Namespace + ResourceQuota + LimitRange + RBAC reconciler from SPUR
+   accounts; ``spur k8s kubeconfig --user``. *(Hard quotas + isolation land here.)*
+2. **M2** — Partition node-labels + per-namespace nodeSelector + PriorityClass
+   from QoS.
+3. **M3** — Usage watcher → accounting/fair-share.
+4. **M4** — Fairness backend: the ``FairnessBackend`` interface + **both** the
+   Kueue-driven impl (default) and the SPUR-native-gating impl, selected by
+   ``[cluster] fairness``, with tests for each.
+5. **M5** — Time-limits, licenses/reservations, ``spur k8s quota``, NetworkPolicy.
+
+Each milestone is independently shippable and testable on a real cluster.
+
+Alternatives considered
+-----------------------
+
+- **Synchronous admission webhook doing all enforcement.** Rejected as the
+  *primary* mechanism: puts a SPUR RPC in the pod-creation hot path (availability
+  + latency risk, fail-open/closed dilemmas) and duplicates what ResourceQuota
+  already does natively. Kept as a *narrow* tool (or a native
+  ``ValidatingAdmissionPolicy``/CEL) only for declarative rules quota can't
+  express.
+- **SPUR replaces the kube-scheduler** (scheduler plugin/extender for all pods).
+  Rejected as primary: heavy, and it makes the cluster *not* behave like regular
+  k8s (surprising placement, preemption semantics). Reasonable as a far-future
+  option; Kueue gets most of the benefit natively first.
+- **Proprietary SPUR API / force all workloads through the Slurm CLI.** Rejected:
+  directly violates "true to k8s" — users must be able to ``kubectl`` normally.
+- **One shared namespace with labels instead of namespace-per-account.**
+  Rejected: ResourceQuota, RBAC, and default-nodeSelector are all *namespace*
+  scoped, so a single namespace can't isolate tenants or cap them independently.
+- **A bespoke fair-share/queue engine in SPUR for k8s.** Rejected in favor of
+  driving **Kueue** (the CNCF-native batch-quota system) — less custom code, and
+  it *is* the standard k8s way — unless we specifically want no extra components
+  (then the native-gating fallback).
+
+M4 resolution — SPUR scheduling model → Kueue / native
+------------------------------------------------------
+
+Grounded in the actual spurctld code (not the Slurm ideal). The key realization:
+**SPUR enforces far less than its structs imply**, so the mapping is small and,
+for GPUs, an *improvement* over SPUR's current behavior.
+
+Ground truth — what SPUR actually enforces
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 45 55
+
+   * - SPUR mechanism
+     - Status in code
+   * - **QoS limits** (per-user + QoS-wide **CPU/Node/Mem** TRES,
+       ``max_jobs``/``max_submit`` per user, ``max_wall``)
+     - **Enforced** — the *only* hard gate; evaluated at *schedule* time (job
+       parks Pending-with-reason, not rejected at submit)
+   * - **Fair-share** (decayed CPU-usage vs target-share, ×10 cap)
+     - **Enforced** as *soft priority* only; **CPU-seconds only**, **flat** (no
+       account tree), per-user shares dead
+   * - **Priority** = ``max(1, base × min(fairshare,10) × age(1–2×@7d) × partition_tier)``
+     - Enforced; **multiplicative**, not Slurm weighted-sum; base 0 → collapses to
+       1 (a bug)
+   * - **Preemption**
+     - Partition ``preempt_mode`` only; victim.pri < challenger.pri/2 + node
+       overlap. **QoS preempt_mode is dead**
+   * - **Partition** ACL (allow/deny **accounts**), node-count/time/state,
+       ``priority_tier``
+     - Enforced (ACL at submit; limits park-as-pending). ``allow_groups`` /
+       ``allow_qos`` / ``default_time`` / ``exclusive_user`` are **inert**
+   * - **GPU** quota / GPU fair-share
+     - **Never enforced** — ``TresType::Gpu`` ignored everywhere; ``gpu_seconds``
+       never written
+   * - Account & association limits (``max_running_jobs``, ``grp_tres``, …)
+     - **Schema-only, unenforced**
+   * - ``Qos.priority``, ``Qos.preempt_mode``, ``Qos.usage_factor``
+     - Parsed/served but **never applied**
+
+So there are really only **three** enforced dimensions to honor: QoS resource caps
+(CPU/Node/Mem), QoS job/submit counts + wall, and fair-share ordering. Everything
+else is either inert or schema-only — which we should *not* port bug-for-bug.
+
+Mapping
+~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 26 26 24
+
+   * - SPUR (enforced)
+     - Kueue backend
+     - Native backend
+     - Fidelity
+   * - Account = tenancy
+     - Namespace + **LocalQueue → ClusterQueue**
+     - Namespace + **ResourceQuota**
+     - exact
+   * - Account allocation / share
+     - ``ClusterQueue.nominalQuota``; org = **cohort** w/ ``fairSharing``
+       (borrow/reclaim)
+     - ResourceQuota caps, SPUR loop resizes
+     - Kueue adds real, *hierarchical* fair borrowing SPUR lacks
+   * - QoS grp/max **CPU/Mem** caps
+     - resources on the ClusterQueue (or a per-QoS ClusterQueue in the cohort)
+     - ``ResourceQuota`` (cpu/memory)
+     - exact
+   * - **GPU** cap
+     - ``nominalQuota[amd.com/gpu]``
+     - ``ResourceQuota[amd.com/gpu]``
+     - **improves on SPUR** (unenforced today)
+   * - ``max_wall``
+     - ``Workload.maximumExecutionTimeSeconds``
+     - inject ``activeDeadlineSeconds``
+     - exact
+   * - ``max_jobs``/``max_submit`` per user
+     - — (Kueue quota is resource-based, not count-based)
+     - per-user pod-count ``ResourceQuota`` or a gate
+     - **partial** — needs a per-user gate either way
+   * - Fair-share ordering
+     - Kueue **fairSharing** (usage-weighted)
+     - SPUR loop resizes quota + orders ``schedulingGates``
+     - Kueue's is better + GPU-aware once we feed GPU usage
+   * - Priority (multiplicative)
+     - **WorkloadPriorityClass** (flat int) + fairSharing
+     - **PriorityClass** buckets
+     - **does not port 1:1**; use Kueue fairSharing + a priority class from
+       QoS/tier; drop the age×tier product
+   * - Preemption
+     - ``ClusterQueue.preemption`` (``reclaimWithinCohort`` +
+       ``withinClusterQueue``)
+     - kube-scheduler preemption via PriorityClass
+     - priority-based, not SPUR's ``<half`` threshold
+   * - Partition (node group)
+     - **ResourceFlavor** (node-label match)
+     - node labels + per-ns default ``nodeSelector``
+     - exact
+   * - Partition account ACL
+     - Namespace + RBAC (who can submit to the account's LocalQueue)
+     - Namespace + RBAC
+     - exact
+   * - Submit-error vs park-pending
+     - Workload stays **inadmissible/suspended** = "pending with reason"
+     - must use **schedulingGates** to *queue*, not bare ResourceQuota
+     - see below
+
+Object model (Kueue backend — the recommended default)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- **Namespace** per account · **LocalQueue** per namespace → **ClusterQueue** per
+  account.
+- **ClusterQueue.nominalQuota** per resource (``cpu``, ``memory``,
+  ``amd.com/gpu``, GRES types) from the account's allocation.
+- **ResourceFlavor** per partition (node-label match) → ``resourceGroups`` on the
+  ClusterQueue.
+- **Cohort** per organization/parent-account with ``fairSharing`` → real,
+  hierarchical fair borrowing (fixes SPUR's flat/CPU-only fair-share; this is
+  where fair-share *actually* becomes better than SPUR).
+- **WorkloadPriorityClass** derived from QoS priority + partition tier (exposes
+  the QoS priority SPUR never wired).
+- Per-user QoS caps (``max_jobs``/``max_tres_per_user``) → a small admission gate
+  (Kueue has no per-user quota) — the one dimension neither backend gets natively.
+
+The one real fidelity cliff: *queue* vs *reject*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+SPUR **parks over-limit jobs as Pending** (it never rejects at submit for a
+limit).
+
+- **Kueue reproduces this exactly** — a Workload over quota is
+  *suspended/inadmissible*, i.e. queued.
+- **Bare ResourceQuota does NOT** — it *rejects the pod at create*. So the native
+  backend must gate with **schedulingGates** (create the pod gated, admit when
+  within the fair-share-adjusted allowance) to preserve "queue, don't reject";
+  ResourceQuota alone is only acceptable for truly-hard caps.
+
+This is the strongest argument for Kueue as the default: it is the only option
+that keeps SPUR's "everything queues, nothing bounces" behavior with native
+objects.
+
+SPUR-side cleanups this surfaced (worth doing regardless of k8s)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- **Enforce GPU** in ``sum_running_tres`` / QoS limits, and **write
+  ``gpu_seconds``** so fair-share is GPU-aware (today a GPU cluster has *no* GPU
+  quota or GPU fairness).
+- The **base-priority-0 multiplicative collapse** (default-priority jobs get
+  effective priority 1, nullifying fair-share/age/tier).
+- Decide the fate of the dead fields (``Qos.priority``/``preempt_mode`` /
+  ``usage_factor``, account/association limits): either wire them or drop them —
+  don't map dead behavior.
+
+Net
+~~~
+
+The mapping is *smaller and cleaner* than feared: only QoS resource caps +
+job/submit counts + fair-share ordering are live. Kueue covers the resource caps,
+wall, fair-share (better, hierarchically, GPU-aware) and preemption natively and
+preserves queue-don't-reject; the native backend covers the same via ResourceQuota
++ PriorityClass + schedulingGates with the one caveat above. Per-user count caps
+need a small gate in both. And the port is the moment to give the GPU cluster the
+GPU quota + GPU fairness it doesn't have today.
+
+Decisions (locked)
+------------------
+
+1. **Namespace granularity:** **one namespace per account** (partition applied via
+   the namespace's default ``nodeSelector``). Simplest tenancy/quota boundary.
+2. **Fairness engine:** support **both** behind a ``FairnessBackend`` interface —
+   **Kueue-driven is the default/recommended path**, SPUR-native gating is the
+   no-extra-component alternative — with **tests for both**.
+3. **Identity:** **ServiceAccount tokens** — ``spur k8s kubeconfig --user <u>``
+   mints a SA + namespace-scoped RBAC + bound (rotatable) token. (OIDC is a future
+   option for human SSO, not M1.)
+
+Open questions / risks
+----------------------
+
+- **Kueue ↔ SPUR-QoS mapping fidelity** needs a spike (cohorts/borrowing vs
+  fair-share half-life; how QoS priority/preemption maps to Kueue).
+- **Reconcile authority / drift:** SPUR owns the ResourceQuota/RBAC/Kueue objects;
+  an admin hand-editing them gets reverted — need a clear "SPUR-managed" contract
+  (labels + admission guard) + an escape hatch.
+- **ResourceQuota can't evict already-running pods** when a quota shrinks; only
+  Kueue/preemption or a controller can reclaim. Define shrink semantics (native
+  backend especially).
+- **GPU accounting granularity** (whole-GPU vs MIG/partitions) for fair-share.
+- **ServiceAccount token lifecycle** — rotation, revocation on account/user
+  removal.

--- a/examples/spur.conf
+++ b/examples/spur.conf
@@ -77,3 +77,24 @@ agent_port = 6818
 [logging]
 level = "info"
 format = "text"
+
+# Native cluster (k0s) that SPUR provisions and owns: `spur k8s up/down`, spurd-owned k0s
+# systemd units, GPU CDI on join. Disabled by default. This is the INVERSE of [kubernetes]
+# (which lets SPUR run inside an existing k8s and accept SpurJob CRDs).
+[cluster]
+enabled = false
+distro = "k0s"                # only k0s is supported today
+pod_cidr = "10.42.0.0/16"     # Calico bird carves per-node /24s from this over the mesh
+service_cidr = "10.43.0.0/16"
+cni_mtu = 1450                # leaves headroom for WireGuard overhead on the mesh
+flannel_iface = "spur0"       # mesh interface k0s/Calico use for node-IP autodetection
+# control_plane_node = "head-node"   # empty = pick from inventory
+gpu_worker_selector = "spur.amd.com/compute=true"
+device_plugin = "rocm"        # rocm | spur (native device-plugin, later milestone)
+
+[cluster.arc]
+enabled = false
+installation_name = "spur-gpu-runners"
+github_config_url = ""        # required when arc.enabled
+container_mode = ""           # dind | kubernetes | "" (hand-authored pod spec)
+runner_image = "ghcr.io/actions/actions-runner:latest"

--- a/examples/spur.conf
+++ b/examples/spur.conf
@@ -89,3 +89,5 @@ service_cidr = "10.43.0.0/16"
 # cni = "kuberouter"          # or "calico" (mesh-native bird routing over WireGuard)
 cni_mtu = 1450                # Calico MTU; leaves headroom for WireGuard overhead on the mesh
 # control_plane_node = "head-node"   # empty = pick from inventory
+storage_provisioner = "local-path"          # ships a default StorageClass so PVCs bind; or "none"
+# local_path_dir = "/mnt/scratch/local-path"  # point local-path at a big disk (default: /var/lib/...)

--- a/examples/spur.conf
+++ b/examples/spur.conf
@@ -86,15 +86,6 @@ enabled = false
 distro = "k0s"                # only k0s is supported today
 pod_cidr = "10.42.0.0/16"     # Calico bird carves per-node /24s from this over the mesh
 service_cidr = "10.43.0.0/16"
-cni_mtu = 1450                # leaves headroom for WireGuard overhead on the mesh
-flannel_iface = "spur0"       # mesh interface k0s/Calico use for node-IP autodetection
+# cni = "kuberouter"          # or "calico" (mesh-native bird routing over WireGuard)
+cni_mtu = 1450                # Calico MTU; leaves headroom for WireGuard overhead on the mesh
 # control_plane_node = "head-node"   # empty = pick from inventory
-gpu_worker_selector = "spur.amd.com/compute=true"
-device_plugin = "rocm"        # rocm | spur (native device-plugin, later milestone)
-
-[cluster.arc]
-enabled = false
-installation_name = "spur-gpu-runners"
-github_config_url = ""        # required when arc.enabled
-container_mode = ""           # dind | kubernetes | "" (hand-authored pod spec)
-runner_image = "ghcr.io/actions/actions-runner:latest"

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -607,6 +607,10 @@ message HeartbeatRequest {
   uint64 free_memory_mb = 3;
   repeated RunningJobStatus running_jobs = 4;
   string node_token = 5;
+  // This node's current WireGuard mesh public key. Re-sent every heartbeat so the controller
+  // learns a key that appears/changes after registration (late mesh, spur0 recreated) and can
+  // include the node in ApplyMesh without a spurd restart. Empty when the node has no mesh key.
+  string wg_pubkey = 6;
 }
 
 message RunningJobStatus {
@@ -689,8 +693,7 @@ message RunStepResponse {
 message ClusterUpRequest {
   // Override the control-plane node; empty = pick from [cluster] config / inventory.
   optional string control_plane_node = 1;
-  // Also install the ARC CI runner scale sets.
-  bool install_arc = 2;
+  reserved 2; // was install_arc — ARC is not installed by spur/k0s
 }
 message ClusterUpResponse {
   bool accepted = 1;

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -325,6 +325,12 @@ service SlurmController {
   // `salloc` interactive shell. The controller picks an allocated node and
   // proxies to its agent's RunCommand RPC (#146).
   rpc RunStep(RunStepRequest) returns (RunStepResponse);
+
+  // -- Native cluster (k0s) lifecycle: SPUR owns the k0s cluster --
+  rpc ClusterUp(ClusterUpRequest) returns (ClusterUpResponse);
+  rpc ClusterDown(ClusterDownRequest) returns (ClusterDownResponse);
+  rpc ClusterStatus(ClusterStatusRequest) returns (ClusterStatusResponse);
+  rpc ClusterKubeconfig(ClusterKubeconfigRequest) returns (ClusterKubeconfigResponse);
 }
 
 // -- Agent service (slurmd) --
@@ -340,6 +346,24 @@ service SlurmAgent {
   rpc StreamJobOutput(StreamJobOutputRequest) returns (stream StreamJobOutputChunk);
   // Interactive attach: bidirectional streaming for stdin/stdout forwarding
   rpc AttachJob(stream AttachJobInput) returns (stream AttachJobOutput);
+
+  // -- Native cluster component control: the controller drives each node's
+  //    spurd-owned k0s systemd unit through these. --
+  rpc StartClusterComponent(StartClusterComponentRequest) returns (StartClusterComponentResponse);
+  rpc StopClusterComponent(StopClusterComponentRequest) returns (StopClusterComponentResponse);
+  rpc GetClusterComponentStatus(GetClusterComponentStatusRequest) returns (GetClusterComponentStatusResponse);
+
+  // -- Control-plane-only cluster admin: the controller calls these on
+  //    the control-plane node's agent, which shells `k0s` against the running
+  //    controller. Worker joins need a fresh token; ClusterKubeconfig needs the
+  //    admin kubeconfig. Erroring on a non-control-plane node is expected. --
+  rpc CreateK0sJoinToken(CreateK0sJoinTokenRequest) returns (CreateK0sJoinTokenResponse);
+  rpc GetAdminKubeconfig(GetAdminKubeconfigRequest) returns (GetAdminKubeconfigResponse);
+
+  // Apply the full-mesh WireGuard membership on this node: the controller pushes the
+  // authoritative peer set so a native-routing CNI (Calico bird) can ride the mesh. Additive +
+  // idempotent — safe to re-push.
+  rpc ApplyMesh(MeshMembership) returns (ApplyMeshResponse);
 }
 
 // -- Accounting service --
@@ -658,6 +682,117 @@ message RunStepResponse {
   string stdout = 2;
   string stderr = 3;
   string node = 4;  // Hostname of the allocated node the command ran on
+}
+
+// -- Native cluster (k0s) lifecycle messages --
+
+message ClusterUpRequest {
+  // Override the control-plane node; empty = pick from [cluster] config / inventory.
+  optional string control_plane_node = 1;
+  // Also install the ARC CI runner scale sets.
+  bool install_arc = 2;
+}
+message ClusterUpResponse {
+  bool accepted = 1;
+  string message = 2;
+  repeated ClusterNodeStatus nodes = 3;
+}
+
+message ClusterDownRequest {
+  // Also `k0s reset` each node (destructive: wipes cluster state).
+  bool reset = 1;
+}
+message ClusterDownResponse {
+  bool accepted = 1;
+  string message = 2;
+}
+
+message ClusterStatusRequest {}
+message ClusterStatusResponse {
+  // "down" | "provisioning" | "ready" | "degraded"
+  string phase = 1;
+  string control_plane_node = 2;
+  repeated ClusterNodeStatus nodes = 3;
+}
+
+message ClusterNodeStatus {
+  string node = 1;
+  string role = 2;             // "controller" | "worker" | "single"
+  string component_state = 3;  // systemd active-state: "active" | "inactive" | "failed" | "unknown"
+  bool enabled = 4;
+}
+
+message ClusterKubeconfigRequest {}
+message ClusterKubeconfigResponse {
+  // Admin kubeconfig YAML (server rewritten to the control-plane's mesh IP).
+  string kubeconfig = 1;
+}
+
+// -- Agent-side cluster component control messages --
+
+message StartClusterComponentRequest {
+  string role = 1;             // "controller" | "worker" | "single"
+  // k0s join token (bearer secret — never log). Empty for single / first controller.
+  optional string join_token = 2;
+  // Rendered k0s config YAML. Empty = agent uses role defaults.
+  optional string k0s_config = 3;
+  // Worker kubelet --node-ip (its mesh IP) for native-routing CNIs. Empty = k0s picks the default.
+  optional string node_ip = 4;
+}
+message StartClusterComponentResponse {
+  bool started = 1;
+  string component_state = 2;  // systemd active-state after the action
+  string message = 3;
+}
+
+message StopClusterComponentRequest {
+  bool reset = 1;              // also `k0s reset` (destructive)
+}
+message StopClusterComponentResponse {
+  bool stopped = 1;
+  string message = 2;
+}
+
+message GetClusterComponentStatusRequest {}
+message GetClusterComponentStatusResponse {
+  string role = 1;
+  string component_state = 2;  // "active" | "inactive" | "failed" | "unknown"
+  bool enabled = 3;
+}
+
+// -- Control-plane-only cluster admin messages --
+
+message CreateK0sJoinTokenRequest {
+  string role = 1;             // "worker" | "controller"
+  uint64 expiry_seconds = 2;   // token lifetime; 0 = k0s default
+}
+message CreateK0sJoinTokenResponse {
+  // k0s join token (bearer secret — never log).
+  string join_token = 1;
+}
+
+message GetAdminKubeconfigRequest {}
+message GetAdminKubeconfigResponse {
+  // Admin kubeconfig YAML read from the control-plane node.
+  string kubeconfig = 1;
+}
+
+// -- Full-mesh membership: proto mirror of spur_net::mesh::MeshNode/MeshMembership --
+
+message MeshNode {
+  string hostname = 1;     // node name (used to resolve self + the agent endpoint)
+  string public_key = 2;   // WireGuard public key
+  string mesh_ip = 3;      // mesh address on spur0 (no prefix), e.g. 10.44.0.2
+  string endpoint = 4;     // underlay endpoint, e.g. 198.51.100.2:51820
+  optional string pod_cidr = 5; // node's pod /24 for native-routing CNIs
+}
+message MeshMembership {
+  repeated MeshNode nodes = 1;
+}
+message ApplyMeshResponse {
+  bool applied = 1;
+  uint32 peers = 2;        // number of peers applied (self excluded)
+  string message = 3;
 }
 
 // Agent-side request: run a command directly on this node (no namespace


### PR DESCRIPTION
Design / RFC for the **quota-enforcement layer** on top of the SPUR-managed k0s cluster (#432): make SPUR enforce its resource model (accounts, QoS, fair-share, partitions, GPU limits) on k8s workloads while the cluster stays a normal Kubernetes deployment to users — vanilla `kubectl`, no proprietary API in the pod-creation hot path.

Docs-only: adds `docs/developer/k8s-quota-enforcement.rst`. **Stacked on #432** (Layer 0 = the SPUR-managed cluster this builds on). Opening for review before we implement M1.

## Covers
- Reconciler architecture — SPUR is the source of truth and projects its model onto native k8s objects (Namespace / ResourceQuota / RBAC / PriorityClass / Kueue); a usage watcher feeds k8s consumption back into accounting + fair-share.
- SPUR → native-k8s concept mapping.
- Layered plan + M1–M5 milestones.
- A pluggable `FairnessBackend` — **Kueue (default/recommended)** + a native `schedulingGates` fallback, with tests for both.
- **M4 mapping grounded in the actual scheduler code**: the key finding is that SPUR enforces far less than its structs imply (only QoS CPU/Mem/count caps + wall + soft, CPU-only fair-share; GPU never enforced), so the mapping is small and giving the GPU cluster real GPU quota is a net improvement.
- The one fidelity cliff: SPUR *parks* over-limit jobs (never rejects) — Kueue reproduces this, bare ResourceQuota rejects at create, so the native backend must gate with `schedulingGates`.
- Alternatives considered + open questions.

## Decisions (locked)
- One namespace per account.
- Both fairness backends behind one interface; Kueue default; tests for both.
- ServiceAccount tokens for identity (OIDC later).

## Related
The M4 analysis surfaced three SPUR-side scheduler cleanups worth doing regardless of k8s, already tracked: #439 (GPU not enforced / not tracked for fair-share), #440 (base-0 priority collapse), #441 (dead QoS/account config fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
