### PR TITLE
fix(spurctld): close QOS enforcement bypass for jobs submitted without a QOS

### DIFF
--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -109,6 +109,38 @@ fn parse_params(params: &[String]) -> std::collections::HashMap<String, String> 
     map
 }
 
+const QOS_KEYS: &[&str] = &[
+    "name",
+    "qos",
+    "description",
+    "priority",
+    "preemptmode",
+    "usagefactor",
+    "maxjobsperuser",
+    "maxjobspu",
+    "maxwall",
+    "maxtresperjob",
+    "maxsubmitjobsperuser",
+    "maxtresperuser",
+    "grptres",
+];
+
+/// Reject keys the command does not understand, so a mistyped or unsupported
+/// field errors loudly instead of being silently dropped (a dropped limit
+/// reads as "set" but never enforces).
+fn reject_unknown_keys(
+    p: &std::collections::HashMap<String, String>,
+    allowed: &[&str],
+) -> Result<()> {
+    if let Some(key) = p.keys().find(|k| !allowed.contains(&k.as_str())) {
+        bail!(
+            "sacctmgr: unknown field '{key}'. Supported: {}",
+            allowed.join(", ")
+        );
+    }
+    Ok(())
+}
+
 async fn connect(addr: &str) -> Result<SlurmAccountingClient<tonic::transport::Channel>> {
     let channel = spur_client::connect_channel(addr)
         .await
@@ -215,6 +247,7 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
             Ok(())
         }
         "qos" => {
+            reject_unknown_keys(&p, QOS_KEYS)?;
             let name = p
                 .get("name")
                 .or_else(|| p.get("qos"))
@@ -231,6 +264,7 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
                 .unwrap_or(1.0);
             let max_jobs: u32 = p
                 .get("maxjobsperuser")
+                .or_else(|| p.get("maxjobspu"))
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(0);
             let max_wall: u32 = p
@@ -376,6 +410,7 @@ async fn modify(entity: &str, params: &[String], addr: &str) -> Result<()> {
             Ok(())
         }
         "qos" => {
+            reject_unknown_keys(&p, QOS_KEYS)?;
             let name = p
                 .get("name")
                 .or_else(|| p.get("qos"))
@@ -397,6 +432,7 @@ async fn modify(entity: &str, params: &[String], addr: &str) -> Result<()> {
                         .unwrap_or(1.0),
                     max_jobs_per_user: p
                         .get("maxjobsperuser")
+                        .or_else(|| p.get("maxjobspu"))
                         .and_then(|v| v.parse().ok())
                         .unwrap_or(0),
                     max_wall_minutes: p
@@ -636,6 +672,27 @@ mod tests {
         assert_eq!(account, "testacct");
         assert_eq!(admin, "none");
         assert_eq!(default_qos, "highprio");
+    }
+
+    #[test]
+    fn reject_unknown_keys_flags_dropped_field() {
+        // A field the command doesn't read must error, not be silently dropped
+        // (a dropped limit reads as "set" but never enforces).
+        let p = parse_params(&["name=normal".into(), "bogusfield=1".into()]);
+        let err = reject_unknown_keys(&p, QOS_KEYS).unwrap_err();
+        assert!(err.to_string().contains("unknown field 'bogusfield'"));
+    }
+
+    #[test]
+    fn reject_unknown_keys_accepts_known_and_alias() {
+        // maxjobspu is the label `sacctmgr show qos` prints, so it must be a
+        // valid input alias for maxjobsperuser.
+        let p = parse_params(&["name=normal".into(), "maxjobspu=5".into()]);
+        assert!(reject_unknown_keys(&p, QOS_KEYS).is_ok());
+        assert_eq!(
+            p.get("maxjobsperuser").or_else(|| p.get("maxjobspu")),
+            Some(&"5".to_string())
+        );
     }
 
     #[test]

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -364,6 +364,18 @@ pub struct AccountingConfig {
     /// How often to refresh fairshare/QoS caches from the accounting database.
     #[serde(default = "default_fairshare_refresh_secs")]
     pub fairshare_refresh_secs: u32,
+    /// Cluster-wide fallback QOS, applied at submit when a job resolves to no
+    /// QOS (no `--qos` and no association default). Analogous to Slurm's stock
+    /// `normal` QOS: it is the last link in the resolution chain so a QOS —
+    /// and its limits — always applies. Empty (default) = no fallback.
+    #[serde(default)]
+    pub default_qos: String,
+    /// When true, reject at submit any job that still has no QOS after the full
+    /// resolution chain (explicit → association default → cluster default_qos).
+    /// Mirrors Slurm's `AccountingStorageEnforce=qos`. Default false = jobs
+    /// without a QOS are accepted (existing behavior).
+    #[serde(default)]
+    pub require_qos: bool,
 }
 
 fn default_fairshare_refresh_secs() -> u32 {
@@ -375,6 +387,8 @@ impl Default for AccountingConfig {
         Self {
             database_url: String::new(),
             fairshare_refresh_secs: 300,
+            default_qos: String::new(),
+            require_qos: false,
         }
     }
 }

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -365,15 +365,12 @@ pub struct AccountingConfig {
     #[serde(default = "default_fairshare_refresh_secs")]
     pub fairshare_refresh_secs: u32,
     /// Cluster-wide fallback QOS, applied at submit when a job resolves to no
-    /// QOS (no `--qos` and no association default). Analogous to Slurm's stock
-    /// `normal` QOS: it is the last link in the resolution chain so a QOS —
-    /// and its limits — always applies. Empty (default) = no fallback.
+    /// QOS. The last link in the resolution chain (Slurm's stock `normal`
+    /// analogue). Empty (default) = no fallback.
     #[serde(default)]
     pub default_qos: String,
-    /// When true, reject at submit any job that still has no QOS after the full
-    /// resolution chain (explicit → association default → cluster default_qos).
-    /// Mirrors Slurm's `AccountingStorageEnforce=qos`. Default false = jobs
-    /// without a QOS are accepted (existing behavior).
+    /// Reject at submit any job that still has no QOS after the resolution
+    /// chain. Mirrors Slurm's `AccountingStorageEnforce=qos`. Default false.
     #[serde(default)]
     pub require_qos: bool,
 }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1352,6 +1352,20 @@ impl ClusterManager {
             }
         }
 
+        // Validate a QOS change before any mutation, so an invalid update is
+        // rejected atomically. An unknown QOS would resolve to the limitless
+        // default, and an empty QOS would clear enforcement entirely — both
+        // reopen the SPUR-64 bypass one command after submit, so reject them
+        // rather than silently accepting.
+        if let Some(ref q) = qos {
+            if q.trim().is_empty() {
+                anyhow::bail!("cannot clear a job's QOS");
+            }
+            if self.qos_cache.get(q).is_none() {
+                anyhow::bail!("QOS '{q}' does not exist");
+            }
+        }
+
         if let Some(p) = priority {
             let old = self
                 .jobs
@@ -4191,14 +4205,12 @@ fn validate_user_account(
     Ok(())
 }
 
-/// Resolve a job's effective QOS at submission time (mirrors
-/// `apply_default_partition`). An explicit `--qos` naming an unknown QOS is
-/// rejected; a stale association default degrades silently instead.
 /// Resolve a job's QOS at submit, in Slurm's order: explicit `--qos`
 /// (must exist) → association default QOS → cluster-wide fallback
 /// (`accounting.default_qos`). If none resolves and `accounting.require_qos`
 /// is set, the job is rejected (mirrors `AccountingStorageEnforce=qos`);
-/// otherwise it is accepted with no QOS (existing behavior).
+/// otherwise it is accepted with no QOS (existing behavior). A stale
+/// association default (points at a deleted QOS) degrades to the fallback.
 fn apply_default_qos(
     spec: &mut JobSpec,
     assoc_cache: &AssociationCache,
@@ -7985,6 +7997,51 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cluster_default_qos_reaches_real_enforcement() {
+        // SPUR-64 end to end: with a cluster fallback QOS configured and no
+        // --qos / no association default, a submitted job is bound to the
+        // fallback and its limits actually block a second job — closing the
+        // "omit --qos to run unenforced" bypass.
+        let dir = TempDir::new().unwrap();
+        let mut config = test_config();
+        config.accounting.default_qos = "normal".into();
+        let cm = test_cluster_with_config(&dir, config).await;
+        register_node(&cm, "n1", 8, 16000);
+        cm.qos_cache().insert(Qos {
+            name: "normal".into(),
+            limits: spur_core::accounting::QosLimits {
+                max_jobs_per_user: Some(1),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let j1 = submit_and_wait(&cm, basic_spec("d1"));
+        assert_eq!(
+            cm.get_job(j1).unwrap().spec.qos.as_deref(),
+            Some("normal"),
+            "no-qos job must be bound to the cluster fallback at submit"
+        );
+        let res = scalar_alloc(1, 1000);
+        cm.start_job(
+            j1,
+            vec!["n1".into()],
+            res.clone(),
+            per_node_for(&["n1"], res),
+        )
+        .unwrap();
+        settle(&cm, j1, JobState::Running);
+
+        let j2 = submit_and_wait(&cm, basic_spec("d2"));
+        cm.tag_blocked_pending_reasons();
+        assert_eq!(
+            cm.get_job(j2).unwrap().pending_reason,
+            PendingReason::QoSMaxJobsPerUser,
+            "the fallback QOS's limits must actually enforce"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn running_job_license_consumption_blocks_next_job() {
         // Concurrent license accounting: a running job holding all of a license
         // must make a second job requesting that license ineligible, even though
@@ -8569,6 +8626,43 @@ mod tests {
             cm.get_job(id).is_some_and(|j| j.priority == 5000)
         });
         assert_eq!(cm.get_job(id).unwrap().priority, 5000);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn update_job_qos_validates_against_cache() {
+        // SPUR-64: `scontrol update job qos=` must not be a second door to the
+        // limitless-default bypass — unknown and empty QOS are rejected, and
+        // the job's QOS is left unchanged.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        cm.qos_cache().insert(Qos {
+            name: "highprio".into(),
+            ..Default::default()
+        });
+        let id = submit_and_wait(&cm, basic_spec("q"));
+        assert_eq!(cm.get_job(id).unwrap().spec.qos, None);
+
+        // Unknown QOS rejected.
+        let err = cm
+            .update_job(id, None, None, None, None, None, Some("ghost".into()))
+            .unwrap_err();
+        assert!(err.to_string().contains("QOS 'ghost' does not exist"));
+        assert_eq!(cm.get_job(id).unwrap().spec.qos, None);
+
+        // Empty QOS (clear-to-limitless) rejected.
+        let err = cm
+            .update_job(id, None, None, None, None, None, Some(String::new()))
+            .unwrap_err();
+        assert!(err.to_string().contains("cannot clear a job's QOS"));
+        assert_eq!(cm.get_job(id).unwrap().spec.qos, None);
+
+        // A valid QOS is applied.
+        cm.update_job(id, None, None, None, None, None, Some("highprio".into()))
+            .unwrap();
+        assert_eq!(
+            cm.get_job(id).unwrap().spec.qos.as_deref(),
+            Some("highprio")
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1354,14 +1354,19 @@ impl ClusterManager {
 
         // Reject before mutating: an unknown QOS resolves to the limitless
         // default and an empty QOS clears enforcement — both reopen the bypass.
-        if let Some(ref q) = qos {
-            if q.trim().is_empty() {
-                anyhow::bail!("cannot clear a job's QOS");
+        let qos = match qos {
+            Some(q) => {
+                let q = q.trim().to_string();
+                if q.is_empty() {
+                    anyhow::bail!("cannot clear a job's QOS");
+                }
+                if self.qos_cache.get(&q).is_none() {
+                    anyhow::bail!("QOS '{q}' does not exist");
+                }
+                Some(q)
             }
-            if self.qos_cache.get(q).is_none() {
-                anyhow::bail!("QOS '{q}' does not exist");
-            }
-        }
+            None => None,
+        };
 
         if let Some(p) = priority {
             let old = self

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1352,11 +1352,8 @@ impl ClusterManager {
             }
         }
 
-        // Validate a QOS change before any mutation, so an invalid update is
-        // rejected atomically. An unknown QOS would resolve to the limitless
-        // default, and an empty QOS would clear enforcement entirely — both
-        // reopen the SPUR-64 bypass one command after submit, so reject them
-        // rather than silently accepting.
+        // Reject before mutating: an unknown QOS resolves to the limitless
+        // default and an empty QOS clears enforcement — both reopen the bypass.
         if let Some(ref q) = qos {
             if q.trim().is_empty() {
                 anyhow::bail!("cannot clear a job's QOS");
@@ -4205,12 +4202,9 @@ fn validate_user_account(
     Ok(())
 }
 
-/// Resolve a job's QOS at submit, in Slurm's order: explicit `--qos`
-/// (must exist) → association default QOS → cluster-wide fallback
-/// (`accounting.default_qos`). If none resolves and `accounting.require_qos`
-/// is set, the job is rejected (mirrors `AccountingStorageEnforce=qos`);
-/// otherwise it is accepted with no QOS (existing behavior). A stale
-/// association default (points at a deleted QOS) degrades to the fallback.
+/// Resolve a job's QOS at submit, in Slurm's order: explicit `--qos` (must
+/// exist) → association default → cluster fallback (`accounting.default_qos`)
+/// → reject if `accounting.require_qos`, else accept with no QOS.
 fn apply_default_qos(
     spec: &mut JobSpec,
     assoc_cache: &AssociationCache,
@@ -4239,10 +4233,8 @@ fn apply_default_qos(
         );
     }
 
-    // Cluster-wide fallback: the last link so a QOS (and its limits) applies
-    // even when no association default is set. A misconfigured fallback (names
-    // a QOS that doesn't exist) is a hard error — silently ignoring it would
-    // reintroduce the very enforcement gap this closes.
+    // A configured fallback naming a nonexistent QOS is a hard error — silently
+    // ignoring it would leave the job unenforced, the gap this closes.
     let fallback = accounting.default_qos.trim();
     if !fallback.is_empty() {
         if qos_cache.get(fallback).is_none() {
@@ -7998,10 +7990,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cluster_default_qos_reaches_real_enforcement() {
-        // SPUR-64 end to end: with a cluster fallback QOS configured and no
-        // --qos / no association default, a submitted job is bound to the
-        // fallback and its limits actually block a second job — closing the
-        // "omit --qos to run unenforced" bypass.
+        // A cluster fallback QOS must bind a no-qos job and its limits must
+        // actually block a second job — end to end.
         let dir = TempDir::new().unwrap();
         let mut config = test_config();
         config.accounting.default_qos = "normal".into();
@@ -8630,9 +8620,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn update_job_qos_validates_against_cache() {
-        // SPUR-64: `scontrol update job qos=` must not be a second door to the
-        // limitless-default bypass — unknown and empty QOS are rejected, and
-        // the job's QOS is left unchanged.
+        // `scontrol update job qos=` must not be a second door to the bypass:
+        // unknown and empty QOS are rejected, leaving the job's QOS unchanged.
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         cm.qos_cache().insert(Qos {
@@ -9309,8 +9298,7 @@ mod tests {
         cache
     }
 
-    // Inert accounting config: no cluster fallback, require_qos off — the
-    // pre-SPUR-64 behavior, so existing tests keep asserting the base chain.
+    // Inert config: no fallback, require_qos off (base resolution chain).
     fn acct_cfg() -> spur_core::config::AccountingConfig {
         spur_core::config::AccountingConfig::default()
     }
@@ -9430,8 +9418,7 @@ mod tests {
 
     #[test]
     fn apply_default_qos_falls_back_to_cluster_default() {
-        // SPUR-64: no --qos, no association default → cluster fallback applies
-        // so a QOS (and its limits) is enforced instead of running limitless.
+        // No --qos and no association default → cluster fallback applies.
         let assoc = AssociationCache::new();
         let qos = qos_cache_with(&["normal"]);
         let mut spec = basic_spec("j");
@@ -9458,8 +9445,7 @@ mod tests {
 
     #[test]
     fn apply_default_qos_nonexistent_cluster_default_is_rejected() {
-        // A misconfigured fallback must hard-error, not silently leave the job
-        // unenforced (that would reintroduce the SPUR-64 gap).
+        // A misconfigured fallback must hard-error, not silently leave it unenforced.
         let assoc = AssociationCache::new();
         let qos = qos_cache_with(&["normal"]);
         let mut spec = basic_spec("j");
@@ -9474,8 +9460,7 @@ mod tests {
 
     #[test]
     fn apply_default_qos_require_qos_rejects_when_none_resolves() {
-        // SPUR-64: with require_qos and no fallback, a job that resolves to no
-        // QOS is rejected at submit (mirrors AccountingStorageEnforce=qos).
+        // require_qos with no fallback rejects a job that resolves to no QOS.
         let assoc = AssociationCache::new();
         let qos = QosCache::new();
         let mut spec = basic_spec("j");

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -243,7 +243,12 @@ impl ClusterManager {
         apply_default_account(&mut spec, &self.association_cache);
         validate_user_account(&spec, &self.association_cache)?;
         self.validate_partition(&spec)?;
-        apply_default_qos(&mut spec, &self.association_cache, &self.qos_cache)?;
+        apply_default_qos(
+            &mut spec,
+            &self.association_cache,
+            &self.qos_cache,
+            &self.config.accounting,
+        )?;
 
         // Checked after defaults are applied so we measure the final spec.
         // Array expansion only adds bounded integer metadata per task, so a
@@ -4189,10 +4194,16 @@ fn validate_user_account(
 /// Resolve a job's effective QOS at submission time (mirrors
 /// `apply_default_partition`). An explicit `--qos` naming an unknown QOS is
 /// rejected; a stale association default degrades silently instead.
+/// Resolve a job's QOS at submit, in Slurm's order: explicit `--qos`
+/// (must exist) → association default QOS → cluster-wide fallback
+/// (`accounting.default_qos`). If none resolves and `accounting.require_qos`
+/// is set, the job is rejected (mirrors `AccountingStorageEnforce=qos`);
+/// otherwise it is accepted with no QOS (existing behavior).
 fn apply_default_qos(
     spec: &mut JobSpec,
     assoc_cache: &AssociationCache,
     qos_cache: &QosCache,
+    accounting: &spur_core::config::AccountingConfig,
 ) -> Result<(), SubmitError> {
     if let Some(name) = spec.qos.as_deref().filter(|n| !n.is_empty()) {
         if qos_cache.get(name).is_none() {
@@ -4203,13 +4214,11 @@ fn apply_default_qos(
 
     let given_account = spec.account.as_deref().filter(|a| !a.is_empty());
     let (account, default_qos) = assoc_cache.resolve(&spec.user, given_account);
-    let Some(default_qos) = default_qos else {
-        return Ok(());
-    };
-
-    if qos_cache.get(&default_qos).is_some() {
-        spec.qos = Some(default_qos);
-    } else {
+    if let Some(default_qos) = default_qos {
+        if qos_cache.get(&default_qos).is_some() {
+            spec.qos = Some(default_qos);
+            return Ok(());
+        }
         warn!(
             user = %spec.user,
             account = account.as_deref().unwrap_or_default(),
@@ -4217,6 +4226,28 @@ fn apply_default_qos(
             "association default QOS no longer exists, ignoring"
         );
     }
+
+    // Cluster-wide fallback: the last link so a QOS (and its limits) applies
+    // even when no association default is set. A misconfigured fallback (names
+    // a QOS that doesn't exist) is a hard error — silently ignoring it would
+    // reintroduce the very enforcement gap this closes.
+    let fallback = accounting.default_qos.trim();
+    if !fallback.is_empty() {
+        if qos_cache.get(fallback).is_none() {
+            return Err(SubmitError::invalid(format!(
+                "configured default QOS '{fallback}' does not exist"
+            )));
+        }
+        spec.qos = Some(fallback.to_string());
+        return Ok(());
+    }
+
+    if accounting.require_qos {
+        return Err(SubmitError::invalid(
+            "no QOS specified and no default QOS is configured for this user/account",
+        ));
+    }
+
     Ok(())
 }
 
@@ -9184,6 +9215,20 @@ mod tests {
         cache
     }
 
+    // Inert accounting config: no cluster fallback, require_qos off — the
+    // pre-SPUR-64 behavior, so existing tests keep asserting the base chain.
+    fn acct_cfg() -> spur_core::config::AccountingConfig {
+        spur_core::config::AccountingConfig::default()
+    }
+
+    fn acct_cfg_with(default_qos: &str, require_qos: bool) -> spur_core::config::AccountingConfig {
+        spur_core::config::AccountingConfig {
+            default_qos: default_qos.into(),
+            require_qos,
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn apply_default_qos_explicit_valid_passes_through() {
         let assoc = AssociationCache::new();
@@ -9191,7 +9236,7 @@ mod tests {
         let mut spec = basic_spec("j");
         spec.qos = Some("highprio".into());
 
-        super::apply_default_qos(&mut spec, &assoc, &qos).unwrap();
+        super::apply_default_qos(&mut spec, &assoc, &qos, &acct_cfg()).unwrap();
         assert_eq!(spec.qos.as_deref(), Some("highprio"));
     }
 
@@ -9202,7 +9247,7 @@ mod tests {
         let mut spec = basic_spec("j");
         spec.qos = Some("doesnotexist".into());
 
-        let err = super::apply_default_qos(&mut spec, &assoc, &qos).unwrap_err();
+        let err = super::apply_default_qos(&mut spec, &assoc, &qos, &acct_cfg()).unwrap_err();
         assert_eq!(
             err,
             SubmitError::invalid("QOS 'doesnotexist' does not exist")
@@ -9217,7 +9262,7 @@ mod tests {
         let mut spec = basic_spec("j");
         spec.account = Some("research".into());
 
-        super::apply_default_qos(&mut spec, &assoc, &qos).unwrap();
+        super::apply_default_qos(&mut spec, &assoc, &qos, &acct_cfg()).unwrap();
         assert_eq!(spec.qos.as_deref(), Some("highprio"));
     }
 
@@ -9261,7 +9306,7 @@ mod tests {
         // No --account given at all.
         assert!(spec.account.is_none());
 
-        super::apply_default_qos(&mut spec, &assoc, &qos).unwrap();
+        super::apply_default_qos(&mut spec, &assoc, &qos, &acct_cfg()).unwrap();
         assert_eq!(spec.qos.as_deref(), Some("highprio"));
     }
 
@@ -9272,7 +9317,7 @@ mod tests {
         let mut spec = basic_spec("j");
         spec.account = Some("research".into());
 
-        super::apply_default_qos(&mut spec, &assoc, &qos).unwrap();
+        super::apply_default_qos(&mut spec, &assoc, &qos, &acct_cfg()).unwrap();
         assert_eq!(spec.qos, None);
     }
 
@@ -9285,8 +9330,94 @@ mod tests {
         let mut spec = basic_spec("j");
         spec.account = Some("research".into());
 
-        super::apply_default_qos(&mut spec, &assoc, &qos).unwrap();
+        super::apply_default_qos(&mut spec, &assoc, &qos, &acct_cfg()).unwrap();
         assert_eq!(spec.qos, None, "must not fail submission on stale data");
+    }
+
+    #[test]
+    fn apply_default_qos_falls_back_to_cluster_default() {
+        // SPUR-64: no --qos, no association default → cluster fallback applies
+        // so a QOS (and its limits) is enforced instead of running limitless.
+        let assoc = AssociationCache::new();
+        let qos = qos_cache_with(&["normal"]);
+        let mut spec = basic_spec("j");
+
+        super::apply_default_qos(&mut spec, &assoc, &qos, &acct_cfg_with("normal", false)).unwrap();
+        assert_eq!(spec.qos.as_deref(), Some("normal"));
+    }
+
+    #[test]
+    fn apply_default_qos_association_default_beats_cluster_default() {
+        let assoc = AssociationCache::new();
+        assoc.insert_default_qos("testuser", "research", "highprio");
+        let qos = qos_cache_with(&["highprio", "normal"]);
+        let mut spec = basic_spec("j");
+        spec.account = Some("research".into());
+
+        super::apply_default_qos(&mut spec, &assoc, &qos, &acct_cfg_with("normal", false)).unwrap();
+        assert_eq!(
+            spec.qos.as_deref(),
+            Some("highprio"),
+            "association default takes precedence over the cluster fallback"
+        );
+    }
+
+    #[test]
+    fn apply_default_qos_nonexistent_cluster_default_is_rejected() {
+        // A misconfigured fallback must hard-error, not silently leave the job
+        // unenforced (that would reintroduce the SPUR-64 gap).
+        let assoc = AssociationCache::new();
+        let qos = qos_cache_with(&["normal"]);
+        let mut spec = basic_spec("j");
+
+        let err = super::apply_default_qos(&mut spec, &assoc, &qos, &acct_cfg_with("ghost", false))
+            .unwrap_err();
+        assert_eq!(
+            err,
+            SubmitError::invalid("configured default QOS 'ghost' does not exist")
+        );
+    }
+
+    #[test]
+    fn apply_default_qos_require_qos_rejects_when_none_resolves() {
+        // SPUR-64: with require_qos and no fallback, a job that resolves to no
+        // QOS is rejected at submit (mirrors AccountingStorageEnforce=qos).
+        let assoc = AssociationCache::new();
+        let qos = QosCache::new();
+        let mut spec = basic_spec("j");
+        spec.account = Some("research".into());
+
+        let err = super::apply_default_qos(&mut spec, &assoc, &qos, &acct_cfg_with("", true))
+            .unwrap_err();
+        assert_eq!(
+            err,
+            SubmitError::invalid(
+                "no QOS specified and no default QOS is configured for this user/account"
+            )
+        );
+    }
+
+    #[test]
+    fn apply_default_qos_require_qos_satisfied_by_cluster_default() {
+        // With both set, the fallback satisfies require_qos — no rejection.
+        let assoc = AssociationCache::new();
+        let qos = qos_cache_with(&["normal"]);
+        let mut spec = basic_spec("j");
+
+        super::apply_default_qos(&mut spec, &assoc, &qos, &acct_cfg_with("normal", true)).unwrap();
+        assert_eq!(spec.qos.as_deref(), Some("normal"));
+    }
+
+    #[test]
+    fn apply_default_qos_require_qos_satisfied_by_explicit() {
+        // An explicit valid QOS satisfies require_qos regardless of fallback.
+        let assoc = AssociationCache::new();
+        let qos = qos_cache_with(&["highprio"]);
+        let mut spec = basic_spec("j");
+        spec.qos = Some("highprio".into());
+
+        super::apply_default_qos(&mut spec, &assoc, &qos, &acct_cfg_with("", true)).unwrap();
+        assert_eq!(spec.qos.as_deref(), Some("highprio"));
     }
 
     // ── array-parent dependency: cancel + display synthesis ──────

--- a/examples/spur.conf
+++ b/examples/spur.conf
@@ -19,6 +19,15 @@ fairshare_halflife_days = 14
 
 [accounting]
 database_url = "postgresql://spur:spur@localhost/spur"
+# Cluster-wide fallback QOS, applied when a job specifies no --qos and its
+# association has no default QOS. Ensures a QOS (and its limits) always
+# applies instead of running unenforced. Must name an existing QOS. Unset =
+# no fallback.
+# default_qos = "normal"
+# Reject at submit any job that still has no QOS after the resolution chain
+# (explicit --qos -> association default -> default_qos above). Mirrors
+# Slurm's AccountingStorageEnforce=qos. Default false.
+# require_qos = false
 
 [auth]
 plugin = "none"

--- a/tests/native_host/e2e/test_accounting.py
+++ b/tests/native_host/e2e/test_accounting.py
@@ -10,7 +10,7 @@ when Docker is unavailable).
 import re
 import time
 
-from cluster import parse_job_id, wait_job, wait_sacct_row
+from cluster import deep_merge, parse_job_id, wait_job, wait_sacct_row
 
 
 class TestSacctExitReporting:
@@ -85,7 +85,10 @@ class TestQosLimitReasons:
         # run unenforced" bypass.
         c = accounting_cluster
         c.sacctmgr(["add", "qos", "name=capped", "maxwall=1"])
-        c.config_overrides = {"accounting": {"default_qos": "capped"}}
+        # Merge the fallback into the on-disk config, then restart so spurctld
+        # re-reads it (restart_controller alone does not re-render the config).
+        deep_merge(c.config_overrides, {"accounting": {"default_qos": "capped"}})
+        c._write_config()
         c.restart_controller()
         time.sleep(15)
 

--- a/tests/native_host/e2e/test_accounting.py
+++ b/tests/native_host/e2e/test_accounting.py
@@ -78,3 +78,33 @@ class TestQosLimitReasons:
         assert reason == "QOSMaxWallDurationPerJobLimit", (
             f"expected QOSMaxWallDurationPerJobLimit, got {reason!r}"
         )
+
+    def test_cluster_default_qos_binds_and_enforces_no_qos_job(self, accounting_cluster):
+        # A job submitted with no -q must be bound to the configured cluster
+        # fallback QOS and subject to its limits, closing the "omit --qos to
+        # run unenforced" bypass.
+        c = accounting_cluster
+        c.sacctmgr(["add", "qos", "name=capped", "maxwall=1"])
+        c.config_overrides = {"accounting": {"default_qos": "capped"}}
+        c.restart_controller()
+        time.sleep(15)
+
+        script = c.write_file("nodefault.sh", "#!/bin/bash\nsleep 30\n")
+        job_id = parse_job_id(
+            c.sbatch(["-J", "no-qos", "-N", "1", "-t", "60", script])
+        )
+        assert job_id is not None
+
+        show = c.scontrol("show", "job", str(job_id))
+        assert "QOS=capped" in show, f"no-qos job not bound to fallback: {show!r}"
+
+        deadline = time.time() + 30
+        reason = ""
+        while time.time() < deadline:
+            reason = _reason(c, job_id)
+            if reason == "QOSMaxWallDurationPerJobLimit":
+                break
+            time.sleep(2)
+        assert reason == "QOSMaxWallDurationPerJobLimit", (
+            f"fallback QOS limit not enforced, got {reason!r}"
+        )


### PR DESCRIPTION
## What this fixes

SPUR-64: a job submitted with no `--qos`, whose user/account association also had no default QOS, was accepted with an empty QOS. `resolve_qos` then returns a limitless `Qos::default()` for a job with no QOS, so **QOS limits could be bypassed entirely just by omitting `--qos`** — `scontrol show job` shows `QOS=` (blank) and the job runs unconstrained.

## Approach

Extend the submit-time QOS resolution chain to match Slurm's model:

**explicit `--qos` (must exist) → association default QOS → cluster-wide fallback (`accounting.default_qos`) → reject if `accounting.require_qos`**

Two new config fields under `[accounting]`, both **inert by default** so existing clusters are unchanged:
- `default_qos` — a cluster-wide fallback applied when nothing else resolves, so a QOS (and its limits) always applies. Analogous to Slurm's stock `normal` QOS. A configured fallback that names a nonexistent QOS is a hard submit error (silently ignoring it would reintroduce the gap).
- `require_qos` — when set, reject at submit any job that still has no QOS after the chain. Mirrors Slurm's `AccountingStorageEnforce=qos`.

## Second bypass door closed

Review found `scontrol update job <id> qos=X` set `job.spec.qos` with **no validation** — an unknown QOS resolved to the limitless default, and an empty QOS cleared enforcement, reopening the bypass one command after submit. `update_job` now validates a QOS change before any mutation (atomic reject): unknown QOS rejected like submit, empty QOS rejected rather than silently clearing.

## Testing

- Unit: full resolution-chain coverage (fallback applied; association default beats fallback; nonexistent fallback rejected; `require_qos` rejects when nothing resolves / satisfied by fallback / satisfied by explicit) and `update_job` QOS validation (unknown rejected, empty rejected, valid applied). Plus an end-to-end test that a cluster-fallback QOS actually blocks a second job via `check_qos_limits`.
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` — clean; `cargo test --locked` — all pass.
- Live on the 2-node lab cluster with accounting (Postgres) enabled: set `default_qos = "normal"` and confirmed a job submitted with no `--qos` is bound to `QOS=normal` at submit (previously blank), identical to an explicit `--qos=normal` job. The core SPUR-64 gap — jobs escaping QOS assignment — is closed.

## Out of scope (separate follow-up tickets)

- **Partition-level DefaultQOS** in the resolution chain (Slurm has it; Spur does not). Related: partition `allow_qos`/`deny_qos` fields exist but are currently **never enforced** — dead config worth its own ticket.
- **Per-association QOS grant-list** enforcement (a user setting a QOS they were never granted).
- **Pre-existing, unrelated bug found during live testing**: `sacctmgr modify qos <name> set maxjobspu=N` reports success and the value shows in `sacctmgr show qos`, but `max_jobs_per_user` is **never written to the `qos` table** (confirmed NULL in Postgres) — so that limit never enforces. Reproduced identically on stock 0.4.1, so it predates and is independent of this change. Filing separately.