### PR TITLE
fix(accounting): filter users by name

### DIFF
--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -1219,4 +1219,14 @@ mod tests {
         assert_eq!(account, "testacct");
         assert_eq!(user, "testuser");
     }
+
+    #[test]
+    fn list_user_filters_include_user_alias() {
+        let p = parse_params(&["user=testuser".into()]);
+
+        let (account, user) = list_user_filters(&p);
+
+        assert!(account.is_empty());
+        assert_eq!(user, "testuser");
+    }
 }

--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -234,6 +234,16 @@ fn build_add_user_request(
     })
 }
 
+fn list_user_filters(p: &std::collections::HashMap<String, String>) -> (String, String) {
+    (
+        p.get("account").cloned().unwrap_or_default(),
+        p.get("name")
+            .or_else(|| p.get("user"))
+            .cloned()
+            .unwrap_or_default(),
+    )
+}
+
 async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
     let p = parse_params(params);
 
@@ -642,12 +652,13 @@ async fn show(entity: &str, params: &[String], addr: &str) -> Result<()> {
             Ok(())
         }
         "user" | "users" => {
-            let account_filter = p.get("account").cloned().unwrap_or_default();
+            let (account_filter, user_filter) = list_user_filters(&p);
 
             let mut client = connect(addr).await?;
             let resp = client
                 .list_users(ListUsersRequest {
                     account: account_filter,
+                    user: user_filter,
                 })
                 .await
                 .context("ListUsers RPC failed")?;
@@ -1197,5 +1208,15 @@ mod tests {
     fn qos_empty_format_string_produces_no_fields() {
         let fields = format_engine::parse_named_format("", &qos_field_spec, &qos_header);
         assert!(fields.is_empty());
+    }
+
+    #[test]
+    fn list_user_filters_include_name() {
+        let p = parse_params(&["name=testuser".into(), "account=testacct".into()]);
+
+        let (account, user) = list_user_filters(&p);
+
+        assert_eq!(account, "testacct");
+        assert_eq!(user, "testuser");
     }
 }

--- a/crates/spur-cli/src/sreport.rs
+++ b/crates/spur-cli/src/sreport.rs
@@ -119,6 +119,7 @@ async fn report_account_utilization_by_user(
     let users_resp = client
         .list_users(ListUsersRequest {
             account: String::new(),
+            user: String::new(),
         })
         .await
         .context("failed to list users")?;
@@ -221,6 +222,7 @@ async fn report_user_utilization_by_account(
     let users_resp = client
         .list_users(ListUsersRequest {
             account: String::new(),
+            user: String::new(),
         })
         .await
         .context("failed to list users")?;
@@ -355,6 +357,7 @@ async fn report_job_sizes_by_user(
     let users_resp = client
         .list_users(ListUsersRequest {
             account: String::new(),
+            user: String::new(),
         })
         .await
         .context("failed to list users")?;

--- a/crates/spur-cli/src/sshare.rs
+++ b/crates/spur-cli/src/sshare.rs
@@ -57,6 +57,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let users_resp = client
         .list_users(ListUsersRequest {
             account: args.account.clone().unwrap_or_default(),
+            user: String::new(),
         })
         .await
         .context("failed to list users")?;

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -652,38 +652,28 @@ pub async fn remove_user(pool: &PgPool, user: &str, account: &str) -> anyhow::Re
 /// List users, joining each one's own association row for `default_qos`.
 /// `DISTINCT ON ... a.id DESC` picks the newest row if legacy duplicates
 /// exist (pre-dating the add_user upsert fix); it never touches the others.
-pub async fn list_users(pool: &PgPool, account: Option<&str>) -> anyhow::Result<Vec<UserRecord>> {
-    let rows = if let Some(acct) = account {
-        sqlx::query(
-            r#"
-            SELECT DISTINCT ON (u.name, u.account)
-                u.name, u.account, u.admin_level, u.default_account, a.default_qos
-            FROM users u
-            LEFT JOIN associations a
-                ON a.user_name = u.name AND a.account = u.account
-                    AND (a.partition_name IS NULL OR a.partition_name = '')
-            WHERE u.account = $1
-            ORDER BY u.name, u.account, a.id DESC NULLS LAST
-            "#,
-        )
-        .bind(acct)
-        .fetch_all(pool)
-        .await?
-    } else {
-        sqlx::query(
-            r#"
-            SELECT DISTINCT ON (u.name, u.account)
-                u.name, u.account, u.admin_level, u.default_account, a.default_qos
-            FROM users u
-            LEFT JOIN associations a
-                ON a.user_name = u.name AND a.account = u.account
-                    AND (a.partition_name IS NULL OR a.partition_name = '')
-            ORDER BY u.name, u.account, a.id DESC NULLS LAST
-            "#,
-        )
-        .fetch_all(pool)
-        .await?
-    };
+pub async fn list_users(
+    pool: &PgPool,
+    account: Option<&str>,
+    user: Option<&str>,
+) -> anyhow::Result<Vec<UserRecord>> {
+    let rows = sqlx::query(
+        r#"
+        SELECT DISTINCT ON (u.name, u.account)
+            u.name, u.account, u.admin_level, u.default_account, a.default_qos
+        FROM users u
+        LEFT JOIN associations a
+            ON a.user_name = u.name AND a.account = u.account
+                AND (a.partition_name IS NULL OR a.partition_name = '')
+        WHERE ($1::TEXT IS NULL OR u.account = $1)
+            AND ($2::TEXT IS NULL OR u.name = $2)
+        ORDER BY u.name, u.account, a.id DESC NULLS LAST
+        "#,
+    )
+    .bind(account)
+    .bind(user)
+    .fetch_all(pool)
+    .await?;
 
     Ok(rows
         .iter()
@@ -1218,7 +1208,7 @@ mod job_history_tests {
             &pool, &user, &account, "none", true, &qos_name, None, None, None, None, None,
         )
         .await?;
-        let got = list_users(&pool, Some(&account))
+        let got = list_users(&pool, Some(&account), None)
             .await?
             .into_iter()
             .find(|u| u.name == user)
@@ -1231,7 +1221,7 @@ mod job_history_tests {
             &pool, &user, &account, "none", true, "", None, None, None, None, None,
         )
         .await?;
-        let got = list_users(&pool, Some(&account))
+        let got = list_users(&pool, Some(&account), None)
             .await?
             .into_iter()
             .find(|u| u.name == user)
@@ -1367,6 +1357,88 @@ mod job_history_tests {
 
     #[tokio::test]
     #[ignore = "requires DATABASE_URL and PostgreSQL"]
+    async fn list_users_filters_by_user_name() -> anyhow::Result<()> {
+        let pool = test_pool().await?;
+        let pid = std::process::id();
+        let account = format!("spur_userfilter_acct_{pid}");
+        let matching_user = format!("spur_userfilter_match_{pid}");
+        let other_user = format!("spur_userfilter_other_{pid}");
+
+        sqlx::query("DELETE FROM associations WHERE user_name IN ($1, $2)")
+            .bind(&matching_user)
+            .bind(&other_user)
+            .execute(&pool)
+            .await?;
+        sqlx::query("DELETE FROM users WHERE name IN ($1, $2)")
+            .bind(&matching_user)
+            .bind(&other_user)
+            .execute(&pool)
+            .await?;
+        sqlx::query("DELETE FROM accounts WHERE name = $1")
+            .bind(&account)
+            .execute(&pool)
+            .await?;
+
+        upsert_account(&pool, &account, "d", "o", None, 1, None).await?;
+        add_user(
+            &pool,
+            &matching_user,
+            &account,
+            "none",
+            true,
+            "",
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await?;
+        add_user(
+            &pool,
+            &other_user,
+            &account,
+            "none",
+            true,
+            "",
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await?;
+
+        let users = list_users(&pool, None, Some(&matching_user)).await?;
+        assert_eq!(users.len(), 1);
+        assert_eq!(users[0].name, matching_user);
+
+        let users = list_users(&pool, Some(&account), Some(&matching_user)).await?;
+        assert_eq!(users.len(), 1);
+        assert_eq!(users[0].account, account);
+
+        let users = list_users(&pool, Some(&account), Some("missing-user")).await?;
+        assert!(users.is_empty());
+
+        sqlx::query("DELETE FROM associations WHERE user_name IN ($1, $2)")
+            .bind(&matching_user)
+            .bind(&other_user)
+            .execute(&pool)
+            .await?;
+        sqlx::query("DELETE FROM users WHERE name IN ($1, $2)")
+            .bind(&matching_user)
+            .bind(&other_user)
+            .execute(&pool)
+            .await?;
+        sqlx::query("DELETE FROM accounts WHERE name = $1")
+            .bind(&account)
+            .execute(&pool)
+            .await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL and PostgreSQL"]
     async fn add_user_never_creates_a_duplicate_association_row() -> anyhow::Result<()> {
         // Repeated add_user calls (what `sacctmgr modify user` now does)
         // must converge on one row, not accumulate duplicates.
@@ -1479,7 +1551,7 @@ mod job_history_tests {
         .execute(&pool)
         .await?;
 
-        let got = list_users(&pool, Some(&account))
+        let got = list_users(&pool, Some(&account), None)
             .await?
             .into_iter()
             .find(|u| u.name == user)

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -440,7 +440,12 @@ impl SlurmAccounting for AccountingService {
         } else {
             Some(req.account.as_str())
         };
-        let records = db::list_users(&self.pool, account)
+        let user = if req.user.is_empty() {
+            None
+        } else {
+            Some(req.user.as_str())
+        };
+        let records = db::list_users(&self.pool, account, user)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
 

--- a/crates/spurctld/src/accounting/mod.rs
+++ b/crates/spurctld/src/accounting/mod.rs
@@ -59,7 +59,7 @@ pub async fn association_maps(
     HashSet<(String, String)>,
     HashMap<(String, String), AccountLimits>,
 )> {
-    let users = db::list_users(pool, None).await?;
+    let users = db::list_users(pool, None, None).await?;
 
     let mut default_qos = HashMap::new();
     let mut default_account = HashMap::new();

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -1027,6 +1027,7 @@ message RemoveUserRequest {
 
 message ListUsersRequest {
   string account = 1;
+  string user = 2;
 }
 
 message ListUsersResponse {


### PR DESCRIPTION
## Summary

Fix `sacctmgr show user name=X` returning every configured user.

The CLI now forwards `name=` and `user=` through the accounting RPC. `ListUsersRequest` gains an additive user field, and the accounting query applies exact user and account filters server-side.

Closes #418.

## Testing

- Full Linux validation: formatting, SPDX headers, cargo-deny, clippy, all-target build, and complete test suite
- Focused sacctmgr parameter regression test
- PostgreSQL integration test covering user-only, account-plus-user, and no-match filtering
- Independent reviewer: PASS
