### PR TITLE
fix(spurd): release GPU allocation on completion and post-record launch failure

### DIFF
--- a/crates/spur-sched/src/cons_tres.rs
+++ b/crates/spur-sched/src/cons_tres.rs
@@ -27,15 +27,12 @@ pub struct NodeAllocation {
     pub gpu_allocated: Vec<bool>,
     /// GPU info for type matching.
     pub gpus: Vec<GpuResource>,
-    /// Per-job ownership of what each job holds, so an allocation can be
-    /// released by job id and orphaned allocations can be reconciled away.
-    /// This is the single source of truth for what is allocated — the bitmaps
-    /// above are a derived index for fast free-count queries.
+    /// Per-job ownership, so an allocation can be released by job id and
+    /// orphans reconciled. Source of truth; the bitmaps above are a derived
+    /// index for fast free-count queries.
     owners: HashMap<u32, AllocationResult>,
-    /// Jobs whose resources are reserved but that have not yet been committed
-    /// to the agent's running set (still mid-launch: image pull, fork, etc.).
-    /// Reconcile must never reclaim these — they have no tracked process yet
-    /// but are not orphaned.
+    /// Reserved but not yet committed to the running set (mid-launch: image
+    /// pull, fork). Reconcile spares these — not yet tracked, but not orphaned.
     launching: HashSet<u32>,
 }
 
@@ -115,16 +112,11 @@ impl NodeAllocation {
         }
     }
 
-    /// Reserve resources for a job, tracked by job id. GPU device ids are the
-    /// hard gate: if any is unknown or already in use, nothing is reserved and
-    /// None is returned (the caller must reject the dispatch). CPU/memory are
-    /// recorded as usage bookkeeping — the controller is authoritative for
-    /// placement, so an oversubscribed CPU count records what is available
-    /// rather than failing. Memory is always accounted, independent of CPU
-    /// count, so release stays symmetric.
-    ///
-    /// The job is marked `launching` until `commit_job` or `release_job` is
-    /// called, so reconcile never reclaims an in-flight launch.
+    /// Reserve resources for a job, keyed by job id. GPU device ids are the
+    /// hard gate (unknown or in-use → None, caller rejects the dispatch); CPU
+    /// is best-effort since the controller owns placement. Memory is always
+    /// accounted so release stays symmetric. Marked `launching` until
+    /// `commit_job`/`release_job` so reconcile spares an in-flight launch.
     pub fn allocate_for_job(
         &mut self,
         job_id: u32,
@@ -182,10 +174,9 @@ impl NodeAllocation {
     }
 
     /// Release every owned allocation whose job is neither in `live` nor still
-    /// launching. Returns the reclaimed job ids. This is the self-healing path:
-    /// if a job's teardown ever fails to release (a completion path that dropped
-    /// the job without releasing), its resources are recovered here instead of
-    /// stranding the node until spurd restart (SPUR-65).
+    /// launching, returning the reclaimed ids. Self-healing backstop: if a
+    /// teardown ever fails to release, resources are recovered here instead of
+    /// stranding the node until spurd restart.
     pub fn reconcile(&mut self, live: &HashSet<u32>) -> Vec<u32> {
         let orphaned: Vec<u32> = self
             .owners
@@ -293,12 +284,9 @@ mod tests {
 
     #[test]
     fn test_record_then_release_noncontiguous_device_ids() {
-        // Real nodes expose GPUs whose device_id is not its position in the
-        // vec (e.g. DRM render ids 128..135). allocate_for_job/release_job key
-        // by device_id, so a released device must return to the free pool —
-        // otherwise the slot is never cleared and the controller's next
-        // legitimate allocation of that device is rejected forever (SPUR-65:
-        // node becomes a black hole -> JobHoldMaxRequeue).
+        // Real nodes expose GPUs whose device_id != vec position (DRM render
+        // ids 128..135). Release keys by device_id, so a released device must
+        // return to the free pool or it is rejected forever.
         let mut node = make_node_with_ids(64, 256_000, vec![128, 129, 130, 131], "mi350x");
 
         assert!(node.allocate_for_job(1, 0, 0, &[129, 131]).is_some());
@@ -378,8 +366,7 @@ mod tests {
         // job 1: committed and live.
         node.allocate_for_job(1, 4, 8_000, &[0]);
         node.commit_job(1);
-        // job 2: committed but NOT live (its teardown failed to release — the
-        // exact SPUR-65 orphan condition).
+        // job 2: committed but NOT live (teardown failed to release — orphan).
         node.allocate_for_job(2, 4, 8_000, &[1]);
         node.commit_job(2);
         // job 3: still launching (reserved, not yet committed) — must be spared.

--- a/crates/spur-sched/src/cons_tres.rs
+++ b/crates/spur-sched/src/cons_tres.rs
@@ -10,6 +10,17 @@ use std::collections::{HashMap, HashSet};
 
 use spur_core::resource::{GpuResource, ResourceSet};
 
+/// Why a reservation could not be made. Distinguished so the caller can map
+/// each to the right gRPC status instead of reporting every failure as GPU
+/// exhaustion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AllocError {
+    /// A controller-allocated GPU is unknown to this node or already in use.
+    GpusUnavailable,
+    /// This job id already holds a reservation (a retried LaunchJob RPC).
+    DuplicateJob,
+}
+
 /// Per-node resource allocation state.
 /// Tracks which specific cores and GPUs are allocated.
 #[derive(Debug, Clone)]
@@ -113,28 +124,33 @@ impl NodeAllocation {
     }
 
     /// Reserve resources for a job, keyed by job id. GPU device ids are the
-    /// hard gate (unknown or in-use → None, caller rejects the dispatch); CPU
-    /// is best-effort since the controller owns placement. Memory is always
-    /// accounted so release stays symmetric. Marked `launching` until
-    /// `commit_job`/`release_job` so reconcile spares an in-flight launch.
+    /// hard gate (unknown or in-use → `GpusUnavailable`); a job id that already
+    /// holds a reservation → `DuplicateJob`. CPU is best-effort since the
+    /// controller owns placement. Memory is always accounted so release stays
+    /// symmetric. Marked `launching` until `commit_job`/`release_job` so
+    /// reconcile spares an in-flight launch.
     pub fn allocate_for_job(
         &mut self,
         job_id: u32,
         cpus: u32,
         memory_mb: u64,
         gpu_device_ids: &[u32],
-    ) -> Option<AllocationResult> {
+    ) -> Result<AllocationResult, AllocError> {
         // A duplicate reservation for the same job (a retried LaunchJob RPC)
         // would double-count CPU/memory and orphan the prior owner entry.
         if self.owners.contains_key(&job_id) {
-            return None;
+            return Err(AllocError::DuplicateJob);
         }
 
         let mut gpu_indices = Vec::with_capacity(gpu_device_ids.len());
         for &id in gpu_device_ids {
-            let idx = self.gpus.iter().position(|g| g.device_id == id)?;
+            let idx = self
+                .gpus
+                .iter()
+                .position(|g| g.device_id == id)
+                .ok_or(AllocError::GpusUnavailable)?;
             if self.gpu_allocated[idx] || gpu_indices.contains(&idx) {
-                return None;
+                return Err(AllocError::GpusUnavailable);
             }
             gpu_indices.push(idx);
         }
@@ -159,7 +175,7 @@ impl NodeAllocation {
         };
         self.owners.insert(job_id, result.clone());
         self.launching.insert(job_id);
-        Some(result)
+        Ok(result)
     }
 
     /// Mark a job's allocation as committed (its process is now tracked), so it
@@ -198,7 +214,7 @@ impl NodeAllocation {
 }
 
 /// Result of a successful allocation.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AllocationResult {
     /// Allocated core IDs.
     pub cpu_ids: Vec<u32>,
@@ -295,7 +311,7 @@ mod tests {
         // return to the free pool or it is rejected forever.
         let mut node = make_node_with_ids(64, 256_000, vec![128, 129, 130, 131], "mi350x");
 
-        assert!(node.allocate_for_job(1, 0, 0, &[129, 131]).is_some());
+        assert!(node.allocate_for_job(1, 0, 0, &[129, 131]).is_ok());
         assert_eq!(node.free_gpus(None), 2);
 
         assert!(node.release_job(1));
@@ -307,7 +323,7 @@ mod tests {
 
         // The whole point: the device is re-allocatable after release.
         assert!(
-            node.allocate_for_job(2, 0, 0, &[129, 131]).is_some(),
+            node.allocate_for_job(2, 0, 0, &[129, 131]).is_ok(),
             "device_ids must be re-allocatable after release"
         );
     }
@@ -315,7 +331,7 @@ mod tests {
     #[test]
     fn test_allocate_rejects_unknown_device_id() {
         let mut node = make_node_with_ids(64, 256_000, vec![128, 129], "mi350x");
-        assert!(node.allocate_for_job(1, 0, 0, &[200]).is_none());
+        assert!(node.allocate_for_job(1, 0, 0, &[200]).is_err());
         // A rejected allocation must not leave partial state behind.
         assert_eq!(node.free_gpus(None), 2);
         assert!(!node.release_job(1));
@@ -326,12 +342,12 @@ mod tests {
         // If a multi-GPU allocation hits a conflict partway, it must not leave
         // the earlier device_ids marked allocated — that is itself a leak.
         let mut node = make_node_with_ids(64, 256_000, vec![128, 129, 130], "mi350x");
-        assert!(node.allocate_for_job(1, 0, 0, &[129]).is_some());
+        assert!(node.allocate_for_job(1, 0, 0, &[129]).is_ok());
         // [128, 129] — 129 already taken, so the whole call must fail and 128
         // must remain free.
-        assert!(node.allocate_for_job(2, 0, 0, &[128, 129]).is_none());
+        assert!(node.allocate_for_job(2, 0, 0, &[128, 129]).is_err());
         assert!(
-            node.allocate_for_job(3, 0, 0, &[128]).is_some(),
+            node.allocate_for_job(3, 0, 0, &[128]).is_ok(),
             "128 must remain free after the failed partial allocation"
         );
     }
@@ -360,21 +376,27 @@ mod tests {
         // A retried reservation for the same job must not double-count CPU/mem
         // or orphan the prior owner entry.
         let mut node = make_node(64, 256_000, 0, "");
-        assert!(node.allocate_for_job(1, 8, 16_000, &[]).is_some());
-        assert!(node.allocate_for_job(1, 8, 16_000, &[]).is_none());
+        assert!(node.allocate_for_job(1, 8, 16_000, &[]).is_ok());
+        assert_eq!(
+            node.allocate_for_job(1, 8, 16_000, &[]),
+            Err(AllocError::DuplicateJob)
+        );
         assert_eq!(node.free_cpus(), 56);
         assert_eq!(node.free_memory_mb(), 240_000);
         // After release the id is free to reserve again.
         assert!(node.release_job(1));
-        assert!(node.allocate_for_job(1, 8, 16_000, &[]).is_some());
+        assert!(node.allocate_for_job(1, 8, 16_000, &[]).is_ok());
     }
 
     #[test]
     fn test_allocate_for_job_rejects_conflicting_gpu() {
         let mut node = make_node_with_ids(64, 256_000, vec![0, 1], "mi300x");
-        assert!(node.allocate_for_job(1, 4, 0, &[0]).is_some());
+        assert!(node.allocate_for_job(1, 4, 0, &[0]).is_ok());
         // Second job wanting the same device id must fail with no state change.
-        assert!(node.allocate_for_job(2, 4, 0, &[0]).is_none());
+        assert_eq!(
+            node.allocate_for_job(2, 4, 0, &[0]),
+            Err(AllocError::GpusUnavailable)
+        );
         assert_eq!(node.free_gpus(None), 1);
         // The failed job left no owner entry.
         assert!(!node.release_job(2));
@@ -384,13 +406,13 @@ mod tests {
     fn test_reconcile_reclaims_orphans_but_spares_live_and_launching() {
         let mut node = make_node_with_ids(64, 256_000, vec![0, 1, 2, 3], "mi300x");
         // job 1: committed and live.
-        node.allocate_for_job(1, 4, 8_000, &[0]);
+        node.allocate_for_job(1, 4, 8_000, &[0]).unwrap();
         node.commit_job(1);
         // job 2: committed but NOT live (teardown failed to release — orphan).
-        node.allocate_for_job(2, 4, 8_000, &[1]);
+        node.allocate_for_job(2, 4, 8_000, &[1]).unwrap();
         node.commit_job(2);
         // job 3: still launching (reserved, not yet committed) — must be spared.
-        node.allocate_for_job(3, 4, 8_000, &[2]);
+        node.allocate_for_job(3, 4, 8_000, &[2]).unwrap();
 
         let live: HashSet<u32> = [1].into_iter().collect();
         let mut reclaimed = node.reconcile(&live);
@@ -407,10 +429,10 @@ mod tests {
     #[test]
     fn test_memory_released_symmetrically_with_zero_cpus() {
         // A job with 0 cpus must still have its memory reserved and released
-        // symmetrically — otherwise release drives allocated_memory_mb below
-        // what was added (the pre-fix drift).
+        // symmetrically, or release drives allocated_memory_mb below what was
+        // added.
         let mut node = make_node(64, 256_000, 0, "");
-        node.allocate_for_job(1, 0, 16_000, &[]);
+        node.allocate_for_job(1, 0, 16_000, &[]).unwrap();
         assert_eq!(node.free_memory_mb(), 240_000);
         node.release_job(1);
         assert_eq!(node.free_memory_mb(), 256_000);

--- a/crates/spur-sched/src/cons_tres.rs
+++ b/crates/spur-sched/src/cons_tres.rs
@@ -17,7 +17,9 @@ use spur_core::resource::{GpuResource, ResourceSet};
 pub enum AllocError {
     /// A controller-allocated GPU is unknown to this node or already in use.
     GpusUnavailable,
-    /// This job id already holds a reservation (a retried LaunchJob RPC).
+    /// A LaunchJob is already in flight for this job id (its reservation is
+    /// still mid-launch, not yet committed or released). A second concurrent
+    /// launch would double-count resources, so it is rejected.
     DuplicateJob,
 }
 
@@ -124,8 +126,8 @@ impl NodeAllocation {
     }
 
     /// Reserve resources for a job, keyed by job id. GPU device ids are the
-    /// hard gate (unknown or in-use → `GpusUnavailable`); a job id that already
-    /// holds a reservation → `DuplicateJob`. CPU is best-effort since the
+    /// hard gate (unknown or in-use → `GpusUnavailable`); a launch already in
+    /// flight for the same job id → `DuplicateJob`. CPU is best-effort since the
     /// controller owns placement. Memory is always accounted so release stays
     /// symmetric. Marked `launching` until `commit_job`/`release_job` so
     /// reconcile spares an in-flight launch.
@@ -136,11 +138,18 @@ impl NodeAllocation {
         memory_mb: u64,
         gpu_device_ids: &[u32],
     ) -> Result<AllocationResult, AllocError> {
-        // A duplicate reservation for the same job (a retried LaunchJob RPC)
-        // would double-count CPU/memory and orphan the prior owner entry.
-        if self.owners.contains_key(&job_id) {
+        // A launch still in flight (reserved, not yet committed or released) is
+        // a genuine concurrent duplicate: a second launch would double-count.
+        if self.launching.contains(&job_id) {
             return Err(AllocError::DuplicateJob);
         }
+        // A committed reservation still owned here means a prior run's teardown
+        // has not released yet (e.g. a preempted-then-requeued job re-dispatched
+        // under the same id before the agent reaped the killed process). The
+        // controller only re-issues LaunchJob after freeing the job, so this
+        // reservation is stale — supersede it rather than reject, releasing it
+        // first so CPU/memory stay symmetric and the owner entry is not orphaned.
+        self.release_job(job_id);
 
         let mut gpu_indices = Vec::with_capacity(gpu_device_ids.len());
         for &id in gpu_device_ids {
@@ -372,9 +381,10 @@ mod tests {
     }
 
     #[test]
-    fn test_allocate_for_job_rejects_duplicate_job_id() {
-        // A retried reservation for the same job must not double-count CPU/mem
-        // or orphan the prior owner entry.
+    fn test_allocate_for_job_rejects_in_flight_duplicate() {
+        // A second launch while the first is still in flight (reserved, not yet
+        // committed or released) is a genuine concurrent duplicate: rejecting it
+        // avoids double-counting CPU/mem and orphaning the prior owner entry.
         let mut node = make_node(64, 256_000, 0, "");
         assert!(node.allocate_for_job(1, 8, 16_000, &[]).is_ok());
         assert_eq!(
@@ -386,6 +396,33 @@ mod tests {
         // After release the id is free to reserve again.
         assert!(node.release_job(1));
         assert!(node.allocate_for_job(1, 8, 16_000, &[]).is_ok());
+    }
+
+    #[test]
+    fn test_allocate_for_job_supersedes_stale_committed_reservation() {
+        // A committed reservation whose teardown has not released yet (e.g. a
+        // preempted-then-requeued job re-dispatched under the same id before the
+        // agent reaped the killed process) must be superseded, not rejected —
+        // otherwise the legitimate re-launch fails and the job never runs. The
+        // stale reservation is released first, so resources are not double-counted.
+        let mut node = make_node(64, 256_000, 0, "");
+        node.allocate_for_job(7, 8, 16_000, &[]).unwrap();
+        node.commit_job(7); // prior run committed, then preempted (not released).
+        assert_eq!(node.free_cpus(), 56);
+
+        // Re-dispatch under the same id succeeds and does not double-count.
+        let alloc = node
+            .allocate_for_job(7, 8, 16_000, &[])
+            .expect("re-dispatch of a stale committed job id must succeed");
+        assert_eq!(alloc.cpu_ids.len(), 8);
+        assert_eq!(node.free_cpus(), 56);
+        assert_eq!(node.free_memory_mb(), 240_000);
+        // Exactly one owner entry remains, and the fresh reservation is again
+        // treated as in-flight until it commits or releases.
+        assert_eq!(
+            node.allocate_for_job(7, 8, 16_000, &[]),
+            Err(AllocError::DuplicateJob)
+        );
     }
 
     #[test]

--- a/crates/spur-sched/src/cons_tres.rs
+++ b/crates/spur-sched/src/cons_tres.rs
@@ -52,6 +52,16 @@ impl NodeAllocation {
             .saturating_sub(self.allocated_memory_mb)
     }
 
+    /// Device ids of all currently-allocated GPUs (for diagnostics).
+    pub fn allocated_gpu_ids(&self) -> Vec<u32> {
+        self.gpu_allocated
+            .iter()
+            .enumerate()
+            .filter(|(_, &a)| a)
+            .filter_map(|(i, _)| self.gpus.get(i).map(|g| g.device_id))
+            .collect()
+    }
+
     /// Available GPU count (optionally filtered by type).
     pub fn free_gpus(&self, gpu_type: Option<&str>) -> u32 {
         self.gpu_allocated
@@ -101,10 +111,12 @@ impl NodeAllocation {
         // Allocate memory
         self.allocated_memory_mb += memory_mb;
 
-        // Allocate GPUs (first-fit with type matching)
+        // Allocate GPUs (first-fit with type matching). gpu_ids holds device
+        // ids (stable hardware identifiers), not vec positions, so release and
+        // record_gpus can agree on a single meaning.
         let mut gpu_ids = Vec::new();
-        for (i, allocated) in self.gpu_allocated.iter_mut().enumerate() {
-            if *allocated || gpu_ids.len() >= gpus as usize {
+        for i in 0..self.gpu_allocated.len() {
+            if self.gpu_allocated[i] || gpu_ids.len() >= gpus as usize {
                 continue;
             }
             if let Some(gtype) = gpu_type {
@@ -112,8 +124,8 @@ impl NodeAllocation {
                     continue;
                 }
             }
-            *allocated = true;
-            gpu_ids.push(i as u32);
+            self.gpu_allocated[i] = true;
+            gpu_ids.push(self.gpus[i].device_id);
         }
 
         Some(AllocationResult {
@@ -123,21 +135,28 @@ impl NodeAllocation {
         })
     }
 
-    /// Record controller-assigned device IDs as in-use.
+    /// Record controller-assigned device IDs as in-use. All-or-nothing: if any
+    /// id is unknown or already allocated, no state is changed and false is
+    /// returned (a partial record would leak the earlier ids).
     pub fn record_gpus(&mut self, device_ids: &[u32]) -> bool {
+        let mut indices = Vec::with_capacity(device_ids.len());
         for &id in device_ids {
             let Some(idx) = self.gpus.iter().position(|g| g.device_id == id) else {
                 return false;
             };
-            if self.gpu_allocated[idx] {
+            if self.gpu_allocated[idx] || indices.contains(&idx) {
                 return false;
             }
+            indices.push(idx);
+        }
+        for idx in indices {
             self.gpu_allocated[idx] = true;
         }
         true
     }
 
-    /// Release previously allocated resources.
+    /// Release previously allocated resources. GPU ids are device ids, matched
+    /// against the node's GPU table the same way record_gpus records them.
     pub fn release(&mut self, alloc: &AllocationResult) {
         for &cpu in &alloc.cpu_ids {
             if let Some(a) = self.allocated_cpus.get_mut(cpu as usize) {
@@ -145,9 +164,9 @@ impl NodeAllocation {
             }
         }
         self.allocated_memory_mb = self.allocated_memory_mb.saturating_sub(alloc.memory_mb);
-        for &gpu in &alloc.gpu_ids {
-            if let Some(a) = self.gpu_allocated.get_mut(gpu as usize) {
-                *a = false;
+        for &device_id in &alloc.gpu_ids {
+            if let Some(idx) = self.gpus.iter().position(|g| g.device_id == device_id) {
+                self.gpu_allocated[idx] = false;
             }
         }
     }
@@ -190,9 +209,19 @@ mod tests {
     use spur_core::resource::GpuLinkType;
 
     fn make_node(cpus: u32, mem: u64, num_gpus: usize, gpu_type: &str) -> NodeAllocation {
-        let gpus: Vec<GpuResource> = (0..num_gpus)
-            .map(|i| GpuResource {
-                device_id: i as u32,
+        make_node_with_ids(cpus, mem, (0..num_gpus as u32).collect(), gpu_type)
+    }
+
+    fn make_node_with_ids(
+        cpus: u32,
+        mem: u64,
+        device_ids: Vec<u32>,
+        gpu_type: &str,
+    ) -> NodeAllocation {
+        let gpus: Vec<GpuResource> = device_ids
+            .into_iter()
+            .map(|device_id| GpuResource {
+                device_id,
                 gpu_type: gpu_type.into(),
                 memory_mb: 192_000,
                 peer_gpus: vec![],
@@ -267,6 +296,61 @@ mod tests {
         assert_eq!(node.free_cpus(), 64);
         assert_eq!(node.free_memory_mb(), 256_000);
         assert_eq!(node.free_gpus(None), 8);
+    }
+
+    #[test]
+    fn test_record_then_release_noncontiguous_device_ids() {
+        // Real nodes expose GPUs whose device_id is not its position in the
+        // vec (e.g. DRM render ids 128..135). record_gpus keys by device_id,
+        // so release must too — otherwise the slot is never cleared and the
+        // controller's next legitimate allocation of that device is rejected
+        // forever (SPUR-65: node becomes a black hole -> JobHoldMaxRequeue).
+        let mut node = make_node_with_ids(64, 256_000, vec![128, 129, 130, 131], "mi350x");
+
+        // Controller assigns device_ids (not indices), mirroring the agent path.
+        assert!(node.record_gpus(&[129, 131]));
+        assert_eq!(node.free_gpus(None), 2);
+
+        let alloc = AllocationResult {
+            cpu_ids: vec![],
+            gpu_ids: vec![129, 131],
+            memory_mb: 0,
+        };
+        node.release(&alloc);
+        assert_eq!(
+            node.free_gpus(None),
+            4,
+            "released GPUs must return to the free pool"
+        );
+
+        // The whole point: the device is re-allocatable after release.
+        assert!(
+            node.record_gpus(&[129, 131]),
+            "device_ids must be re-recordable after release"
+        );
+    }
+
+    #[test]
+    fn test_record_gpus_rejects_unknown_device_id() {
+        let mut node = make_node_with_ids(64, 256_000, vec![128, 129], "mi350x");
+        assert!(!node.record_gpus(&[200]));
+        // A rejected record must not leave partial state behind.
+        assert_eq!(node.free_gpus(None), 2);
+    }
+
+    #[test]
+    fn test_record_gpus_rolls_back_on_partial_conflict() {
+        // If a multi-GPU record hits a conflict partway, it must not leave the
+        // earlier device_ids marked allocated — that is itself a leak.
+        let mut node = make_node_with_ids(64, 256_000, vec![128, 129, 130], "mi350x");
+        assert!(node.record_gpus(&[129]));
+        // [128, 129] — 129 already taken, so the whole call must fail and 128
+        // must remain free.
+        assert!(!node.record_gpus(&[128, 129]));
+        assert!(
+            node.record_gpus(&[128]),
+            "128 must remain free after the failed partial record"
+        );
     }
 
     #[test]

--- a/crates/spur-sched/src/cons_tres.rs
+++ b/crates/spur-sched/src/cons_tres.rs
@@ -124,6 +124,12 @@ impl NodeAllocation {
         memory_mb: u64,
         gpu_device_ids: &[u32],
     ) -> Option<AllocationResult> {
+        // A duplicate reservation for the same job (a retried LaunchJob RPC)
+        // would double-count CPU/memory and orphan the prior owner entry.
+        if self.owners.contains_key(&job_id) {
+            return None;
+        }
+
         let mut gpu_indices = Vec::with_capacity(gpu_device_ids.len());
         for &id in gpu_device_ids {
             let idx = self.gpus.iter().position(|g| g.device_id == id)?;
@@ -347,6 +353,20 @@ mod tests {
         assert_eq!(node.free_memory_mb(), 256_000);
         // Idempotent: releasing again is a no-op.
         assert!(!node.release_job(1));
+    }
+
+    #[test]
+    fn test_allocate_for_job_rejects_duplicate_job_id() {
+        // A retried reservation for the same job must not double-count CPU/mem
+        // or orphan the prior owner entry.
+        let mut node = make_node(64, 256_000, 0, "");
+        assert!(node.allocate_for_job(1, 8, 16_000, &[]).is_some());
+        assert!(node.allocate_for_job(1, 8, 16_000, &[]).is_none());
+        assert_eq!(node.free_cpus(), 56);
+        assert_eq!(node.free_memory_mb(), 240_000);
+        // After release the id is free to reserve again.
+        assert!(node.release_job(1));
+        assert!(node.allocate_for_job(1, 8, 16_000, &[]).is_some());
     }
 
     #[test]

--- a/crates/spur-sched/src/cons_tres.rs
+++ b/crates/spur-sched/src/cons_tres.rs
@@ -6,6 +6,8 @@
 //! Tracks resources at core/socket/GPU granularity within a node.
 //! This is the equivalent of Slurm's select/cons_tres plugin.
 
+use std::collections::{HashMap, HashSet};
+
 use spur_core::resource::{GpuResource, ResourceSet};
 
 /// Per-node resource allocation state.
@@ -25,6 +27,16 @@ pub struct NodeAllocation {
     pub gpu_allocated: Vec<bool>,
     /// GPU info for type matching.
     pub gpus: Vec<GpuResource>,
+    /// Per-job ownership of what each job holds, so an allocation can be
+    /// released by job id and orphaned allocations can be reconciled away.
+    /// This is the single source of truth for what is allocated — the bitmaps
+    /// above are a derived index for fast free-count queries.
+    owners: HashMap<u32, AllocationResult>,
+    /// Jobs whose resources are reserved but that have not yet been committed
+    /// to the agent's running set (still mid-launch: image pull, fork, etc.).
+    /// Reconcile must never reclaim these — they have no tracked process yet
+    /// but are not orphaned.
+    launching: HashSet<u32>,
 }
 
 impl NodeAllocation {
@@ -38,6 +50,8 @@ impl NodeAllocation {
             allocated_memory_mb: 0,
             gpu_allocated: vec![false; num_gpus],
             gpus: resources.gpus.clone(),
+            owners: HashMap::new(),
+            launching: HashSet::new(),
         }
     }
 
@@ -83,81 +97,11 @@ impl NodeAllocation {
             .count() as u32
     }
 
-    /// Try to allocate resources. Returns allocated core IDs and GPU IDs, or None if insufficient.
-    pub fn try_allocate(
-        &mut self,
-        cpus: u32,
-        memory_mb: u64,
-        gpus: u32,
-        gpu_type: Option<&str>,
-    ) -> Option<AllocationResult> {
-        // Check availability
-        if self.free_cpus() < cpus
-            || self.free_memory_mb() < memory_mb
-            || self.free_gpus(gpu_type) < gpus
-        {
-            return None;
-        }
-
-        // Allocate CPUs (first-fit)
-        let mut cpu_ids = Vec::new();
-        for (i, allocated) in self.allocated_cpus.iter_mut().enumerate() {
-            if !*allocated && cpu_ids.len() < cpus as usize {
-                *allocated = true;
-                cpu_ids.push(i as u32);
-            }
-        }
-
-        // Allocate memory
-        self.allocated_memory_mb += memory_mb;
-
-        // Allocate GPUs (first-fit with type matching). gpu_ids holds device
-        // ids (stable hardware identifiers), not vec positions, so release and
-        // record_gpus can agree on a single meaning.
-        let mut gpu_ids = Vec::new();
-        for i in 0..self.gpu_allocated.len() {
-            if self.gpu_allocated[i] || gpu_ids.len() >= gpus as usize {
-                continue;
-            }
-            if let Some(gtype) = gpu_type {
-                if gtype != "any" && self.gpus.get(i).map(|g| g.gpu_type.as_str()) != Some(gtype) {
-                    continue;
-                }
-            }
-            self.gpu_allocated[i] = true;
-            gpu_ids.push(self.gpus[i].device_id);
-        }
-
-        Some(AllocationResult {
-            cpu_ids,
-            gpu_ids,
-            memory_mb,
-        })
-    }
-
-    /// Record controller-assigned device IDs as in-use. All-or-nothing: if any
-    /// id is unknown or already allocated, no state is changed and false is
-    /// returned (a partial record would leak the earlier ids).
-    pub fn record_gpus(&mut self, device_ids: &[u32]) -> bool {
-        let mut indices = Vec::with_capacity(device_ids.len());
-        for &id in device_ids {
-            let Some(idx) = self.gpus.iter().position(|g| g.device_id == id) else {
-                return false;
-            };
-            if self.gpu_allocated[idx] || indices.contains(&idx) {
-                return false;
-            }
-            indices.push(idx);
-        }
-        for idx in indices {
-            self.gpu_allocated[idx] = true;
-        }
-        true
-    }
-
-    /// Release previously allocated resources. GPU ids are device ids, matched
-    /// against the node's GPU table the same way record_gpus records them.
-    pub fn release(&mut self, alloc: &AllocationResult) {
+    /// Free the bitmaps/counters an allocation held. Internal helper: callers
+    /// go through `release_job` so per-job ownership stays consistent. GPU ids
+    /// are device ids, matched against the node's GPU table the same way
+    /// `allocate_for_job` records them.
+    fn release(&mut self, alloc: &AllocationResult) {
         for &cpu in &alloc.cpu_ids {
             if let Some(a) = self.allocated_cpus.get_mut(cpu as usize) {
                 *a = false;
@@ -169,6 +113,90 @@ impl NodeAllocation {
                 self.gpu_allocated[idx] = false;
             }
         }
+    }
+
+    /// Reserve resources for a job, tracked by job id. GPU device ids are the
+    /// hard gate: if any is unknown or already in use, nothing is reserved and
+    /// None is returned (the caller must reject the dispatch). CPU/memory are
+    /// recorded as usage bookkeeping — the controller is authoritative for
+    /// placement, so an oversubscribed CPU count records what is available
+    /// rather than failing. Memory is always accounted, independent of CPU
+    /// count, so release stays symmetric.
+    ///
+    /// The job is marked `launching` until `commit_job` or `release_job` is
+    /// called, so reconcile never reclaims an in-flight launch.
+    pub fn allocate_for_job(
+        &mut self,
+        job_id: u32,
+        cpus: u32,
+        memory_mb: u64,
+        gpu_device_ids: &[u32],
+    ) -> Option<AllocationResult> {
+        let mut gpu_indices = Vec::with_capacity(gpu_device_ids.len());
+        for &id in gpu_device_ids {
+            let idx = self.gpus.iter().position(|g| g.device_id == id)?;
+            if self.gpu_allocated[idx] || gpu_indices.contains(&idx) {
+                return None;
+            }
+            gpu_indices.push(idx);
+        }
+
+        let mut cpu_ids = Vec::new();
+        for (i, allocated) in self.allocated_cpus.iter_mut().enumerate() {
+            if !*allocated && cpu_ids.len() < cpus as usize {
+                *allocated = true;
+                cpu_ids.push(i as u32);
+            }
+        }
+
+        self.allocated_memory_mb += memory_mb;
+        for &idx in &gpu_indices {
+            self.gpu_allocated[idx] = true;
+        }
+
+        let result = AllocationResult {
+            cpu_ids,
+            gpu_ids: gpu_device_ids.to_vec(),
+            memory_mb,
+        };
+        self.owners.insert(job_id, result.clone());
+        self.launching.insert(job_id);
+        Some(result)
+    }
+
+    /// Mark a job's allocation as committed (its process is now tracked), so it
+    /// is no longer exempt from reconcile.
+    pub fn commit_job(&mut self, job_id: u32) {
+        self.launching.remove(&job_id);
+    }
+
+    /// Release a job's allocation by id. Idempotent: releasing an unknown or
+    /// already-released job is a no-op returning false.
+    pub fn release_job(&mut self, job_id: u32) -> bool {
+        self.launching.remove(&job_id);
+        let Some(alloc) = self.owners.remove(&job_id) else {
+            return false;
+        };
+        self.release(&alloc);
+        true
+    }
+
+    /// Release every owned allocation whose job is neither in `live` nor still
+    /// launching. Returns the reclaimed job ids. This is the self-healing path:
+    /// if a job's teardown ever fails to release (a completion path that dropped
+    /// the job without releasing), its resources are recovered here instead of
+    /// stranding the node until spurd restart (SPUR-65).
+    pub fn reconcile(&mut self, live: &HashSet<u32>) -> Vec<u32> {
+        let orphaned: Vec<u32> = self
+            .owners
+            .keys()
+            .copied()
+            .filter(|id| !live.contains(id) && !self.launching.contains(id))
+            .collect();
+        for &id in &orphaned {
+            self.release_job(id);
+        }
+        orphaned
     }
 }
 
@@ -250,73 +278,33 @@ mod tests {
     #[test]
     fn test_allocate_cpus() {
         let mut node = make_node(64, 256_000, 0, "");
-        let alloc = node.try_allocate(16, 0, 0, None).unwrap();
+        let alloc = node.allocate_for_job(1, 16, 0, &[]).unwrap();
         assert_eq!(alloc.cpu_ids.len(), 16);
         assert_eq!(node.free_cpus(), 48);
     }
 
     #[test]
-    fn test_allocate_gpus() {
+    fn test_allocate_gpus_by_device_id() {
         let mut node = make_node(64, 256_000, 8, "mi300x");
-        let alloc = node.try_allocate(0, 0, 4, Some("mi300x")).unwrap();
-        assert_eq!(alloc.gpu_ids.len(), 4);
-        assert_eq!(node.free_gpus(Some("mi300x")), 4);
-    }
-
-    #[test]
-    fn test_allocate_wrong_gpu_type() {
-        let mut node = make_node(64, 256_000, 8, "mi300x");
-        let result = node.try_allocate(0, 0, 4, Some("h100"));
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn test_allocate_any_gpu() {
-        let mut node = make_node(64, 256_000, 8, "mi300x");
-        let alloc = node.try_allocate(0, 0, 4, Some("any")).unwrap();
-        assert_eq!(alloc.gpu_ids.len(), 4);
-    }
-
-    #[test]
-    fn test_insufficient_resources() {
-        let mut node = make_node(32, 128_000, 4, "mi300x");
-        assert!(node.try_allocate(64, 0, 0, None).is_none()); // Too many CPUs
-        assert!(node.try_allocate(0, 256_000, 0, None).is_none()); // Too much memory
-        assert!(node.try_allocate(0, 0, 8, None).is_none()); // Too many GPUs
-    }
-
-    #[test]
-    fn test_release() {
-        let mut node = make_node(64, 256_000, 8, "mi300x");
-        let alloc = node.try_allocate(32, 128_000, 4, None).unwrap();
-        assert_eq!(node.free_cpus(), 32);
+        let alloc = node.allocate_for_job(1, 0, 0, &[0, 1, 2, 3]).unwrap();
+        assert_eq!(alloc.gpu_ids, vec![0, 1, 2, 3]);
         assert_eq!(node.free_gpus(None), 4);
-
-        node.release(&alloc);
-        assert_eq!(node.free_cpus(), 64);
-        assert_eq!(node.free_memory_mb(), 256_000);
-        assert_eq!(node.free_gpus(None), 8);
     }
 
     #[test]
     fn test_record_then_release_noncontiguous_device_ids() {
         // Real nodes expose GPUs whose device_id is not its position in the
-        // vec (e.g. DRM render ids 128..135). record_gpus keys by device_id,
-        // so release must too — otherwise the slot is never cleared and the
-        // controller's next legitimate allocation of that device is rejected
-        // forever (SPUR-65: node becomes a black hole -> JobHoldMaxRequeue).
+        // vec (e.g. DRM render ids 128..135). allocate_for_job/release_job key
+        // by device_id, so a released device must return to the free pool —
+        // otherwise the slot is never cleared and the controller's next
+        // legitimate allocation of that device is rejected forever (SPUR-65:
+        // node becomes a black hole -> JobHoldMaxRequeue).
         let mut node = make_node_with_ids(64, 256_000, vec![128, 129, 130, 131], "mi350x");
 
-        // Controller assigns device_ids (not indices), mirroring the agent path.
-        assert!(node.record_gpus(&[129, 131]));
+        assert!(node.allocate_for_job(1, 0, 0, &[129, 131]).is_some());
         assert_eq!(node.free_gpus(None), 2);
 
-        let alloc = AllocationResult {
-            cpu_ids: vec![],
-            gpu_ids: vec![129, 131],
-            memory_mb: 0,
-        };
-        node.release(&alloc);
+        assert!(node.release_job(1));
         assert_eq!(
             node.free_gpus(None),
             4,
@@ -325,39 +313,107 @@ mod tests {
 
         // The whole point: the device is re-allocatable after release.
         assert!(
-            node.record_gpus(&[129, 131]),
-            "device_ids must be re-recordable after release"
+            node.allocate_for_job(2, 0, 0, &[129, 131]).is_some(),
+            "device_ids must be re-allocatable after release"
         );
     }
 
     #[test]
-    fn test_record_gpus_rejects_unknown_device_id() {
+    fn test_allocate_rejects_unknown_device_id() {
         let mut node = make_node_with_ids(64, 256_000, vec![128, 129], "mi350x");
-        assert!(!node.record_gpus(&[200]));
-        // A rejected record must not leave partial state behind.
+        assert!(node.allocate_for_job(1, 0, 0, &[200]).is_none());
+        // A rejected allocation must not leave partial state behind.
         assert_eq!(node.free_gpus(None), 2);
+        assert!(!node.release_job(1));
     }
 
     #[test]
-    fn test_record_gpus_rolls_back_on_partial_conflict() {
-        // If a multi-GPU record hits a conflict partway, it must not leave the
-        // earlier device_ids marked allocated — that is itself a leak.
+    fn test_allocate_rolls_back_on_partial_gpu_conflict() {
+        // If a multi-GPU allocation hits a conflict partway, it must not leave
+        // the earlier device_ids marked allocated — that is itself a leak.
         let mut node = make_node_with_ids(64, 256_000, vec![128, 129, 130], "mi350x");
-        assert!(node.record_gpus(&[129]));
+        assert!(node.allocate_for_job(1, 0, 0, &[129]).is_some());
         // [128, 129] — 129 already taken, so the whole call must fail and 128
         // must remain free.
-        assert!(!node.record_gpus(&[128, 129]));
+        assert!(node.allocate_for_job(2, 0, 0, &[128, 129]).is_none());
         assert!(
-            node.record_gpus(&[128]),
-            "128 must remain free after the failed partial record"
+            node.allocate_for_job(3, 0, 0, &[128]).is_some(),
+            "128 must remain free after the failed partial allocation"
         );
+    }
+
+    #[test]
+    fn test_allocate_for_job_release_by_id() {
+        let mut node = make_node_with_ids(64, 256_000, vec![128, 129, 130, 131], "mi350x");
+        let alloc = node
+            .allocate_for_job(1, 8, 32_000, &[129, 131])
+            .expect("allocation should succeed");
+        assert_eq!(alloc.gpu_ids, vec![129, 131]);
+        assert_eq!(node.free_cpus(), 56);
+        assert_eq!(node.free_gpus(None), 2);
+        assert_eq!(node.free_memory_mb(), 224_000);
+
+        assert!(node.release_job(1));
+        assert_eq!(node.free_cpus(), 64);
+        assert_eq!(node.free_gpus(None), 4);
+        assert_eq!(node.free_memory_mb(), 256_000);
+        // Idempotent: releasing again is a no-op.
+        assert!(!node.release_job(1));
+    }
+
+    #[test]
+    fn test_allocate_for_job_rejects_conflicting_gpu() {
+        let mut node = make_node_with_ids(64, 256_000, vec![0, 1], "mi300x");
+        assert!(node.allocate_for_job(1, 4, 0, &[0]).is_some());
+        // Second job wanting the same device id must fail with no state change.
+        assert!(node.allocate_for_job(2, 4, 0, &[0]).is_none());
+        assert_eq!(node.free_gpus(None), 1);
+        // The failed job left no owner entry.
+        assert!(!node.release_job(2));
+    }
+
+    #[test]
+    fn test_reconcile_reclaims_orphans_but_spares_live_and_launching() {
+        let mut node = make_node_with_ids(64, 256_000, vec![0, 1, 2, 3], "mi300x");
+        // job 1: committed and live.
+        node.allocate_for_job(1, 4, 8_000, &[0]);
+        node.commit_job(1);
+        // job 2: committed but NOT live (its teardown failed to release — the
+        // exact SPUR-65 orphan condition).
+        node.allocate_for_job(2, 4, 8_000, &[1]);
+        node.commit_job(2);
+        // job 3: still launching (reserved, not yet committed) — must be spared.
+        node.allocate_for_job(3, 4, 8_000, &[2]);
+
+        let live: HashSet<u32> = [1].into_iter().collect();
+        let mut reclaimed = node.reconcile(&live);
+        reclaimed.sort();
+        assert_eq!(reclaimed, vec![2], "only the orphan (job 2) is reclaimed");
+
+        // job 1 (live) and job 3 (launching) still hold their resources.
+        assert!(!node.release_job(2), "job 2 already reconciled");
+        assert!(node.release_job(1));
+        assert!(node.release_job(3));
+        assert_eq!(node.free_gpus(None), 4);
+    }
+
+    #[test]
+    fn test_memory_released_symmetrically_with_zero_cpus() {
+        // A job with 0 cpus must still have its memory reserved and released
+        // symmetrically — otherwise release drives allocated_memory_mb below
+        // what was added (the pre-fix drift).
+        let mut node = make_node(64, 256_000, 0, "");
+        node.allocate_for_job(1, 0, 16_000, &[]);
+        assert_eq!(node.free_memory_mb(), 240_000);
+        node.release_job(1);
+        assert_eq!(node.free_memory_mb(), 256_000);
     }
 
     #[test]
     fn test_multiple_allocations() {
         let mut node = make_node(64, 256_000, 8, "mi300x");
-        let a1 = node.try_allocate(16, 64_000, 2, None).unwrap();
-        let a2 = node.try_allocate(16, 64_000, 2, None).unwrap();
+        let a1 = node.allocate_for_job(1, 16, 64_000, &[0, 1]).unwrap();
+        let a2 = node.allocate_for_job(2, 16, 64_000, &[2, 3]).unwrap();
         assert_eq!(node.free_cpus(), 32);
         assert_eq!(node.free_gpus(None), 4);
 

--- a/crates/spur-tests/src/t01_run.rs
+++ b/crates/spur-tests/src/t01_run.rs
@@ -102,7 +102,9 @@ mod tests {
         };
 
         let mut node = NodeAllocation::new("gpu001".into(), &resources);
-        let alloc = node.try_allocate(32, 128_000, 4, Some("mi300x")).unwrap();
+        let alloc = node
+            .allocate_for_job(1, 32, 128_000, &[0, 1, 2, 3])
+            .unwrap();
 
         assert_eq!(alloc.cpu_ids.len(), 32);
         assert_eq!(alloc.gpu_ids.len(), 4);
@@ -120,8 +122,8 @@ mod tests {
         };
         let mut node = NodeAllocation::new("cpu001".into(), &resources);
 
-        let a1 = node.try_allocate(16, 64_000, 0, None).unwrap();
-        let a2 = node.try_allocate(16, 64_000, 0, None).unwrap();
+        let a1 = node.allocate_for_job(1, 16, 64_000, &[]).unwrap();
+        let a2 = node.allocate_for_job(2, 16, 64_000, &[]).unwrap();
 
         // No CPU overlap
         for id in &a1.cpu_ids {
@@ -138,10 +140,10 @@ mod tests {
         };
         let mut node = NodeAllocation::new("cpu001".into(), &resources);
 
-        let alloc = node.try_allocate(32, 128_000, 0, None).unwrap();
+        node.allocate_for_job(1, 32, 128_000, &[]).unwrap();
         assert_eq!(node.free_cpus(), 32);
 
-        node.release(&alloc);
+        node.release_job(1);
         assert_eq!(node.free_cpus(), 64);
         assert_eq!(node.free_memory_mb(), 256_000);
     }

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -16,7 +16,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use spur_proto::proto::slurm_agent_server::SlurmAgent;
 use spur_proto::proto::*;
 
-use spur_sched::cons_tres::{AllocationResult, NodeAllocation};
+use spur_sched::cons_tres::{AllocError, AllocationResult, NodeAllocation};
 
 use spur_spank::{SpankContext, SpankHandle, SpankHook, SpankHost};
 
@@ -812,10 +812,7 @@ impl SlurmAgent for AgentService {
             cfg.device_plan = Some(container_device_plan);
         }
 
-        let cpu_ids: Vec<u32> = alloc_result
-            .as_ref()
-            .map(|a| a.cpu_ids.clone())
-            .unwrap_or_default();
+        let cpu_ids: Vec<u32> = alloc_result.cpu_ids.clone();
 
         // Guard rather than unwrap: these are always Some when the image is
         // set, but an early exit before commit must release the reservation.
@@ -1454,7 +1451,7 @@ impl AgentService {
         job_id: u32,
         spec: &JobSpec,
         allocated: Option<&ResourceAllocations>,
-    ) -> Result<(Option<AllocationResult>, Vec<u32>), Status> {
+    ) -> Result<(AllocationResult, Vec<u32>), Status> {
         let controller_gpu_ids: Vec<u32> = allocated
             .and_then(|a| a.devices.get("gpu"))
             .map(|d| d.devices.iter().map(|dev| dev.device_id).collect())
@@ -1477,23 +1474,41 @@ impl AgentService {
         } else {
             0
         };
-        let Some(result) =
-            alloc.allocate_for_job(job_id, cpus, spec.memory_per_node_mb, &controller_gpu_ids)
-        else {
-            warn!(
-                job_id,
-                requested = ?controller_gpu_ids,
-                already_allocated = ?alloc.allocated_gpu_ids(),
-                "rejecting dispatch: controller-allocated GPUs already in use in the local \
-                 allocation table (stale allocation from a prior job would strand this node)"
-            );
-            return Err(Status::resource_exhausted(
-                "controller-allocated GPUs unavailable on this node",
-            ));
+        let result = match alloc.allocate_for_job(
+            job_id,
+            cpus,
+            spec.memory_per_node_mb,
+            &controller_gpu_ids,
+        ) {
+            Ok(result) => result,
+            Err(AllocError::GpusUnavailable) => {
+                warn!(
+                    job_id,
+                    requested = ?controller_gpu_ids,
+                    already_allocated = ?alloc.allocated_gpu_ids(),
+                    "rejecting dispatch: controller-allocated GPUs already in use in the local \
+                     allocation table (stale allocation from a prior job would strand this node)"
+                );
+                return Err(Status::resource_exhausted(
+                    "controller-allocated GPUs unavailable on this node",
+                ));
+            }
+            Err(AllocError::DuplicateJob) => {
+                // A retried LaunchJob for a job that already holds a
+                // reservation: the RPC was already accepted, so this is a
+                // protocol-level duplicate, not resource exhaustion.
+                warn!(
+                    job_id,
+                    "rejecting duplicate launch: job already has a reservation"
+                );
+                return Err(Status::already_exists(format!(
+                    "job {job_id} already has a reservation on this node"
+                )));
+            }
         };
 
         let gpu_ids = controller_gpu_ids;
-        Ok((Some(result), gpu_ids))
+        Ok((result, gpu_ids))
     }
 
     fn parse_gpu_gres(gres: &[String]) -> (u32, Option<String>) {
@@ -2022,7 +2037,7 @@ mod tests {
         );
     }
 
-    // The monitor loop.s reconcile step must reclaim an
+    // The monitor loop's reconcile step must reclaim an
     // allocation whose job is no longer tracked, while sparing a job that is
     // still in `running`. Exercises the real reconcile_orphaned_allocations
     // wiring the monitor loop calls, without driving the timed loop.
@@ -2041,9 +2056,9 @@ mod tests {
         // (simulating a teardown path that dropped the job without releasing).
         {
             let mut alloc = svc.allocation.lock().await;
-            alloc.allocate_for_job(1, 2, 0, &[0]);
+            alloc.allocate_for_job(1, 2, 0, &[0]).unwrap();
             alloc.commit_job(1);
-            alloc.allocate_for_job(2, 2, 0, &[1]);
+            alloc.allocate_for_job(2, 2, 0, &[1]).unwrap();
             alloc.commit_job(2);
         }
         assert_eq!(svc.free_gpu_count().await, 0);

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -206,13 +206,10 @@ impl AgentService {
                     }
                 }
 
-                // Self-heal: reclaim any allocation that no longer maps to a
-                // tracked job and is not mid-launch. This is the backstop for
-                // SPUR-65 — if any teardown path ever fails to release, the
-                // node recovers on the next tick instead of silently rejecting
-                // dispatches until spurd restart. `jobs` is still held, so the
-                // live set is a consistent snapshot and cannot race a launch
-                // that is committing (commit_job takes the running lock first).
+                // Self-heal backstop: reclaim allocations with no tracked,
+                // non-launching job. `jobs` is held so the live set is a
+                // consistent snapshot that can't race a committing launch
+                // (commit_job takes the running lock first).
                 reconcile_orphaned_allocations(&jobs, &mut *allocation.lock().await);
 
                 // Release lock BEFORE network I/O — holding the lock during
@@ -790,13 +787,9 @@ impl SlurmAgent for AgentService {
             .allocate_local_resources(job_id, &spec, req.allocated.as_ref())
             .await?;
 
-        // Any failure between here and committing the job into `running` must
-        // release the allocation just reserved by allocate_local_resources —
-        // otherwise the GPUs stay marked in-use with no tracked job to ever
-        // free them, and the node silently rejects every future dispatch while
-        // the controller still believes it is IDLE (SPUR-65 stranding). The
-        // allocation is `launching` until commit_job, so reconcile is also a
-        // backstop, but releasing eagerly here reclaims immediately.
+        // Any failure before commit must release the reservation, or the GPUs
+        // stay in-use with no tracked job while the controller sees the node
+        // IDLE. Reconcile is a backstop; releasing eagerly reclaims at once.
         let injection = {
             let reg = self.device_registry.lock().await;
             reg.build_job_injection_plans("gpu", &allocated_device_ids, spec.uid, spec.gid)
@@ -824,11 +817,8 @@ impl SlurmAgent for AgentService {
             .map(|a| a.cpu_ids.clone())
             .unwrap_or_default();
 
-        // Build container launch config if this is a containerized job.
-        // container_config/rootfs_path are always Some here when the image is
-        // set (populated together above), but guard rather than unwrap so a
-        // future refactor can't leak the reservation: any exit before commit
-        // must release, since the job is still `launching` (SPUR-65).
+        // Guard rather than unwrap: these are always Some when the image is
+        // set, but an early exit before commit must release the reservation.
         let container_launch = if !spec.container_image.is_empty() {
             match (container_config.take(), rootfs_path.take()) {
                 (Some(config), Some(rootfs)) => {
@@ -1974,7 +1964,7 @@ mod tests {
         ))
     }
 
-    // SPUR-65: a dispatch that records GPUs but then fails before the job is
+    // A dispatch that records GPUs but fails before the job is
     // tracked (here: device-registry resolution fails) must release those GPUs.
     // Otherwise the node keeps rejecting every future dispatch ("controller-
     // allocated GPUs unavailable") while the controller still sees it IDLE,
@@ -2032,7 +2022,7 @@ mod tests {
         );
     }
 
-    // SPUR-65 self-heal: the monitor loop's reconcile step must reclaim an
+    // The monitor loop.s reconcile step must reclaim an
     // allocation whose job is no longer tracked, while sparing a job that is
     // still in `running`. Exercises the real reconcile_orphaned_allocations
     // wiring the monitor loop calls, without driving the timed loop.

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -765,7 +765,7 @@ impl SlurmAgent for AgentService {
         };
 
         let (alloc_result, allocated_device_ids) = self
-            .allocate_local_resources(&spec, req.allocated.as_ref())
+            .allocate_local_resources(job_id, &spec, req.allocated.as_ref())
             .await?;
 
         let (host_device_plan, container_device_plan) = {
@@ -1413,6 +1413,7 @@ impl AgentService {
     /// Record controller-allocated GPUs and allocate local CPU/memory resources.
     async fn allocate_local_resources(
         &self,
+        job_id: u32,
         spec: &JobSpec,
         allocated: Option<&ResourceAllocations>,
     ) -> Result<(Option<AllocationResult>, Vec<u32>), Status> {
@@ -1434,6 +1435,13 @@ impl AgentService {
         let mut alloc = self.allocation.lock().await;
 
         if !controller_gpu_ids.is_empty() && !alloc.record_gpus(&controller_gpu_ids) {
+            warn!(
+                job_id,
+                requested = ?controller_gpu_ids,
+                already_allocated = ?alloc.allocated_gpu_ids(),
+                "rejecting dispatch: controller-allocated GPUs already in use in the local \
+                 allocation table (stale allocation from a prior job would strand this node)"
+            );
             return Err(Status::resource_exhausted(
                 "controller-allocated GPUs unavailable on this node",
             ));

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -768,13 +768,27 @@ impl SlurmAgent for AgentService {
             .allocate_local_resources(job_id, &spec, req.allocated.as_ref())
             .await?;
 
-        let (host_device_plan, container_device_plan) = {
+        // Any failure between here and inserting the job into `running` must
+        // release the allocation just recorded by allocate_local_resources —
+        // otherwise the GPUs stay marked in-use with no tracked job to ever
+        // free them, and the node silently rejects every future dispatch while
+        // the controller still believes it is IDLE (SPUR-65 stranding).
+        let injection = {
             let reg = self.device_registry.lock().await;
             reg.build_job_injection_plans("gpu", &allocated_device_ids, spec.uid, spec.gid)
-                .map_err(|e| {
-                    error!(job_id, error = %e, "device registry resolution failed");
-                    Status::failed_precondition(format!("device resolution failed: {}", e))
-                })?
+        };
+        let (host_device_plan, container_device_plan) = match injection {
+            Ok(plans) => plans,
+            Err(e) => {
+                error!(job_id, error = %e, "device registry resolution failed");
+                if let Some(ref alloc) = alloc_result {
+                    self.allocation.lock().await.release(alloc);
+                }
+                return Err(Status::failed_precondition(format!(
+                    "device resolution failed: {}",
+                    e
+                )));
+            }
         };
 
         // Wire allocated device IDs and injection plan into container config.
@@ -1583,6 +1597,10 @@ impl AgentService {
     async fn insert_test_job(&self, job_id: u32, job: TrackedJob) {
         self.running.lock().await.insert(job_id, job);
     }
+
+    async fn free_gpu_count(&self) -> u32 {
+        self.allocation.lock().await.free_gpus(None)
+    }
 }
 
 #[cfg(test)]
@@ -1894,6 +1912,96 @@ mod tests {
         assert_eq!(resp.exit_code, 0);
         let observed_canonical = std::fs::canonicalize(resp.stdout.trim()).unwrap();
         assert_eq!(observed_canonical, tmp_canonical);
+    }
+
+    fn test_reporter_with_gpus(device_ids: &[u32]) -> Arc<NodeReporter> {
+        use spur_core::resource::{GpuLinkType, GpuResource};
+        let gpus = device_ids
+            .iter()
+            .map(|&device_id| GpuResource {
+                device_id,
+                gpu_type: "mi300x".into(),
+                memory_mb: 192_000,
+                peer_gpus: vec![],
+                link_type: GpuLinkType::XGMI,
+            })
+            .collect();
+        Arc::new(NodeReporter::new(
+            "test-node".into(),
+            "http://localhost:6817".into(),
+            ResourceSet {
+                cpus: 4,
+                memory_mb: 8192,
+                gpus,
+                ..Default::default()
+            },
+            spur_net::NodeAddress {
+                ip: "127.0.0.1".into(),
+                hostname: "test-node".into(),
+                port: 6818,
+                source: spur_net::AddressSource::Static,
+            },
+            std::collections::HashMap::new(),
+            String::new(),
+        ))
+    }
+
+    // SPUR-65: a dispatch that records GPUs but then fails before the job is
+    // tracked (here: device-registry resolution fails) must release those GPUs.
+    // Otherwise the node keeps rejecting every future dispatch ("controller-
+    // allocated GPUs unavailable") while the controller still sees it IDLE,
+    // stranding the node until spurd restart -> JobHoldMaxRequeue.
+    #[tokio::test]
+    async fn launch_failure_after_gpu_record_releases_allocation() {
+        // Reporter advertises GPU device_id 0 so record_gpus succeeds, but the
+        // device registry is empty so build_job_injection_plans fails.
+        let svc = AgentService::new(
+            test_reporter_with_gpus(&[0]),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        assert_eq!(svc.free_gpu_count().await, 1);
+
+        let mut devices = std::collections::HashMap::new();
+        devices.insert(
+            "gpu".to_string(),
+            DeviceAllocations {
+                devices: vec![AllocatedDevice {
+                    device_id: 0,
+                    count: 1,
+                }],
+            },
+        );
+
+        let req = Request::new(LaunchJobRequest {
+            job_id: 65,
+            spec: Some(JobSpec {
+                script: "#!/bin/sh\ntrue\n".into(),
+                cpus_per_task: 1,
+                gres: vec!["gpu:1".into()],
+                ..Default::default()
+            }),
+            allocated: Some(ResourceAllocations {
+                cpus: 1,
+                memory_mb: 0,
+                devices,
+            }),
+            ..Default::default()
+        });
+
+        let result = svc.launch_job(req).await;
+        assert!(
+            result.is_err(),
+            "expected launch to fail on registry resolution"
+        );
+
+        assert_eq!(
+            svc.free_gpu_count().await,
+            1,
+            "GPU allocation must be released after a post-record launch failure"
+        );
     }
 
     #[tokio::test]

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -31,7 +31,6 @@ use crate::reporter::NodeReporter;
 struct TrackedJob {
     job: executor::RunningJob,
     rootfs_mode: crate::container::RootfsMode,
-    allocation: Option<AllocationResult>,
     stdout_path: String,
     stderr_path: String,
     has_pid_namespace: bool,
@@ -50,7 +49,6 @@ struct CompletedJob {
     exit_code: i32,
     signal: i32,
     rootfs_mode: crate::container::RootfsMode,
-    allocation: Option<AllocationResult>,
     cgroup: Option<std::path::PathBuf>,
     work_dir: String,
     uid: u32,
@@ -177,7 +175,6 @@ impl AgentService {
                                 exit_code,
                                 signal,
                                 rootfs_mode: tracked.rootfs_mode.clone(),
-                                allocation: tracked.allocation.take(),
                                 cgroup,
                                 work_dir: tracked.work_dir.clone(),
                                 uid: tracked.uid,
@@ -203,11 +200,27 @@ impl AgentService {
                     if let Some(ref cgroup) = c.cgroup {
                         crate::executor::cleanup_cgroup(cgroup);
                     }
-                    if let Some(ref alloc) = c.allocation {
-                        allocation.lock().await.release(alloc);
-                    }
+                    allocation.lock().await.release_job(c.job_id);
                     if let Some(pmi) = pmi_servers.lock().await.remove(&c.job_id) {
                         pmi.cleanup();
+                    }
+                }
+
+                // Self-heal: reclaim any allocation that no longer maps to a
+                // tracked job and is not mid-launch. This is the backstop for
+                // SPUR-65 — if any teardown path ever fails to release, the
+                // node recovers on the next tick instead of silently rejecting
+                // dispatches until spurd restart. `jobs` is still held, so the
+                // live set is a consistent snapshot and cannot race a launch
+                // that is committing (commit_job takes the running lock first).
+                {
+                    let live: std::collections::HashSet<u32> = jobs.keys().copied().collect();
+                    let reclaimed = allocation.lock().await.reconcile(&live);
+                    if !reclaimed.is_empty() {
+                        warn!(
+                            ?reclaimed,
+                            "reconciled orphaned resource allocations with no tracked job"
+                        );
                     }
                 }
 
@@ -768,11 +781,13 @@ impl SlurmAgent for AgentService {
             .allocate_local_resources(job_id, &spec, req.allocated.as_ref())
             .await?;
 
-        // Any failure between here and inserting the job into `running` must
-        // release the allocation just recorded by allocate_local_resources —
+        // Any failure between here and committing the job into `running` must
+        // release the allocation just reserved by allocate_local_resources —
         // otherwise the GPUs stay marked in-use with no tracked job to ever
         // free them, and the node silently rejects every future dispatch while
-        // the controller still believes it is IDLE (SPUR-65 stranding).
+        // the controller still believes it is IDLE (SPUR-65 stranding). The
+        // allocation is `launching` until commit_job, so reconcile is also a
+        // backstop, but releasing eagerly here reclaims immediately.
         let injection = {
             let reg = self.device_registry.lock().await;
             reg.build_job_injection_plans("gpu", &allocated_device_ids, spec.uid, spec.gid)
@@ -781,9 +796,7 @@ impl SlurmAgent for AgentService {
             Ok(plans) => plans,
             Err(e) => {
                 error!(job_id, error = %e, "device registry resolution failed");
-                if let Some(ref alloc) = alloc_result {
-                    self.allocation.lock().await.release(alloc);
-                }
+                self.allocation.lock().await.release_job(job_id);
                 return Err(Status::failed_precondition(format!(
                     "device resolution failed: {}",
                     e
@@ -842,13 +855,17 @@ impl SlurmAgent for AgentService {
         match executor::launch_job(&launch_cfg, (*self.spank).as_ref()).await {
             Ok(result) => {
                 let mut jobs = self.running.lock().await;
+                // Commit the reservation: the job now has a tracked process, so
+                // it is no longer exempt from reconcile. Take the running lock
+                // first so a job is never briefly absent from BOTH `running` and
+                // `launching` (which would let reconcile reclaim it).
+                self.allocation.lock().await.commit_job(job_id);
                 info!(job_id, gpus = ?launch_cfg.gpu_devices, "job launched successfully");
                 jobs.insert(
                     job_id,
                     TrackedJob {
                         job: result.job,
                         rootfs_mode: rootfs_mode.clone(),
-                        allocation: alloc_result,
                         stdout_path: result.stdout_path,
                         stderr_path: result.stderr_path,
                         has_pid_namespace: nix::unistd::geteuid().is_root(),
@@ -868,10 +885,7 @@ impl SlurmAgent for AgentService {
                 }))
             }
             Err(e) => {
-                // Release allocation on launch failure
-                if let Some(ref alloc) = alloc_result {
-                    self.allocation.lock().await.release(alloc);
-                }
+                self.allocation.lock().await.release_job(job_id);
 
                 let is_prolog_failure = matches!(e, executor::LaunchError::PrologFailed(_));
                 let err_msg = e.to_string();
@@ -1448,7 +1462,14 @@ impl AgentService {
 
         let mut alloc = self.allocation.lock().await;
 
-        if !controller_gpu_ids.is_empty() && !alloc.record_gpus(&controller_gpu_ids) {
+        let cpus = if spec.cpus_per_task > 0 {
+            spec.cpus_per_task
+        } else {
+            0
+        };
+        let Some(result) =
+            alloc.allocate_for_job(job_id, cpus, spec.memory_per_node_mb, &controller_gpu_ids)
+        else {
             warn!(
                 job_id,
                 requested = ?controller_gpu_ids,
@@ -1459,21 +1480,9 @@ impl AgentService {
             return Err(Status::resource_exhausted(
                 "controller-allocated GPUs unavailable on this node",
             ));
-        }
-
-        let cpu_alloc = if spec.cpus_per_task > 0 {
-            alloc.try_allocate(spec.cpus_per_task.max(1), spec.memory_per_node_mb, 0, None)
-        } else {
-            None
         };
 
-        let gpu_ids = controller_gpu_ids.clone();
-        let result = AllocationResult {
-            cpu_ids: cpu_alloc.map(|a| a.cpu_ids).unwrap_or_default(),
-            gpu_ids: controller_gpu_ids,
-            memory_mb: spec.memory_per_node_mb,
-        };
-
+        let gpu_ids = controller_gpu_ids;
         Ok((Some(result), gpu_ids))
     }
 
@@ -1576,7 +1585,6 @@ impl TrackedJob {
                 cgroup_path: None,
             },
             rootfs_mode: crate::container::RootfsMode::Extracted,
-            allocation: None,
             stdout_path: "/dev/null".into(),
             stderr_path: "/dev/null".into(),
             has_pid_namespace: false,
@@ -2107,7 +2115,6 @@ mod tests {
                 cgroup_path: None,
             },
             rootfs_mode: crate::container::RootfsMode::Extracted,
-            allocation: None,
             stdout_path: "/dev/null".into(),
             stderr_path: "/dev/null".into(),
             has_pid_namespace: false,

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -213,16 +213,7 @@ impl AgentService {
                 // dispatches until spurd restart. `jobs` is still held, so the
                 // live set is a consistent snapshot and cannot race a launch
                 // that is committing (commit_job takes the running lock first).
-                {
-                    let live: std::collections::HashSet<u32> = jobs.keys().copied().collect();
-                    let reclaimed = allocation.lock().await.reconcile(&live);
-                    if !reclaimed.is_empty() {
-                        warn!(
-                            ?reclaimed,
-                            "reconciled orphaned resource allocations with no tracked job"
-                        );
-                    }
-                }
+                reconcile_orphaned_allocations(&jobs, &mut *allocation.lock().await);
 
                 // Release lock BEFORE network I/O — holding the lock during
                 // report_completion blocks new job launches and can lose
@@ -306,6 +297,24 @@ impl AgentService {
 
 struct DrainRequest {
     reason: String,
+}
+
+/// Reclaim allocations whose job is no longer tracked and is not mid-launch,
+/// using the running set as ground truth. Callers hold the `running` lock
+/// across building `running` and this call so the live set is a consistent
+/// snapshot (see the monitor loop). Returns nothing; logs what it reclaimed.
+fn reconcile_orphaned_allocations(
+    running: &HashMap<u32, TrackedJob>,
+    allocation: &mut NodeAllocation,
+) {
+    let live: std::collections::HashSet<u32> = running.keys().copied().collect();
+    let reclaimed = allocation.reconcile(&live);
+    if !reclaimed.is_empty() {
+        warn!(
+            ?reclaimed,
+            "reconciled orphaned resource allocations with no tracked job"
+        );
+    }
 }
 
 fn completion_report_retryable(status: &tonic::Status) -> bool {
@@ -815,12 +824,23 @@ impl SlurmAgent for AgentService {
             .map(|a| a.cpu_ids.clone())
             .unwrap_or_default();
 
-        // Build container launch config if this is a containerized job
+        // Build container launch config if this is a containerized job.
+        // container_config/rootfs_path are always Some here when the image is
+        // set (populated together above), but guard rather than unwrap so a
+        // future refactor can't leak the reservation: any exit before commit
+        // must release, since the job is still `launching` (SPUR-65).
         let container_launch = if !spec.container_image.is_empty() {
-            Some(executor::ContainerLaunchConfig {
-                config: container_config.take().unwrap(),
-                rootfs: rootfs_path.take().unwrap(),
-            })
+            match (container_config.take(), rootfs_path.take()) {
+                (Some(config), Some(rootfs)) => {
+                    Some(executor::ContainerLaunchConfig { config, rootfs })
+                }
+                _ => {
+                    self.allocation.lock().await.release_job(job_id);
+                    return Err(Status::internal(
+                        "internal error: container config missing after setup",
+                    ));
+                }
+            }
         } else {
             None
         };
@@ -1961,7 +1981,7 @@ mod tests {
     // stranding the node until spurd restart -> JobHoldMaxRequeue.
     #[tokio::test]
     async fn launch_failure_after_gpu_record_releases_allocation() {
-        // Reporter advertises GPU device_id 0 so record_gpus succeeds, but the
+        // Reporter advertises GPU device_id 0 so allocate_for_job succeeds, but the
         // device registry is empty so build_job_injection_plans fails.
         let svc = AgentService::new(
             test_reporter_with_gpus(&[0]),
@@ -2009,6 +2029,45 @@ mod tests {
             svc.free_gpu_count().await,
             1,
             "GPU allocation must be released after a post-record launch failure"
+        );
+    }
+
+    // SPUR-65 self-heal: the monitor loop's reconcile step must reclaim an
+    // allocation whose job is no longer tracked, while sparing a job that is
+    // still in `running`. Exercises the real reconcile_orphaned_allocations
+    // wiring the monitor loop calls, without driving the timed loop.
+    #[tokio::test]
+    async fn reconcile_reclaims_orphan_but_spares_tracked_job() {
+        let svc = AgentService::new(
+            test_reporter_with_gpus(&[0, 1]),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        // job 1: tracked (live) and committed.
+        svc.insert_test_job(1, TrackedJob::dummy(0)).await;
+        // job 2: orphan — committed allocation but never entered `running`
+        // (simulating a teardown path that dropped the job without releasing).
+        {
+            let mut alloc = svc.allocation.lock().await;
+            alloc.allocate_for_job(1, 2, 0, &[0]);
+            alloc.commit_job(1);
+            alloc.allocate_for_job(2, 2, 0, &[1]);
+            alloc.commit_job(2);
+        }
+        assert_eq!(svc.free_gpu_count().await, 0);
+
+        {
+            let jobs = svc.running.lock().await;
+            reconcile_orphaned_allocations(&jobs, &mut *svc.allocation.lock().await);
+        }
+
+        // Orphan (job 2) reclaimed; live job 1 still holds its GPU.
+        assert_eq!(
+            svc.free_gpu_count().await,
+            1,
+            "exactly the orphan's GPU must be reclaimed; the tracked job's is spared"
         );
     }
 

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1494,15 +1494,17 @@ impl AgentService {
                 ));
             }
             Err(AllocError::DuplicateJob) => {
-                // A retried LaunchJob for a job that already holds a
-                // reservation: the RPC was already accepted, so this is a
-                // protocol-level duplicate, not resource exhaustion.
+                // A launch is already in flight for this job id (reserved, not
+                // yet committed or released). This is a concurrent duplicate,
+                // not resource exhaustion. A stale reservation from a prior,
+                // already-torn-down run is superseded inside allocate_for_job
+                // and does not reach here.
                 warn!(
                     job_id,
-                    "rejecting duplicate launch: job already has a reservation"
+                    "rejecting duplicate launch: a launch is already in flight for this job"
                 );
                 return Err(Status::already_exists(format!(
-                    "job {job_id} already has a reservation on this node"
+                    "job {job_id} already has a launch in flight on this node"
                 )));
             }
         };

--- a/tests/native_host/e2e/test_single_node.py
+++ b/tests/native_host/e2e/test_single_node.py
@@ -124,6 +124,31 @@ class TestJobLifecycle:
             time.sleep(2)
         assert False, "node should return to idle after cancel"
 
+    def test_failed_launch_releases_reservation(self, cluster):
+        # A launch that fails after the agent reserves resources (here: a
+        # nonexistent container image) must release them, or the node becomes a
+        # black hole that rejects every future dispatch while looking idle.
+        script = cluster.write_file("badimg.sh", "#!/bin/bash\nhostname\n")
+        bad = cluster.sbatch(
+            ["-J", "badimg", "-N", "1",
+             "--container-image=/tmp/does-not-exist-9999.sqsh", script]
+        )
+        bad_id = parse_job_id(bad)
+        assert bad_id is not None
+        time.sleep(6)
+
+        # The node must still accept and complete a normal job afterwards.
+        out_path = f"{cluster.remote_dir}/after-bad.out"
+        ok = cluster.sbatch(
+            ["-J", "after-bad", "-N", "1", "-o", out_path,
+             cluster.write_file("after.sh", "#!/bin/bash\necho AFTER_OK\n")]
+        )
+        ok_id = parse_job_id(ok)
+        assert ok_id is not None
+        wait_job(cluster, ok_id, timeout=60)
+        assert "AFTER_OK" in cluster.read_output_on_any_node(out_path)
+        cluster.scancel(str(bad_id))
+
     def test_job_hold_and_release(self, cluster):
         out_path = f"{cluster.remote_dir}/hold.out"
         script = cluster.write_file("test-hold.sh", "#!/bin/bash\necho HOLD_OK\n")


### PR DESCRIPTION
## What this fixes

SPUR-65 (P2): a `spurd` agent could permanently retain a completed/failed job's resource reservation in its in-memory allocation table. Once stranded, every subsequent dispatch to that node was rejected with `controller-allocated GPUs unavailable on this node`, even though the resources were physically free and the controller still saw the node `IDLE`. The controller kept selecting the node, so jobs bounced there and ended in `JobHoldMaxRequeue` — a silent black hole until `spurd` restart.

This is the agent-side counterpart of SPUR-16 ("nodes not released after job completion"), whose controller-side release path was previously audited and found correct. This PR addresses the agent side; it resolves the SPUR-16 symptom for the allocation-leak case. (SPUR-16's separately-reported `exit_code=126` aspect traces to GH #364, an unrelated work_dir-permission bug, and is out of scope here.)

## Root cause & fix

The production-reachable leak was a **missing release on the launch path**. `allocate_local_resources` reserved the job's resources, but the job was only inserted into `running` — whose completion path is the only place release happened — after several more fallible steps. If device-registry resolution failed, the `?` returned early and the reservation was never released, with no tracked job to ever free it. The node then rejected all future dispatches while the controller believed it was idle.

The fix reworks agent-side allocation to be **per-job and self-healing**:

- **Per-job ownership**: `NodeAllocation` now tracks what each job holds by job id (`owners` map), so an allocation is released by id on any teardown path rather than by replaying a specific `AllocationResult` on one path.
- **Eager release on every launch-failure exit** (device-injection failure, missing container config, executor error): the reservation is freed immediately.
- **Self-healing reconcile**: the monitor loop reclaims any allocation whose job is no longer tracked and is not mid-launch, so the node recovers on the next tick instead of stranding until restart. A `launching` guard marks reservations between allocate and commit (`commit_job` runs under the `running` lock before insertion) so an in-flight launch — slow image pull, fork — is never mistaken for an orphan, and a launch that never commits can never leave a permanent phantom reservation.
- **device_id unification** (`spur-sched`): `AllocationResult.gpu_ids` previously meant vec indices in one path and device_ids in another; release/record interpreted them differently. Unified to device_id everywhere. Today `assign_device_ids` makes device_id a dense `0..N` counter equal to vec position, so the mismatch does not currently misfire — this is hardening against that latent trap, honestly labeled as such.
- **Memory-accounting fix**: memory was only added to the used pool when `cpus_per_task > 0` but always subtracted on release, so a 0-cpu job would drift the used count downward over time. Memory is now accounted symmetrically.

The old `try_allocate` / `record_gpus` had no remaining callers after this rework and were removed; `release` is now a private helper of `release_job`.

## Not in this PR

- Controller-driven heartbeat reconciliation was considered but is unnecessary: the agent's own `running` set is authoritative, so agent-local reconcile covers the orphan class without a proto change or controller cooperation.

## Testing

- Unit (`cons_tres.rs`): device-id release with non-contiguous ids; all-or-nothing GPU reservation rollback; release-by-id idempotency; reconcile spares live + launching and reclaims only true orphans; memory symmetry with 0 cpus. Each new invariant confirmed to fail against the pre-fix code.
- Agent-level (`agent_server.rs`): a launch that fails after reservation releases it; reconcile reclaims an orphan while sparing a tracked job (exercises the real monitor-loop wiring without driving the timed loop).
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` — clean; `cargo test --locked` — all pass.
- Live on the 2-node lab cluster (CPU-only, so the GPU-specific rejection path can't run directly, but the leak/strand and accounting mechanisms are resource-agnostic): deployed to both nodes and verified (a) bursts of concurrent jobs all complete with the node returning to `IDLE`/`CPUAlloc=0` and **no spurious reconcile warnings** (launch race does not misfire under real load); (b) a job whose launch fails after reservation requeues to `JobHoldMaxRequeue` while the node stays fully allocatable — the next job launches and completes on it; (c) memory returns exactly to baseline across repeated `--mem` job cycles (no drift).