### PR TITLE
fix(spurctld): delete sacctmgr users atomically

### DIFF
--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -534,18 +534,26 @@ async fn delete(entity: &str, params: &[String], addr: &str) -> Result<()> {
             let account = p.get("account").cloned().unwrap_or_default();
 
             let mut client = connect(addr).await?;
-            client
+            let acct_display = if account.is_empty() { "all" } else { &account };
+            match client
                 .remove_user(RemoveUserRequest {
                     user: name.clone(),
                     account: account.clone(),
                 })
                 .await
-                .context("RemoveUser RPC failed")?;
-
-            let acct_display = if account.is_empty() { "all" } else { &account };
-            println!(" Deleting user {} from account {}", name, acct_display);
-            println!(" Done.");
-            Ok(())
+            {
+                Ok(_) => {
+                    println!(" Deleting user {} from account {}", name, acct_display);
+                    println!(" Done.");
+                    Ok(())
+                }
+                // Slurm prints "Nothing deleted" and exits 0 when the delete is a no-op.
+                Err(status) if status.code() == tonic::Code::NotFound => {
+                    println!(" Nothing deleted.");
+                    Ok(())
+                }
+                Err(status) => Err(anyhow::Error::new(status).context("RemoveUser RPC failed")),
+            }
         }
         "qos" => {
             let name = p

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -855,19 +855,22 @@ pub async fn add_user<'a>(
     Ok(())
 }
 
-/// Remove a user from an account.
-pub async fn remove_user(pool: &PgPool, user: &str, account: &str) -> anyhow::Result<()> {
-    sqlx::query("DELETE FROM users WHERE name = $1 AND account = $2")
+/// Remove a user from one account, or every account when `account` is empty.
+pub async fn remove_user(pool: &PgPool, user: &str, account: &str) -> anyhow::Result<u64> {
+    let mut tx = pool.begin().await?;
+    let associations =
+        sqlx::query("DELETE FROM associations WHERE user_name = $1 AND ($2 = '' OR account = $2)")
+            .bind(user)
+            .bind(account)
+            .execute(&mut *tx)
+            .await?;
+    let users = sqlx::query("DELETE FROM users WHERE name = $1 AND ($2 = '' OR account = $2)")
         .bind(user)
         .bind(account)
-        .execute(pool)
+        .execute(&mut *tx)
         .await?;
-    sqlx::query("DELETE FROM associations WHERE user_name = $1 AND account = $2")
-        .bind(user)
-        .bind(account)
-        .execute(pool)
-        .await?;
-    Ok(())
+    tx.commit().await?;
+    Ok(associations.rows_affected() + users.rows_affected())
 }
 
 /// List users, joining each one's own association row for `default_qos`/
@@ -2314,6 +2317,66 @@ mod job_history_tests {
             .await?;
         sqlx::query("DELETE FROM accounts WHERE name = $1")
             .bind(&account)
+            .execute(&pool)
+            .await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL and PostgreSQL"]
+    async fn remove_user_deletes_one_or_all_account_associations() -> anyhow::Result<()> {
+        let pool = test_pool().await?;
+        let pid = std::process::id();
+        let user = format!("spur_remove_user_{pid}");
+        let account_one = format!("spur_remove_acct_one_{pid}");
+        let account_two = format!("spur_remove_acct_two_{pid}");
+
+        sqlx::query("DELETE FROM associations WHERE user_name = $1")
+            .bind(&user)
+            .execute(&pool)
+            .await?;
+        sqlx::query("DELETE FROM users WHERE name = $1")
+            .bind(&user)
+            .execute(&pool)
+            .await?;
+        sqlx::query("DELETE FROM accounts WHERE name IN ($1, $2)")
+            .bind(&account_one)
+            .bind(&account_two)
+            .execute(&pool)
+            .await?;
+
+        upsert_account(&pool, &account_one, "d", "o", None, 1, None).await?;
+        upsert_account(&pool, &account_two, "d", "o", None, 1, None).await?;
+        add_user(&pool, &user, &account_one, "none", true, "").await?;
+        add_user(&pool, &user, &account_two, "none", false, "").await?;
+
+        let deleted = remove_user(&pool, &user, &account_one).await?;
+        assert_eq!(deleted, 2);
+        let remaining = list_users(&pool, None).await?;
+        assert!(!remaining
+            .iter()
+            .any(|record| record.name == user && record.account == account_one));
+        assert!(remaining
+            .iter()
+            .any(|record| record.name == user && record.account == account_two));
+
+        let deleted = remove_user(&pool, &user, "").await?;
+        assert_eq!(deleted, 2);
+        let remaining = list_users(&pool, None).await?;
+        assert!(!remaining.iter().any(|record| record.name == user));
+        let association_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM associations WHERE user_name = $1")
+                .bind(&user)
+                .fetch_one(&pool)
+                .await?;
+        assert_eq!(association_count, 0);
+
+        let deleted = remove_user(&pool, &user, "").await?;
+        assert_eq!(deleted, 0);
+
+        sqlx::query("DELETE FROM accounts WHERE name IN ($1, $2)")
+            .bind(&account_one)
+            .bind(&account_two)
             .execute(&pool)
             .await?;
         Ok(())

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -2345,14 +2345,42 @@ mod job_history_tests {
             .execute(&pool)
             .await?;
 
-        upsert_account(&pool, &account_one, "d", "o", None, 1, None).await?;
-        upsert_account(&pool, &account_two, "d", "o", None, 1, None).await?;
-        add_user(&pool, &user, &account_one, "none", true, "").await?;
-        add_user(&pool, &user, &account_two, "none", false, "").await?;
+        let acct_update = || AccountUpdate {
+            description: Some("d"),
+            organization: Some("o"),
+            fairshare: Some(1),
+            ..Default::default()
+        };
+        upsert_account(&pool, &account_one, acct_update()).await?;
+        upsert_account(&pool, &account_two, acct_update()).await?;
+        add_user(
+            &pool,
+            &user,
+            &account_one,
+            UserUpdate {
+                admin_level: Some("none"),
+                is_default: Some(true),
+                max_running_jobs: Some(Some(1)),
+                ..Default::default()
+            },
+        )
+        .await?;
+        add_user(
+            &pool,
+            &user,
+            &account_two,
+            UserUpdate {
+                admin_level: Some("none"),
+                is_default: Some(false),
+                max_running_jobs: Some(Some(1)),
+                ..Default::default()
+            },
+        )
+        .await?;
 
         let deleted = remove_user(&pool, &user, &account_one).await?;
         assert_eq!(deleted, 2);
-        let remaining = list_users(&pool, None).await?;
+        let remaining = list_users(&pool, None, None).await?;
         assert!(!remaining
             .iter()
             .any(|record| record.name == user && record.account == account_one));
@@ -2362,7 +2390,7 @@ mod job_history_tests {
 
         let deleted = remove_user(&pool, &user, "").await?;
         assert_eq!(deleted, 2);
-        let remaining = list_users(&pool, None).await?;
+        let remaining = list_users(&pool, None, None).await?;
         assert!(!remaining.iter().any(|record| record.name == user));
         let association_count: i64 =
             sqlx::query_scalar("SELECT COUNT(*) FROM associations WHERE user_name = $1")

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -460,9 +460,17 @@ impl SlurmAccounting for AccountingService {
         request: Request<RemoveUserRequest>,
     ) -> Result<Response<()>, Status> {
         let req = request.into_inner();
-        db::remove_user(&self.pool, &req.user, &req.account)
+        let deleted = db::remove_user(&self.pool, &req.user, &req.account)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
+        if deleted == 0 {
+            let target = if req.account.is_empty() {
+                format!("user '{}'", req.user)
+            } else {
+                format!("user '{}' in account '{}'", req.user, req.account)
+            };
+            return Err(Status::not_found(format!("{target} does not exist")));
+        }
         Ok(Response::new(()))
     }
 

--- a/tests/native_host/e2e/test_accounting.py
+++ b/tests/native_host/e2e/test_accounting.py
@@ -723,6 +723,43 @@ class TestSacctmgrQosAuthorization:
         c.scancel(str(job_id))
 
 
+class TestSacctmgrDeleteUser:
+    """`sacctmgr delete user` deletes the real association rows and reports
+    `Done.` only when something changed, `Nothing deleted.` (exit 0) on a no-op."""
+
+    def test_delete_user_removes_association_and_reports_truthfully(self, accounting_cluster):
+        c = accounting_cluster
+        user = c.nodes[0].user
+
+        c.sacctmgr(["add", "account", "name=delone"])
+        c.sacctmgr(["add", "account", "name=deltwo"])
+        c.sacctmgr(["add", "user", f"name={user}", "account=delone"])
+        c.sacctmgr(["add", "user", f"name={user}", "account=deltwo"])
+
+        out = c.sacctmgr(["delete", "user", f"name={user}", "account=delone"])
+        assert "Done." in out, f"a real delete must report Done., got {out!r}"
+
+        shown = c.sacctmgr(["show", "user"])
+        rows = [line for line in shown.splitlines() if user in line]
+        assert any("deltwo" in line for line in rows), f"deltwo association must survive, got {rows!r}"
+        assert not any("delone" in line for line in rows), f"delone association must be gone, got {rows!r}"
+
+        # No account= targets every account; the surviving deltwo row goes too.
+        out = c.sacctmgr(["delete", "user", f"name={user}"])
+        assert "Done." in out, f"all-account delete must report Done., got {out!r}"
+        shown = c.sacctmgr(["show", "user"])
+        assert not any(user in line and ("delone" in line or "deltwo" in line)
+                       for line in shown.splitlines()), "every association for the user must be gone"
+
+    def test_delete_nonexistent_user_is_a_clean_no_op(self, accounting_cluster):
+        # Regression guard: the CLI once printed Done. while nothing was
+        # deleted. A no-op must say so and still exit 0 (sacctmgr() raises otherwise).
+        c = accounting_cluster
+        out = c.sacctmgr(["delete", "user", "name=spur_ghost_user"])
+        assert "Nothing deleted." in out, f"a no-op delete must say so, got {out!r}"
+        assert "Done." not in out, f"a no-op must not falsely report Done., got {out!r}"
+
+
 class TestSacctmgrModifyPartialPatch:
     """`sacctmgr modify` restates only the fields it names; every unstated
     field keeps its stored value, and an explicitly empty field clears it.


### PR DESCRIPTION
Fixes #435.

`sacctmgr delete user` could report `Done.` without deleting anything because the all-accounts form sent an empty account while the database required an exact account match. The RPC also ignored zero affected rows.

This change deletes matching `users` and `associations` rows in one transaction, treats an omitted account as all accounts, and returns `NotFound` when no row was removed instead of reporting false success.

Testing:
- focused PostgreSQL regression covering one-account deletion, all-account deletion, association cleanup, and repeated deletion
- `cargo fmt --all --check`
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked`
- `cargo test --locked`
