### PR TITLE
feat(spurctld): show valid accounts in association errors

### DIFF
--- a/crates/spurctld/src/association_cache.rs
+++ b/crates/spurctld/src/association_cache.rs
@@ -16,6 +16,13 @@ struct Snapshot {
     loaded: bool,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum AccountMembership {
+    CacheUnavailable,
+    Member,
+    NotMember(Vec<String>),
+}
+
 /// Controller-side cache of user/account association defaults. Mirrors
 /// `FairshareCache`/`QosCache`: one lock guards one atomic snapshot, so a
 /// refresh can never be observed half-applied.
@@ -40,11 +47,26 @@ impl AssociationCache {
         self.snapshot.read().loaded
     }
 
-    pub fn has_membership(&self, user: &str, account: &str) -> bool {
-        self.snapshot
-            .read()
+    pub fn account_membership(&self, user: &str, account: &str) -> AccountMembership {
+        let snapshot = self.snapshot.read();
+        if !snapshot.loaded {
+            return AccountMembership::CacheUnavailable;
+        }
+        if snapshot
             .memberships
             .contains(&(user.to_owned(), account.to_owned()))
+        {
+            return AccountMembership::Member;
+        }
+
+        let mut accounts: Vec<_> = snapshot
+            .memberships
+            .iter()
+            .filter(|(member_user, _)| member_user == user)
+            .map(|(_, account)| account.clone())
+            .collect();
+        accounts.sort_unstable();
+        AccountMembership::NotMember(accounts)
     }
 
     /// The effective account (given, or the user's default) and that
@@ -257,11 +279,26 @@ mod tests {
     }
 
     #[test]
-    fn has_membership_tracks_inserted_associations() {
+    fn account_membership_returns_sorted_accounts_for_non_member() {
         let cache = AssociationCache::new();
-        assert!(!cache.has_membership("alice", "research"));
-        cache.insert_association("alice", "research");
-        assert!(cache.has_membership("alice", "research"));
-        assert!(!cache.has_membership("alice", "other"));
+        assert_eq!(
+            cache.account_membership("alice", "research"),
+            AccountMembership::CacheUnavailable
+        );
+        cache.insert_association("alice", "research-z");
+        cache.insert_association("alice", "research-a");
+        cache.insert_association("bob", "other");
+        assert_eq!(
+            cache.account_membership("alice", "research-a"),
+            AccountMembership::Member
+        );
+        assert_eq!(
+            cache.account_membership("alice", "missing"),
+            AccountMembership::NotMember(vec!["research-a".into(), "research-z".into()])
+        );
+        assert_eq!(
+            cache.account_membership("carol", "missing"),
+            AccountMembership::NotMember(Vec::new())
+        );
     }
 }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -4031,7 +4031,7 @@ fn validate_user_account(
             )))
         }
         AccountMembership::NotMember(valid_accounts) => Err(SubmitError::invalid(format!(
-            "user '{}' is not associated with account '{account}'. Valid accounts for this user: [{}]. Use --account=<account> to specify.",
+            "user '{}' is not associated with account '{account}'. Accounts associated with this user: [{}].",
             spec.user,
             valid_accounts.join(", ")
         ))),
@@ -6421,7 +6421,7 @@ mod tests {
         assert_eq!(
             err,
             SubmitError::invalid(
-                "user 'testuser' is not associated with account 'research'. Valid accounts for this user: [student-a, student-z]. Use --account=<account> to specify."
+                "user 'testuser' is not associated with account 'research'. Accounts associated with this user: [student-a, student-z]."
             )
         );
     }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -31,7 +31,7 @@ use spur_metrics::partition::PartitionMetricsSnapshot;
 use spur_metrics::user_acct::UserAcctMetricsSnapshot;
 
 use crate::accounting::{AccountingNotifier, JobStartRecord};
-use crate::association_cache::AssociationCache;
+use crate::association_cache::{AccountMembership, AssociationCache};
 use crate::fairshare_cache::FairshareCache;
 use crate::limits_cache::QosCache;
 use crate::raft::{ClientResponse, JobFinalized, SpurRaft, StateMachineApply};
@@ -4022,16 +4022,20 @@ fn validate_user_account(
     let Some(account) = spec.account.as_deref().filter(|a| !a.is_empty()) else {
         return Ok(());
     };
-    if !assoc_cache.is_loaded() {
-        return Ok(());
+    match assoc_cache.account_membership(&spec.user, account) {
+        AccountMembership::CacheUnavailable | AccountMembership::Member => Ok(()),
+        AccountMembership::NotMember(valid_accounts) if valid_accounts.is_empty() => {
+            Err(SubmitError::invalid(format!(
+                "user '{}' has no account associations. Contact your cluster admin to run: sacctmgr add user name={} account=<account>",
+                spec.user, spec.user
+            )))
+        }
+        AccountMembership::NotMember(valid_accounts) => Err(SubmitError::invalid(format!(
+            "user '{}' is not associated with account '{account}'. Valid accounts for this user: [{}]. Use --account=<account> to specify.",
+            spec.user,
+            valid_accounts.join(", ")
+        ))),
     }
-    if !assoc_cache.has_membership(&spec.user, account) {
-        return Err(SubmitError::invalid(format!(
-            "user '{}' is not associated with account '{account}'",
-            spec.user
-        )));
-    }
-    Ok(())
 }
 
 /// Resolve a job's effective QOS at submission time (mirrors
@@ -6407,14 +6411,35 @@ mod tests {
         cfg.partitions[0].allow_accounts = vec!["research".into()];
         let cm = test_cluster_with_config(&dir, cfg).await;
         cm.association_cache()
-            .insert_association("testuser", "student");
+            .insert_association("testuser", "student-z");
+        cm.association_cache()
+            .insert_association("testuser", "student-a");
 
         let mut spec = basic_spec("spoof");
         spec.account = Some("research".into());
         let err = cm.submit_job(spec).unwrap_err();
         assert_eq!(
             err,
-            SubmitError::invalid("user 'testuser' is not associated with account 'research'")
+            SubmitError::invalid(
+                "user 'testuser' is not associated with account 'research'. Valid accounts for this user: [student-a, student-z]. Use --account=<account> to specify."
+            )
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_rejects_account_when_user_has_no_associations() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        cm.association_cache().set_loaded_without_associations();
+
+        let mut spec = basic_spec("unassociated");
+        spec.account = Some("research".into());
+        let err = cm.submit_job(spec).unwrap_err();
+        assert_eq!(
+            err,
+            SubmitError::invalid(
+                "user 'testuser' has no account associations. Contact your cluster admin to run: sacctmgr add user name=testuser account=<account>"
+            )
         );
     }
 


### PR DESCRIPTION
## Summary

- Show a user's valid account associations when job submission specifies an invalid account.
- Direct users with no associations to the appropriate `sacctmgr add user` command.
- Read membership status and alternatives from one cache snapshot while preserving the constant-time valid-membership path.

## Testing

- `git spur-check`

Closes #420
