### PR TITLE
feat(spurctld): auto-derive raft node_id from controller.peers position

### DIFF
--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -269,33 +269,17 @@ pub struct ControllerConfig {
     #[serde(default = "default_one")]
     pub first_job_id: u32,
 
-    /// Raft peers for HA consensus. Each entry is "host:port" (Raft gRPC address).
-    /// If empty, single-node mode (no Raft, no replication).
+    /// Raft peers for HA consensus, "host:port" each. Empty = single-node mode.
+    /// Must be identically ordered on every controller: node ids derive from
+    /// list position, so a reordered list can form an inconsistent voter set.
     /// Example: ["node1:6821", "node2:6821", "node3:6821"]
-    ///
-    /// INVARIANT: every controller must be given a byte-identical,
-    /// identically-ordered `peers` list. Node ids derive from list position, so
-    /// a reordered list makes a host derive a different id for itself than its
-    /// peers map to it — at initial bootstrap this can form an inconsistent
-    /// voter set.
     #[serde(default)]
     pub peers: Vec<String>,
 
-    /// This node's Raft ID. Normally left unset. Only consulted in multi-node
-    /// mode (`peers` non-empty); single-node mode always uses id 1.
-    ///
-    /// In multi-node mode the id is resolved by precedence:
-    /// 1. this explicit value, if set;
-    /// 2. this host's position in `peers` (its hostname matched against each
-    ///    entry's host part, on the full name or first DNS label);
-    /// 3. the hostname ordinal (e.g. spurctld-2 → node_id 3), only for IP-only
-    ///    peer lists where hostname matching cannot work.
-    ///
-    /// The resolved id must fall within `1..=peers.len()`, else startup fails.
-    /// Only needed when peers are IP-only and cannot match a hostname. An
-    /// explicit id that is in range but disagrees with this host's positional
-    /// index in `peers` is accepted silently, so when set it must match that
-    /// position (id == index + 1) or peers will map the host to a different id.
+    /// This node's Raft ID. Normally unset; single-node mode always uses 1.
+    /// Otherwise resolved as: explicit value, else position in `peers` (by
+    /// hostname), else hostname ordinal (IP-only peers). Must be in
+    /// `1..=peers.len()` and, if set, equal its position (index + 1).
     pub node_id: Option<u64>,
 
     /// Listen address for Raft internal gRPC traffic (separate from client API).

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -275,11 +275,15 @@ pub struct ControllerConfig {
     #[serde(default)]
     pub peers: Vec<String>,
 
-    /// This node's Raft ID. Normally left unset. Resolution precedence is:
+    /// This node's Raft ID. Normally left unset. Only consulted in multi-node
+    /// mode (`peers` non-empty); single-node mode always uses id 1.
+    ///
+    /// In multi-node mode the id is resolved by precedence:
     /// 1. this explicit value, if set;
     /// 2. this host's position in `peers` (its hostname matched against each
     ///    entry's host part, on the full name or first DNS label);
-    /// 3. the hostname ordinal (e.g. spurctld-2 → node_id 3).
+    /// 3. the hostname ordinal (e.g. spurctld-2 → node_id 3), only for IP-only
+    ///    peer lists where hostname matching cannot work.
     ///
     /// The resolved id must fall within `1..=peers.len()`, else startup fails.
     /// Only needed when peers are IP-only and cannot match a hostname.

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -272,6 +272,12 @@ pub struct ControllerConfig {
     /// Raft peers for HA consensus. Each entry is "host:port" (Raft gRPC address).
     /// If empty, single-node mode (no Raft, no replication).
     /// Example: ["node1:6821", "node2:6821", "node3:6821"]
+    ///
+    /// INVARIANT: every controller must be given a byte-identical,
+    /// identically-ordered `peers` list. Node ids derive from list position, so
+    /// a reordered list makes a host derive a different id for itself than its
+    /// peers map to it — at initial bootstrap this can form an inconsistent
+    /// voter set.
     #[serde(default)]
     pub peers: Vec<String>,
 
@@ -286,7 +292,10 @@ pub struct ControllerConfig {
     ///    peer lists where hostname matching cannot work.
     ///
     /// The resolved id must fall within `1..=peers.len()`, else startup fails.
-    /// Only needed when peers are IP-only and cannot match a hostname.
+    /// Only needed when peers are IP-only and cannot match a hostname. An
+    /// explicit id that is in range but disagrees with this host's positional
+    /// index in `peers` is accepted silently, so when set it must match that
+    /// position (id == index + 1) or peers will map the host to a different id.
     pub node_id: Option<u64>,
 
     /// Listen address for Raft internal gRPC traffic (separate from client API).

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -275,8 +275,14 @@ pub struct ControllerConfig {
     #[serde(default)]
     pub peers: Vec<String>,
 
-    /// This node's Raft ID. If not set, auto-derived from hostname ordinal
-    /// (e.g. spurctld-2 → node_id 3) or defaults to 1.
+    /// This node's Raft ID. Normally left unset. Resolution precedence is:
+    /// 1. this explicit value, if set;
+    /// 2. this host's position in `peers` (its hostname matched against each
+    ///    entry's host part, on the full name or first DNS label);
+    /// 3. the hostname ordinal (e.g. spurctld-2 → node_id 3).
+    ///
+    /// The resolved id must fall within `1..=peers.len()`, else startup fails.
+    /// Only needed when peers are IP-only and cannot match a hostname.
     pub node_id: Option<u64>,
 
     /// Listen address for Raft internal gRPC traffic (separate from client API).

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -127,19 +127,16 @@ async fn main() -> anyhow::Result<()> {
         info!("single-node Raft mode (no peers configured)");
         (vec![raft_addr], 1u64)
     } else {
-        let id = config
-            .controller
-            .node_id
-            .or_else(raft::detect_node_id_from_hostname)
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "Raft peers configured but node_id could not be determined. \
-                 Set controller.node_id in spur.conf or use a hostname ending \
-                 in -N (e.g. spurctld-0)."
-                )
-            })?;
+        let hostname = raft::system_hostname()?;
+        let (id, source) = raft::resolve_node_id(
+            config.controller.node_id,
+            &hostname,
+            &config.controller.peers,
+        )?;
         info!(
             node_id = id,
+            source = %source,
+            hostname,
             peers = ?config.controller.peers,
             "initializing Raft consensus"
         );

--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -759,10 +759,76 @@ impl RaftHandle {
     }
 }
 
-/// Auto-detect node_id from hostname ordinal (e.g., "spurctld-2" → 3).
-pub fn detect_node_id_from_hostname() -> Option<u64> {
-    let hostname = hostname::get().ok()?;
-    node_id_from_hostname(&hostname.to_string_lossy())
+/// The system hostname as a UTF-8 string.
+pub fn system_hostname() -> anyhow::Result<String> {
+    let name = hostname::get().map_err(|e| anyhow::anyhow!("failed to read hostname: {e}"))?;
+    Ok(name.to_string_lossy().into_owned())
+}
+
+/// How a node's Raft id was determined, for startup diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeIdSource {
+    Explicit,
+    PeersPosition,
+    HostnameOrdinal,
+}
+
+impl std::fmt::Display for NodeIdSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            NodeIdSource::Explicit => "explicit controller.node_id",
+            NodeIdSource::PeersPosition => "position in controller.peers",
+            NodeIdSource::HostnameOrdinal => "hostname ordinal",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Resolve this node's Raft id for a multi-node cluster (`peers` non-empty).
+///
+/// Precedence: explicit `controller.node_id` -> position in `peers` -> hostname
+/// ordinal. Every path is validated to fall in `1..=peers.len()` so a
+/// mismatched id fails fast at startup instead of silently splitting the
+/// cluster (an id outside that range exists in no peer's `build_peer_map`).
+pub fn resolve_node_id(
+    explicit: Option<u64>,
+    hostname: &str,
+    peers: &[String],
+) -> anyhow::Result<(u64, NodeIdSource)> {
+    let n = peers.len() as u64;
+
+    if let Some(id) = explicit {
+        if !(1..=n).contains(&id) {
+            anyhow::bail!(
+                "controller.node_id = {id} is out of range for {n} configured \
+                 controller.peers (must be 1..={n})"
+            );
+        }
+        return Ok((id, NodeIdSource::Explicit));
+    }
+
+    if let Some(id) = node_id_from_peers(hostname, peers)? {
+        return Ok((id, NodeIdSource::PeersPosition));
+    }
+
+    // Hostname-ordinal is a legacy fallback, reached only when the host matched
+    // no peer entry (e.g. IP-only peers). Accept it only if it lands in range;
+    // an out-of-range ordinal is a misconfiguration, not a valid member.
+    if let Some(id) = node_id_from_hostname(hostname) {
+        if (1..=n).contains(&id) {
+            return Ok((id, NodeIdSource::HostnameOrdinal));
+        }
+        anyhow::bail!(
+            "hostname {hostname:?} yields Raft node_id {id} via ordinal fallback, \
+             out of range for {n} configured controller.peers; fix the hostname \
+             to match its controller.peers entry or set controller.node_id"
+        );
+    }
+
+    anyhow::bail!(
+        "this host ({hostname:?}) matched no entry in controller.peers; fix the \
+         hostname to match its peers entry or set controller.node_id in spur.conf"
+    )
 }
 
 /// Parse a node_id from a hostname string. The ordinal after the last '-'
@@ -770,6 +836,56 @@ pub fn detect_node_id_from_hostname() -> Option<u64> {
 pub fn node_id_from_hostname(hostname: &str) -> Option<u64> {
     let ordinal: u64 = hostname.rsplit('-').next()?.parse().ok()?;
     Some(ordinal + 1)
+}
+
+/// Derive a node_id from `hostname`'s position in `peers` (index + 1, matching
+/// `build_peer_map`). Matching is on the full name or the first DNS label, so a
+/// short hostname like `spurctld-0` matches `spurctld-0.ns.svc.cluster.local`.
+/// Returns `Ok(None)` when no entry matches, and errors when more than one does
+/// (ambiguous: silently picking one risks a split-brain).
+pub fn node_id_from_peers(hostname: &str, peers: &[String]) -> anyhow::Result<Option<u64>> {
+    let matches: Vec<u64> = peers
+        .iter()
+        .enumerate()
+        .filter(|(_, entry)| host_matches(hostname, peer_host(entry)))
+        .map(|(i, _)| i as u64 + 1)
+        .collect();
+    match matches.as_slice() {
+        [] => Ok(None),
+        [id] => Ok(Some(*id)),
+        ids => anyhow::bail!(
+            "hostname {hostname:?} matches multiple controller.peers entries \
+             (node ids {ids:?}); set controller.node_id explicitly"
+        ),
+    }
+}
+
+/// Extract the host part from a `host:port` peer entry, handling bracketed IPv6
+/// (`[::1]:6821`) and bare hosts.
+fn peer_host(entry: &str) -> &str {
+    let entry = entry.trim();
+    if let Some(rest) = entry.strip_prefix('[') {
+        return rest.split(']').next().unwrap_or(rest);
+    }
+    // A single ':' delimits "host:port"; more colons mean an unbracketed IPv6
+    // literal, which has no port to strip and is returned unchanged.
+    match entry.rsplit_once(':') {
+        Some((host, _)) if !host.contains(':') => host,
+        _ => entry,
+    }
+}
+
+/// True if `hostname` matches `peer_host` in full or on the first DNS label.
+fn host_matches(hostname: &str, peer_host: &str) -> bool {
+    if hostname.eq_ignore_ascii_case(peer_host) {
+        return true;
+    }
+    first_label(hostname).eq_ignore_ascii_case(first_label(peer_host))
+}
+
+/// The segment of a hostname before the first '.' (its first DNS label).
+fn first_label(host: &str) -> &str {
+    host.split('.').next().unwrap_or(host)
 }
 
 /// Build a 1-indexed peer map from the config peers list.
@@ -917,6 +1033,128 @@ mod tests {
     #[test]
     fn hostname_non_numeric_suffix() {
         assert_eq!(node_id_from_hostname("ctrl-abc"), None);
+    }
+
+    #[test]
+    fn peers_position_mapping() {
+        let peers = vec![
+            "hostA:6821".to_string(),
+            "hostB:6821".to_string(),
+            "hostC:6821".to_string(),
+        ];
+        assert_eq!(node_id_from_peers("hostA", &peers).unwrap(), Some(1));
+        assert_eq!(node_id_from_peers("hostB", &peers).unwrap(), Some(2));
+        assert_eq!(node_id_from_peers("hostC", &peers).unwrap(), Some(3));
+    }
+
+    #[test]
+    fn peers_short_hostname_matches_fqdn_entry() {
+        let peers = vec![
+            "spurctld-0.ns.svc.cluster.local:6821".to_string(),
+            "spurctld-1.ns.svc.cluster.local:6821".to_string(),
+        ];
+        assert_eq!(node_id_from_peers("spurctld-0", &peers).unwrap(), Some(1));
+        assert_eq!(node_id_from_peers("spurctld-1", &peers).unwrap(), Some(2));
+    }
+
+    #[test]
+    fn peers_fqdn_hostname_matches_short_entry() {
+        let peers = vec!["node1:6821".to_string(), "node2:6821".to_string()];
+        assert_eq!(
+            node_id_from_peers("node2.example.com", &peers).unwrap(),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn peers_no_match_is_none() {
+        let peers = vec!["hostA:6821".to_string(), "hostB:6821".to_string()];
+        assert_eq!(node_id_from_peers("hostZ", &peers).unwrap(), None);
+    }
+
+    #[test]
+    fn peers_ambiguous_match_errors() {
+        // Same first DNS label in two different domains: both reduce to "n1".
+        let peers = vec!["n1.dc-a:6821".to_string(), "n1.dc-b:6821".to_string()];
+        assert!(node_id_from_peers("n1", &peers).is_err());
+    }
+
+    #[test]
+    fn peers_matches_bracketed_ipv6_entry() {
+        let peers = vec!["[::1]:6821".to_string(), "hostB:6821".to_string()];
+        assert_eq!(peer_host("[::1]:6821"), "::1");
+        assert_eq!(node_id_from_peers("hostB", &peers).unwrap(), Some(2));
+    }
+
+    #[test]
+    fn peer_host_parsing() {
+        assert_eq!(peer_host("host:6821"), "host");
+        assert_eq!(peer_host("host"), "host");
+        assert_eq!(peer_host("host.example.com:6821"), "host.example.com");
+        assert_eq!(peer_host("[2001:db8::1]:6821"), "2001:db8::1");
+    }
+
+    fn three_peers() -> Vec<String> {
+        vec![
+            "hostA:6821".to_string(),
+            "hostB:6821".to_string(),
+            "hostC:6821".to_string(),
+        ]
+    }
+
+    #[test]
+    fn resolve_explicit_wins() {
+        let (id, source) = resolve_node_id(Some(2), "hostA", &three_peers()).unwrap();
+        assert_eq!(id, 2);
+        assert_eq!(source, NodeIdSource::Explicit);
+    }
+
+    #[test]
+    fn resolve_explicit_out_of_range_errors() {
+        assert!(resolve_node_id(Some(9), "hostA", &three_peers()).is_err());
+        assert!(resolve_node_id(Some(0), "hostA", &three_peers()).is_err());
+    }
+
+    #[test]
+    fn resolve_peers_position() {
+        let (id, source) = resolve_node_id(None, "hostC", &three_peers()).unwrap();
+        assert_eq!(id, 3);
+        assert_eq!(source, NodeIdSource::PeersPosition);
+    }
+
+    #[test]
+    fn resolve_hostname_ordinal_fallback_for_ip_peers() {
+        // IP-only peers can't match a hostname; the ordinal fallback applies.
+        let peers = vec![
+            "10.0.0.1:6821".to_string(),
+            "10.0.0.2:6821".to_string(),
+            "10.0.0.3:6821".to_string(),
+        ];
+        let (id, source) = resolve_node_id(None, "spurctld-1", &peers).unwrap();
+        assert_eq!(id, 2);
+        assert_eq!(source, NodeIdSource::HostnameOrdinal);
+    }
+
+    #[test]
+    fn resolve_ordinal_out_of_range_errors() {
+        // spurctld-5 -> ordinal id 6, but only 3 IP-only peers exist.
+        let peers = vec![
+            "10.0.0.1:6821".to_string(),
+            "10.0.0.2:6821".to_string(),
+            "10.0.0.3:6821".to_string(),
+        ];
+        assert!(resolve_node_id(None, "spurctld-5", &peers).is_err());
+    }
+
+    #[test]
+    fn resolve_no_match_errors() {
+        assert!(resolve_node_id(None, "unknownhost", &three_peers()).is_err());
+    }
+
+    #[test]
+    fn resolve_ambiguous_match_errors() {
+        let peers = vec!["n1.dc-a:6821".to_string(), "n1.dc-b:6821".to_string()];
+        assert!(resolve_node_id(None, "n1", &peers).is_err());
     }
 
     #[test]

--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -784,12 +784,9 @@ impl std::fmt::Display for NodeIdSource {
     }
 }
 
-/// Resolve this node's Raft id for a multi-node cluster (`peers` non-empty).
-///
-/// Precedence: explicit `controller.node_id` -> position in `peers` -> hostname
-/// ordinal. Every path is validated to fall in `1..=peers.len()` so a
-/// mismatched id fails fast at startup instead of silently splitting the
-/// cluster (an id outside that range exists in no peer's `build_peer_map`).
+/// Resolve this node's Raft id (multi-node; `peers` non-empty). Precedence:
+/// explicit -> position in `peers` -> hostname ordinal. Validated to be in
+/// `1..=peers.len()`, else fails fast (an out-of-range id splits brain).
 pub fn resolve_node_id(
     explicit: Option<u64>,
     hostname: &str,
@@ -811,10 +808,8 @@ pub fn resolve_node_id(
         return Ok((id, NodeIdSource::PeersPosition));
     }
 
-    // Hostname-ordinal is a legacy fallback for IP-only peer lists, where
-    // hostname matching is impossible. When peers carry hostnames, a no-match
-    // means the host is misconfigured, so fail fast rather than risk assigning
-    // an in-range but wrong id (silent split-brain).
+    // Ordinal fallback only fits IP-only peers (no hostname to match). With
+    // hostname peers a no-match is a misconfig: fail fast, don't guess an id.
     if !all_peers_ip_only(peers) {
         anyhow::bail!(
             "this host ({hostname:?}) matched no entry in controller.peers; fix the \
@@ -822,8 +817,7 @@ pub fn resolve_node_id(
         );
     }
 
-    // IP-only peers: accept the ordinal only if it lands in range; an
-    // out-of-range ordinal is a misconfiguration, not a valid member.
+    // Accept the ordinal only if in range; out-of-range is a misconfig.
     if let Some(id) = node_id_from_hostname(hostname) {
         if (1..=n).contains(&id) {
             return Ok((id, NodeIdSource::HostnameOrdinal));
@@ -841,8 +835,7 @@ pub fn resolve_node_id(
     )
 }
 
-/// True when every peer entry's host part is an IP literal (no hostname to
-/// match against), meaning position matching cannot work.
+/// True when every peer host is an IP literal (no hostname to match against).
 fn all_peers_ip_only(peers: &[String]) -> bool {
     peers
         .iter()
@@ -856,11 +849,9 @@ pub fn node_id_from_hostname(hostname: &str) -> Option<u64> {
     Some(ordinal + 1)
 }
 
-/// Derive a node_id from `hostname`'s position in `peers` (index + 1, matching
-/// `build_peer_map`). Matching is on the full name or the first DNS label, so a
-/// short hostname like `spurctld-0` matches `spurctld-0.ns.svc.cluster.local`.
-/// Returns `Ok(None)` when no entry matches, and errors when more than one does
-/// (ambiguous: silently picking one risks a split-brain).
+/// Node id (index + 1) of the `peers` entry matching `hostname`, on the full
+/// name or first DNS label (so `spurctld-0` matches `spurctld-0.ns.svc...`).
+/// `Ok(None)` if none match; errors if several do (guessing risks split-brain).
 pub fn node_id_from_peers(hostname: &str, peers: &[String]) -> anyhow::Result<Option<u64>> {
     let matches: Vec<u64> = peers
         .iter()
@@ -885,8 +876,7 @@ fn peer_host(entry: &str) -> &str {
     if let Some(rest) = entry.strip_prefix('[') {
         return rest.split(']').next().unwrap_or(rest);
     }
-    // A single ':' delimits "host:port"; more colons mean an unbracketed IPv6
-    // literal, which has no port to strip and is returned unchanged.
+    // One ':' is "host:port"; more colons are an unbracketed IPv6 literal (no port).
     match entry.rsplit_once(':') {
         Some((host, _)) if !host.contains(':') => host,
         _ => entry,
@@ -906,14 +896,9 @@ fn first_label(host: &str) -> &str {
     host.split('.').next().unwrap_or(host)
 }
 
-/// Guard against a shifted node identity across restarts.
-///
-/// The resolved id is derived from the live hostname and `peers` on every boot,
-/// but the persisted Raft state (vote/log) belongs to the id this node last ran
-/// under. If a peer is inserted or removed before this host in the list, or the
-/// host is renamed, the derived id would silently diverge from the on-disk state
-/// and openraft would orphan committed entries. Persist the id on first boot and
-/// fail fast if a later boot derives a different one.
+/// Guard against a shifted node identity across restarts: the id is re-derived
+/// each boot but persisted Raft state belongs to the old id, so a reordered or
+/// renamed peer would orphan committed entries. Persist first, then verify.
 fn persist_or_verify_node_id(state_dir: &Path, node_id: NodeId) -> anyhow::Result<()> {
     let raft_dir = state_dir.join("raft");
     std::fs::create_dir_all(&raft_dir)?;
@@ -1216,9 +1201,8 @@ mod tests {
 
     #[test]
     fn resolve_hostname_peers_no_match_does_not_fall_back_to_ordinal() {
-        // Peers carry hostnames and none match, but the host has a valid
-        // in-range ordinal (spurctld-1 -> 2). It must still fail fast rather
-        // than silently joining with the ordinal-derived id.
+        // spurctld-1 has a valid in-range ordinal (2), but hostname peers with
+        // no match must fail fast, not fall back to it.
         let err = resolve_node_id(None, "spurctld-1", &three_peers()).unwrap_err();
         assert!(
             err.to_string().contains("matched no entry"),
@@ -1244,7 +1228,6 @@ mod tests {
     fn node_id_same_across_restart_is_ok() {
         let dir = TempDir::new().unwrap();
         persist_or_verify_node_id(dir.path(), 3).unwrap();
-        // A second boot with the same derived id must succeed.
         persist_or_verify_node_id(dir.path(), 3).unwrap();
     }
 

--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -906,6 +906,49 @@ fn first_label(host: &str) -> &str {
     host.split('.').next().unwrap_or(host)
 }
 
+/// Guard against a shifted node identity across restarts.
+///
+/// The resolved id is derived from the live hostname and `peers` on every boot,
+/// but the persisted Raft state (vote/log) belongs to the id this node last ran
+/// under. If a peer is inserted or removed before this host in the list, or the
+/// host is renamed, the derived id would silently diverge from the on-disk state
+/// and openraft would orphan committed entries. Persist the id on first boot and
+/// fail fast if a later boot derives a different one.
+fn persist_or_verify_node_id(state_dir: &Path, node_id: NodeId) -> anyhow::Result<()> {
+    let raft_dir = state_dir.join("raft");
+    std::fs::create_dir_all(&raft_dir)?;
+    let path = raft_dir.join("node_id");
+
+    match std::fs::read_to_string(&path) {
+        Ok(contents) => {
+            let prev: NodeId = contents.trim().parse().map_err(|_| {
+                anyhow::anyhow!(
+                    "failed to parse persisted node_id {:?} at {}",
+                    contents.trim(),
+                    path.display()
+                )
+            })?;
+            if prev != node_id {
+                anyhow::bail!(
+                    "resolved Raft node_id {node_id} differs from persisted id {prev} at {}; \
+                     the controller.peers ordering or this host's name likely changed. \
+                     Running under a new id would orphan committed Raft state. Restore the \
+                     previous identity, or wipe the raft state dir to rejoin as a fresh member.",
+                    path.display()
+                );
+            }
+            Ok(())
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            let tmp = raft_dir.join("node_id.tmp");
+            std::fs::write(&tmp, node_id.to_string())?;
+            std::fs::rename(&tmp, &path)?;
+            Ok(())
+        }
+        Err(e) => Err(anyhow::anyhow!("failed to read {}: {e}", path.display())),
+    }
+}
+
 /// Build a 1-indexed peer map from the config peers list.
 pub fn build_peer_map(peers: &[String]) -> BTreeMap<NodeId, String> {
     peers
@@ -944,6 +987,8 @@ pub async fn start_raft_with_recovery_mode(
         ..Default::default()
     };
     let config = Arc::new(config.validate().map_err(|e| anyhow::anyhow!("{e}"))?);
+
+    persist_or_verify_node_id(state_dir, node_id)?;
 
     let store = Arc::new(SpurStore::new_with_recovery_mode(
         state_dir,
@@ -1185,6 +1230,33 @@ mod tests {
     fn resolve_ip_only_peers_without_ordinal_errors() {
         let peers = vec!["10.0.0.1:6821".to_string(), "10.0.0.2:6821".to_string()];
         assert!(resolve_node_id(None, "plainhost", &peers).is_err());
+    }
+
+    #[test]
+    fn node_id_persists_on_first_boot() {
+        let dir = TempDir::new().unwrap();
+        persist_or_verify_node_id(dir.path(), 2).unwrap();
+        let persisted = std::fs::read_to_string(dir.path().join("raft").join("node_id")).unwrap();
+        assert_eq!(persisted.trim(), "2");
+    }
+
+    #[test]
+    fn node_id_same_across_restart_is_ok() {
+        let dir = TempDir::new().unwrap();
+        persist_or_verify_node_id(dir.path(), 3).unwrap();
+        // A second boot with the same derived id must succeed.
+        persist_or_verify_node_id(dir.path(), 3).unwrap();
+    }
+
+    #[test]
+    fn node_id_shift_across_restart_fails_fast() {
+        let dir = TempDir::new().unwrap();
+        persist_or_verify_node_id(dir.path(), 1).unwrap();
+        let err = persist_or_verify_node_id(dir.path(), 2).unwrap_err();
+        assert!(
+            err.to_string().contains("differs from persisted id"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/spurctld/src/raft.rs
+++ b/crates/spurctld/src/raft.rs
@@ -811,9 +811,19 @@ pub fn resolve_node_id(
         return Ok((id, NodeIdSource::PeersPosition));
     }
 
-    // Hostname-ordinal is a legacy fallback, reached only when the host matched
-    // no peer entry (e.g. IP-only peers). Accept it only if it lands in range;
-    // an out-of-range ordinal is a misconfiguration, not a valid member.
+    // Hostname-ordinal is a legacy fallback for IP-only peer lists, where
+    // hostname matching is impossible. When peers carry hostnames, a no-match
+    // means the host is misconfigured, so fail fast rather than risk assigning
+    // an in-range but wrong id (silent split-brain).
+    if !all_peers_ip_only(peers) {
+        anyhow::bail!(
+            "this host ({hostname:?}) matched no entry in controller.peers; fix the \
+             hostname to match its peers entry or set controller.node_id in spur.conf"
+        );
+    }
+
+    // IP-only peers: accept the ordinal only if it lands in range; an
+    // out-of-range ordinal is a misconfiguration, not a valid member.
     if let Some(id) = node_id_from_hostname(hostname) {
         if (1..=n).contains(&id) {
             return Ok((id, NodeIdSource::HostnameOrdinal));
@@ -826,9 +836,17 @@ pub fn resolve_node_id(
     }
 
     anyhow::bail!(
-        "this host ({hostname:?}) matched no entry in controller.peers; fix the \
-         hostname to match its peers entry or set controller.node_id in spur.conf"
+        "controller.peers are IP-only and hostname {hostname:?} has no ordinal to \
+         derive a node_id from; set controller.node_id in spur.conf"
     )
+}
+
+/// True when every peer entry's host part is an IP literal (no hostname to
+/// match against), meaning position matching cannot work.
+fn all_peers_ip_only(peers: &[String]) -> bool {
+    peers
+        .iter()
+        .all(|entry| peer_host(entry).parse::<std::net::IpAddr>().is_ok())
 }
 
 /// Parse a node_id from a hostname string. The ordinal after the last '-'
@@ -1149,6 +1167,24 @@ mod tests {
     #[test]
     fn resolve_no_match_errors() {
         assert!(resolve_node_id(None, "unknownhost", &three_peers()).is_err());
+    }
+
+    #[test]
+    fn resolve_hostname_peers_no_match_does_not_fall_back_to_ordinal() {
+        // Peers carry hostnames and none match, but the host has a valid
+        // in-range ordinal (spurctld-1 -> 2). It must still fail fast rather
+        // than silently joining with the ordinal-derived id.
+        let err = resolve_node_id(None, "spurctld-1", &three_peers()).unwrap_err();
+        assert!(
+            err.to_string().contains("matched no entry"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_ip_only_peers_without_ordinal_errors() {
+        let peers = vec!["10.0.0.1:6821".to_string(), "10.0.0.2:6821".to_string()];
+        assert!(resolve_node_id(None, "plainhost", &peers).is_err());
     }
 
     #[test]

--- a/docs/deployment/kubernetes.rst
+++ b/docs/deployment/kubernetes.rst
@@ -74,7 +74,15 @@ The ConfigMap (``examples/k8s/configmap.yaml``) embeds ``spur.conf``:
    state = "UP"
    default = true
 
-Raft peers use StatefulSet DNS names. The node ID is auto-detected from the pod hostname ordinal.
+Raft peers use StatefulSet DNS names. The node ID is auto-derived from each pod's
+position in ``peers`` by matching the pod hostname (e.g. ``spurctld-0``) against
+each entry's host part, so ``controller.node_id`` never needs to be set. Each
+pod's hostname must correspond to its own ``peers`` entry.
+
+Resolution precedence is: explicit ``controller.node_id`` -> position in
+``peers`` -> hostname ordinal. The resolved id must fall within
+``1..=len(peers)``; if a pod's hostname matches no entry (or matches more than
+one), the controller fails fast at startup rather than joining with a wrong ID.
 
 Adjust partition definitions and node resources to match your cluster hardware.
 

--- a/examples/k8s/configmap.yaml
+++ b/examples/k8s/configmap.yaml
@@ -9,7 +9,8 @@ data:
 
     [controller]
     # Raft peers use StatefulSet DNS names on the dedicated Raft port.
-    # node_id is auto-detected from the pod hostname ordinal (spurctld-N → N+1).
+    # node_id is auto-derived from each pod's position in this peers list
+    # (its hostname matched against each entry), so it never needs to be set.
     peers = [
       "spurctld-0.spurctld.spur.svc.cluster.local:6821",
       "spurctld-1.spurctld.spur.svc.cluster.local:6821",


### PR DESCRIPTION
Derive each controller's Raft node_id from its position in controller.peers by matching the system hostname against each entry's host part (full name or first DNS label), so operators no longer need to set controller.node_id. This also supports hostnames the ordinal path could not, e.g. spur-node1.

Resolution precedence is explicit controller.node_id -> peers position -> hostname ordinal, extracted into a testable resolve_node_id(). Every path is validated to fall within 1..=peers.len(), ambiguous multi-matches are rejected, and an unmatched host fails fast at startup with a descriptive error instead of silently splitting the cluster. Startup logs the derivation source.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
