### PR TITLE
fix(spurctld): pass name filter to get_jobs in accounting reconcile

### DIFF
--- a/crates/spurctld/src/accounting/reconcile.rs
+++ b/crates/spurctld/src/accounting/reconcile.rs
@@ -50,7 +50,7 @@ pub fn spawn_loop(
 /// not candidates.
 async fn run_once(pool: &PgPool, cluster: &ClusterManager) {
     let candidates: Vec<Job> = cluster
-        .get_jobs(&[], None, None, None, &[])
+        .get_jobs(&[], None, None, None, None, &[])
         .into_iter()
         .filter(|j| j.start_time.is_some())
         .collect();


### PR DESCRIPTION
Fix build break where the accounting reconcile loop called `get_jobs` with the old signature after it gained a `name` filter parameter.