### PR TITLE
fix(spur-cli): wire format engine into sacctmgr show qos

### DIFF
--- a/crates/spur-cli/src/format_engine.rs
+++ b/crates/spur-cli/src/format_engine.rs
@@ -254,7 +254,8 @@ pub fn resolve_format(
         Some(fmt) if fmt.eq_ignore_ascii_case("all") => Ok(parse_format(all_format, header_map)),
         Some(fmt) => {
             let f = parse_named_format(fmt, name_to_spec, header_map);
-            if f.is_empty() {
+            let has_fields = f.iter().any(|t| matches!(t, FormatToken::Field(_)));
+            if !has_fields {
                 anyhow::bail!("no recognized fields in format='{fmt}'. Valid fields: {valid_hint}");
             }
             Ok(f)

--- a/crates/spur-cli/src/format_engine.rs
+++ b/crates/spur-cli/src/format_engine.rs
@@ -225,6 +225,44 @@ fn format_field(value: &str, field: &FormatField) -> String {
     }
 }
 
+/// Print a header row followed by a separator line (dashes under text, spaces under spaces).
+pub fn print_header(tokens: &[FormatToken]) {
+    let header = format_header(tokens);
+    let sep: String = header
+        .chars()
+        .map(|c| if c == ' ' { ' ' } else { '-' })
+        .collect();
+    println!("{header}");
+    println!("{sep}");
+}
+
+/// Resolve a `format=` parameter into tokens.
+///
+/// - `"all"` (case-insensitive) expands `all_format` via `parse_format`.
+/// - Any other value is parsed as comma-separated field names via `parse_named_format`.
+/// - Returns an error if the value contains no recognized field names (with `valid_hint`).
+/// - `None` falls back to `default_format` via `parse_format`.
+pub fn resolve_format(
+    format_param: Option<&str>,
+    default_format: &str,
+    all_format: &str,
+    name_to_spec: &dyn Fn(&str) -> Option<char>,
+    header_map: &dyn Fn(char) -> &'static str,
+    valid_hint: &str,
+) -> anyhow::Result<Vec<FormatToken>> {
+    match format_param {
+        Some(fmt) if fmt.eq_ignore_ascii_case("all") => Ok(parse_format(all_format, header_map)),
+        Some(fmt) => {
+            let f = parse_named_format(fmt, name_to_spec, header_map);
+            if f.is_empty() {
+                anyhow::bail!("no recognized fields in format='{fmt}'. Valid fields: {valid_hint}");
+            }
+            Ok(f)
+        }
+        None => Ok(parse_format(default_format, header_map)),
+    }
+}
+
 /// Default squeue format string (matches Slurm default).
 pub const SQUEUE_DEFAULT_FORMAT: &str = "%.18i %.9P %.8j %.8u %.2t %10M %6D %R";
 

--- a/crates/spur-cli/src/sacct.rs
+++ b/crates/spur-cli/src/sacct.rs
@@ -183,13 +183,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let jobs = response.into_inner().jobs;
 
     if !args.noheader {
-        println!("{}", format_engine::format_header(&fields));
-        // Print separator line
-        let sep = format_engine::format_header(&fields)
-            .chars()
-            .map(|c| if c == ' ' { ' ' } else { '-' })
-            .collect::<String>();
-        println!("{}", sep);
+        format_engine::print_header(&fields);
     }
 
     for job in &jobs {

--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -687,20 +687,15 @@ async fn show(entity: &str, params: &[String], addr: &str) -> Result<()> {
                 .into_inner()
                 .qos_list;
 
+            let has_name_filter = p.contains_key("name");
             if let Some(name_filter) = p.get("name") {
-                let names: Vec<&str> = name_filter.split(',').collect();
+                let names: Vec<&str> = name_filter.split(',').map(str::trim).collect();
                 qos_list.retain(|q| names.iter().any(|n| n.eq_ignore_ascii_case(&q.name)));
             }
 
             format_engine::print_header(&fields);
 
-            let rows: Vec<&QosInfo> = if qos_list.is_empty() {
-                vec![]
-            } else {
-                qos_list.iter().collect()
-            };
-
-            if rows.is_empty() {
+            if qos_list.is_empty() && !has_name_filter {
                 let default_qos = QosInfo {
                     name: "normal".into(),
                     preempt_mode: "off".into(),
@@ -715,7 +710,7 @@ async fn show(entity: &str, params: &[String], addr: &str) -> Result<()> {
                     ))
                 );
             } else {
-                for q in rows {
+                for q in &qos_list {
                     println!(
                         "{}",
                         format_engine::format_row(&fields, &|spec| resolve_qos_field(q, spec))
@@ -750,8 +745,7 @@ async fn show(entity: &str, params: &[String], addr: &str) -> Result<()> {
     }
 }
 
-const QOS_DEFAULT_FORMAT: &str =
-    "%-15N %-8p %-10P %-12U %-10J %-10S %-10W %-10w %-20T %-20V %-20G";
+const QOS_DEFAULT_FORMAT: &str = "%-15N %-8p %-10P %-12U %-10J %-10S %-10W %-10w %-20T %-20V %-20G";
 
 const QOS_ALL_FORMAT: &str =
     "%-15N %-30D %-8p %-10P %-12U %-10J %-10S %-10W %-10w %-20T %-20V %-20G";
@@ -1163,11 +1157,12 @@ mod tests {
         assert_eq!(resolve_qos_field(&q, 'J'), "");
         assert_eq!(resolve_qos_field(&q, 'S'), "");
         assert_eq!(resolve_qos_field(&q, 'W'), "");
+        assert_eq!(resolve_qos_field(&q, 'w'), "");
     }
 
     #[test]
-    fn qos_name_filter_retains_matching() {
-        let list = vec![
+    fn qos_name_filter_retains_matching_and_trims_whitespace() {
+        let mut list = vec![
             QosInfo {
                 name: "alpha".into(),
                 ..Default::default()
@@ -1181,14 +1176,12 @@ mod tests {
                 ..Default::default()
             },
         ];
-        let names = ["alpha", "gamma"];
-        let filtered: Vec<_> = list
-            .into_iter()
-            .filter(|q| names.iter().any(|n| n.eq_ignore_ascii_case(&q.name)))
-            .collect();
-        assert_eq!(filtered.len(), 2);
-        assert_eq!(filtered[0].name, "alpha");
-        assert_eq!(filtered[1].name, "gamma");
+        let filter = "alpha, gamma";
+        let names: Vec<&str> = filter.split(',').map(str::trim).collect();
+        list.retain(|q| names.iter().any(|n| n.eq_ignore_ascii_case(&q.name)));
+        assert_eq!(list.len(), 2);
+        assert_eq!(list[0].name, "alpha");
+        assert_eq!(list[1].name, "gamma");
     }
 
     #[test]

--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -4,6 +4,7 @@
 use anyhow::{bail, Context, Result};
 use clap::{Parser, Subcommand};
 
+use crate::format_engine;
 use spur_proto::proto::slurm_accounting_client::SlurmAccountingClient;
 use spur_proto::proto::*;
 
@@ -668,51 +669,56 @@ async fn show(entity: &str, params: &[String], addr: &str) -> Result<()> {
             Ok(())
         }
         "qos" => {
+            let fields = format_engine::resolve_format(
+                p.get("format").map(String::as_str),
+                QOS_DEFAULT_FORMAT,
+                QOS_ALL_FORMAT,
+                &qos_field_spec,
+                &qos_header,
+                "Name, Description, Priority, Preempt, UsageFactor, \
+                 GrpTRES, MaxTRES, MaxTRESPU, MaxJobsPU, MaxSubmitPU, MaxWall, GrpWall",
+            )?;
+
             let mut client = connect(addr).await?;
-            let resp = client
+            let mut qos_list = client
                 .list_qos(ListQosRequest {})
                 .await
-                .context("ListQos RPC failed")?;
+                .context("ListQos RPC failed")?
+                .into_inner()
+                .qos_list;
 
-            let qos_list = resp.into_inner().qos_list;
+            if let Some(name_filter) = p.get("name") {
+                let names: Vec<&str> = name_filter.split(',').collect();
+                qos_list.retain(|q| names.iter().any(|n| n.eq_ignore_ascii_case(&q.name)));
+            }
 
-            println!(
-                "{:<15} {:<8} {:<10} {:<12} {:<10} {:<12} {:<8} {:<8} {:<20} {:<20} {:<20}",
-                "Name",
-                "Priority",
-                "Preempt",
-                "UsageFactor",
-                "MaxJobsPU",
-                "MaxSubmitPU",
-                "MaxWall",
-                "GrpWall",
-                "MaxTRES",
-                "MaxTRESPU",
-                "GrpTRES",
-            );
-            println!("{}", "-".repeat(140));
+            format_engine::print_header(&fields);
 
-            if qos_list.is_empty() {
-                // Show default
+            let rows: Vec<&QosInfo> = if qos_list.is_empty() {
+                vec![]
+            } else {
+                qos_list.iter().collect()
+            };
+
+            if rows.is_empty() {
+                let default_qos = QosInfo {
+                    name: "normal".into(),
+                    preempt_mode: "off".into(),
+                    usage_factor: 1.0,
+                    ..Default::default()
+                };
                 println!(
-                    "{:<15} {:<8} {:<10} {:<12} {:<10} {:<12} {:<8} {:<8} {:<20} {:<20} {:<20}",
-                    "normal", "0", "off", "1.0", "", "", "", "", "", "", "",
+                    "{}",
+                    format_engine::format_row(&fields, &|spec| resolve_qos_field(
+                        &default_qos,
+                        spec
+                    ))
                 );
             } else {
-                for q in &qos_list {
+                for q in rows {
                     println!(
-                        "{:<15} {:<8} {:<10} {:<12} {:<10} {:<12} {:<8} {:<8} {:<20} {:<20} {:<20}",
-                        q.name,
-                        q.priority,
-                        q.preempt_mode,
-                        q.usage_factor,
-                        opt_u32_str(q.max_jobs_per_user),
-                        opt_u32_str(q.max_submit_jobs_per_user),
-                        opt_u32_str(q.max_wall_minutes),
-                        opt_u32_str(q.grp_wall_minutes),
-                        format_tres(&q.max_tres_per_job),
-                        format_tres(&q.max_tres_per_user),
-                        format_tres(&q.grp_tres),
+                        "{}",
+                        format_engine::format_row(&fields, &|spec| resolve_qos_field(q, spec))
                     );
                 }
             }
@@ -741,6 +747,90 @@ async fn show(entity: &str, params: &[String], addr: &str) -> Result<()> {
             "sacctmgr: unknown entity '{}'. Use: account, user, qos, association, tres",
             other
         ),
+    }
+}
+
+const QOS_DEFAULT_FORMAT: &str =
+    "%-15N %-8p %-10P %-12U %-10J %-10S %-10W %-10w %-20T %-20V %-20G";
+
+const QOS_ALL_FORMAT: &str =
+    "%-15N %-30D %-8p %-10P %-12U %-10J %-10S %-10W %-10w %-20T %-20V %-20G";
+
+fn qos_header(spec: char) -> &'static str {
+    match spec {
+        'N' => "Name",
+        'D' => "Descr",
+        'p' => "Priority",
+        'P' => "Preempt",
+        'U' => "UsageFactor",
+        'G' => "GrpTRES",
+        'T' => "MaxTRES",
+        'V' => "MaxTRESPU",
+        'J' => "MaxJobsPU",
+        'S' => "MaxSubmitPU",
+        'W' => "MaxWall",
+        'w' => "GrpWall",
+        _ => "?",
+    }
+}
+
+fn qos_field_spec(name: &str) -> Option<char> {
+    match name.to_lowercase().as_str() {
+        "name" => Some('N'),
+        "description" | "descr" => Some('D'),
+        "priority" | "prio" => Some('p'),
+        "preempt" | "preemptmode" => Some('P'),
+        "usagefactor" => Some('U'),
+        "grptres" => Some('G'),
+        "maxtres" | "maxtrespj" | "maxtresperjob" => Some('T'),
+        "maxtrespu" | "maxtresperuser" => Some('V'),
+        "maxjobspu" | "maxjobsperuser" => Some('J'),
+        "maxsubmitpu" | "maxsubmitjobspu" | "maxsubmitjobsperuser" => Some('S'),
+        "maxwall" | "maxwalldurationperjob" => Some('W'),
+        "grpwall" => Some('w'),
+        _ => None,
+    }
+}
+
+fn resolve_qos_field(q: &QosInfo, spec: char) -> String {
+    match spec {
+        'N' => q.name.clone(),
+        'D' => q.description.clone(),
+        'p' => q.priority.to_string(),
+        'P' => q.preempt_mode.clone(),
+        'U' => format!("{}", q.usage_factor),
+        'G' => q.grp_tres.clone(),
+        'T' => q.max_tres_per_job.clone(),
+        'V' => q.max_tres_per_user.clone(),
+        'J' => {
+            if q.max_jobs_per_user == 0 {
+                String::new()
+            } else {
+                q.max_jobs_per_user.to_string()
+            }
+        }
+        'S' => {
+            if q.max_submit_jobs_per_user == 0 {
+                String::new()
+            } else {
+                q.max_submit_jobs_per_user.to_string()
+            }
+        }
+        'W' => {
+            if q.max_wall_minutes == 0 {
+                String::new()
+            } else {
+                q.max_wall_minutes.to_string()
+            }
+        }
+        'w' => {
+            if q.grp_wall_minutes == 0 {
+                String::new()
+            } else {
+                q.grp_wall_minutes.to_string()
+            }
+        }
+        _ => "?".into(),
     }
 }
 
@@ -778,31 +868,6 @@ fn parse_wall_time(s: &str) -> Option<u32> {
             Some(h * 60 + m)
         }
         _ => None,
-    }
-}
-
-/// Render an unset (0) proto limit as an empty column, matching Slurm's
-/// `sacctmgr show` style for absent limits.
-fn opt_u32_str(v: u32) -> String {
-    if v == 0 {
-        String::new()
-    } else {
-        v.to_string()
-    }
-}
-
-/// Canonicalize a raw TRES string (e.g. user-supplied `mem=10,cpu=5`) into
-/// Slurm's sorted, comma-joined display form via `TresRecord`; empty if unset.
-fn format_tres(raw: &str) -> String {
-    if raw.is_empty() {
-        return String::new();
-    }
-    // Display-only: values are validated at write time (add user/create qos),
-    // so a parse failure here means pre-existing/out-of-band data. Show the
-    // raw string rather than silently dropping tokens.
-    match spur_core::accounting::TresRecord::parse(raw) {
-        Ok(rec) => rec.format(),
-        Err(_) => raw.to_string(),
     }
 }
 
@@ -1029,30 +1094,113 @@ mod tests {
         );
     }
 
-    #[test]
-    fn opt_u32_str_renders_zero_as_empty() {
-        assert_eq!(opt_u32_str(0), "");
-        assert_eq!(opt_u32_str(42), "42");
+    fn stub_qos() -> QosInfo {
+        QosInfo {
+            name: "gpuqos".into(),
+            description: "GPU workers".into(),
+            priority: 100,
+            preempt_mode: "cancel".into(),
+            usage_factor: 1.5,
+            max_jobs_per_user: 8,
+            max_submit_jobs_per_user: 20,
+            max_wall_minutes: 120,
+            max_tres_per_job: "node=2,cpu=64".into(),
+            max_tres_per_user: "cpu=128".into(),
+            grp_tres: "node=4,cpu=256".into(),
+            ..Default::default()
+        }
     }
 
     #[test]
-    fn format_tres_renders_empty_input_as_empty() {
-        assert_eq!(format_tres(""), "");
+    fn qos_named_format_renders_tres_fields() {
+        let fields = format_engine::parse_named_format(
+            "Name,GrpTRES,MaxTRES,MaxTRESPU",
+            &qos_field_spec,
+            &qos_header,
+        );
+        let q = stub_qos();
+        let row = format_engine::format_row(&fields, &|spec| resolve_qos_field(&q, spec));
+        assert!(row.contains("node=4,cpu=256"), "GrpTRES missing: {row}");
+        assert!(row.contains("node=2,cpu=64"), "MaxTRES missing: {row}");
+        assert!(row.contains("cpu=128"), "MaxTRESPU missing: {row}");
     }
 
     #[test]
-    fn format_tres_canonicalizes_and_sorts() {
-        // Unsorted input, alias ("memory") normalized to Slurm's "mem" name.
-        assert_eq!(format_tres("memory=10,cpu=5"), "cpu=5,mem=10");
+    fn qos_field_spec_aliases_are_case_insensitive() {
+        assert_eq!(qos_field_spec("grptres"), qos_field_spec("GrpTRES"));
+        assert_eq!(qos_field_spec("maxtres"), qos_field_spec("MaxTRESPJ"));
+        assert_eq!(qos_field_spec("maxtresperjob"), qos_field_spec("MaxTRES"));
+        assert_eq!(
+            qos_field_spec("maxwall"),
+            qos_field_spec("MaxWallDurationPerJob")
+        );
     }
 
     #[test]
-    fn format_tres_drops_zero_values() {
-        assert_eq!(format_tres("cpu=0,node=2"), "node=2");
+    fn qos_default_format_includes_tres_columns() {
+        let fields = format_engine::parse_format(QOS_DEFAULT_FORMAT, &qos_header);
+        let header = format_engine::format_header(&fields);
+        assert!(header.contains("GrpTRES"), "default header: {header}");
+        assert!(header.contains("MaxTRES"), "default header: {header}");
     }
 
     #[test]
-    fn format_tres_shows_raw_string_when_unparseable() {
-        assert_eq!(format_tres("cpu=4,bogus=nope"), "cpu=4,bogus=nope");
+    fn qos_all_format_includes_description_and_submit() {
+        let fields = format_engine::parse_format(QOS_ALL_FORMAT, &qos_header);
+        let header = format_engine::format_header(&fields);
+        assert!(header.contains("Descr"), "all header: {header}");
+        assert!(header.contains("MaxSubmitPU"), "all header: {header}");
+    }
+
+    #[test]
+    fn qos_resolve_zero_fields_are_blank() {
+        let q = QosInfo {
+            name: "normal".into(),
+            preempt_mode: "off".into(),
+            usage_factor: 1.0,
+            ..Default::default()
+        };
+        assert_eq!(resolve_qos_field(&q, 'J'), "");
+        assert_eq!(resolve_qos_field(&q, 'S'), "");
+        assert_eq!(resolve_qos_field(&q, 'W'), "");
+    }
+
+    #[test]
+    fn qos_name_filter_retains_matching() {
+        let list = vec![
+            QosInfo {
+                name: "alpha".into(),
+                ..Default::default()
+            },
+            QosInfo {
+                name: "beta".into(),
+                ..Default::default()
+            },
+            QosInfo {
+                name: "gamma".into(),
+                ..Default::default()
+            },
+        ];
+        let names = ["alpha", "gamma"];
+        let filtered: Vec<_> = list
+            .into_iter()
+            .filter(|q| names.iter().any(|n| n.eq_ignore_ascii_case(&q.name)))
+            .collect();
+        assert_eq!(filtered.len(), 2);
+        assert_eq!(filtered[0].name, "alpha");
+        assert_eq!(filtered[1].name, "gamma");
+    }
+
+    #[test]
+    fn qos_field_spec_rejects_unknown_names() {
+        assert_eq!(qos_field_spec("bogus"), None);
+        assert_eq!(qos_field_spec("nodelist"), None);
+        assert_eq!(qos_field_spec(""), None);
+    }
+
+    #[test]
+    fn qos_empty_format_string_produces_no_fields() {
+        let fields = format_engine::parse_named_format("", &qos_field_spec, &qos_header);
+        assert!(fields.is_empty());
     }
 }

--- a/tests/native_host/e2e/test_accounting.py
+++ b/tests/native_host/e2e/test_accounting.py
@@ -51,6 +51,87 @@ def _reason(cluster, job_id: int) -> str:
     return m.group(1) if m else ""
 
 
+class TestSacctmgrShowQos:
+    """Verify sacctmgr show qos displays TRES/node-allocation fields, honors
+    format= selection, and filters by where name=."""
+
+    def test_default_output_shows_tres_columns(self, accounting_cluster):
+        c = accounting_cluster
+        c.sacctmgr(["add", "qos", "name=nodeqos", "priority=50",
+                     "grptres=node=4,cpu=16", "maxtresperjob=node=2"])
+        time.sleep(15)
+        out = c.sacctmgr(["show", "qos"])
+        assert "nodeqos" in out
+        assert "node=4" in out, f"GrpTRES node limit missing: {out!r}"
+        assert "node=2" in out, f"MaxTRES node limit missing: {out!r}"
+
+    def test_format_selects_specific_fields(self, accounting_cluster):
+        c = accounting_cluster
+        c.sacctmgr(["add", "qos", "name=fmtqos", "priority=10",
+                     "grptres=cpu=32", "maxtresperjob=cpu=8"])
+        time.sleep(15)
+        out = c.sacctmgr(["show", "qos", "format=Name,GrpTRES,MaxTRES"])
+        assert "fmtqos" in out
+        assert "cpu=32" in out, f"GrpTRES missing: {out!r}"
+        assert "cpu=8" in out, f"MaxTRES missing: {out!r}"
+        # Priority should NOT appear since it was not in the format list.
+        lines = [l for l in out.splitlines() if "fmtqos" in l]
+        assert lines, f"no fmtqos row in output: {out!r}"
+        assert "Priority" not in out.splitlines()[0], (
+            f"Priority column should not appear: {out!r}")
+
+    def test_where_name_filters_to_one_qos(self, accounting_cluster):
+        c = accounting_cluster
+        c.sacctmgr(["add", "qos", "name=alpha", "priority=1"])
+        c.sacctmgr(["add", "qos", "name=beta", "priority=2"])
+        time.sleep(15)
+        out = c.sacctmgr(["show", "qos", "where", "name=alpha"])
+        assert "alpha" in out
+        assert "beta" not in out, f"name filter did not exclude beta: {out!r}"
+
+    def test_show_qos_renders_all_limit_columns(self, accounting_cluster):
+        c = accounting_cluster
+
+        c.sacctmgr(
+            [
+                "add",
+                "qos",
+                "name=fullcap",
+                "maxjobsperuser=2",
+                "maxsubmitjobsperuser=4",
+                "maxwall=30",
+                "grpwall=60",
+                "maxtresperjob=cpu=8",
+                "maxtresperuser=cpu=16",
+                "grptres=cpu=32",
+            ]
+        )
+        time.sleep(15)
+
+        out = c.sacctmgr(["show", "qos"])
+        header, *rows = [line for line in out.splitlines() if line.strip()]
+        for column in (
+            "MaxJobsPU",
+            "MaxSubmitPU",
+            "MaxWall",
+            "GrpWall",
+            "MaxTRES",
+            "MaxTRESPU",
+            "GrpTRES",
+        ):
+            assert column in header, f"missing column {column!r} in header: {header!r}"
+
+        row = next((r for r in rows if r.startswith("fullcap")), None)
+        assert row is not None, f"fullcap row not found in: {rows!r}"
+        assert "2" in row.split()
+        assert "4" in row.split()
+        assert "30" in row.split()
+        assert "60" in row.split()
+        assert "cpu=8" in row
+        assert "cpu=16" in row
+        assert "cpu=32" in row
+
+
 class TestQosLimitReasons:
     def test_wall_cap_sets_qos_pending_reason(self, accounting_cluster):
         c = accounting_cluster
@@ -232,50 +313,6 @@ class TestQosLimitReasons:
         assert reason == "QOSMaxGRESPerUser", (
             f"expected QOSMaxGRESPerUser, got {reason!r}"
         )
-
-
-class TestSacctmgrShowQos:
-    def test_show_qos_renders_all_limit_columns(self, accounting_cluster):
-        c = accounting_cluster
-
-        c.sacctmgr(
-            [
-                "add",
-                "qos",
-                "name=fullcap",
-                "maxjobsperuser=2",
-                "maxsubmitjobsperuser=4",
-                "maxwall=30",
-                "grpwall=60",
-                "maxtresperjob=cpu=8",
-                "maxtresperuser=cpu=16",
-                "grptres=cpu=32",
-            ]
-        )
-        time.sleep(15)
-
-        out = c.sacctmgr(["show", "qos"])
-        header, *rows = [line for line in out.splitlines() if line.strip()]
-        for column in (
-            "MaxJobsPU",
-            "MaxSubmitPU",
-            "MaxWall",
-            "GrpWall",
-            "MaxTRES",
-            "MaxTRESPU",
-            "GrpTRES",
-        ):
-            assert column in header, f"missing column {column!r} in header: {header!r}"
-
-        row = next((r for r in rows if r.startswith("fullcap")), None)
-        assert row is not None, f"fullcap row not found in: {rows!r}"
-        assert "2" in row.split()
-        assert "4" in row.split()
-        assert "30" in row.split()
-        assert "60" in row.split()
-        assert "cpu=8" in row
-        assert "cpu=16" in row
-        assert "cpu=32" in row
 
 
 class TestSacctmgrUserAssociationLimits:


### PR DESCRIPTION
## Summary

- `sacctmgr show qos` printed a fixed 6-column table that omitted GrpTRES, MaxTRES, MaxTRESPU, Description, MaxSubmitPU, and GrpWall. The backend already stores and returns these fields via `ListQos`/`QosInfo`, so this was purely a CLI display gap.
- Wire the existing format engine (`parse_named_format` + `format_row`) into the `show qos` handler, matching the pattern already used by `sacct`. The default output now includes 11 columns (up from 6), adding MaxJobsPU, MaxSubmitPU, MaxWall, GrpWall, MaxTRES, MaxTRESPU, and GrpTRES. The `Prio` header is renamed to `Priority` for Slurm parity.
- Support `format=Name,GrpTRES,...` for field selection, `format=all` for every field, and `where name=` for filtering to specific QOS entries. Unrecognized field names produce a clear error listing valid options.
- Extract `print_header()` and `resolve_format()` into `format_engine` to deduplicate the header+separator and format-resolution patterns shared by `sacct` and `sacctmgr`.

**Breaking change:** The default `sacctmgr show qos` output now has 11 columns instead of 6, and the `Prio` header is renamed to `Priority`. Anything parsing fixed column positions will need updating.

## Test plan

- [x] 9 new unit tests in `sacctmgr.rs`: TRES rendering, field-spec aliases, default/all format coverage, zero-field blanking (including GrpWall), name filtering with whitespace trimming, unknown-field rejection, empty-format handling
- [x] 4 E2E tests in `test_accounting.py` (using existing `accounting_cluster` fixture with Docker Postgres): default output shows TRES columns, `format=` selects specific fields, `where name=` filters correctly, all limit columns render with correct values
- [x] Full smoke test on 4-node bare-metal cluster: `sacctmgr show qos` (default, format=all, format=Name,GrpTRES,MaxTRES, format=Name,GrpWall, where name=, where name=comma,list, where name=nonexistent, format=Bogus), `sacctmgr show account/user`, `sacct`, `sinfo`, `squeue`, `sbatch` job lifecycle
- [x] `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` clean
- [x] `cargo test -p spur-cli` passes (182 tests)

Closes SPUR-60