### PR TITLE
fix(spurctld): enforce ownership on reservation delete and update

### DIFF
--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -266,6 +266,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
                     remove_users: split_csv(&remove_users),
                     add_accounts: split_csv(&add_accounts),
                     remove_accounts: split_csv(&remove_accounts),
+                    user: whoami::username().unwrap_or_else(|_| "unknown".into()),
                 })
                 .await
                 .context("failed to update reservation")?;
@@ -456,6 +457,9 @@ async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> 
                 }
                 if !res.users.is_empty() {
                     println!("   Users={}", res.users);
+                }
+                if !res.owner.is_empty() {
+                    println!("   Owner={}", res.owner);
                 }
                 println!();
             }
@@ -736,6 +740,7 @@ async fn create_reservation(
             accounts: account_list,
             users: user_list,
             flags: flag_list,
+            user: whoami::username().unwrap_or_else(|_| "unknown".into()),
         })
         .await
         .context("failed to create reservation")?;
@@ -754,6 +759,7 @@ async fn delete_reservation(controller: &str, name: &str) -> Result<()> {
     client
         .delete_reservation(spur_proto::proto::DeleteReservationRequest {
             name: name.to_string(),
+            user: whoami::username().unwrap_or_else(|_| "unknown".into()),
         })
         .await
         .context("failed to delete reservation")?;

--- a/crates/spur-core/src/reservation.rs
+++ b/crates/spur-core/src/reservation.rs
@@ -80,6 +80,11 @@ pub struct Reservation {
     pub users: Vec<String>,
     #[serde(default)]
     pub flags: ReservationFlags,
+    /// User who created the reservation. Empty for reservations created before
+    /// ownership tracking existed (and for trusted internal callers), which are
+    /// treated as unowned and mutable by any authenticated user.
+    #[serde(default)]
+    pub owner: String,
 }
 
 impl Reservation {
@@ -107,6 +112,14 @@ impl Reservation {
 
     pub fn covers_node(&self, node: &str) -> bool {
         self.nodes.iter().any(|n| n == node)
+    }
+
+    /// Whether `user` may modify or delete this reservation. Root and trusted
+    /// internal callers (empty user) are always allowed, as is the recorded
+    /// owner. Reservations with no recorded owner (created before ownership
+    /// tracking) stay mutable by any authenticated user.
+    pub fn can_be_managed_by(&self, user: &str) -> bool {
+        user.is_empty() || user == "root" || self.owner.is_empty() || self.owner == user
     }
 
     pub fn allows_user(&self, user: &str, account: Option<&str>) -> bool {
@@ -304,6 +317,7 @@ mod tests {
             accounts: vec!["research".into()],
             users: vec!["alice".into()],
             flags: ReservationFlags::default(),
+            owner: String::new(),
         }
     }
 
@@ -333,6 +347,26 @@ mod tests {
     }
 
     #[test]
+    fn owner_can_manage_and_others_cannot() {
+        let mut res = make_reservation();
+        res.owner = "alice".into();
+        assert!(res.can_be_managed_by("alice"), "owner may manage");
+        assert!(res.can_be_managed_by("root"), "root may manage");
+        assert!(res.can_be_managed_by(""), "internal calls may manage");
+        assert!(!res.can_be_managed_by("bob"), "non-owner may not manage");
+    }
+
+    #[test]
+    fn unowned_reservation_is_manageable_by_anyone() {
+        let res = make_reservation();
+        assert_eq!(res.owner, "");
+        assert!(
+            res.can_be_managed_by("bob"),
+            "reservations without a recorded owner stay mutable"
+        );
+    }
+
+    #[test]
     fn test_unrestricted_reservation() {
         let now = Utc::now();
         let res = Reservation {
@@ -343,6 +377,7 @@ mod tests {
             accounts: Vec::new(),
             users: Vec::new(),
             flags: ReservationFlags::default(),
+            owner: String::new(),
         };
         assert!(res.allows_user("anyone", None));
     }
@@ -372,6 +407,7 @@ mod tests {
             accounts: Vec::new(),
             users: Vec::new(),
             flags: ReservationFlags::default(),
+            owner: String::new(),
         };
         let b = Reservation {
             name: "b".into(),
@@ -381,6 +417,7 @@ mod tests {
             accounts: Vec::new(),
             users: Vec::new(),
             flags: ReservationFlags::default(),
+            owner: String::new(),
         };
         assert!(reservations_overlap(&a, &b));
     }
@@ -399,6 +436,7 @@ mod tests {
                 overlap: true,
                 ..Default::default()
             },
+            owner: String::new(),
         };
         let b = Reservation {
             name: "b".into(),
@@ -408,6 +446,7 @@ mod tests {
             accounts: Vec::new(),
             users: Vec::new(),
             flags: ReservationFlags::default(),
+            owner: String::new(),
         };
         assert!(overlap_allowed(&a, &b));
         a.flags.overlap = false;
@@ -425,6 +464,7 @@ mod tests {
             accounts: Vec::new(),
             users: vec!["alice".into()],
             flags: ReservationFlags::default(),
+            owner: String::new(),
         };
         let job = Job::new(1, JobSpec::default());
         assert!(prospective_overlap(
@@ -459,6 +499,7 @@ mod tests {
             accounts: Vec::new(),
             users: vec!["alice".into()],
             flags: ReservationFlags::default(),
+            owner: String::new(),
         };
         let job = Job::new(1, JobSpec::default());
         assert!(prospective_overlap(

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -287,6 +287,7 @@ mod reservation_wal_tests {
                     maint: true,
                     ..Default::default()
                 },
+                owner: String::new(),
             },
         };
         let json = serde_json::to_string(&op).unwrap();

--- a/crates/spur-sched/src/backfill.rs
+++ b/crates/spur-sched/src/backfill.rs
@@ -1059,6 +1059,7 @@ mod tests {
             accounts: Vec::new(),
             users,
             flags: Default::default(),
+            owner: String::new(),
         }
     }
 
@@ -1179,6 +1180,7 @@ mod tests {
             accounts: Vec::new(),
             users: vec!["alice".into()],
             flags: Default::default(),
+            owner: String::new(),
         };
 
         // Non-reservation job should be able to use node001 since reservation is inactive
@@ -1215,6 +1217,7 @@ mod tests {
             accounts: Vec::new(),
             users: vec!["alice".into()],
             flags: Default::default(),
+            owner: String::new(),
         };
 
         let mut job = make_job(1, 1, 1);

--- a/crates/spur-sched/src/node_match.rs
+++ b/crates/spur-sched/src/node_match.rs
@@ -294,6 +294,7 @@ mod tests {
             accounts: Vec::new(),
             users: vec!["alice".into()],
             flags: Default::default(),
+            owner: String::new(),
         };
         assert!(!p.matches(&node("node001"), std::slice::from_ref(&res), now));
         assert!(p.matches(&node("node002"), &[res], now));

--- a/crates/spur-tests/src/t07_sched.rs
+++ b/crates/spur-tests/src/t07_sched.rs
@@ -553,6 +553,7 @@ mod tests {
             users: vec!["alice".into()],
             accounts: Vec::new(),
             flags: Default::default(),
+            owner: String::new(),
         };
 
         // A job with no reservation spec should NOT land on node001.
@@ -587,6 +588,7 @@ mod tests {
             users: vec!["bob".into()],
             accounts: Vec::new(),
             flags: Default::default(),
+            owner: String::new(),
         };
 
         let mut job = make_job_with_resources("reserved-job", 1, 1, 1, Some(60));

--- a/crates/spur-tests/src/t50_core.rs
+++ b/crates/spur-tests/src/t50_core.rs
@@ -785,6 +785,7 @@ mod tests {
             users: vec!["alice".into()],
             accounts: Vec::new(),
             flags: Default::default(),
+            owner: String::new(),
         };
         // All fields must be mutable for an update to work.
         res.end_time = now + chrono::Duration::hours(8);

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -56,6 +56,7 @@ pub enum ReservationError {
     InvalidArgument(String),
     NotFound(String),
     AlreadyExists(String),
+    PermissionDenied(String),
     Raft(String),
 }
 
@@ -65,6 +66,7 @@ impl std::fmt::Display for ReservationError {
             Self::InvalidArgument(m)
             | Self::NotFound(m)
             | Self::AlreadyExists(m)
+            | Self::PermissionDenied(m)
             | Self::Raft(m) => f.write_str(m),
         }
     }
@@ -156,6 +158,10 @@ impl ReservationError {
 
     pub fn already_exists(msg: impl Into<String>) -> Self {
         Self::AlreadyExists(msg.into())
+    }
+
+    pub fn permission_denied(msg: impl Into<String>) -> Self {
+        Self::PermissionDenied(msg.into())
     }
 
     pub fn raft(msg: impl Into<String>) -> Self {
@@ -2319,6 +2325,7 @@ impl ClusterManager {
         remove_users: &[String],
         add_accounts: &[String],
         remove_accounts: &[String],
+        user: &str,
     ) -> Result<(), ReservationError> {
         let mut preview = self
             .reservations
@@ -2329,6 +2336,13 @@ impl ClusterManager {
             .ok_or_else(|| {
                 ReservationError::not_found(format!("reservation '{}' not found", name))
             })?;
+
+        if !preview.can_be_managed_by(user) {
+            return Err(ReservationError::permission_denied(format!(
+                "user '{}' cannot modify reservation '{}' owned by '{}'",
+                user, name, preview.owner
+            )));
+        }
 
         if duration_minutes > 0 {
             preview.end_time =
@@ -2380,13 +2394,23 @@ impl ClusterManager {
         Ok(())
     }
 
-    /// Delete a reservation by name (persisted via Raft).
-    pub fn delete_reservation(&self, name: &str) -> Result<(), ReservationError> {
-        if !self.reservations.read().iter().any(|r| r.name == name) {
-            return Err(ReservationError::not_found(format!(
-                "reservation '{}' not found",
-                name
-            )));
+    /// Delete a reservation by name (persisted via Raft). The requesting `user`
+    /// must be the reservation owner, root, or empty (trusted internal calls).
+    pub fn delete_reservation(&self, name: &str, user: &str) -> Result<(), ReservationError> {
+        {
+            let reservations = self.reservations.read();
+            let res = reservations
+                .iter()
+                .find(|r| r.name == name)
+                .ok_or_else(|| {
+                    ReservationError::not_found(format!("reservation '{}' not found", name))
+                })?;
+            if !res.can_be_managed_by(user) {
+                return Err(ReservationError::permission_denied(format!(
+                    "user '{}' cannot delete reservation '{}' owned by '{}'",
+                    user, name, res.owner
+                )));
+            }
         }
 
         for job in self.jobs.read().values() {
@@ -6887,6 +6911,7 @@ mod tests {
             accounts: Vec::new(),
             users: vec!["alice".into()],
             flags: Default::default(),
+            owner: String::new(),
         };
         let mut r1 = base.clone();
         r1.name = "r1".into();
@@ -6911,6 +6936,7 @@ mod tests {
             accounts: Vec::new(),
             users: vec!["alice".into()],
             flags: Default::default(),
+            owner: String::new(),
         };
         let mut r1 = base.clone();
         r1.name = "r1".into();
@@ -6936,6 +6962,7 @@ mod tests {
             accounts: Vec::new(),
             users: vec!["testuser".into()],
             flags: Default::default(),
+            owner: String::new(),
         })
         .unwrap();
 
@@ -7102,6 +7129,7 @@ mod tests {
             accounts: Vec::new(),
             users: vec!["testuser".into()],
             flags: Default::default(),
+            owner: String::new(),
         })
         .unwrap();
 
@@ -7138,6 +7166,7 @@ mod tests {
             accounts: Vec::new(),
             users: vec!["testuser".into()],
             flags: Default::default(),
+            owner: String::new(),
         })
         .unwrap();
 
@@ -7298,6 +7327,7 @@ mod tests {
                 accounts: Vec::new(),
                 users: vec!["testuser".into()],
                 flags: Default::default(),
+                owner: String::new(),
             },
         });
 
@@ -7327,6 +7357,7 @@ mod tests {
             accounts: Vec::new(),
             users: vec!["alice".into()],
             flags: Default::default(),
+            owner: String::new(),
         };
         cm.apply_operation(&WalOperation::ReservationCreate {
             reservation: res.clone(),
@@ -7373,6 +7404,7 @@ mod tests {
             accounts: Vec::new(),
             users: vec!["alice".into()],
             flags: Default::default(),
+            owner: String::new(),
         };
         cm.apply_operation(&WalOperation::ReservationCreate {
             reservation: res.clone(),
@@ -7396,6 +7428,7 @@ mod tests {
             accounts: Vec::new(),
             users: vec!["alice".into()],
             flags: Default::default(),
+            owner: String::new(),
         };
         let cm1 = cm.clone();
         let cm2 = cm.clone();
@@ -7430,6 +7463,7 @@ mod tests {
                 accounts: Vec::new(),
                 users: vec!["alice".into()],
                 flags: Default::default(),
+                owner: String::new(),
             })
             .unwrap();
             assert_eq!(cm.get_reservations().len(), 1);
@@ -7459,6 +7493,7 @@ mod tests {
                 no_hold_jobs: true,
                 ..Default::default()
             },
+            owner: String::new(),
         })
         .unwrap();
 
@@ -7466,7 +7501,7 @@ mod tests {
         spec.reservation = Some("r1".into());
         let job_id = submit_and_wait(&cm, spec);
 
-        cm.delete_reservation("r1").unwrap();
+        cm.delete_reservation("r1", "root").unwrap();
         wait_for("reservation deleted", || cm.get_reservations().is_empty());
 
         let job = cm.get_job(job_id).unwrap();
@@ -7478,6 +7513,106 @@ mod tests {
             cm.pending_jobs().iter().any(|j| j.job_id == job_id),
             "job must remain schedulable after no_hold_jobs delete"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn delete_reservation_rejects_non_owner() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+        let now = chrono::Utc::now();
+        cm.create_reservation(Reservation {
+            name: "r1".into(),
+            start_time: now - chrono::Duration::minutes(5),
+            end_time: now + chrono::Duration::hours(2),
+            nodes: vec!["n1".into()],
+            accounts: Vec::new(),
+            users: Vec::new(),
+            flags: Default::default(),
+            owner: "alice".into(),
+        })
+        .unwrap();
+
+        let err = cm.delete_reservation("r1", "bob").unwrap_err();
+        assert!(
+            matches!(err, ReservationError::PermissionDenied(_)),
+            "non-owner delete must be denied, got {err:?}"
+        );
+        assert_eq!(cm.get_reservations().len(), 1, "reservation must survive");
+
+        cm.delete_reservation("r1", "alice").unwrap();
+        assert!(
+            cm.get_reservations().is_empty(),
+            "owner delete must succeed"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn update_reservation_rejects_non_owner() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+        let now = chrono::Utc::now();
+        cm.create_reservation(Reservation {
+            name: "r1".into(),
+            start_time: now - chrono::Duration::minutes(5),
+            end_time: now + chrono::Duration::hours(2),
+            nodes: vec!["n1".into()],
+            accounts: Vec::new(),
+            users: Vec::new(),
+            flags: Default::default(),
+            owner: "alice".into(),
+        })
+        .unwrap();
+
+        let err = cm
+            .update_reservation("r1", 30, &[], &[], &[], &[], &[], &[], "bob")
+            .unwrap_err();
+        assert!(
+            matches!(err, ReservationError::PermissionDenied(_)),
+            "non-owner update must be denied, got {err:?}"
+        );
+
+        cm.update_reservation("r1", 30, &[], &[], &[], &[], &[], &[], "alice")
+            .expect("owner update must succeed");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn delete_reservation_allows_root_and_unowned() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+        let now = chrono::Utc::now();
+        cm.create_reservation(Reservation {
+            name: "owned".into(),
+            start_time: now - chrono::Duration::minutes(5),
+            end_time: now + chrono::Duration::hours(2),
+            nodes: vec!["n1".into()],
+            accounts: Vec::new(),
+            users: Vec::new(),
+            flags: Default::default(),
+            owner: "alice".into(),
+        })
+        .unwrap();
+        cm.create_reservation(Reservation {
+            name: "legacy".into(),
+            start_time: now - chrono::Duration::minutes(5),
+            end_time: now + chrono::Duration::hours(2),
+            nodes: vec!["n1".into()],
+            accounts: Vec::new(),
+            users: Vec::new(),
+            flags: spur_core::reservation::ReservationFlags {
+                overlap: true,
+                ..Default::default()
+            },
+            owner: String::new(),
+        })
+        .unwrap();
+
+        cm.delete_reservation("owned", "root")
+            .expect("root may delete any reservation");
+        cm.delete_reservation("legacy", "bob")
+            .expect("unowned reservation stays manageable by anyone");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -7498,6 +7633,7 @@ mod tests {
                     no_hold_jobs: true,
                     ..Default::default()
                 },
+                owner: String::new(),
             },
         });
 
@@ -7531,6 +7667,7 @@ mod tests {
             accounts: Vec::new(),
             users: vec!["alice".into()],
             flags: Default::default(),
+            owner: String::new(),
         })
         .unwrap();
 
@@ -7664,13 +7801,14 @@ mod tests {
                 accounts: Vec::new(),
                 users: vec!["testuser".into()],
                 flags: Default::default(),
+                owner: String::new(),
             })
             .unwrap();
 
             let mut spec = basic_spec("resv-hold");
             spec.reservation = Some("r1".into());
             let job_id = submit_and_wait(&cm, spec);
-            cm.delete_reservation("r1").unwrap();
+            cm.delete_reservation("r1", "root").unwrap();
             wait_for("job held after delete", || {
                 cm.get_job(job_id).is_some_and(|j| {
                     j.pending_reason == PendingReason::ReservationDeleted && j.priority == 0
@@ -7706,13 +7844,14 @@ mod tests {
                     no_hold_jobs: true,
                     ..Default::default()
                 },
+                owner: String::new(),
             })
             .unwrap();
 
             let mut spec = basic_spec("resv-no-hold");
             spec.reservation = Some("r1".into());
             job_id = submit_and_wait(&cm, spec);
-            cm.delete_reservation("r1").unwrap();
+            cm.delete_reservation("r1", "root").unwrap();
             wait_for("reservation detached from job", || {
                 cm.get_job(job_id)
                     .is_some_and(|j| j.spec.reservation.is_none() && j.priority > 0)
@@ -7740,13 +7879,14 @@ mod tests {
             accounts: Vec::new(),
             users: vec!["testuser".into()],
             flags: Default::default(),
+            owner: String::new(),
         })
         .unwrap();
 
         let mut spec = basic_spec("release-me");
         spec.reservation = Some("r1".into());
         let job_id = submit_and_wait(&cm, spec);
-        cm.delete_reservation("r1").unwrap();
+        cm.delete_reservation("r1", "root").unwrap();
         wait_for("job held after delete", || {
             cm.get_job(job_id).is_some_and(|j| {
                 j.pending_reason == PendingReason::ReservationDeleted && j.priority == 0

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2313,7 +2313,10 @@ impl ClusterManager {
         Ok(())
     }
 
-    /// Update an existing reservation (validated, persisted via Raft).
+    /// Update an existing reservation (validated, persisted via Raft). The
+    /// requesting `user` must be the reservation owner, root, or empty (trusted
+    /// internal calls); legacy reservations with no recorded owner are
+    /// modifiable by anyone.
     #[allow(clippy::too_many_arguments)]
     pub fn update_reservation(
         &self,
@@ -2395,7 +2398,8 @@ impl ClusterManager {
     }
 
     /// Delete a reservation by name (persisted via Raft). The requesting `user`
-    /// must be the reservation owner, root, or empty (trusted internal calls).
+    /// must be the reservation owner, root, or empty (trusted internal calls);
+    /// legacy reservations with no recorded owner are deletable by anyone.
     pub fn delete_reservation(&self, name: &str, user: &str) -> Result<(), ReservationError> {
         {
             let reservations = self.reservations.read();

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2362,9 +2362,9 @@ impl ClusterManager {
             }
         }
         preview.nodes.retain(|n| !remove_nodes.contains(n));
-        for user in add_users {
-            if !preview.users.contains(user) {
-                preview.users.push(user.clone());
+        for add_user in add_users {
+            if !preview.users.contains(add_user) {
+                preview.users.push(add_user.clone());
             }
         }
         preview.users.retain(|u| !remove_users.contains(u));

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1224,6 +1224,7 @@ impl SlurmController for ControllerService {
             accounts: req.accounts,
             users: req.users,
             flags,
+            owner: req.user,
         };
 
         self.cluster
@@ -1263,6 +1264,7 @@ impl SlurmController for ControllerService {
                 &req.remove_users,
                 &req.add_accounts,
                 &req.remove_accounts,
+                &req.user,
             )
             .map_err(reservation_rpc_status)?;
         Ok(Response::new(()))
@@ -1287,9 +1289,9 @@ impl SlurmController for ControllerService {
             }
         }
 
-        let name = request.into_inner().name;
+        let req = request.into_inner();
         self.cluster
-            .delete_reservation(&name)
+            .delete_reservation(&req.name, &req.user)
             .map_err(reservation_rpc_status)?;
         Ok(Response::new(()))
     }
@@ -1320,6 +1322,7 @@ impl SlurmController for ControllerService {
                 users: r.users.join(","),
                 flags: r.flags.display_csv(),
                 state: r.state_label(now).into(),
+                owner: r.owner.clone(),
             })
             .collect();
         Ok(Response::new(ListReservationsResponse {
@@ -2131,6 +2134,7 @@ fn reservation_rpc_status(err: ReservationError) -> Status {
         ReservationError::InvalidArgument(m) => Status::invalid_argument(m),
         ReservationError::NotFound(m) => Status::not_found(m),
         ReservationError::AlreadyExists(m) => Status::already_exists(m),
+        ReservationError::PermissionDenied(m) => Status::permission_denied(m),
         ReservationError::Raft(m) => Status::internal(m),
     }
 }
@@ -2222,6 +2226,7 @@ mod tests {
             accounts: Vec::new(),
             users: Vec::new(),
             flags: Default::default(),
+            owner: String::new(),
         }
     }
 
@@ -2357,6 +2362,7 @@ mod tests {
                 overlap: true,
                 ..Default::default()
             },
+            owner: String::new(),
         };
         let maint = Reservation {
             name: "maint".into(),
@@ -2370,6 +2376,7 @@ mod tests {
                 overlap: true,
                 ..Default::default()
             },
+            owner: String::new(),
         };
         let reservations = vec![plain, maint];
         annotate_nodes_with_reservations(&mut nodes, &reservations, Utc::now());

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -1083,6 +1083,7 @@ message CreateReservationRequest {
   repeated string accounts = 5;
   repeated string users = 6;
   repeated string flags = 7;
+  string user = 8;            // requesting user; recorded as reservation owner
 }
 
 message UpdateReservationRequest {
@@ -1094,10 +1095,12 @@ message UpdateReservationRequest {
   repeated string remove_users = 6;
   repeated string add_accounts = 7;
   repeated string remove_accounts = 8;
+  string user = 9;              // requesting user; must be owner or root
 }
 
 message DeleteReservationRequest {
   string name = 1;
+  string user = 2;             // requesting user; must be owner or root
 }
 
 message ListReservationsRequest { }
@@ -1115,6 +1118,7 @@ message ReservationInfo {
   string users = 6;
   string flags = 7;
   string state = 8;
+  string owner = 9;
 }
 
 // ============================================================

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -1095,12 +1095,12 @@ message UpdateReservationRequest {
   repeated string remove_users = 6;
   repeated string add_accounts = 7;
   repeated string remove_accounts = 8;
-  string user = 9;              // requesting user; must be owner or root
+  string user = 9;              // requesting user; must be the owner (root and trusted internal callers always allowed; legacy reservations with no recorded owner are mutable by anyone)
 }
 
 message DeleteReservationRequest {
   string name = 1;
-  string user = 2;             // requesting user; must be owner or root
+  string user = 2;             // requesting user; must be the owner (root and trusted internal callers always allowed; legacy reservations with no recorded owner are mutable by anyone)
 }
 
 message ListReservationsRequest { }

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -346,6 +346,25 @@ class SpurCluster:
         cmd_parts.extend(f"'{a}'" for a in args[1:])
         return self.nodes[0].exec_allow_fail(" ".join(cmd_parts))
 
+    def cli_as_user(
+        self, run_as: str, args: list[str], controller_addr: str | None = None
+    ) -> str:
+        """Run a spur CLI command as a specific UNIX user via sudo, returning
+        stdout+stderr regardless of exit code.
+
+        Commands that carry an identity (reservation create/update/delete,
+        job cancel, ...) derive it from the invoking account (``whoami``), so
+        this is how a test exercises owner-vs-non-owner behavior end to end.
+        """
+        inner = [
+            f"SPUR_CONTROLLER_ADDR='{controller_addr or self.controller_addr}'",
+            f"PATH='{self.bin_dir}':$PATH",
+            f"'{self.bin_dir}/{args[0]}'",
+        ]
+        inner.extend(f"'{a}'" for a in args[1:])
+        cmd = f"{self._sudo_prefix()}-u '{run_as}' env {' '.join(inner)}"
+        return self.nodes[0].exec_allow_fail(cmd)
+
     def sbatch(self, args: list[str]) -> str:
         return self.cli(["sbatch"] + args)
 

--- a/tests/native_host/e2e/test_reservations.py
+++ b/tests/native_host/e2e/test_reservations.py
@@ -5,6 +5,8 @@
 
 import time
 
+import pytest
+
 from cluster import parse_job_id, wait_job, wait_job_state
 
 
@@ -196,3 +198,64 @@ class TestReservations:
         )
         msg = out.lower()
         assert "busy" in msg or "until after reservation start" in msg, f"unexpected: {out}"
+
+    def test_non_owner_cannot_delete_or_update_reservation(self, cluster):
+        """A reservation is owned by its creator; a different user must not be
+        able to delete or update it, but the owner still can. Exercises the
+        full CLI -> gRPC -> controller ownership check (SPUR-69)."""
+        submit_user = cluster.nodes[0].user
+        if submit_user == "root":
+            pytest.skip("need a non-root SSH user to test non-owner rejection")
+
+        # Verify passwordless/known-password sudo -u works in this environment;
+        # otherwise we cannot assume a second identity.
+        probe = cluster.cli_as_user("root", ["scontrol", "show", "reservation"])
+        if "sudo" in probe.lower() and (
+            "password" in probe.lower() or "not allowed" in probe.lower()
+        ):
+            pytest.skip(f"sudo -u unavailable in this environment: {probe.strip()}")
+
+        res_name = f"res-owner-{int(time.time())}"
+        node = cluster.node_names[0]
+
+        # Create as root -> owner is root.
+        create_out = cluster.cli_as_user(
+            "root",
+            [
+                "scontrol",
+                "create-reservation",
+                f"--name={res_name}",
+                "--start-time=now",
+                "--duration=60",
+                f"--nodes={node}",
+                "--users=testuser",
+            ],
+        )
+        assert "created" in create_out.lower(), f"create failed: {create_out}"
+
+        show_out = cluster.scontrol("show", "reservation")
+        assert res_name in show_out
+        assert "Owner=root" in show_out
+
+        # Non-owner (the ordinary SSH user) delete must be rejected.
+        del_denied = cluster.cli_as_user(
+            submit_user, ["scontrol", "delete-reservation", res_name]
+        )
+        assert "deleted" not in del_denied.lower(), f"unexpected delete: {del_denied}"
+        assert "cannot delete" in del_denied.lower() or "permission" in del_denied.lower()
+        assert res_name in cluster.scontrol("show", "reservation")
+
+        # Non-owner update must be rejected too.
+        upd_denied = cluster.cli_as_user(
+            submit_user,
+            ["scontrol", "update-reservation", f"--name={res_name}", "--duration=120"],
+        )
+        assert "cannot modify" in upd_denied.lower() or "permission" in upd_denied.lower()
+        assert res_name in cluster.scontrol("show", "reservation")
+
+        # Owner (root) can still delete.
+        del_ok = cluster.cli_as_user(
+            "root", ["scontrol", "delete-reservation", res_name]
+        )
+        assert "deleted" in del_ok.lower(), f"owner delete failed: {del_ok}"
+        assert res_name not in cluster.scontrol("show", "reservation")


### PR DESCRIPTION
## What this fixes

`scontrol delete-reservation` allowed **any** user to delete a reservation created by another user — there was no ownership check on the delete path at all, and reservations had no owner concept. `scontrol update-reservation` had the identical hole. Job-level ownership (cancel/suspend/resume) already existed, but reservations were never covered. SPUR-69.

## Approach

- Add an `owner` field to the `Reservation` struct (`#[serde(default)]` for on-disk/WAL backward compat) and record the requesting user as owner at create time.
- Add `Reservation::can_be_managed_by(user)` and enforce it on **both** delete and update paths, before any state mutation. Allowed: the recorded owner, `root`, or an empty user (trusted internal/daemon calls) — this mirrors the existing `check_job_owner` trust model.
- New `ReservationError::PermissionDenied` mapped to gRPC `permission_denied`.
- Thread a `user` field through the Create/Update/Delete reservation RPCs; the CLI populates it from the invoking UNIX account (`whoami`), same as the existing job commands. Surface the owner in `scontrol show reservations`.

## Design choices / trade-offs

- The `user` field is **client-declared and unauthenticated at the gRPC ingress** — this is the pre-existing trust model shared with job submission/cancel (the only token check is node admission), not something this PR changes. This brings reservations to parity with jobs; it does not attempt to fix authenticated-identity spoofing that affects all commands.
- `can_be_managed_by` deliberately treats **empty-owner** reservations as manageable by anyone. This is a migration accommodation: reservations created before this change deserialize with an empty owner and stay usable after upgrade. No CLI path produces an empty owner for a *new* reservation (the `whoami` fallback is the literal `"unknown"`), so this is not a new-reservation bypass. Note this is one extra allow-clause beyond `check_job_owner`.
- The update RPC does not modify `owner`, so ownership cannot be transferred or cleared via update.

## Testing

- Unit tests: `can_be_managed_by` (owner/root/internal allowed, non-owner denied; unowned = anyone). Cluster-level tests: non-owner delete and update rejected (reservation survives), owner succeeds, root and unowned deletes succeed.
- `cargo clippy --workspace --exclude spur-ffi --all-targets` clean; full `cargo test` green.
- Live-tested on a real 2-node spur cluster (isolated ports): created a reservation as user `nobody` (recorded `Owner=nobody`, shown in `scontrol show`); delete and update as `vm` both returned `permission denied` and the reservation survived; delete as `nobody` (owner) succeeded; `root` deleted another user's reservation successfully.