### PR TITLE
feat(quota): Kubernetes quota-enforcement — M1 (tenancy + hard quotas + scoped kubeconfig)

### DIFF
--- a/crates/spur-cli/src/k8s.rs
+++ b/crates/spur-cli/src/k8s.rs
@@ -44,8 +44,13 @@ pub enum K8sCommand {
     },
     /// Show cluster phase + per-node component status.
     Status,
-    /// Print the admin kubeconfig to stdout.
-    Kubeconfig,
+    /// Print a kubeconfig to stdout. Default: the cluster-admin kubeconfig. With `--user`, a
+    /// namespace-scoped kubeconfig (a ServiceAccount token in that user's account namespace).
+    Kubeconfig {
+        /// Mint a scoped kubeconfig for this SPUR user instead of the admin one.
+        #[arg(long)]
+        user: Option<String>,
+    },
     /// Download + install the k0s binary on THIS node (local; no controller needed).
     /// Run as root for the default /usr/local/bin path.
     InstallK0s {
@@ -72,7 +77,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         K8sCommand::Up { control_plane_node } => cmd_up(&controller, control_plane_node).await,
         K8sCommand::Down { reset } => cmd_down(&controller, reset).await,
         K8sCommand::Status => cmd_status(&controller).await,
-        K8sCommand::Kubeconfig => cmd_kubeconfig(&controller).await,
+        K8sCommand::Kubeconfig { user } => cmd_kubeconfig(&controller, user).await,
         K8sCommand::InstallK0s {
             version,
             path,
@@ -149,10 +154,12 @@ async fn cmd_status(controller: &str) -> Result<()> {
     Ok(())
 }
 
-async fn cmd_kubeconfig(controller: &str) -> Result<()> {
+async fn cmd_kubeconfig(controller: &str, user: Option<String>) -> Result<()> {
     let mut client = SlurmControllerClient::new(spur_client::connect_channel(controller).await?);
     let resp = client
-        .cluster_kubeconfig(ClusterKubeconfigRequest {})
+        .cluster_kubeconfig(ClusterKubeconfigRequest {
+            user: user.unwrap_or_default(),
+        })
         .await?
         .into_inner();
     // stdout = data (the YAML), so it can be redirected to a kubeconfig file.

--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -256,6 +256,9 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
                 .map(|v| parse_limit("maxjobs", v))
                 .transpose()?
                 .unwrap_or(0);
+            // Account resource allocation, e.g. grptres=cpu=16,mem=32768,gres/gpu=8. Projected to a
+            // per-account k8s ResourceQuota by the quota reconciler.
+            let grp_tres = p.get("grptres").cloned().unwrap_or_default();
 
             let mut client = connect(addr).await?;
             client
@@ -266,6 +269,7 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
                     parent_account: parent.clone(),
                     fairshare_weight: fairshare,
                     max_running_jobs: max_jobs,
+                    grp_tres: grp_tres.clone(),
                 })
                 .await
                 .context("CreateAccount RPC failed")?;
@@ -495,6 +499,7 @@ async fn modify(entity: &str, params: &[String], addr: &str) -> Result<()> {
                         .map(|v| parse_limit("maxjobs", v))
                         .transpose()?
                         .unwrap_or(0),
+                    grp_tres: p.get("grptres").cloned().unwrap_or_default(),
                 })
                 .await
                 .context("CreateAccount (modify) RPC failed")?;

--- a/crates/spur-core/src/lib.rs
+++ b/crates/spur-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod k0s;
 pub mod node;
 pub mod partition;
 pub mod qos;
+pub mod quota_names;
 pub mod reservation;
 pub mod resource;
 pub mod spur_env;

--- a/crates/spur-core/src/quota_names.rs
+++ b/crates/spur-core/src/quota_names.rs
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared naming for the SPUR quota layer.
+//!
+//! The operator's quota reconciler creates a per-account Namespace and grants each member a
+//! per-user ServiceAccount; spurctld mints a scoped kubeconfig into that same namespace/SA. They
+//! must agree on the exact names, so the convention lives here in spur-core (both depend on it).
+
+/// Kubernetes namespace for a SPUR account (DNS-1123 label safe).
+pub fn account_namespace(account: &str) -> String {
+    format!("spur-acct-{}", sanitize_dns_label(account))
+}
+
+/// Per-user ServiceAccount name within the account namespace — what `spur k8s kubeconfig --user`
+/// mints a token for and what the account RoleBinding grants.
+pub fn user_service_account(user: &str) -> String {
+    format!("spur-user-{}", sanitize_dns_label(user))
+}
+
+/// Lower-case, replace any char that isn't `[a-z0-9-]` with `-`, collapse/trim leading-trailing `-`,
+/// and cap at 63 chars — a DNS-1123 label. Empty input yields "x" so a name is always valid.
+pub fn sanitize_dns_label(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        let c = c.to_ascii_lowercase();
+        if c.is_ascii_alphanumeric() {
+            out.push(c);
+        } else if !out.ends_with('-') {
+            out.push('-');
+        }
+    }
+    let trimmed = out.trim_matches('-');
+    let capped: String = trimmed.chars().take(63).collect();
+    let capped = capped.trim_matches('-').to_string();
+    if capped.is_empty() {
+        "x".to_string()
+    } else {
+        capped
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn names_are_dns_safe() {
+        assert_eq!(account_namespace("Physics_Lab"), "spur-acct-physics-lab");
+        assert_eq!(user_service_account("Alice.Smith"), "spur-user-alice-smith");
+        assert_eq!(account_namespace("__weird__"), "spur-acct-weird");
+        assert_eq!(sanitize_dns_label(""), "x");
+        assert!(sanitize_dns_label(&"a".repeat(200)).len() <= 63);
+    }
+}

--- a/crates/spur-k8s/src/lib.rs
+++ b/crates/spur-k8s/src/lib.rs
@@ -7,3 +7,4 @@ pub mod health;
 pub mod heartbeat;
 pub mod job_controller;
 pub mod node_watcher;
+pub mod quota;

--- a/crates/spur-k8s/src/lib.rs
+++ b/crates/spur-k8s/src/lib.rs
@@ -8,3 +8,4 @@ pub mod heartbeat;
 pub mod job_controller;
 pub mod node_watcher;
 pub mod quota;
+pub mod quota_controller;

--- a/crates/spur-k8s/src/main.rs
+++ b/crates/spur-k8s/src/main.rs
@@ -7,6 +7,8 @@ mod health;
 mod heartbeat;
 mod job_controller;
 mod node_watcher;
+mod quota;
+mod quota_controller;
 
 use std::net::SocketAddr;
 use std::time::Duration;
@@ -43,6 +45,11 @@ struct Args {
     /// K8s node label selector
     #[arg(long, default_value = "spur.amd.com/managed=true")]
     node_selector: String,
+
+    /// Enable the quota policy reconciler: project SPUR accounts into per-account Namespace +
+    /// ResourceQuota + LimitRange + RBAC. Off by default (opt-in policy plane).
+    #[arg(long, default_value_t = false)]
+    enable_quota: bool,
 
     /// HTTP health/metrics server address
     #[arg(long, default_value = "[::]:8080")]
@@ -168,6 +175,21 @@ async fn main() -> anyhow::Result<()> {
         })
         .await;
     });
+
+    // Spawn the quota policy reconciler (opt-in): projects SPUR accounts into per-account k8s
+    // Namespace + ResourceQuota + LimitRange + RBAC, and drift-corrects them.
+    if args.enable_quota {
+        let q_client = client.clone();
+        let q_ctrl_addr = args.controller_addr.clone();
+        tokio::spawn(async move {
+            run_with_retry("quota reconciler", || {
+                let c = q_client.clone();
+                let ctrl = q_ctrl_addr.clone();
+                Box::pin(quota_controller::run(c, ctrl))
+            })
+            .await;
+        });
+    }
 
     // Start virtual agent gRPC server
     let virtual_agent = agent::VirtualAgent::new(client);

--- a/crates/spur-k8s/src/quota.rs
+++ b/crates/spur-k8s/src/quota.rs
@@ -16,6 +16,10 @@ use k8s_openapi::api::rbac::v1::{PolicyRule, Role, RoleBinding, RoleRef, Subject
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use spur_core::accounting::{TresRecord, TresType};
+// Namespace + ServiceAccount naming lives in spur-core so spurctld's `kubeconfig --user` path agrees
+// with what this reconciler creates.
+use spur_core::quota_names::sanitize_dns_label;
+pub use spur_core::quota_names::{account_namespace, user_service_account};
 
 /// Value of the `app.kubernetes.io/managed-by` label stamped on every object this reconciler owns.
 /// The controller finds + drift-corrects its objects by this label and it encodes the
@@ -40,17 +44,6 @@ pub struct AccountQuota {
     /// Users associated with the account. Each becomes a RoleBinding subject via their per-namespace
     /// ServiceAccount (minted by `spur k8s kubeconfig --user`).
     pub members: Vec<String>,
-}
-
-/// Kubernetes namespace for a SPUR account (DNS-1123 label safe).
-pub fn account_namespace(account: &str) -> String {
-    format!("spur-acct-{}", sanitize_dns_label(account))
-}
-
-/// Per-user ServiceAccount name within the account namespace — what `kubeconfig --user` mints and
-/// what the RoleBinding grants.
-pub fn user_service_account(user: &str) -> String {
-    format!("spur-user-{}", sanitize_dns_label(user))
 }
 
 fn managed_labels(account: &str) -> BTreeMap<String, String> {
@@ -209,28 +202,6 @@ pub fn role_binding(aq: &AccountQuota) -> RoleBinding {
     }
 }
 
-/// Lower-case, replace any char that isn't `[a-z0-9-]` with `-`, collapse/trim leading-trailing `-`,
-/// and cap at 63 chars — a DNS-1123 label. Empty input yields "x" so a name is always valid.
-fn sanitize_dns_label(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        let c = c.to_ascii_lowercase();
-        if c.is_ascii_alphanumeric() {
-            out.push(c);
-        } else if !out.ends_with('-') {
-            out.push('-');
-        }
-    }
-    let trimmed = out.trim_matches('-');
-    let capped: String = trimmed.chars().take(63).collect();
-    let capped = capped.trim_matches('-').to_string();
-    if capped.is_empty() {
-        "x".to_string()
-    } else {
-        capped
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -271,16 +242,6 @@ mod tests {
         t.set(TresType::Node, 3);
         t.set(TresType::Billing, 100);
         assert!(quota_hard(&t).is_empty());
-    }
-
-    #[test]
-    fn namespace_and_sa_names_are_dns_safe() {
-        assert_eq!(account_namespace("Physics_Lab"), "spur-acct-physics-lab");
-        assert_eq!(user_service_account("Alice.Smith"), "spur-user-alice-smith");
-        // leading/trailing junk trimmed; empty -> valid.
-        assert_eq!(account_namespace("__weird__"), "spur-acct-weird");
-        assert_eq!(sanitize_dns_label(""), "x");
-        assert!(sanitize_dns_label("a".repeat(200).as_str()).len() <= 63);
     }
 
     #[test]

--- a/crates/spur-k8s/src/quota.rs
+++ b/crates/spur-k8s/src/quota.rs
@@ -1,0 +1,327 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Projects a SPUR account's allocation into the native Kubernetes objects that ENFORCE it:
+//! a Namespace (tenancy), a ResourceQuota (hard caps from the account's `grp_tres` allocation),
+//! a LimitRange (default requests so unset-request pods can't dodge the quota), and RBAC (a Role
+//! + a RoleBinding to the account's members). Pure — no I/O — so the whole mapping is unit-tested
+//! here; the quota controller applies what these return and drift-corrects.
+
+use std::collections::BTreeMap;
+
+use k8s_openapi::api::core::v1::{
+    LimitRange, LimitRangeItem, LimitRangeSpec, Namespace, ResourceQuota, ResourceQuotaSpec,
+};
+use k8s_openapi::api::rbac::v1::{PolicyRule, Role, RoleBinding, RoleRef, Subject};
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use spur_core::accounting::{TresRecord, TresType};
+
+/// Value of the `app.kubernetes.io/managed-by` label stamped on every object this reconciler owns.
+/// The controller finds + drift-corrects its objects by this label and it encodes the
+/// "SPUR-managed" contract (an admin hand-edit is reverted).
+pub const MANAGED_BY: &str = "spur-quota";
+
+/// Name of the (single) ResourceQuota / LimitRange / Role per account namespace.
+const QUOTA_NAME: &str = "spur-account-quota";
+const LIMITS_NAME: &str = "spur-account-defaults";
+const ROLE_NAME: &str = "spur-account-editor";
+const BINDING_NAME: &str = "spur-account-members";
+
+/// A SPUR account's projected allocation. The controller builds this from `ListAccounts` (the
+/// account's `grp_tres` allocation) joined with `ListUsers` (its member users).
+#[derive(Debug, Clone)]
+pub struct AccountQuota {
+    /// SPUR account name (e.g. "physics").
+    pub account: String,
+    /// The account's resource allocation. Only Cpu/Memory/Gpu map to a ResourceQuota; a 0/unset
+    /// dimension is left uncapped (a 0 cap would block every pod).
+    pub grp_tres: TresRecord,
+    /// Users associated with the account. Each becomes a RoleBinding subject via their per-namespace
+    /// ServiceAccount (minted by `spur k8s kubeconfig --user`).
+    pub members: Vec<String>,
+}
+
+/// Kubernetes namespace for a SPUR account (DNS-1123 label safe).
+pub fn account_namespace(account: &str) -> String {
+    format!("spur-acct-{}", sanitize_dns_label(account))
+}
+
+/// Per-user ServiceAccount name within the account namespace — what `kubeconfig --user` mints and
+/// what the RoleBinding grants.
+pub fn user_service_account(user: &str) -> String {
+    format!("spur-user-{}", sanitize_dns_label(user))
+}
+
+fn managed_labels(account: &str) -> BTreeMap<String, String> {
+    BTreeMap::from([
+        (
+            "app.kubernetes.io/managed-by".to_string(),
+            MANAGED_BY.to_string(),
+        ),
+        (
+            "spur.amd.com/account".to_string(),
+            sanitize_dns_label(account),
+        ),
+    ])
+}
+
+fn meta(name: &str, namespace: Option<&str>, account: &str) -> ObjectMeta {
+    ObjectMeta {
+        name: Some(name.to_string()),
+        namespace: namespace.map(str::to_string),
+        labels: Some(managed_labels(account)),
+        ..Default::default()
+    }
+}
+
+/// Map the account allocation to ResourceQuota `hard` entries. CPU (cores) and memory (MB→Mi) are
+/// capped on both requests and limits; GPUs go on `requests.amd.com/gpu` (an extended resource). A
+/// dimension left at 0 is omitted (uncapped). Node/Energy/Billing have no pod-level quota analog.
+pub fn quota_hard(grp_tres: &TresRecord) -> BTreeMap<String, Quantity> {
+    let mut hard = BTreeMap::new();
+    let cpu = grp_tres.get(TresType::Cpu);
+    if cpu > 0 {
+        hard.insert("requests.cpu".into(), Quantity(cpu.to_string()));
+        hard.insert("limits.cpu".into(), Quantity(cpu.to_string()));
+    }
+    let mem_mb = grp_tres.get(TresType::Memory);
+    if mem_mb > 0 {
+        hard.insert("requests.memory".into(), Quantity(format!("{mem_mb}Mi")));
+        hard.insert("limits.memory".into(), Quantity(format!("{mem_mb}Mi")));
+    }
+    let gpu = grp_tres.get(TresType::Gpu);
+    if gpu > 0 {
+        hard.insert("requests.amd.com/gpu".into(), Quantity(gpu.to_string()));
+    }
+    hard
+}
+
+/// The account's Namespace.
+pub fn namespace(account: &str) -> Namespace {
+    Namespace {
+        metadata: meta(&account_namespace(account), None, account),
+        ..Default::default()
+    }
+}
+
+/// The account's ResourceQuota (hard caps from its allocation).
+pub fn resource_quota(aq: &AccountQuota) -> ResourceQuota {
+    let ns = account_namespace(&aq.account);
+    ResourceQuota {
+        metadata: meta(QUOTA_NAME, Some(&ns), &aq.account),
+        spec: Some(ResourceQuotaSpec {
+            hard: Some(quota_hard(&aq.grp_tres)),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+/// A LimitRange giving every container a default request, so a pod that omits requests still counts
+/// against the ResourceQuota (otherwise unset-request pods dodge the cap).
+pub fn limit_range(account: &str) -> LimitRange {
+    let ns = account_namespace(account);
+    let default_request = BTreeMap::from([
+        ("cpu".to_string(), Quantity("100m".into())),
+        ("memory".to_string(), Quantity("128Mi".into())),
+    ]);
+    let default_limit = BTreeMap::from([
+        ("cpu".to_string(), Quantity("1".into())),
+        ("memory".to_string(), Quantity("1Gi".into())),
+    ]);
+    LimitRange {
+        metadata: meta(LIMITS_NAME, Some(&ns), account),
+        spec: Some(LimitRangeSpec {
+            limits: vec![LimitRangeItem {
+                type_: "Container".to_string(),
+                default_request: Some(default_request),
+                default: Some(default_limit),
+                ..Default::default()
+            }],
+        }),
+    }
+}
+
+/// A namespace-scoped Role granting the account's members ordinary workload management (no cluster
+/// resources, no quota/RBAC self-editing — those stay SPUR-managed).
+pub fn role(account: &str) -> Role {
+    let ns = account_namespace(account);
+    let rule = |api_groups: &[&str], resources: &[&str], verbs: &[&str]| PolicyRule {
+        api_groups: Some(api_groups.iter().map(|s| s.to_string()).collect()),
+        resources: Some(resources.iter().map(|s| s.to_string()).collect()),
+        verbs: verbs.iter().map(|s| s.to_string()).collect(),
+        ..Default::default()
+    };
+    let rw = &["get", "list", "watch", "create", "update", "patch", "delete"];
+    Role {
+        metadata: meta(ROLE_NAME, Some(&ns), account),
+        rules: Some(vec![
+            rule(
+                &[""],
+                &[
+                    "pods",
+                    "pods/log",
+                    "pods/exec",
+                    "pods/attach",
+                    "pods/portforward",
+                    "services",
+                    "configmaps",
+                    "secrets",
+                    "persistentvolumeclaims",
+                ],
+                rw,
+            ),
+            rule(&[""], &["events"], &["get", "list", "watch"]),
+            rule(&["batch"], &["jobs", "cronjobs"], rw),
+            rule(
+                &["apps"],
+                &["deployments", "replicasets", "statefulsets", "daemonsets"],
+                rw,
+            ),
+        ]),
+    }
+}
+
+/// The RoleBinding granting the account Role to each member's per-namespace ServiceAccount.
+pub fn role_binding(aq: &AccountQuota) -> RoleBinding {
+    let ns = account_namespace(&aq.account);
+    let subjects: Vec<Subject> = aq
+        .members
+        .iter()
+        .map(|user| Subject {
+            kind: "ServiceAccount".to_string(),
+            name: user_service_account(user),
+            namespace: Some(ns.clone()),
+            api_group: None,
+        })
+        .collect();
+    RoleBinding {
+        metadata: meta(BINDING_NAME, Some(&ns), &aq.account),
+        role_ref: RoleRef {
+            api_group: Some("rbac.authorization.k8s.io".to_string()),
+            kind: "Role".to_string(),
+            name: ROLE_NAME.to_string(),
+        },
+        subjects: Some(subjects),
+    }
+}
+
+/// Lower-case, replace any char that isn't `[a-z0-9-]` with `-`, collapse/trim leading-trailing `-`,
+/// and cap at 63 chars — a DNS-1123 label. Empty input yields "x" so a name is always valid.
+fn sanitize_dns_label(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        let c = c.to_ascii_lowercase();
+        if c.is_ascii_alphanumeric() {
+            out.push(c);
+        } else if !out.ends_with('-') {
+            out.push('-');
+        }
+    }
+    let trimmed = out.trim_matches('-');
+    let capped: String = trimmed.chars().take(63).collect();
+    let capped = capped.trim_matches('-').to_string();
+    if capped.is_empty() {
+        "x".to_string()
+    } else {
+        capped
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tres(cpu: u64, mem_mb: u64, gpu: u64) -> TresRecord {
+        let mut t = TresRecord::new();
+        if cpu > 0 {
+            t.set(TresType::Cpu, cpu);
+        }
+        if mem_mb > 0 {
+            t.set(TresType::Memory, mem_mb);
+        }
+        if gpu > 0 {
+            t.set(TresType::Gpu, gpu);
+        }
+        t
+    }
+
+    #[test]
+    fn quota_hard_maps_cpu_mem_gpu() {
+        let h = quota_hard(&tres(16, 32768, 8));
+        assert_eq!(h["requests.cpu"].0, "16");
+        assert_eq!(h["limits.cpu"].0, "16");
+        assert_eq!(h["requests.memory"].0, "32768Mi");
+        assert_eq!(h["limits.memory"].0, "32768Mi");
+        assert_eq!(h["requests.amd.com/gpu"].0, "8");
+    }
+
+    #[test]
+    fn quota_hard_omits_zero_dimensions() {
+        // GPU-only allocation: cpu/mem uncapped (no key), gpu capped.
+        let h = quota_hard(&tres(0, 0, 4));
+        assert!(!h.contains_key("requests.cpu"));
+        assert!(!h.contains_key("requests.memory"));
+        assert_eq!(h["requests.amd.com/gpu"].0, "4");
+        // Node/Energy/Billing never map even when set.
+        let mut t = TresRecord::new();
+        t.set(TresType::Node, 3);
+        t.set(TresType::Billing, 100);
+        assert!(quota_hard(&t).is_empty());
+    }
+
+    #[test]
+    fn namespace_and_sa_names_are_dns_safe() {
+        assert_eq!(account_namespace("Physics_Lab"), "spur-acct-physics-lab");
+        assert_eq!(user_service_account("Alice.Smith"), "spur-user-alice-smith");
+        // leading/trailing junk trimmed; empty -> valid.
+        assert_eq!(account_namespace("__weird__"), "spur-acct-weird");
+        assert_eq!(sanitize_dns_label(""), "x");
+        assert!(sanitize_dns_label("a".repeat(200).as_str()).len() <= 63);
+    }
+
+    #[test]
+    fn resource_quota_carries_hard_caps_and_managed_label() {
+        let aq = AccountQuota {
+            account: "physics".into(),
+            grp_tres: tres(16, 1024, 2),
+            members: vec![],
+        };
+        let rq = resource_quota(&aq);
+        assert_eq!(rq.metadata.namespace.as_deref(), Some("spur-acct-physics"));
+        assert_eq!(rq.metadata.name.as_deref(), Some(QUOTA_NAME));
+        assert_eq!(
+            rq.metadata.labels.as_ref().unwrap()["app.kubernetes.io/managed-by"],
+            MANAGED_BY
+        );
+        let hard = rq.spec.unwrap().hard.unwrap();
+        assert_eq!(hard["requests.amd.com/gpu"].0, "2");
+    }
+
+    #[test]
+    fn role_binding_has_a_service_account_subject_per_member() {
+        let aq = AccountQuota {
+            account: "physics".into(),
+            grp_tres: tres(1, 0, 0),
+            members: vec!["alice".into(), "bob".into()],
+        };
+        let rb = role_binding(&aq);
+        let subs = rb.subjects.unwrap();
+        assert_eq!(subs.len(), 2);
+        assert!(subs.iter().all(|s| s.kind == "ServiceAccount"
+            && s.namespace.as_deref() == Some("spur-acct-physics")));
+        assert_eq!(subs[0].name, "spur-user-alice");
+        assert_eq!(rb.role_ref.name, ROLE_NAME);
+        assert_eq!(rb.role_ref.kind, "Role");
+    }
+
+    #[test]
+    fn limit_range_defaults_requests_so_pods_count_against_quota() {
+        let lr = limit_range("physics");
+        let item = &lr.spec.unwrap().limits[0];
+        assert_eq!(item.type_, "Container");
+        assert_eq!(item.default_request.as_ref().unwrap()["cpu"].0, "100m");
+        assert_eq!(item.default.as_ref().unwrap()["memory"].0, "1Gi");
+    }
+}

--- a/crates/spur-k8s/src/quota.rs
+++ b/crates/spur-k8s/src/quota.rs
@@ -3,8 +3,8 @@
 
 //! Projects a SPUR account's allocation into the native Kubernetes objects that ENFORCE it:
 //! a Namespace (tenancy), a ResourceQuota (hard caps from the account's `grp_tres` allocation),
-//! a LimitRange (default requests so unset-request pods can't dodge the quota), and RBAC (a Role
-//! + a RoleBinding to the account's members). Pure — no I/O — so the whole mapping is unit-tested
+//! a LimitRange (default requests so unset-request pods can't dodge the quota), and RBAC (a Role and
+//! a RoleBinding to the account's members). Pure — no I/O — so the whole mapping is unit-tested
 //! here; the quota controller applies what these return and drift-corrects.
 
 use std::collections::BTreeMap;
@@ -153,7 +153,9 @@ pub fn role(account: &str) -> Role {
         verbs: verbs.iter().map(|s| s.to_string()).collect(),
         ..Default::default()
     };
-    let rw = &["get", "list", "watch", "create", "update", "patch", "delete"];
+    let rw = &[
+        "get", "list", "watch", "create", "update", "patch", "delete",
+    ];
     Role {
         metadata: meta(ROLE_NAME, Some(&ns), account),
         rules: Some(vec![
@@ -309,8 +311,10 @@ mod tests {
         let rb = role_binding(&aq);
         let subs = rb.subjects.unwrap();
         assert_eq!(subs.len(), 2);
-        assert!(subs.iter().all(|s| s.kind == "ServiceAccount"
-            && s.namespace.as_deref() == Some("spur-acct-physics")));
+        assert!(subs
+            .iter()
+            .all(|s| s.kind == "ServiceAccount"
+                && s.namespace.as_deref() == Some("spur-acct-physics")));
         assert_eq!(subs[0].name, "spur-user-alice");
         assert_eq!(rb.role_ref.name, ROLE_NAME);
         assert_eq!(rb.role_ref.kind, "Role");

--- a/crates/spur-k8s/src/quota_controller.rs
+++ b/crates/spur-k8s/src/quota_controller.rs
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Quota policy reconciler.
+//!
+//! Projects every SPUR account into the native Kubernetes tenancy + quota objects that enforce it
+//! (Namespace, ResourceQuota, LimitRange, Role, RoleBinding — the mapping is in [`crate::quota`]).
+//! Reads accounts (with their `grp_tres` allocation) and members over the SlurmAccounting gRPC, then
+//! server-side-applies the objects with `force`, so the reconciler both fills drift and reverts an
+//! admin's hand-edit (the "SPUR-managed" contract). Runs on a level-triggered interval loop; a
+//! converged cluster re-applies the same objects (a no-op) and self-heals otherwise.
+
+use std::time::Duration;
+
+use anyhow::Context;
+use k8s_openapi::api::core::v1::{LimitRange, Namespace, ResourceQuota};
+use k8s_openapi::api::rbac::v1::{Role, RoleBinding};
+use kube::api::{Patch, PatchParams};
+use kube::{Api, Client, Resource};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use serde_json::json;
+use tonic::transport::Channel;
+use tracing::{info, warn};
+
+use spur_core::accounting::TresRecord;
+use spur_proto::proto::slurm_accounting_client::SlurmAccountingClient;
+use spur_proto::proto::{AccountInfo, ListAccountsRequest, ListUsersRequest, UserInfo};
+
+use crate::quota::{self, AccountQuota, MANAGED_BY};
+
+const RECONCILE_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Reconcile loop. Returns `Err` only on a fatal connect error so the caller (`run_with_retry`)
+/// restarts it with backoff; per-tick failures are logged and retried on the next interval.
+pub async fn run(client: Client, controller_addr: String) -> anyhow::Result<()> {
+    let url = if controller_addr.starts_with("http") {
+        controller_addr
+    } else {
+        format!("http://{controller_addr}")
+    };
+    let mut acct = SlurmAccountingClient::connect(url)
+        .await
+        .context("connect to spurctld accounting service")?;
+    info!("quota reconciler started");
+
+    let mut interval = tokio::time::interval(RECONCILE_INTERVAL);
+    loop {
+        interval.tick().await;
+        if let Err(e) = reconcile_once(&client, &mut acct).await {
+            warn!(error = %e, "quota reconcile tick failed; retrying next interval");
+        }
+    }
+}
+
+/// One reconcile pass: project every account into its k8s objects.
+async fn reconcile_once(
+    client: &Client,
+    acct: &mut SlurmAccountingClient<Channel>,
+) -> anyhow::Result<()> {
+    let accounts = acct
+        .list_accounts(ListAccountsRequest {})
+        .await
+        .context("ListAccounts RPC")?
+        .into_inner()
+        .accounts;
+
+    for a in accounts {
+        let users = acct
+            .list_users(ListUsersRequest {
+                account: a.name.clone(),
+            })
+            .await
+            .context("ListUsers RPC")?
+            .into_inner()
+            .users;
+        let aq = build_account_quota(&a, &users);
+        // Isolate per-account failures so one bad account can't stall the rest of the reconcile.
+        if let Err(e) = apply_account(client, &aq).await {
+            warn!(account = %a.name, error = %e, "failed to reconcile account quota");
+        }
+    }
+    Ok(())
+}
+
+/// Build the account's projected quota from its `AccountInfo` (the `grp_tres` allocation) and its
+/// member users. Pure — unit-tested.
+pub fn build_account_quota(account: &AccountInfo, users: &[UserInfo]) -> AccountQuota {
+    AccountQuota {
+        account: account.name.clone(),
+        // A malformed allocation string leaves the account uncapped rather than stalling the loop.
+        grp_tres: TresRecord::parse(&account.grp_tres).unwrap_or_default(),
+        members: users.iter().map(|u| u.name.clone()).collect(),
+    }
+}
+
+/// Apply the Namespace + ResourceQuota + LimitRange + Role + RoleBinding for one account. The
+/// Namespace is applied first so the namespaced objects have a home on a fresh cluster.
+async fn apply_account(client: &Client, aq: &AccountQuota) -> anyhow::Result<()> {
+    let ns = quota::account_namespace(&aq.account);
+    apply(
+        &Api::<Namespace>::all(client.clone()),
+        &quota::namespace(&aq.account),
+    )
+    .await?;
+    apply(
+        &Api::<ResourceQuota>::namespaced(client.clone(), &ns),
+        &quota::resource_quota(aq),
+    )
+    .await?;
+    apply(
+        &Api::<LimitRange>::namespaced(client.clone(), &ns),
+        &quota::limit_range(&aq.account),
+    )
+    .await?;
+    apply(
+        &Api::<Role>::namespaced(client.clone(), &ns),
+        &quota::role(&aq.account),
+    )
+    .await?;
+    apply(
+        &Api::<RoleBinding>::namespaced(client.clone(), &ns),
+        &quota::role_binding(aq),
+    )
+    .await?;
+    Ok(())
+}
+
+/// Server-side apply one object (create-or-update; `force` reverts drift from other field managers).
+/// k8s-openapi types don't serialize their `apiVersion`/`kind`, which SSA requires in the body, so
+/// they're injected from the type's `Resource` metadata.
+async fn apply<K>(api: &Api<K>, obj: &K) -> anyhow::Result<()>
+where
+    K: Resource<DynamicType = ()> + Serialize + DeserializeOwned + Clone + std::fmt::Debug,
+{
+    let name = obj
+        .meta()
+        .name
+        .clone()
+        .context("SPUR quota object has no name")?;
+    let mut body = serde_json::to_value(obj)?;
+    body["apiVersion"] = json!(K::api_version(&()).into_owned());
+    body["kind"] = json!(K::kind(&()).into_owned());
+    api.patch(
+        &name,
+        &PatchParams::apply(MANAGED_BY).force(),
+        &Patch::Apply(body),
+    )
+    .await
+    .with_context(|| format!("server-side apply {name}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spur_core::accounting::TresType;
+
+    fn account(name: &str, grp_tres: &str) -> AccountInfo {
+        AccountInfo {
+            name: name.into(),
+            grp_tres: grp_tres.into(),
+            ..Default::default()
+        }
+    }
+    fn user(name: &str, account: &str) -> UserInfo {
+        UserInfo {
+            name: name.into(),
+            account: account.into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn builds_account_quota_from_grp_tres_and_members() {
+        let aq = build_account_quota(
+            &account("physics", "cpu=16,mem=32768,gres/gpu=8"),
+            &[user("alice", "physics"), user("bob", "physics")],
+        );
+        assert_eq!(aq.account, "physics");
+        assert_eq!(aq.grp_tres.get(TresType::Cpu), 16);
+        assert_eq!(aq.grp_tres.get(TresType::Memory), 32768);
+        assert_eq!(aq.grp_tres.get(TresType::Gpu), 8);
+        assert_eq!(aq.members, vec!["alice".to_string(), "bob".to_string()]);
+    }
+
+    #[test]
+    fn empty_grp_tres_yields_uncapped_allocation() {
+        // An account with no allocation string -> empty TresRecord -> ResourceQuota with no caps.
+        let aq = build_account_quota(&account("open", ""), &[]);
+        assert_eq!(aq.grp_tres.get(TresType::Cpu), 0);
+        assert!(quota::quota_hard(&aq.grp_tres).is_empty());
+        assert!(aq.members.is_empty());
+    }
+}

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -46,6 +46,7 @@ CREATE TABLE IF NOT EXISTS accounts (
     parent_account  TEXT,
     fairshare_weight INTEGER NOT NULL DEFAULT 1,
     max_running_jobs INTEGER,
+    grp_tres        TEXT,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
@@ -125,6 +126,8 @@ ALTER TABLE jobs ADD COLUMN IF NOT EXISTS reservation TEXT NOT NULL DEFAULT '';
 -- default) must degrade gracefully at read time, not be blocked here.
 ALTER TABLE associations ADD COLUMN IF NOT EXISTS default_qos TEXT;
 ALTER TABLE qos ADD COLUMN IF NOT EXISTS grp_wall_min INTEGER;
+-- Account-level resource allocation (TRES string) -> projected to a per-account k8s ResourceQuota.
+ALTER TABLE accounts ADD COLUMN IF NOT EXISTS grp_tres TEXT;
 "#;
 
 /// Record a job start in the database.
@@ -483,6 +486,7 @@ use chrono::Timelike;
 // ============================================================
 
 /// Create or update an account.
+#[allow(clippy::too_many_arguments)]
 pub async fn upsert_account(
     pool: &PgPool,
     name: &str,
@@ -491,18 +495,19 @@ pub async fn upsert_account(
     parent: Option<&str>,
     fairshare: i32,
     max_running_jobs: Option<i32>,
+    grp_tres: Option<&str>,
 ) -> anyhow::Result<()> {
     sqlx::query(
         r#"
-        INSERT INTO accounts (name, description, organization, parent_account, fairshare_weight, max_running_jobs)
-        VALUES ($1, $2, $3, $4, $5, $6)
+        INSERT INTO accounts (name, description, organization, parent_account, fairshare_weight, max_running_jobs, grp_tres)
+        VALUES ($1, $2, $3, $4, $5, $6, $7)
         ON CONFLICT (name) DO UPDATE SET
             description = $2, organization = $3, parent_account = $4,
-            fairshare_weight = $5, max_running_jobs = $6
+            fairshare_weight = $5, max_running_jobs = $6, grp_tres = $7
         "#,
     )
     .bind(name).bind(description).bind(organization)
-    .bind(parent).bind(fairshare).bind(max_running_jobs)
+    .bind(parent).bind(fairshare).bind(max_running_jobs).bind(grp_tres)
     .execute(pool).await?;
     Ok(())
 }
@@ -519,7 +524,7 @@ pub async fn delete_account(pool: &PgPool, name: &str) -> anyhow::Result<()> {
 /// List all accounts.
 pub async fn list_accounts(pool: &PgPool) -> anyhow::Result<Vec<AccountRecord>> {
     let rows = sqlx::query(
-        "SELECT name, description, organization, parent_account, fairshare_weight, max_running_jobs FROM accounts ORDER BY name"
+        "SELECT name, description, organization, parent_account, fairshare_weight, max_running_jobs, grp_tres FROM accounts ORDER BY name"
     ).fetch_all(pool).await?;
 
     Ok(rows
@@ -531,6 +536,7 @@ pub async fn list_accounts(pool: &PgPool) -> anyhow::Result<Vec<AccountRecord>> 
             parent: r.get("parent_account"),
             fairshare_weight: r.get("fairshare_weight"),
             max_running_jobs: r.get("max_running_jobs"),
+            grp_tres: r.get("grp_tres"),
         })
         .collect())
 }
@@ -543,6 +549,8 @@ pub struct AccountRecord {
     pub parent: Option<String>,
     pub fairshare_weight: i32,
     pub max_running_jobs: Option<i32>,
+    /// Account resource allocation as a TRES string ("cpu=N,mem=N,gres/gpu=N"); None = unlimited.
+    pub grp_tres: Option<String>,
 }
 
 /// Add a user-account association. Like `upsert_account`/`upsert_qos`, this
@@ -1184,6 +1192,52 @@ mod job_history_tests {
 
     #[tokio::test]
     #[ignore = "requires DATABASE_URL and PostgreSQL"]
+    async fn account_grp_tres_round_trips() -> anyhow::Result<()> {
+        let pool = test_pool().await?;
+        let account = format!("spur_acct_grptres_{}", std::process::id());
+        sqlx::query("DELETE FROM accounts WHERE name = $1")
+            .bind(&account)
+            .execute(&pool)
+            .await?;
+
+        // Persist an account allocation, then read it back through list_accounts.
+        upsert_account(
+            &pool,
+            &account,
+            "d",
+            "o",
+            None,
+            1,
+            Some(5),
+            Some("cpu=16,mem=32768,gres/gpu=8"),
+        )
+        .await?;
+        let got = list_accounts(&pool)
+            .await?
+            .into_iter()
+            .find(|a| a.name == account)
+            .expect("account present");
+        assert_eq!(got.grp_tres.as_deref(), Some("cpu=16,mem=32768,gres/gpu=8"));
+        assert_eq!(got.max_running_jobs, Some(5));
+
+        // Re-upsert with no allocation clears it (full resend, not a partial patch).
+        upsert_account(&pool, &account, "d", "o", None, 1, None, None).await?;
+        let got = list_accounts(&pool)
+            .await?
+            .into_iter()
+            .find(|a| a.name == account)
+            .expect("account present");
+        assert_eq!(got.grp_tres, None);
+
+        sqlx::query("DELETE FROM accounts WHERE name = $1")
+            .bind(&account)
+            .execute(&pool)
+            .await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL and PostgreSQL"]
     async fn add_user_round_trips_default_qos() -> anyhow::Result<()> {
         let pool = test_pool().await?;
         let pid = std::process::id();
@@ -1208,7 +1262,7 @@ mod job_history_tests {
             .execute(&pool)
             .await?;
 
-        upsert_account(&pool, &account, "d", "o", None, 1, None).await?;
+        upsert_account(&pool, &account, "d", "o", None, 1, None, None).await?;
         upsert_qos(
             &pool, &qos_name, "d", 0, "off", 1.0, None, None, None, None, None, None, None,
         )
@@ -1278,7 +1332,7 @@ mod job_history_tests {
             .execute(&pool)
             .await?;
 
-        upsert_account(&pool, &account, "d", "o", None, 1, None).await?;
+        upsert_account(&pool, &account, "d", "o", None, 1, None, None).await?;
 
         add_user(
             &pool,
@@ -1388,7 +1442,7 @@ mod job_history_tests {
             .execute(&pool)
             .await?;
 
-        upsert_account(&pool, &account, "d", "o", None, 1, None).await?;
+        upsert_account(&pool, &account, "d", "o", None, 1, None, None).await?;
 
         add_user(
             &pool, &user, &account, "none", true, "", None, None, None, None, None,
@@ -1464,7 +1518,7 @@ mod job_history_tests {
             .execute(&pool)
             .await?;
 
-        upsert_account(&pool, &account, "d", "o", None, 1, None).await?;
+        upsert_account(&pool, &account, "d", "o", None, 1, None, None).await?;
         sqlx::query("INSERT INTO users (name, account, admin_level) VALUES ($1, $2, 'none')")
             .bind(&user)
             .bind(&account)
@@ -1518,7 +1572,7 @@ mod job_history_tests {
             .execute(&pool)
             .await?;
 
-        upsert_account(&pool, &account, "d", "o", None, 1, None).await?;
+        upsert_account(&pool, &account, "d", "o", None, 1, None, None).await?;
         sqlx::query(
             "INSERT INTO associations \
              (user_name, account, max_running_jobs, max_submit_jobs, max_tres_per_job, grp_tres, max_wall_min) \

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -300,6 +300,11 @@ impl SlurmAccounting for AccountingService {
         } else {
             Some(req.max_running_jobs as i32)
         };
+        let grp_tres = if req.grp_tres.is_empty() {
+            None
+        } else {
+            Some(req.grp_tres.as_str())
+        };
         db::upsert_account(
             &self.pool,
             &req.name,
@@ -308,6 +313,7 @@ impl SlurmAccounting for AccountingService {
             parent,
             req.fairshare_weight as i32,
             max_running,
+            grp_tres,
         )
         .await
         .map_err(|e| Status::internal(e.to_string()))?;
@@ -342,6 +348,7 @@ impl SlurmAccounting for AccountingService {
                 parent_account: r.parent.unwrap_or_default(),
                 fairshare_weight: r.fairshare_weight as f64,
                 max_running_jobs: r.max_running_jobs.unwrap_or(0) as u32,
+                grp_tres: r.grp_tres.unwrap_or_default(),
             })
             .collect();
 

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -383,9 +383,30 @@ async fn mint_worker_token(cluster: &ClusterManager) -> anyhow::Result<String> {
 pub async fn fetch_admin_kubeconfig(cluster: &ClusterManager) -> anyhow::Result<String> {
     let mut client = connect_control_plane(cluster).await?;
     let resp = client
-        .get_admin_kubeconfig(GetAdminKubeconfigRequest {})
+        .get_admin_kubeconfig(GetAdminKubeconfigRequest::default())
         .await
         .map_err(|e| anyhow::anyhow!("get_admin_kubeconfig RPC failed: {e}"))?;
+    Ok(resp.into_inner().kubeconfig)
+}
+
+/// Mint a namespace-scoped kubeconfig for a SPUR user: the control-plane agent ensures the
+/// ServiceAccount exists in the account namespace and mints a bound token. `namespace` + `sa` are
+/// derived by the caller from the user's account via `spur_core::quota_names`.
+pub async fn fetch_user_kubeconfig(
+    cluster: &ClusterManager,
+    user: &str,
+    namespace: &str,
+    service_account: &str,
+) -> anyhow::Result<String> {
+    let mut client = connect_control_plane(cluster).await?;
+    let resp = client
+        .get_admin_kubeconfig(GetAdminKubeconfigRequest {
+            user: user.to_string(),
+            namespace: namespace.to_string(),
+            service_account: service_account.to_string(),
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("get_admin_kubeconfig (scoped) RPC failed: {e}"))?;
     Ok(resp.into_inner().kubeconfig)
 }
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1588,11 +1588,34 @@ impl SlurmController for ControllerService {
             *fwd.metadata_mut() = Self::forwarded_metadata();
             return client.cluster_kubeconfig(fwd).await;
         }
-        // Ask the control-plane node's agent to run `k0s kubeconfig admin`.
-        match crate::cluster_k8s::fetch_admin_kubeconfig(&self.cluster).await {
+        let req = request.into_inner();
+        if req.user.is_empty() {
+            // Cluster-admin kubeconfig (`k0s kubeconfig admin` on the control-plane agent).
+            return match crate::cluster_k8s::fetch_admin_kubeconfig(&self.cluster).await {
+                Ok(kubeconfig) => Ok(Response::new(ClusterKubeconfigResponse { kubeconfig })),
+                Err(e) => Err(Status::unavailable(format!(
+                    "could not fetch admin kubeconfig from the control-plane agent: {e}"
+                ))),
+            };
+        }
+        // Scoped kubeconfig: resolve the user's account -> its namespace + per-user ServiceAccount,
+        // then have the control-plane agent mint a bound token there.
+        let (account, _qos) = self.cluster.association_cache().resolve(&req.user, None);
+        let account = account.ok_or_else(|| {
+            Status::not_found(format!(
+                "user '{}' is not associated with any account",
+                req.user
+            ))
+        })?;
+        let namespace = spur_core::quota_names::account_namespace(&account);
+        let sa = spur_core::quota_names::user_service_account(&req.user);
+        match crate::cluster_k8s::fetch_user_kubeconfig(&self.cluster, &req.user, &namespace, &sa)
+            .await
+        {
             Ok(kubeconfig) => Ok(Response::new(ClusterKubeconfigResponse { kubeconfig })),
             Err(e) => Err(Status::unavailable(format!(
-                "could not fetch admin kubeconfig from the control-plane agent: {e}"
+                "could not mint a scoped kubeconfig for user '{}': {e}",
+                req.user
             ))),
         }
     }

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1543,13 +1543,21 @@ impl SlurmAgent for AgentService {
 
     async fn get_admin_kubeconfig(
         &self,
-        _request: Request<GetAdminKubeconfigRequest>,
+        request: Request<GetAdminKubeconfigRequest>,
     ) -> Result<Response<GetAdminKubeconfigResponse>, Status> {
-        match self.k0s.admin_kubeconfig().await {
+        let req = request.into_inner();
+        // Empty user -> cluster-admin kubeconfig; set -> a scoped kubeconfig (SA + bound token in the
+        // user's account namespace).
+        let result = if req.user.is_empty() {
+            self.k0s.admin_kubeconfig().await
+        } else {
+            self.k0s
+                .user_kubeconfig(&req.user, &req.namespace, &req.service_account)
+                .await
+        };
+        match result {
             Ok(kubeconfig) => Ok(Response::new(GetAdminKubeconfigResponse { kubeconfig })),
-            Err(e) => Err(Status::internal(format!(
-                "k0s kubeconfig admin failed: {e}"
-            ))),
+            Err(e) => Err(Status::internal(format!("get kubeconfig failed: {e}"))),
         }
     }
 

--- a/crates/spurd/src/cluster.rs
+++ b/crates/spurd/src/cluster.rs
@@ -365,6 +365,87 @@ fn parse_execstart(exec: &str) -> anyhow::Result<ClusterConfig> {
     })
 }
 
+/// Extract the cluster CA (base64) + server URL from an admin kubeconfig YAML. k0s's admin
+/// kubeconfig has exactly one cluster, so a dependency-free line scan is sufficient.
+fn parse_cluster_ca_server(admin: &str) -> anyhow::Result<(String, String)> {
+    let mut ca = None;
+    let mut server = None;
+    for line in admin.lines() {
+        let t = line.trim();
+        if let Some(v) = t.strip_prefix("certificate-authority-data:") {
+            ca = Some(v.trim().to_string());
+        } else if let Some(v) = t.strip_prefix("server:") {
+            server = Some(v.trim().to_string());
+        }
+    }
+    match (ca, server) {
+        (Some(ca), Some(server)) => Ok((ca, server)),
+        _ => anyhow::bail!("admin kubeconfig missing certificate-authority-data or server"),
+    }
+}
+
+/// Template a namespace-scoped kubeconfig. `name` (the ServiceAccount name) is DNS-safe and the
+/// ca/server/token carry no YAML-breaking characters, so plain interpolation is safe.
+fn build_scoped_kubeconfig(
+    ca: &str,
+    server: &str,
+    token: &str,
+    name: &str,
+    namespace: &str,
+) -> String {
+    format!(
+        r#"apiVersion: v1
+kind: Config
+clusters:
+- name: spur
+  cluster:
+    certificate-authority-data: {ca}
+    server: {server}
+contexts:
+- name: {name}
+  context:
+    cluster: spur
+    namespace: {namespace}
+    user: {name}
+current-context: {name}
+users:
+- name: {name}
+  user:
+    token: {token}
+"#
+    )
+}
+
+#[cfg(test)]
+mod scoped_kubeconfig_tests {
+    use super::{build_scoped_kubeconfig, parse_cluster_ca_server};
+
+    #[test]
+    fn parses_ca_and_server() {
+        let admin = "clusters:\n- cluster:\n    certificate-authority-data: QUJD\n    server: https://10.0.0.1:6443\n  name: k0s\n";
+        let (ca, server) = parse_cluster_ca_server(admin).unwrap();
+        assert_eq!(ca, "QUJD");
+        assert_eq!(server, "https://10.0.0.1:6443");
+        assert!(parse_cluster_ca_server("apiVersion: v1\n").is_err());
+    }
+
+    #[test]
+    fn builds_scoped_kubeconfig_yaml() {
+        let kc = build_scoped_kubeconfig(
+            "QUJD",
+            "https://x:6443",
+            "tok123",
+            "spur-user-alice",
+            "spur-acct-physics",
+        );
+        assert!(kc.starts_with("apiVersion: v1\nkind: Config\n"));
+        assert!(kc.contains("namespace: spur-acct-physics"));
+        assert!(kc.contains("token: tok123"));
+        assert!(kc.contains("certificate-authority-data: QUJD"));
+        assert!(kc.contains("current-context: spur-user-alice"));
+    }
+}
+
 /// Write a bearer-secret file (0600). Content is never logged.
 async fn write_secret_file(path: &Path, content: &[u8]) -> anyhow::Result<()> {
     use tokio::io::AsyncWriteExt;
@@ -686,6 +767,72 @@ impl K0sAgent {
             anyhow::bail!("k0s kubeconfig admin returned empty output");
         }
         Ok(kubeconfig)
+    }
+
+    /// Mint a namespace-scoped kubeconfig on this (control-plane) node: ensure `service_account`
+    /// exists in `namespace`, mint a bound token for it (`k0s kubectl create token`), and template a
+    /// kubeconfig with the admin cluster CA + server scoped to that namespace. The namespace + its
+    /// RBAC are expected to exist (created by the operator's quota reconciler). Token never logged.
+    pub async fn user_kubeconfig(
+        &self,
+        user: &str,
+        namespace: &str,
+        service_account: &str,
+    ) -> anyhow::Result<String> {
+        // Ensure the ServiceAccount exists — idempotent (an already-existing SA is fine).
+        let create = Command::new(&self.k0s_binary)
+            .args([
+                "kubectl",
+                "create",
+                "serviceaccount",
+                service_account,
+                "-n",
+                namespace,
+            ])
+            .output()
+            .await?;
+        if !create.status.success() {
+            let err = String::from_utf8_lossy(&create.stderr);
+            if !err.contains("AlreadyExists") && !err.contains("already exists") {
+                anyhow::bail!(
+                    "create serviceaccount {service_account} in {namespace} failed: {}",
+                    err.trim()
+                );
+            }
+        }
+        // Mint a bound (rotatable) token for the ServiceAccount.
+        let tok = Command::new(&self.k0s_binary)
+            .args([
+                "kubectl",
+                "create",
+                "token",
+                service_account,
+                "-n",
+                namespace,
+                "--duration=8760h",
+            ])
+            .output()
+            .await?;
+        if !tok.status.success() {
+            anyhow::bail!(
+                "create token for {service_account} in {namespace} failed: {}",
+                String::from_utf8_lossy(&tok.stderr).trim()
+            );
+        }
+        let token = String::from_utf8_lossy(&tok.stdout).trim().to_string();
+        if token.is_empty() {
+            anyhow::bail!("k0s kubectl create token returned empty output");
+        }
+        // Reuse the admin kubeconfig for the cluster CA + server URL.
+        let (ca, server) = parse_cluster_ca_server(&self.admin_kubeconfig().await?)?;
+        info!(user, namespace, service_account, "minted scoped kubeconfig");
+        Ok(build_scoped_kubeconfig(
+            &ca,
+            &server,
+            &token,
+            service_account,
+            namespace,
+        ))
     }
 
     /// (role, active_state, enabled) for the node's component. When there is no tracked component,

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -729,9 +729,14 @@ message ClusterNodeStatus {
   bool enabled = 4;
 }
 
-message ClusterKubeconfigRequest {}
+message ClusterKubeconfigRequest {
+  // Empty -> the cluster-admin kubeconfig. Set -> a namespace-scoped kubeconfig for this SPUR user
+  // (a ServiceAccount + bound token in the user's account namespace).
+  string user = 1;
+}
 message ClusterKubeconfigResponse {
-  // Admin kubeconfig YAML (server rewritten to the control-plane's mesh IP).
+  // Admin kubeconfig YAML (server rewritten to the control-plane's mesh IP), or the scoped kubeconfig
+  // when `user` was set.
   string kubeconfig = 1;
 }
 
@@ -778,9 +783,16 @@ message CreateK0sJoinTokenResponse {
   string join_token = 1;
 }
 
-message GetAdminKubeconfigRequest {}
+message GetAdminKubeconfigRequest {
+  // All empty -> the cluster-admin kubeconfig. When `user` is set, the control-plane node mints a
+  // scoped kubeconfig: a bound token for `service_account` in `namespace` (created if absent), with
+  // the admin cluster CA + server. spurctld resolves the SPUR user -> account namespace + SA name.
+  string user = 1;
+  string namespace = 2;
+  string service_account = 3;
+}
 message GetAdminKubeconfigResponse {
-  // Admin kubeconfig YAML read from the control-plane node.
+  // Admin (or scoped) kubeconfig YAML read/minted on the control-plane node.
   string kubeconfig = 1;
 }
 

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -939,6 +939,9 @@ message CreateAccountRequest {
   string parent_account = 4;
   double fairshare_weight = 5;
   uint32 max_running_jobs = 6;
+  // Account resource allocation as a TRES string ("cpu=N,mem=N,gres/gpu=N"; empty = unlimited).
+  // The quota reconciler projects this to a per-account Kubernetes ResourceQuota.
+  string grp_tres = 7;
 }
 
 message DeleteAccountRequest {
@@ -958,6 +961,8 @@ message AccountInfo {
   string parent_account = 4;
   double fairshare_weight = 5;
   uint32 max_running_jobs = 6;
+  // Account resource allocation as a TRES string ("cpu=N,mem=N,gres/gpu=N"; empty = unlimited).
+  string grp_tres = 7;
 }
 
 message AddUserRequest {


### PR DESCRIPTION
## What

Implements **M1** of the Kubernetes quota-enforcement design ([#444 RFC](https://github.com/ROCm/spur/pull/444)): the **tenancy + hard-quota** layer that projects SPUR accounts onto native Kubernetes objects, plus per-user scoped kubeconfigs — so a cluster is a *completely normal* Kubernetes deployment to its users while SPUR is the invisible policy plane.

> **Draft** because the cluster end-to-end test on crsuse2 is still pending (see *Status* below). All code is build- + unit-test-verified, including spurd on Linux.

> **Stacked on #432** — the base branch is `users/powderluv/m8-native-k8s`, so this diff is just the 4 quota commits. Re-target to `main` once #432 merges.

## End-to-end flow this lands

```
sacctmgr add account physics grptres=cpu=64,mem=131072,gres/gpu=8
  → the operator's quota reconciler (opt-in --enable-quota) projects it to:
      namespace spur-acct-physics
      + ResourceQuota (requests/limits.cpu, .memory, requests.amd.com/gpu)
      + LimitRange (default requests so unset-request pods still count)
      + Role + RoleBinding (the account's members)

spur k8s kubeconfig --user alice
  → spurctld resolves alice → physics → its namespace, the control-plane agent
    mints a ServiceAccount + bound token there → a namespace-scoped kubeconfig
    (no cluster-admin credential ever handed out)
```

## Increments (each independently reviewable)

| Commit | Increment |
|---|---|
| projection module | Pure `account → Namespace/ResourceQuota/LimitRange/RBAC` mapping (`spur-k8s/quota.rs`), fully unit-tested |
| persist `grp_tres` | Account-level TRES allocation through DB (column + migration) + proto + gRPC + `sacctmgr` |
| reconciler | `quota_controller` in the operator: lists accounts+members over gRPC, server-side-applies with `force` (drift-correcting), opt-in `--enable-quota` |
| `kubeconfig --user` | Shared naming in `spur-core`, scoped kubeconfig minted by the control-plane agent (`k0s kubectl create token`), CLI flag |

## Design decision

Per the RFC, SPUR persists resource caps on **QoS**, not accounts. M1 **wires account-level allocations** (`grp_tres` on the `Account`) so each account/namespace has a definite ResourceQuota — the cleanest tenancy model, and it gives the GPU cluster the GPU quota it lacks today.

## Status / not in this PR

- **Opt-in**: the reconciler only runs with `--enable-quota` (off by default) — zero effect on existing deployments.
- **Not yet cluster-tested**: the SA/token minting + the reconcile *apply* path are integration-level and pending a crsuse2 run. The pure logic (TRES→ResourceQuota mapping, DNS-safe naming, CA/server parse, kubeconfig template, `build_account_quota`) is unit-tested.
- Later milestones (M2 partitions+priority, M3 usage feedback, M4 Kueue/native fairness, M5 polish) are separate.

## Testing

Build + tests + `fmt` + `clippy -D warnings` green across every crate — `spur-core`/`spurctld`/`spur-cli`/`spur-k8s` on macOS and **`spurd` on Linux** (`cargo test -p spurd`, clippy clean). DB round-trip tests are `#[ignore]` (run in CI's Postgres).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
