### PR TITLE
feat(spur-cli): support nodefile-based nodelists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3482,6 +3482,7 @@ dependencies = [
  "spur-proto",
  "spur-update",
  "tar",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",

--- a/crates/spur-cli/Cargo.toml
+++ b/crates/spur-cli/Cargo.toml
@@ -34,6 +34,7 @@ shlex = "2"
 
 [dev-dependencies]
 serial_test = { workspace = true }
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/crates/spur-cli/src/main.rs
+++ b/crates/spur-cli/src/main.rs
@@ -8,6 +8,7 @@ mod format_engine;
 mod image;
 mod net;
 mod node;
+mod nodelist;
 mod sacct;
 mod sacctmgr;
 mod salloc;

--- a/crates/spur-cli/src/nodelist.rs
+++ b/crates/spur-cli/src/nodelist.rs
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+pub fn resolve(nodelist: Option<String>, nodefile: Option<String>) -> Result<Option<String>> {
+    if let Some(path) = nodefile {
+        return read(&path).map(Some);
+    }
+
+    match nodelist {
+        Some(value) if value.contains('/') => read(&value).map(Some),
+        value => Ok(value),
+    }
+}
+
+fn read(path: &str) -> Result<String> {
+    let contents = std::fs::read_to_string(path).with_context(|| {
+        format!(
+            "failed to read node list file: {}",
+            Path::new(path).display()
+        )
+    })?;
+
+    Ok(contents
+        .split(|c: char| c == ',' || c.is_whitespace())
+        .filter(|name| !name.is_empty())
+        .collect::<Vec<_>>()
+        .join(","))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use super::*;
+
+    static NEXT_FIXTURE: AtomicU64 = AtomicU64::new(0);
+
+    struct NodeFileFixture {
+        directory: PathBuf,
+        path: PathBuf,
+    }
+
+    impl NodeFileFixture {
+        fn new(contents: &str) -> Self {
+            let directory = std::env::temp_dir().join(format!(
+                "spur-nodefile-test-{}-{}",
+                std::process::id(),
+                NEXT_FIXTURE.fetch_add(1, Ordering::Relaxed)
+            ));
+            std::fs::create_dir(&directory).expect("create fixture directory");
+            let path = directory.join("nodes.txt");
+            std::fs::write(&path, contents).expect("write node file fixture");
+            Self { directory, path }
+        }
+
+        fn path(&self) -> String {
+            self.path.to_string_lossy().into_owned()
+        }
+    }
+
+    impl Drop for NodeFileFixture {
+        fn drop(&mut self) {
+            std::fs::remove_dir_all(&self.directory).expect("remove fixture directory");
+        }
+    }
+
+    #[test]
+    fn leaves_literal_nodelist_unchanged() {
+        let resolved = resolve(Some("node[001-004]".into()), None).expect("resolve nodelist");
+        assert_eq!(resolved.as_deref(), Some("node[001-004]"));
+    }
+
+    #[test]
+    fn reads_nodelist_value_containing_slash() {
+        let fixture = NodeFileFixture::new("node001\nnode002,node003\n");
+        let resolved = resolve(Some(fixture.path()), None).expect("resolve nodelist file");
+        assert_eq!(resolved.as_deref(), Some("node001,node002,node003"));
+    }
+
+    #[test]
+    fn explicit_nodefile_always_reads_file() {
+        let fixture = NodeFileFixture::new("node[001-003,007] node008\n");
+        let resolved = resolve(None, Some(fixture.path()));
+        assert_eq!(
+            resolved.expect("resolve nodefile").as_deref(),
+            Some("node[001-003,007],node008")
+        );
+    }
+
+    #[test]
+    fn reports_nodefile_path_on_read_failure() {
+        let error = resolve(None, Some("missing-nodes.txt".into())).expect_err("read must fail");
+        assert!(error
+            .to_string()
+            .contains("failed to read node list file: missing-nodes.txt"));
+    }
+}

--- a/crates/spur-cli/src/nodelist.rs
+++ b/crates/spur-cli/src/nodelist.rs
@@ -33,40 +33,13 @@ fn read(path: &str) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-    use std::sync::atomic::{AtomicU64, Ordering};
-
     use super::*;
 
-    static NEXT_FIXTURE: AtomicU64 = AtomicU64::new(0);
-
-    struct NodeFileFixture {
-        directory: PathBuf,
-        path: PathBuf,
-    }
-
-    impl NodeFileFixture {
-        fn new(contents: &str) -> Self {
-            let directory = std::env::temp_dir().join(format!(
-                "spur-nodefile-test-{}-{}",
-                std::process::id(),
-                NEXT_FIXTURE.fetch_add(1, Ordering::Relaxed)
-            ));
-            std::fs::create_dir(&directory).expect("create fixture directory");
-            let path = directory.join("nodes.txt");
-            std::fs::write(&path, contents).expect("write node file fixture");
-            Self { directory, path }
-        }
-
-        fn path(&self) -> String {
-            self.path.to_string_lossy().into_owned()
-        }
-    }
-
-    impl Drop for NodeFileFixture {
-        fn drop(&mut self) {
-            std::fs::remove_dir_all(&self.directory).expect("remove fixture directory");
-        }
+    fn node_file(contents: &str) -> (tempfile::TempDir, String) {
+        let directory = tempfile::tempdir().expect("create fixture directory");
+        let path = directory.path().join("nodes.txt");
+        std::fs::write(&path, contents).expect("write node file fixture");
+        (directory, path.to_string_lossy().into_owned())
     }
 
     #[test]
@@ -77,15 +50,15 @@ mod tests {
 
     #[test]
     fn reads_nodelist_value_containing_slash() {
-        let fixture = NodeFileFixture::new("node001\nnode002,node003\n");
-        let resolved = resolve(Some(fixture.path()), None).expect("resolve nodelist file");
+        let (_directory, path) = node_file("node001\nnode002,node003\n");
+        let resolved = resolve(Some(path), None).expect("resolve nodelist file");
         assert_eq!(resolved.as_deref(), Some("node001,node002,node003"));
     }
 
     #[test]
     fn explicit_nodefile_always_reads_file() {
-        let fixture = NodeFileFixture::new("node[001-003,007] node008\n");
-        let resolved = resolve(None, Some(fixture.path()));
+        let (_directory, path) = node_file("node[001-003,007] node008\n");
+        let resolved = resolve(None, Some(path));
         assert_eq!(
             resolved.expect("resolve nodefile").as_deref(),
             Some("node[001-003,007],node008")

--- a/crates/spur-cli/src/salloc.rs
+++ b/crates/spur-cli/src/salloc.rs
@@ -59,8 +59,20 @@ pub struct SallocArgs {
     pub constraint: Option<String>,
 
     /// Node list
-    #[arg(short = 'w', long)]
+    #[arg(
+        short = 'w',
+        long,
+        overrides_with_all = ["nodelist", "nodefile"]
+    )]
     pub nodelist: Option<String>,
+
+    /// Read the node list from a file
+    #[arg(
+        short = 'F',
+        long,
+        overrides_with_all = ["nodelist", "nodefile"]
+    )]
+    pub nodefile: Option<String>,
 
     /// Exclude nodes
     #[arg(short = 'x', long)]
@@ -91,6 +103,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let matches = SallocArgs::command().try_get_matches_from(&args)?;
     let mut args = SallocArgs::from_arg_matches(&matches)?;
     resolve_salloc_env(&matches, &mut args);
+    let nodelist = crate::nodelist::resolve(args.nodelist.take(), args.nodefile.take())?;
 
     let name = args.job_name.unwrap_or_else(|| "interactive".into());
     let mut gres = args.gres;
@@ -115,7 +128,6 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let controller = args.controller.clone();
     let exclusive = args.exclusive;
     let constraint = args.constraint;
-    let nodelist = args.nodelist;
     let exclude = args.exclude;
     let reservation = args.reservation;
     let partition = args.partition;
@@ -372,6 +384,19 @@ mod tests {
                 .expect("parse failed");
         assert_eq!(args.nodelist.as_deref(), Some("node001"));
         assert_eq!(args.exclude.as_deref(), Some("node002"));
+    }
+
+    #[test]
+    fn parses_nodefile_short_and_long() {
+        let short = SallocArgs::try_parse_from(["salloc", "-F", "nodes.txt"])
+            .expect("parse short nodefile");
+        assert_eq!(short.nodefile.as_deref(), Some("nodes.txt"));
+        assert!(short.nodelist.is_none());
+
+        let long = SallocArgs::try_parse_from(["salloc", "--nodefile=other.txt"])
+            .expect("parse long nodefile");
+        assert_eq!(long.nodefile.as_deref(), Some("other.txt"));
+        assert!(long.nodelist.is_none());
     }
 
     // These mutate process-global env vars, so they run serially and use the

--- a/crates/spur-cli/src/sbatch.rs
+++ b/crates/spur-cli/src/sbatch.rs
@@ -123,9 +123,17 @@ pub struct SbatchArgs {
         short = 'w',
         long,
         env = "SBATCH_NODELIST",
-        overrides_with = "nodelist"
+        overrides_with_all = ["nodelist", "nodefile"]
     )]
     pub nodelist: Option<String>,
+
+    /// Read the node list from a file
+    #[arg(
+        short = 'F',
+        long,
+        overrides_with_all = ["nodelist", "nodefile"]
+    )]
+    pub nodefile: Option<String>,
 
     /// Exclude nodes
     #[arg(short = 'x', long, env = "SBATCH_EXCLUDE", overrides_with = "exclude")]
@@ -401,7 +409,10 @@ fn merge_resolved(cli_matches: &clap::ArgMatches, cli: SbatchArgs, dir: SbatchAr
     fallback!(error, "error");
     fallback!(qos, "qos");
     fallback!(dependency, "dependency");
-    fallback!(nodelist, "nodelist");
+    if is_default(cli_matches, "nodelist") && is_default(cli_matches, "nodefile") {
+        out.nodelist = dir.nodelist;
+        out.nodefile = dir.nodefile;
+    }
     fallback!(exclude, "exclude");
     fallback!(constraint, "constraint");
     fallback!(reservation, "reservation");
@@ -673,6 +684,7 @@ pub async fn main_with_args(cli_args: Vec<String>) -> Result<()> {
         .unwrap_or_default();
 
     let mut args = resolve_sbatch_args(&directive_args, &cli_args)?;
+    let nodelist = crate::nodelist::resolve(args.nodelist.take(), args.nodefile.take())?;
 
     // Build the job spec
     let is_wrap = args.wrap.is_some();
@@ -773,7 +785,7 @@ pub async fn main_with_args(cli_args: Vec<String>) -> Result<()> {
         priority: 0,
         reservation: args.reservation.unwrap_or_default(),
         dependency: dependencies,
-        nodelist: args.nodelist.unwrap_or_default(),
+        nodelist: nodelist.unwrap_or_default(),
         exclude: args.exclude.unwrap_or_default(),
         constraint: args.constraint.unwrap_or_default(),
         mpi: args.mpi,
@@ -1006,6 +1018,27 @@ echo "hello world"
         assert_eq!(args.nodes, 4);
         assert_eq!(args.time.as_deref(), Some("1:00:00"));
         assert_eq!(args.job_name.as_deref(), Some("script-name"));
+    }
+
+    #[test]
+    fn test_nodefile_directive_is_parsed() {
+        let args = parse_merged(&["--nodefile=nodes.txt"], &["sbatch"]);
+        assert_eq!(args.nodefile.as_deref(), Some("nodes.txt"));
+        assert!(args.nodelist.is_none());
+    }
+
+    #[test]
+    fn test_cli_nodelist_overrides_nodefile_directive() {
+        let args = parse_merged(&["--nodefile=nodes.txt"], &["sbatch", "--nodelist=node001"]);
+        assert_eq!(args.nodelist.as_deref(), Some("node001"));
+        assert!(args.nodefile.is_none());
+    }
+
+    #[test]
+    fn test_cli_nodefile_overrides_nodelist_directive() {
+        let args = parse_merged(&["--nodelist=node001"], &["sbatch", "-F", "nodes.txt"]);
+        assert_eq!(args.nodefile.as_deref(), Some("nodes.txt"));
+        assert!(args.nodelist.is_none());
     }
 
     #[test]

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -81,8 +81,20 @@ pub struct SrunArgs {
     pub constraint: Option<String>,
 
     /// Node list
-    #[arg(short = 'w', long)]
+    #[arg(
+        short = 'w',
+        long,
+        overrides_with_all = ["nodelist", "nodefile"]
+    )]
     pub nodelist: Option<String>,
+
+    /// Read the node list from a file
+    #[arg(
+        short = 'F',
+        long,
+        overrides_with_all = ["nodelist", "nodefile"]
+    )]
+    pub nodefile: Option<String>,
 
     /// Exclude nodes
     #[arg(short = 'x', long)]
@@ -166,6 +178,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let matches = SrunArgs::command().try_get_matches_from(&args)?;
     let mut args = SrunArgs::from_arg_matches(&matches)?;
     resolve_srun_env(&matches, &mut args)?;
+    args.nodelist = crate::nodelist::resolve(args.nodelist.take(), args.nodefile.take())?;
 
     if args.command.is_empty() {
         eprintln!("srun: no command specified");
@@ -982,6 +995,19 @@ mod tests {
         .expect("parse failed");
         assert_eq!(args.nodelist.as_deref(), Some("node001"));
         assert_eq!(args.exclude.as_deref(), Some("node002"));
+    }
+
+    #[test]
+    fn parses_nodefile_short_and_long() {
+        let short = SrunArgs::try_parse_from(["srun", "-F", "nodes.txt", "hostname"])
+            .expect("parse short nodefile");
+        assert_eq!(short.nodefile.as_deref(), Some("nodes.txt"));
+        assert!(short.nodelist.is_none());
+
+        let long = SrunArgs::try_parse_from(["srun", "--nodefile=other.txt", "hostname"])
+            .expect("parse long nodefile");
+        assert_eq!(long.nodefile.as_deref(), Some("other.txt"));
+        assert!(long.nodelist.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add `-F/--nodefile` support to `sbatch`, `salloc`, and `srun`
- interpret `-w/--nodelist` values containing `/` as node-list files
- normalize comma- and whitespace-separated node names into the existing nodelist submission path
- preserve `sbatch` CLI, environment, and directive precedence across both option forms

Nodefile resolution stays in `spur-cli`, so the controller and scheduler continue using the existing `JobSpec.nodelist` behavior. Repetition syntax remains unchanged because arbitrary task distribution is not implemented by Spur yet.

## Testing

- `cargo test -p spur-cli --locked`
- `cargo clippy -p spur-cli --all-targets --locked`
- `cargo fmt --all -- --check`
- local compiled-CLI smoke tests for `-F`, slash-containing `-w`, and missing-file errors

Workspace-wide tests and clippy were attempted but are currently blocked on macOS by pre-existing Linux-only `spurd` mount, namespace, Landlock, and seccomp APIs.

Closes #378
