### PR TITLE
fix(spurd): raise RLIMIT_MEMLOCK for job steps (default unlimited)

### DIFF
--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -103,6 +103,10 @@ pub struct SlurmConfig {
     /// Node admission control.
     #[serde(default)]
     pub admission: AdmissionConfig,
+
+    /// POSIX per-process resource limits applied to job steps at launch.
+    #[serde(default)]
+    pub rlimits: RlimitsConfig,
 }
 
 /// Configuration for auto-update checking and self-update.
@@ -790,6 +794,62 @@ pub enum AdmissionMode {
     Token,
 }
 
+/// POSIX per-process resource limits (`RLIMIT_*`) applied to job steps at launch.
+///
+/// Distinct from QoS/association caps (scheduling policy) and cgroup limits
+/// (derived per-job from the allocation). This is where Tier 2 propagation
+/// controls (`propagate`, `propagate_except`) will live.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RlimitsConfig {
+    /// RLIMIT_MEMLOCK applied to job processes.
+    /// "unlimited" (default) | "inherit" | byte count as string.
+    #[serde(default = "default_memlock")]
+    pub memlock: String,
+}
+
+fn default_memlock() -> String {
+    "unlimited".into()
+}
+
+impl Default for RlimitsConfig {
+    fn default() -> Self {
+        Self {
+            memlock: default_memlock(),
+        }
+    }
+}
+
+/// Parsed value for RLIMIT_MEMLOCK configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemlockLimit {
+    /// Set both soft and hard to RLIM_INFINITY.
+    Unlimited,
+    /// Do not call setrlimit; inherit from spurd's process.
+    Inherit,
+    /// Set both soft and hard to a fixed byte count.
+    Bytes(u64),
+}
+
+impl RlimitsConfig {
+    pub fn memlock_limit(&self) -> Result<MemlockLimit, ConfigError> {
+        match self.memlock.trim().to_lowercase().as_str() {
+            "unlimited" | "" => Ok(MemlockLimit::Unlimited),
+            "inherit" => Ok(MemlockLimit::Inherit),
+            other => match other.parse::<u64>() {
+                Ok(0) => Ok(MemlockLimit::Unlimited),
+                Ok(n) => Ok(MemlockLimit::Bytes(n)),
+                Err(_) => Err(ConfigError::InvalidValue {
+                    field: "rlimits.memlock".into(),
+                    value: format!(
+                        "{:?} (expected \"unlimited\", \"inherit\", or byte count)",
+                        other
+                    ),
+                }),
+            },
+        }
+    }
+}
+
 impl SlurmConfig {
     /// Load from a TOML file.
     pub fn load_from_file(path: &Path) -> Result<Self, ConfigError> {
@@ -1325,5 +1385,78 @@ listen_addr = "[::]:6817"
 "#;
         let config = SlurmConfig::load_from_str(toml).unwrap();
         assert_eq!(config.controller.heartbeat_timeout_secs, None);
+    }
+
+    #[test]
+    fn rlimits_default_is_unlimited() {
+        let cfg = RlimitsConfig::default();
+        assert_eq!(cfg.memlock_limit().unwrap(), MemlockLimit::Unlimited);
+    }
+
+    #[test]
+    fn rlimits_parses_unlimited() {
+        let cfg = RlimitsConfig {
+            memlock: "unlimited".into(),
+        };
+        assert_eq!(cfg.memlock_limit().unwrap(), MemlockLimit::Unlimited);
+    }
+
+    #[test]
+    fn rlimits_parses_inherit() {
+        let cfg = RlimitsConfig {
+            memlock: "inherit".into(),
+        };
+        assert_eq!(cfg.memlock_limit().unwrap(), MemlockLimit::Inherit);
+    }
+
+    #[test]
+    fn rlimits_parses_bytes() {
+        let cfg = RlimitsConfig {
+            memlock: "1048576".into(),
+        };
+        assert_eq!(cfg.memlock_limit().unwrap(), MemlockLimit::Bytes(1048576));
+    }
+
+    #[test]
+    fn rlimits_invalid_errors() {
+        let cfg = RlimitsConfig {
+            memlock: "bogus".into(),
+        };
+        assert!(cfg.memlock_limit().is_err());
+    }
+
+    #[test]
+    fn rlimits_zero_treated_as_unlimited() {
+        let cfg = RlimitsConfig {
+            memlock: "0".into(),
+        };
+        assert_eq!(cfg.memlock_limit().unwrap(), MemlockLimit::Unlimited);
+    }
+
+    #[test]
+    fn rlimits_from_toml_default() {
+        let toml = r#"
+cluster_name = "test"
+"#;
+        let config = SlurmConfig::load_from_str(toml).unwrap();
+        assert_eq!(
+            config.rlimits.memlock_limit().unwrap(),
+            MemlockLimit::Unlimited
+        );
+    }
+
+    #[test]
+    fn rlimits_from_toml_explicit() {
+        let toml = r#"
+cluster_name = "test"
+
+[rlimits]
+memlock = "inherit"
+"#;
+        let config = SlurmConfig::load_from_str(toml).unwrap();
+        assert_eq!(
+            config.rlimits.memlock_limit().unwrap(),
+            MemlockLimit::Inherit
+        );
     }
 }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -4339,6 +4339,7 @@ mod tests {
             hooks: Default::default(),
             devices: Default::default(),
             admission: Default::default(),
+            rlimits: Default::default(),
         }
     }
 

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -344,5 +344,6 @@ fn default_config() -> spur_core::config::SlurmConfig {
         hooks: Default::default(),
         devices: Default::default(),
         admission: Default::default(),
+        rlimits: Default::default(),
     }
 }

--- a/crates/spurctld/src/metrics_server.rs
+++ b/crates/spurctld/src/metrics_server.rs
@@ -181,6 +181,7 @@ mod tests {
             devices: Default::default(),
             admission: Default::default(),
             burst_buffer: Default::default(),
+            rlimits: Default::default(),
         }
     }
 

--- a/crates/spurctld/src/rpc_middleware.rs
+++ b/crates/spurctld/src/rpc_middleware.rs
@@ -202,6 +202,7 @@ mod tests {
                 devices: Default::default(),
                 admission: Default::default(),
                 burst_buffer: Default::default(),
+                rlimits: Default::default(),
             }
         }
 

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -1836,6 +1836,7 @@ mod tests {
                 hooks: Default::default(),
                 devices: Default::default(),
                 admission: Default::default(),
+                rlimits: Default::default(),
             }
         }
 

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -69,6 +69,7 @@ pub struct AgentService {
     spank: Arc<Option<SpankHost>>,
     pmi_servers: Arc<Mutex<HashMap<u32, Arc<PmiServer>>>>,
     hooks: Arc<HooksConfig>,
+    memlock: spur_core::config::MemlockLimit,
     #[allow(dead_code)]
     device_registry: Arc<Mutex<DeviceRegistry>>,
 }
@@ -78,6 +79,7 @@ impl AgentService {
         reporter: Arc<NodeReporter>,
         hooks: HooksConfig,
         device_registry: Arc<Mutex<DeviceRegistry>>,
+        memlock: spur_core::config::MemlockLimit,
     ) -> Self {
         let allocation = NodeAllocation::new(
             hostname::get()
@@ -137,6 +139,7 @@ impl AgentService {
             spank: Arc::new(spank),
             pmi_servers: Arc::new(Mutex::new(HashMap::new())),
             hooks: Arc::new(hooks),
+            memlock,
             device_registry,
         }
     }
@@ -812,6 +815,7 @@ impl SlurmAgent for AgentService {
             partition: spec.partition.clone(),
             nodelist: spec.nodelist.clone(),
             host_device_plan: Some(host_device_plan),
+            memlock: self.memlock,
         };
 
         match executor::launch_job(&launch_cfg, (*self.spank).as_ref()).await {
@@ -1039,20 +1043,21 @@ impl SlurmAgent for AgentService {
             cmd.env(k, v);
         }
 
-        // Drop privilege if requested (and we're root). Mirrors the privilege
-        // drop in launch_job's non-namespace path.
-        if req.uid > 0 && nix::unistd::geteuid().is_root() {
-            let target_uid = req.uid;
-            let target_gid = req.gid;
-            unsafe {
-                cmd.pre_exec(move || {
+        let memlock = self.memlock;
+        let drop_privilege = req.uid > 0 && nix::unistd::geteuid().is_root();
+        let target_uid = req.uid;
+        let target_gid = req.gid;
+        unsafe {
+            cmd.pre_exec(move || {
+                crate::executor::apply_memlock(memlock);
+                if drop_privilege {
                     nix::unistd::setgid(nix::unistd::Gid::from_raw(target_gid))
                         .map_err(std::io::Error::other)?;
                     nix::unistd::setuid(nix::unistd::Uid::from_raw(target_uid))
                         .map_err(std::io::Error::other)?;
-                    Ok(())
-                });
-            }
+                }
+                Ok(())
+            });
         }
 
         info!(
@@ -1646,6 +1651,7 @@ mod tests {
             test_reporter(),
             HooksConfig::default(),
             Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
         );
         let job_id = 100;
         svc.insert_test_job(job_id, TrackedJob::dummy(0)).await;
@@ -1696,6 +1702,7 @@ mod tests {
             test_reporter(),
             HooksConfig::default(),
             Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
         );
         let pid = std::process::id();
         svc.insert_test_job(42, TrackedJob::dummy(pid)).await;
@@ -1715,6 +1722,7 @@ mod tests {
             test_reporter(),
             HooksConfig::default(),
             Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
         );
 
         let req = Request::new(ExecInJobRequest {
@@ -1794,6 +1802,7 @@ mod tests {
             test_reporter(),
             HooksConfig::default(),
             Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
         );
         let req = Request::new(RunCommandRequest {
             command: vec![],
@@ -1813,6 +1822,7 @@ mod tests {
             test_reporter(),
             HooksConfig::default(),
             Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
         );
         let req = Request::new(RunCommandRequest {
             command: vec!["echo".into(), "hi".into()],
@@ -1832,6 +1842,7 @@ mod tests {
             test_reporter(),
             HooksConfig::default(),
             Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
         );
         let req = Request::new(RunCommandRequest {
             command: vec!["echo".into(), "hi".into()],
@@ -1876,6 +1887,7 @@ mod tests {
             test_reporter(),
             HooksConfig::default(),
             Arc::new(Mutex::new(test_gpu_registry())),
+            spur_core::config::MemlockLimit::Unlimited,
         );
 
         let job_id = 700;
@@ -1930,6 +1942,7 @@ mod tests {
             test_reporter(),
             HooksConfig::default(),
             Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
         );
         svc.start_monitor("http://127.0.0.1:1".into());
 
@@ -1950,6 +1963,7 @@ mod tests {
             test_reporter(),
             HooksConfig::default(),
             Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
         );
         svc.start_monitor("http://127.0.0.1:1".into());
 
@@ -2024,6 +2038,7 @@ mod tests {
             test_reporter(),
             HooksConfig::default(),
             Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
         );
         svc.start_monitor("http://127.0.0.1:1".into());
 
@@ -2055,6 +2070,7 @@ mod tests {
             test_reporter(),
             HooksConfig::default(),
             Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
         );
         svc.start_monitor("http://127.0.0.1:1".into());
 

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -14,6 +14,7 @@ use nix::unistd::Pid;
 use tokio::process::Command;
 use tracing::{debug, info, warn};
 
+use spur_core::config::MemlockLimit;
 use spur_core::job::JobId;
 use spur_spank::SpankHost;
 
@@ -78,6 +79,8 @@ pub struct JobLaunchConfig {
     pub nodelist: String,
     /// Registry-based device injection plan for host (non-container) jobs.
     pub host_device_plan: Option<spur_devices::inject::HostInjectionPlan>,
+    /// RLIMIT_MEMLOCK to apply before exec (while still privileged).
+    pub memlock: MemlockLimit,
 }
 
 pub struct LaunchResult {
@@ -110,6 +113,35 @@ pub fn decode_wait_status(status: nix::sys::wait::WaitStatus) -> (i32, i32) {
         nix::sys::wait::WaitStatus::Exited(_, code) => (code, 0),
         nix::sys::wait::WaitStatus::Signaled(_, sig, _) => (0, sig as i32),
         _ => (-1, 0), // unreachable from try_wait (only Exited/Signaled reach here); -1 = shouldn't-happen sentinel
+    }
+}
+
+/// Set RLIMIT_MEMLOCK in the current process. Best-effort: a non-root spurd
+/// cannot raise the hard limit beyond what it inherited.
+pub(crate) fn apply_memlock(limit: MemlockLimit) {
+    let v = match limit {
+        MemlockLimit::Inherit => return,
+        MemlockLimit::Unlimited => libc::RLIM_INFINITY,
+        MemlockLimit::Bytes(n) => n as libc::rlim_t,
+    };
+    let rl = libc::rlimit {
+        rlim_cur: v,
+        rlim_max: v,
+    };
+    if unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &rl) } == 0 {
+        return;
+    }
+    // Non-root cannot raise hard limit. Fall back: raise soft to current hard.
+    let mut current = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    if unsafe { libc::getrlimit(libc::RLIMIT_MEMLOCK, &mut current) } == 0 {
+        let fallback = libc::rlimit {
+            rlim_cur: current.rlim_max,
+            rlim_max: current.rlim_max,
+        };
+        unsafe { libc::setrlimit(libc::RLIMIT_MEMLOCK, &fallback) };
     }
 }
 
@@ -444,6 +476,15 @@ async fn spawn_job_process(
             ] {
                 let _ = signal::sigaction(sig, &dfl);
             }
+            Ok(())
+        });
+    }
+
+    // RLIMIT_MEMLOCK: raise before privilege drop so RDMA/NCCL ibv_reg_mr works.
+    let memlock = cfg.memlock;
+    unsafe {
+        cmd.pre_exec(move || {
+            apply_memlock(memlock);
             Ok(())
         });
     }
@@ -1042,6 +1083,9 @@ async fn launch_container_job(
 
             // Close inherited fds (gRPC sockets, other jobs' files)
             crate::container::close_inherited_fds(ready_w);
+
+            // RLIMIT_MEMLOCK: raise while still root, before container_init drops privileges.
+            apply_memlock(cfg.memlock);
 
             // Run container init: namespaces, mounts, pivot_root, priv drop
             let hook_env = match crate::container::container_init(config, &rootfs) {

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -22,6 +22,34 @@ use spur_devices::DeviceRegistry;
 
 use reporter::NodeReporter;
 
+fn log_memlock_status(memlock: spur_core::config::MemlockLimit) {
+    use spur_core::config::MemlockLimit;
+    let configured_desc = match memlock {
+        MemlockLimit::Unlimited => "unlimited",
+        MemlockLimit::Inherit => "inherit",
+        MemlockLimit::Bytes(_) => "bytes",
+    };
+    let mut current = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    unsafe { libc::getrlimit(libc::RLIMIT_MEMLOCK, &mut current) };
+    let effective = if current.rlim_max == libc::RLIM_INFINITY {
+        "unlimited".to_string()
+    } else {
+        format!("{} bytes", current.rlim_max)
+    };
+    info!(configured = configured_desc, effective_hard = %effective, "memlock rlimit");
+    let is_root = unsafe { libc::geteuid() } == 0;
+    if memlock == MemlockLimit::Unlimited && current.rlim_max != libc::RLIM_INFINITY && !is_root {
+        warn!(
+            effective_hard = %effective,
+            "configured memlock=unlimited but process hard limit is finite; \
+             jobs will get at most the hard limit unless spurd runs as root"
+        );
+    }
+}
+
 /// Parse a "key=value" string into a validated label.
 fn parse_label(s: &str) -> Result<String, String> {
     if s.contains('=') && s.split('=').next().is_some_and(|k| !k.is_empty()) {
@@ -212,8 +240,15 @@ async fn main() -> anyhow::Result<()> {
     });
 
     // Start agent gRPC server (receives job launches from spurctld)
+    let memlock = match config.as_ref() {
+        Some(c) => c.rlimits.memlock_limit()?,
+        None => spur_core::config::MemlockLimit::Unlimited,
+    };
+
+    log_memlock_status(memlock);
+
     let agent_service =
-        agent_server::AgentService::new(reporter.clone(), hooks_config, registry.clone());
+        agent_server::AgentService::new(reporter.clone(), hooks_config, registry.clone(), memlock);
     agent_service.start_monitor(args.controller.clone());
 
     let addr = args.listen.parse()?;

--- a/docs/deployment/native-host.rst
+++ b/docs/deployment/native-host.rst
@@ -148,6 +148,29 @@ Verify:
    spur net status    # WireGuard peers and handshake times
    spur nodes         # All registered nodes
 
+Resource Limits (rlimits)
+-------------------------
+
+By default, ``spurd`` raises ``RLIMIT_MEMLOCK`` to unlimited for every job step
+before dropping to the submitting user. This is required for InfiniBand/RDMA
+verbs (``ibv_reg_mr``, ``ibv_create_cq``) and NCCL collective communication.
+Without it, jobs fail with ``Cannot allocate memory`` from libibverbs.
+
+The default can be changed in ``spur.conf``:
+
+.. code-block:: toml
+
+   [rlimits]
+   memlock = "unlimited"   # default: RDMA/NCCL just works
+   # memlock = "inherit"   # keep whatever spurd inherited
+   # memlock = "1073741824" # fixed cap in bytes
+
+.. note::
+
+   With the default ``"unlimited"`` setting, a ``LimitMEMLOCK=infinity`` line on
+   the ``spurd`` systemd unit is no longer required. The agent raises the limit
+   itself while still privileged.
+
 Submitting Jobs
 ---------------
 


### PR DESCRIPTION
## Summary

- spurd never called `setrlimit(RLIMIT_MEMLOCK)`, so job steps inherited the systemd default (8 MiB). NCCL/InfiniBand RDMA failed with `ibv_create_cq: Cannot allocate memory`.
- Adds a `[rlimits]` config section with a `memlock` knob (default `"unlimited"`). spurd raises the limit as root before dropping privilege, on both launch paths (non-container `pre_exec` and container `fork`).
- With the default, NCCL jobs work out of the box. No operator action needed.

## Approach

The fix mirrors how Slurm's `slurmstepd` sets rlimits: a privileged actor (`spurd`, running as root) calls `setrlimit` in the child process before the uid/gid drop. The limit persists across `setpriv`/`setuid`/`unshare`/`exec`.

Three config values are supported:
- `"unlimited"` (default) — `RLIM_INFINITY`, fixes RDMA/NCCL
- `"inherit"` — do not call setrlimit (old behavior)
- `"<bytes>"` — fixed cap

The `[rlimits]` section is scoped to POSIX per-process resource limits only (not QoS caps, not cgroup limits). Tier 2 (per-submission propagation from the submitter) will extend this section later.

## Test plan

- [x] Unit tests for parser: unlimited, inherit, bytes, invalid input, zero (treated as unlimited)
- [x] `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` clean
- [x] `cargo test --locked` all passing
- [x] Validated on bare-metal cluster: root spurd -> job gets `unlimited` memlock; non-root spurd -> raises to system hard limit (best-effort)