### PR TITLE
test(e2e): fix flaky chronic-preemption test case

### DIFF
--- a/tests/native_host/e2e/test_preemption.py
+++ b/tests/native_host/e2e/test_preemption.py
@@ -16,6 +16,12 @@ import pytest
 
 from cluster import parse_job_id, wait_job, wait_job_state
 
+# Time allowed for a requeued low-priority job to get back to RUNNING after a
+# preemption cycle. Generous because it spans the eligibility hold plus node
+# release, scheduler pickup, and spurd relaunch, which is sensitive to CI host
+# load — not a latency assertion.
+RESCHEDULE_TIMEOUT = 60
+
 
 class TestChronicPreemption:
     """A job preempted more times than max_batch_requeue must stay
@@ -53,14 +59,14 @@ class TestChronicPreemption:
             )
             low_id = parse_job_id(sb)
             assert low_id is not None, f"submit failed:\n{sb}"
-            wait_job_state(cluster, low_id, "R", timeout=30)
+            wait_job_state(cluster, low_id, "R", timeout=RESCHEDULE_TIMEOUT)
 
             # One more preemption cycle than max_batch_requeue: if preemption
             # requeues wrongly counted against the failure-requeue budget, the
             # job would be held with JobHoldMaxRequeue by the last cycle.
             cycles = self.MAX_BATCH_REQUEUE + 3
             for i in range(cycles):
-                wait_job_state(cluster, low_id, "R", timeout=30)
+                wait_job_state(cluster, low_id, "R", timeout=RESCHEDULE_TIMEOUT)
 
                 hi_script = cluster.write_file(
                     f"chronic-high-{i}.sh", "#!/bin/bash\nsleep 2\n"
@@ -84,7 +90,7 @@ class TestChronicPreemption:
                 state = wait_job(cluster, hi_id, timeout=30)
                 assert state == "CD", f"high job {hi_id} did not complete: {state}"
 
-            wait_job_state(cluster, low_id, "R", timeout=30)
+            wait_job_state(cluster, low_id, "R", timeout=RESCHEDULE_TIMEOUT)
             show = cluster.scontrol("show", "job", str(low_id))
             assert "Reason=JobHoldMaxRequeue" not in show, (
                 f"low-priority job held after {cycles} preemption cycles "


### PR DESCRIPTION
## What this fixes

`test_preemption.py::TestChronicPreemption::test_chronic_preemption_never_holds_job` is intermittently flaky in CI (observed failing on `main` and on unrelated PR runs), with:

```
TimeoutError: Job 1 did not reach state R within 30s
```

## Root cause

The test waits only 30s for the requeued low-priority job to get back to RUNNING after each preemption cycle. That window has to cover the requeue eligibility hold (`interval_secs*2+3`, ~5s) **plus** node release, scheduler pickup, and spurd relaunch. Locally the full 5-cycle test runs in ~45s (~8s/cycle), but under CI host load a single cycle can exceed the 30s per-wait budget.

This is a **test-timing issue, not a product bug** — the behavior actually under test (a chronically preempted job never lands in `JobHoldMaxRequeue`) is correct; the job just occasionally reschedules slower than the tight timeout allowed. Verified by reproducing on a real cluster: 8 runs → 7 passed, 1 failed at the same spot on identical binaries.

## Change

Raise the three "wait for the requeued job to reach RUNNING" calls from 30s to 60s via a named `RESCHEDULE_TIMEOUT` constant. The preemption wait (`->PD`, 15s) and high-job completion wait (30s) are left unchanged — neither flaked.

## Testing

- Reproduced the flake locally (1/8 runs failed at 30s), then confirmed the affected waits complete well within 60s across repeated runs.
- Test-only change; no product code touched.