### PR TITLE
fix(spur-core): derive version from cargo version plus git sha

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,7 +23,6 @@ jobs:
       date: ${{ steps.meta.outputs.date }}
       short_sha: ${{ steps.meta.outputs.short_sha }}
       full_sha: ${{ steps.meta.outputs.full_sha }}
-      git_describe: ${{ steps.meta.outputs.git_describe }}
     steps:
       - uses: actions/checkout@v7
 
@@ -48,9 +47,8 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         run: |
           echo "date=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
-          echo "short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
           echo "full_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          echo "git_describe=$(git describe --always --dirty)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         if: steps.check.outputs.skip != 'true'
@@ -66,7 +64,8 @@ jobs:
           push: false
           outputs: type=local,dest=./dist
           build-args: |
-            SPUR_GIT_DESCRIBE=${{ steps.meta.outputs.git_describe }}
+            SPUR_GIT_SHA=${{ steps.meta.outputs.short_sha }}
+            SPUR_GIT_DIRTY=false
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -171,7 +170,8 @@ jobs:
             rocm/spur:nightly
             rocm/spur:nightly-${{ needs.build.outputs.date }}
           build-args: |
-            SPUR_GIT_DESCRIBE=${{ needs.build.outputs.git_describe }}
+            SPUR_GIT_SHA=${{ needs.build.outputs.short_sha }}
+            SPUR_GIT_DIRTY=false
           cache-from: type=gha,scope=nightly-docker
           cache-to: type=gha,scope=nightly-docker,mode=max
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,6 @@ jobs:
           target: dist
           push: false
           outputs: type=local,dest=./dist
-          build-args: |
-            SPUR_GIT_DESCRIBE=${{ env.TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -156,8 +154,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            SPUR_GIT_DESCRIBE=${{ env.TAG }}
           cache-from: type=gha,scope=release-docker
           cache-to: type=gha,scope=release-docker,mode=max
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
+      - name: Set metadata
+        id: gitmeta
+        run: echo "short_sha=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Build portable binaries (Ubuntu 22.04+ compatible)
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
@@ -42,6 +46,9 @@ jobs:
           target: dist
           push: false
           outputs: type=local,dest=./dist
+          build-args: |
+            SPUR_GIT_SHA=${{ steps.gitmeta.outputs.short_sha }}
+            SPUR_GIT_DIRTY=false
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -130,6 +137,10 @@ jobs:
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
+      - name: Set metadata
+        id: gitmeta
+        run: echo "short_sha=$(git rev-parse --short=8 HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Log in to Docker Hub
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
@@ -154,6 +165,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            SPUR_GIT_SHA=${{ steps.gitmeta.outputs.short_sha }}
+            SPUR_GIT_DIRTY=false
           cache-from: type=gha,scope=release-docker
           cache-to: type=gha,scope=release-docker,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,10 @@ COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
-ARG SPUR_GIT_DESCRIBE
-ENV SPUR_GIT_DESCRIBE=$SPUR_GIT_DESCRIBE
+ARG SPUR_GIT_SHA
+ARG SPUR_GIT_DIRTY
+ENV SPUR_GIT_SHA=$SPUR_GIT_SHA
+ENV SPUR_GIT_DIRTY=$SPUR_GIT_DIRTY
 
 COPY --from=planner /build/recipe.json recipe.json
 RUN cargo chef cook --release --locked --recipe-path recipe.json

--- a/crates/spur-core/build.rs
+++ b/crates/spur-core/build.rs
@@ -4,31 +4,41 @@
 use std::path::Path;
 use std::process::Command;
 
-fn git_describe(manifest_dir: &Path) -> String {
+fn git(manifest_dir: &Path, args: &[&str]) -> Option<String> {
     Command::new("git")
-        .args(["describe", "--always", "--dirty"])
+        .args(args)
         .current_dir(manifest_dir)
         .output()
         .ok()
         .filter(|output| output.status.success())
         .and_then(|output| String::from_utf8(output.stdout).ok())
         .map(|s| s.trim().to_string())
-        .unwrap_or_default()
+}
+
+fn git_sha(manifest_dir: &Path) -> String {
+    git(manifest_dir, &["rev-parse", "--short=8", "HEAD"]).unwrap_or_default()
+}
+
+fn git_dirty(manifest_dir: &Path) -> bool {
+    // Any porcelain output means uncommitted changes; no git means clean.
+    git(manifest_dir, &["status", "--porcelain"])
+        .map(|s| !s.is_empty())
+        .unwrap_or(false)
 }
 
 fn main() {
-    // `--dirty` reflects the whole working tree, not just this crate's
-    // files, so no `rerun-if-changed` path can scope this correctly.
-    // Watching a path that never exists forces Cargo to treat the build
-    // script as always out of date, so it reruns on every build.
+    // Git state spans the whole tree, so no path scopes it; watching a
+    // nonexistent path forces a rerun on every build.
     println!("cargo:rerun-if-changed=__spur_always_rerun__");
 
     let manifest_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
-    // Docker builds don't ship `.git` (see `.dockerignore`), so CI passes the
-    // descriptor in directly; only shell out to git for local dev builds.
-    let describe =
-        std::env::var("SPUR_GIT_DESCRIBE").unwrap_or_else(|_| git_describe(&manifest_dir));
+    // Docker builds omit `.git`, so CI passes these in; local builds read git.
+    let sha = std::env::var("SPUR_GIT_SHA").unwrap_or_else(|_| git_sha(&manifest_dir));
+    let dirty = std::env::var("SPUR_GIT_DIRTY")
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or_else(|_| git_dirty(&manifest_dir));
 
-    println!("cargo:rustc-env=SPUR_GIT_DESCRIBE={describe}");
+    println!("cargo:rustc-env=SPUR_GIT_SHA={sha}");
+    println!("cargo:rustc-env=SPUR_GIT_DIRTY={dirty}");
 }

--- a/crates/spur-core/src/version.rs
+++ b/crates/spur-core/src/version.rs
@@ -1,24 +1,24 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Git descriptor captured at build time (`git describe --always --dirty`).
-/// Empty when git was unavailable at build time (e.g. building from a
-/// released source tarball with no `.git` directory).
-pub const GIT_DESCRIBE: &str = env!("SPUR_GIT_DESCRIBE");
+/// Short git commit hash at build time; empty when git was unavailable.
+pub const GIT_SHA: &str = env!("SPUR_GIT_SHA");
 
-fn format_version(pkg_version: &str, git_describe: &str) -> String {
-    let tag = format!("v{pkg_version}");
-    if git_describe.is_empty() || git_describe == tag {
-        format!("spur {pkg_version}")
-    } else {
-        format!("spur {pkg_version} ({git_describe})")
+/// Whether the working tree had uncommitted changes at build time.
+pub const GIT_DIRTY: bool = matches!(env!("SPUR_GIT_DIRTY").as_bytes(), b"true");
+
+fn format_version(pkg_version: &str, git_sha: &str, git_dirty: bool) -> String {
+    // Cargo.toml version is authoritative; git metadata is only build provenance.
+    if git_sha.is_empty() {
+        return format!("spur {pkg_version}");
     }
+    let dirty = if git_dirty { "-dirty" } else { "" };
+    format!("spur {pkg_version} ({git_sha}{dirty})")
 }
 
-/// User-facing version string, matching Slurm's `<product> <version>` format
-/// for release builds and appending git metadata for dev builds.
+/// User-facing version string: package version plus git commit and dirty state.
 pub fn version_string() -> String {
-    format_version(env!("CARGO_PKG_VERSION"), GIT_DESCRIBE)
+    format_version(env!("CARGO_PKG_VERSION"), GIT_SHA, GIT_DIRTY)
 }
 
 #[cfg(test)]
@@ -26,44 +26,28 @@ mod tests {
     use super::*;
 
     #[test]
-    fn empty_git_describe_yields_plain_version() {
-        assert_eq!(format_version("0.4.1", ""), "spur 0.4.1");
+    fn no_git_info_yields_plain_version() {
+        assert_eq!(format_version("0.5.0", "", false), "spur 0.5.0");
     }
 
     #[test]
-    fn exact_tag_match_yields_plain_version() {
-        assert_eq!(format_version("0.4.1", "v0.4.1"), "spur 0.4.1");
-    }
-
-    #[test]
-    fn commits_past_tag_includes_git_describe() {
+    fn clean_build_includes_sha() {
         assert_eq!(
-            format_version("0.4.1", "v0.4.1-45-gabc1234"),
-            "spur 0.4.1 (v0.4.1-45-gabc1234)"
+            format_version("0.5.0", "fd995b2a", false),
+            "spur 0.5.0 (fd995b2a)"
         );
     }
 
     #[test]
-    fn dirty_tree_includes_dirty_suffix() {
+    fn dirty_build_appends_dirty_suffix() {
         assert_eq!(
-            format_version("0.4.1", "v0.4.1-dirty"),
-            "spur 0.4.1 (v0.4.1-dirty)"
+            format_version("0.5.0", "fd995b2a", true),
+            "spur 0.5.0 (fd995b2a-dirty)"
         );
     }
 
     #[test]
-    fn commits_past_tag_and_dirty_includes_full_descriptor() {
-        assert_eq!(
-            format_version("0.4.1", "v0.4.1-45-gabc1234-dirty"),
-            "spur 0.4.1 (v0.4.1-45-gabc1234-dirty)"
-        );
-    }
-
-    #[test]
-    fn descriptor_from_older_tag_is_not_treated_as_exact_match() {
-        assert_eq!(
-            format_version("0.4.1", "v0.3.0-251-g4b85bd7"),
-            "spur 0.4.1 (v0.3.0-251-g4b85bd7)"
-        );
+    fn dirty_flag_without_sha_stays_plain() {
+        assert_eq!(format_version("0.5.0", "", true), "spur 0.5.0");
     }
 }


### PR DESCRIPTION
## What

`--version` showed a stale version (`spur 0.5.0 (v0.3.0-262-gfd995b2-dirty)` or similar) because the string was built from `git describe --always --dirty`.

## Why

`git describe` anchors to the most recent *annotated* tag. `v0.3.0` is annotated; `v0.4.x`/`v0.5.0` are lightweight and not ancestors of `main`'s HEAD, so `describe` walks back to `v0.3.0`. The result always drifts from the declared package version.

## Approach

Make `Cargo.toml` authoritative and reduce git to build provenance (the Kubernetes `gitVersion`/`gitCommit`/`gitTreeState` model):

- `build.rs` captures the short commit hash (`SPUR_GIT_SHA`) and dirty state (`SPUR_GIT_DIRTY`). It honors env overrides first (CI/Docker, where `.git` is absent) and falls back to shelling out to git for local builds.
- `version_string()` formats `spur <cargo-version> (<sha>[-dirty])`, or plain `spur <version>` when no git info is available.
- Docker `ARG`/`ENV` and the release/nightly workflows updated to pass sha/dirty. Both release and nightly pass the short sha, so release and nightly binaries/images carry commit provenance.

## Output

| Build | Version |
|---|---|
| tagged release | `spur 0.5.0 (<sha>)` |
| nightly | `spur 0.5.0 (<sha>)` |
| local, clean | `spur 0.5.0 (<sha>)` |
| local, dirty | `spur 0.5.0 (<sha>-dirty)` |
| no git (tarball) | `spur 0.5.0` |

## Testing

- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked`: clean.
- `cargo test -p spur-core version`: 4/4 pass.
- Verified all five override/fallback scenarios produce the expected `--version` output across `spur`, `spurctld`, `spurd`.
