### PR TITLE
fix(srun): fan out tasks across nodes in standalone and step mode

### DIFF
--- a/crates/spur-cli/src/sbatch.rs
+++ b/crates/spur-cli/src/sbatch.rs
@@ -835,6 +835,7 @@ pub async fn main_with_args(cli_args: Vec<String>) -> Result<()> {
         shm_size: String::new(),
         extra_resources: std::collections::HashMap::new(),
         open_mode: args.open_mode.unwrap_or_default(),
+        srun_job: false,
     };
 
     // Submit to controller

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -599,7 +599,9 @@ async fn dispatch_step(
 
     let environment = srun_dispatch_environment(args);
     warn_unsupported_cpu_bind(&environment);
-    if let Some(err) = spur_core::task_launch::map_cpu_bind_error(&environment, args.ntasks) {
+    if let Some(err) = spur_core::task_launch::map_cpu_bind_error(&environment, args.ntasks)
+        .or_else(|| spur_core::task_launch::mask_cpu_bind_error(&environment, args.ntasks))
+    {
         anyhow::bail!("{err}");
     }
     let resp = client
@@ -666,26 +668,18 @@ async fn dispatch_step_cancellable(
     client: &mut SlurmControllerClient<tonic::transport::Channel>,
     args: &SrunArgs,
     job_id: u32,
-    user: &str,
+    _user: &str,
     work_dir: &str,
     io: &ResolvedIoPaths,
     cancel_job_on_interrupt: bool,
 ) -> Result<StepDispatchResult> {
+    if cancel_job_on_interrupt {
+        return dispatch_step(client, args, job_id, work_dir, io).await;
+    }
     tokio::select! {
         result = dispatch_step(client, args, job_id, work_dir, io) => result,
         _ = tokio::signal::ctrl_c() => {
-            if cancel_job_on_interrupt {
-                eprintln!("\nsrun: cancelling job {}...", job_id);
-                let _ = client
-                    .cancel_job(CancelJobRequest {
-                        job_id,
-                        signal: 2,
-                        user: user.to_string(),
-                    })
-                    .await;
-            } else {
-                eprintln!("\nsrun: step interrupted");
-            }
+            eprintln!("\nsrun: step interrupted");
             std::process::exit(130);
         }
     }
@@ -710,6 +704,8 @@ async fn run_standalone_srun(args: &SrunArgs, hooks: &HooksConfig, work_dir: &st
         .job_id;
 
     eprintln!("srun: Pending job allocation {}...", job_id);
+
+    install_ctrl_c_cancel(client.clone(), job_id, user.clone());
 
     let nodelist = wait_for_job_running(&mut client, job_id).await?;
     if !nodelist.is_empty() {
@@ -747,8 +743,6 @@ async fn run_standalone_srun(args: &SrunArgs, hooks: &HooksConfig, work_dir: &st
         )
         .await;
     }
-
-    install_ctrl_c_cancel(client.clone(), job_id, user.clone());
 
     let output_streamed = if io.stdout.is_empty() {
         try_stream_output(&mut client, &nodelist, job_id).await

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -8,11 +8,11 @@ use spur_core::config::HooksConfig;
 use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{
-    CancelJobRequest, CreateJobStepRequest, GetJobRequest, GetNodeRequest, JobSpec, JobState,
-    StreamJobOutputRequest, SubmitJobRequest,
+    CancelJobRequest, CompleteJobRequest, CreateJobStepRequest, GetJobRequest, GetNodeRequest,
+    JobSpec, JobState, RunStepRequest, StreamJobOutputRequest, SubmitJobRequest,
 };
 use std::collections::HashMap;
-use std::io::Write;
+use std::io::Write as _;
 
 /// Run a parallel job (interactive or allocation-based).
 #[derive(Parser, Debug)]
@@ -68,7 +68,7 @@ pub struct SrunArgs {
     #[arg(short = 'D', long)]
     pub chdir: Option<String>,
 
-    /// CPU binding (none, cores, threads, sockets, ldoms, rank, map_cpu, mask_cpu)
+    /// CPU binding (none, rank, map_cpu, mask_cpu; topology modes cores/threads/sockets/ldoms are not applied in step mode)
     #[arg(long)]
     pub cpu_bind: Option<String>,
 
@@ -201,196 +201,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         }
     }
 
-    let io = resolve_io_paths(&args);
-
-    let name = args.job_name.unwrap_or_else(|| args.command[0].clone());
-
-    let script = build_command_script(&args.command)?;
-
-    // Build GRES list
-    let mut gres = args.gres;
-    if let Some(gpus) = &args.gpus {
-        gres.push(format!("gpu:{}", gpus));
-    }
-    // Don't push licenses into gres here — proto_to_job_spec already folds them in.
-
-    let time_limit = args
-        .time
-        .as_ref()
-        .and_then(|t| spur_core::config::parse_time_minutes(t))
-        .map(|mins| prost_types::Duration {
-            seconds: mins as i64 * 60,
-            nanos: 0,
-        });
-
-    // Build environment — pass CPU/GPU binding via env vars
-    let mut environment: HashMap<String, String> = std::env::vars().collect();
-    if let Some(ref cpu_bind) = args.cpu_bind {
-        environment.insert("SPUR_CPU_BIND".into(), cpu_bind.clone());
-    }
-    if let Some(ref gpu_bind) = args.gpu_bind {
-        environment.insert("SPUR_GPU_BIND".into(), gpu_bind.clone());
-    }
-    if args.label {
-        environment.insert("SPUR_LABEL".into(), "1".into());
-    }
-
-    let memory_mb = args
-        .mem
-        .as_ref()
-        .map(|m| parse_memory_mb(m))
-        .transpose()?
-        .unwrap_or(0);
-
-    // Submit as a batch job
-    let channel = spur_client::connect_channel(&args.controller)
-        .await
-        .context("failed to connect to spurctld")?;
-    let mut client = spur_proto::controller_client(channel);
-
-    let job_spec = JobSpec {
-        name,
-        partition: args.partition.unwrap_or_default(),
-        account: args.account.unwrap_or_default(),
-        user: whoami::username().unwrap_or_else(|_| "unknown".into()),
-        uid: nix::unistd::getuid().as_raw(),
-        gid: nix::unistd::getgid().as_raw(),
-        num_nodes: args.nodes,
-        num_tasks: args.ntasks,
-        cpus_per_task: args.cpus_per_task,
-        memory_per_node_mb: memory_mb,
-        gres,
-        script,
-        work_dir: work_dir.clone(),
-        stdout_path: io.stdout.clone(),
-        stderr_path: io.stderr.clone(),
-        stdin_path: io.stdin.clone(),
-        environment,
-        time_limit,
-        constraint: args.constraint.unwrap_or_default(),
-        nodelist: args.nodelist.unwrap_or_default(),
-        exclude: args.exclude.unwrap_or_default(),
-        reservation: args.reservation.unwrap_or_default(),
-        mpi: args.mpi,
-        container_image: args.container_image.unwrap_or_default(),
-        container_mounts: args.container_mounts,
-        container_workdir: args.container_workdir.unwrap_or_default(),
-        container_mount_home: args.container_mount_home,
-        container_env: args
-            .container_env
-            .iter()
-            .filter_map(|s| {
-                s.split_once('=')
-                    .map(|(k, v)| (k.to_string(), v.to_string()))
-            })
-            .collect(),
-        container_remap_root: args.container_remap_root,
-        ..Default::default()
-    };
-
-    let response = client
-        .submit_job(SubmitJobRequest {
-            spec: Some(job_spec),
-        })
-        .await
-        .context("job submission failed")?;
-
-    let job_id = response.into_inner().job_id;
-    let user = whoami::username().unwrap_or_else(|_| "unknown".into());
-    eprintln!("srun: job {} submitted, waiting for completion...", job_id);
-
-    // Set up Ctrl+C handler to cancel the job on interrupt
-    let cancel_client = client.clone();
-    let cancel_user = user.clone();
-    tokio::spawn(async move {
-        let mut cancel_client = cancel_client;
-        if tokio::signal::ctrl_c().await.is_ok() {
-            eprintln!("\nsrun: cancelling job {}...", job_id);
-            let _ = cancel_client
-                .cancel_job(CancelJobRequest {
-                    job_id,
-                    signal: 2, // SIGINT
-                    user: cancel_user,
-                })
-                .await;
-            std::process::exit(130); // Standard SIGINT exit code
-        }
-    });
-
-    // Wait for the job to start running
-    let mut poll_interval = tokio::time::interval(tokio::time::Duration::from_secs(1));
-    #[allow(unused_assignments)]
-    let mut nodelist = String::new();
-    let mut warned_unknown_state = false;
-
-    loop {
-        poll_interval.tick().await;
-
-        match client.get_job(GetJobRequest { job_id }).await {
-            Ok(resp) => {
-                let job = resp.into_inner();
-                match JobState::try_from(job.state) {
-                    Ok(JobState::JobRunning) => {
-                        nodelist = job.nodelist.clone();
-                        if !nodelist.is_empty() {
-                            eprintln!("srun: job {} running on {}", job_id, nodelist);
-                        }
-                        break;
-                    }
-                    Ok(
-                        state @ (JobState::JobCompleted
-                        | JobState::JobFailed
-                        | JobState::JobCancelled
-                        | JobState::JobTimeout
-                        | JobState::JobNodeFail
-                        | JobState::JobDeadline),
-                    ) => {
-                        handle_terminal_state(
-                            state,
-                            job_id,
-                            job.exit_code,
-                            &work_dir,
-                            &io.stdout,
-                            &hooks,
-                            false,
-                        )
-                        .await;
-                    }
-                    Ok(_) => {}
-                    Err(_) if !warned_unknown_state => {
-                        warned_unknown_state = true;
-                        eprintln!(
-                            "srun: warning: job {} has unrecognized state {} \
-                             (controller may be newer than client)",
-                            job_id, job.state
-                        );
-                    }
-                    Err(_) => {}
-                }
-            }
-            Err(e) => {
-                eprintln!("srun: warning: failed to get job status: {}", e.message());
-            }
-        }
-    }
-
-    // Stream output to terminal only when the user didn't ask for file output.
-    let output_streamed = if io.stdout.is_empty() {
-        try_stream_output(&mut client, &nodelist, job_id).await
-    } else {
-        false
-    };
-    poll_for_completion(
-        &mut client,
-        job_id,
-        &work_dir,
-        &io.stdout,
-        &hooks,
-        output_streamed,
-    )
-    .await;
-
-    Ok(())
+    run_standalone_srun(&args, &hooks, &work_dir).await
 }
 
 /// Apply environment-variable defaults to any flag not set on the command
@@ -560,8 +371,436 @@ fn resolve_srun_env(matches: &ArgMatches, args: &mut SrunArgs) -> Result<()> {
     Ok(())
 }
 
-/// Try to stream live output from the agent.
-/// Returns true if streaming connected and delivered output.
+struct ResolvedIoPaths {
+    stdout: String,
+    stderr: String,
+    stdin: String,
+}
+
+/// Resolve I/O paths from CLI args. When `-o` is set but `-e` is not,
+/// stderr follows stdout (Slurm default behavior).
+fn resolve_io_paths(args: &SrunArgs) -> ResolvedIoPaths {
+    let stdout = args.output.clone().unwrap_or_default();
+    let stderr = args.error.clone().unwrap_or_else(|| {
+        if stdout.is_empty() {
+            String::new()
+        } else {
+            stdout.clone()
+        }
+    });
+    let stdin = args.input.clone().unwrap_or_default();
+    ResolvedIoPaths {
+        stdout,
+        stderr,
+        stdin,
+    }
+}
+
+struct StepDispatchResult {
+    exit_code: i32,
+}
+
+fn srun_dispatch_environment(args: &SrunArgs) -> HashMap<String, String> {
+    let mut environment: HashMap<String, String> = std::env::vars().collect();
+    if let Some(ref cpu_bind) = args.cpu_bind {
+        environment.insert("SPUR_CPU_BIND".into(), cpu_bind.clone());
+    }
+    if let Some(ref gpu_bind) = args.gpu_bind {
+        environment.insert("SPUR_GPU_BIND".into(), gpu_bind.clone());
+    }
+    if args.label {
+        environment.insert("SPUR_LABEL".into(), "1".into());
+    }
+    environment
+}
+
+fn build_srun_job_spec(args: &SrunArgs, work_dir: &str, io: &ResolvedIoPaths) -> Result<JobSpec> {
+    let mut gres = args.gres.clone();
+    if let Some(gpus) = &args.gpus {
+        gres.push(format!("gpu:{}", gpus));
+    }
+
+    let time_limit = args
+        .time
+        .as_ref()
+        .and_then(|t| spur_core::config::parse_time_minutes(t))
+        .map(|mins| prost_types::Duration {
+            seconds: mins as i64 * 60,
+            nanos: 0,
+        });
+
+    let environment = srun_dispatch_environment(args);
+
+    let memory_mb = args
+        .mem
+        .as_ref()
+        .map(|m| parse_memory_mb(m))
+        .transpose()?
+        .unwrap_or(0);
+
+    Ok(JobSpec {
+        name: args
+            .job_name
+            .clone()
+            .unwrap_or_else(|| args.command[0].clone()),
+        partition: args.partition.clone().unwrap_or_default(),
+        account: args.account.clone().unwrap_or_default(),
+        user: whoami::username().unwrap_or_else(|_| "unknown".into()),
+        uid: nix::unistd::getuid().as_raw(),
+        gid: nix::unistd::getgid().as_raw(),
+        num_nodes: args.nodes,
+        num_tasks: args.ntasks,
+        cpus_per_task: args.cpus_per_task,
+        memory_per_node_mb: memory_mb,
+        gres,
+        script: build_command_script(&args.command)?,
+        work_dir: work_dir.to_string(),
+        stdout_path: io.stdout.clone(),
+        stderr_path: io.stderr.clone(),
+        stdin_path: io.stdin.clone(),
+        environment,
+        time_limit,
+        constraint: args.constraint.clone().unwrap_or_default(),
+        nodelist: args.nodelist.clone().unwrap_or_default(),
+        exclude: args.exclude.clone().unwrap_or_default(),
+        reservation: args.reservation.clone().unwrap_or_default(),
+        mpi: args.mpi.clone(),
+        licenses: args.licenses.clone(),
+        container_image: args.container_image.clone().unwrap_or_default(),
+        container_mounts: args.container_mounts.clone(),
+        container_workdir: args.container_workdir.clone().unwrap_or_default(),
+        container_mount_home: args.container_mount_home,
+        container_env: args
+            .container_env
+            .iter()
+            .filter_map(|s| {
+                s.split_once('=')
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+            })
+            .collect(),
+        container_remap_root: args.container_remap_root,
+        srun_job: true,
+        ..Default::default()
+    })
+}
+
+fn install_ctrl_c_cancel(
+    client: SlurmControllerClient<tonic::transport::Channel>,
+    job_id: u32,
+    user: String,
+) {
+    tokio::spawn(async move {
+        let mut client = client;
+        if tokio::signal::ctrl_c().await.is_ok() {
+            eprintln!("\nsrun: cancelling job {}...", job_id);
+            let _ = client
+                .cancel_job(CancelJobRequest {
+                    job_id,
+                    signal: 2,
+                    user,
+                })
+                .await;
+            std::process::exit(130);
+        }
+    });
+}
+
+async fn wait_for_job_running(
+    client: &mut SlurmControllerClient<tonic::transport::Channel>,
+    job_id: u32,
+) -> Result<String> {
+    let mut poll_interval = tokio::time::interval(tokio::time::Duration::from_secs(1));
+    let mut warned_unknown_state = false;
+
+    loop {
+        poll_interval.tick().await;
+        let job = client
+            .get_job(GetJobRequest { job_id })
+            .await
+            .context("failed to get job status")?
+            .into_inner();
+
+        match JobState::try_from(job.state) {
+            Ok(JobState::JobRunning) => return Ok(job.nodelist),
+            Ok(
+                JobState::JobCompleted
+                | JobState::JobFailed
+                | JobState::JobCancelled
+                | JobState::JobTimeout
+                | JobState::JobNodeFail
+                | JobState::JobDeadline,
+            ) => {
+                anyhow::bail!(
+                    "job {} reached terminal state before allocation was ready",
+                    job_id
+                );
+            }
+            Ok(_) => {}
+            Err(_) if !warned_unknown_state => {
+                warned_unknown_state = true;
+                eprintln!(
+                    "srun: warning: job {} has unrecognized state {} \
+                     (controller may be newer than client)",
+                    job_id, job.state
+                );
+            }
+            Err(_) => {}
+        }
+    }
+}
+
+async fn emit_step_output(
+    io: &ResolvedIoPaths,
+    job_id: u32,
+    work_dir: &str,
+    stdout: &str,
+    stderr: &str,
+) {
+    let stderr_appends = !io.stderr.is_empty() && io.stderr == io.stdout;
+
+    if !stdout.is_empty() {
+        if io.stdout.is_empty() {
+            print!("{stdout}");
+        } else {
+            write_step_file(stdout, &io.stdout, job_id, work_dir, false).await;
+        }
+    }
+    if !stderr.is_empty() {
+        if io.stderr.is_empty() {
+            eprint!("{stderr}");
+        } else {
+            write_step_file(stderr, &io.stderr, job_id, work_dir, stderr_appends).await;
+        }
+    }
+}
+
+async fn dispatch_step(
+    client: &mut SlurmControllerClient<tonic::transport::Channel>,
+    args: &SrunArgs,
+    job_id: u32,
+    work_dir: &str,
+    io: &ResolvedIoPaths,
+) -> Result<StepDispatchResult> {
+    let step_id = client
+        .create_job_step(CreateJobStepRequest {
+            job_id,
+            command: args.command.clone(),
+            num_tasks: args.ntasks,
+            cpus_per_task: args.cpus_per_task,
+        })
+        .await
+        .context("failed to create job step")?
+        .into_inner()
+        .step_id;
+
+    if args.input.is_some() {
+        eprintln!("srun: warning: --input is not supported in step mode, ignoring");
+    }
+
+    let environment = srun_dispatch_environment(args);
+    warn_unsupported_cpu_bind(&environment);
+    if let Some(err) = spur_core::task_launch::map_cpu_bind_error(&environment, args.ntasks) {
+        anyhow::bail!("{err}");
+    }
+    let resp = client
+        .run_step(RunStepRequest {
+            job_id,
+            command: args.command.clone(),
+            uid: nix::unistd::geteuid().as_raw(),
+            gid: nix::unistd::getegid().as_raw(),
+            work_dir: work_dir.to_string(),
+            environment,
+            step_id,
+            label: args.label,
+        })
+        .await
+        .context("RunStep dispatch failed")?
+        .into_inner();
+
+    if !resp.node.is_empty() {
+        eprintln!("srun: dispatched to node {}", resp.node);
+    }
+
+    emit_step_output(io, job_id, work_dir, &resp.stdout, &resp.stderr).await;
+
+    Ok(StepDispatchResult {
+        exit_code: resp.exit_code,
+    })
+}
+
+async fn release_srun_allocation(
+    client: &mut SlurmControllerClient<tonic::transport::Channel>,
+    job_id: u32,
+    user: &str,
+    exit_code: i32,
+) {
+    if let Err(e) = client
+        .complete_job(CompleteJobRequest {
+            job_id,
+            exit_code,
+            user: user.to_string(),
+        })
+        .await
+    {
+        eprintln!(
+            "srun: warning: failed to release allocation for job {}: {}",
+            job_id, e
+        );
+        if let Err(ce) = client
+            .cancel_job(CancelJobRequest {
+                job_id,
+                signal: 2,
+                user: user.to_string(),
+            })
+            .await
+        {
+            eprintln!(
+                "srun: warning: failed to cancel job {} after CompleteJob failure: {}",
+                job_id, ce
+            );
+        }
+    }
+}
+
+async fn dispatch_step_cancellable(
+    client: &mut SlurmControllerClient<tonic::transport::Channel>,
+    args: &SrunArgs,
+    job_id: u32,
+    user: &str,
+    work_dir: &str,
+    io: &ResolvedIoPaths,
+    cancel_job_on_interrupt: bool,
+) -> Result<StepDispatchResult> {
+    tokio::select! {
+        result = dispatch_step(client, args, job_id, work_dir, io) => result,
+        _ = tokio::signal::ctrl_c() => {
+            if cancel_job_on_interrupt {
+                eprintln!("\nsrun: cancelling job {}...", job_id);
+                let _ = client
+                    .cancel_job(CancelJobRequest {
+                        job_id,
+                        signal: 2,
+                        user: user.to_string(),
+                    })
+                    .await;
+            } else {
+                eprintln!("\nsrun: step interrupted");
+            }
+            std::process::exit(130);
+        }
+    }
+}
+
+async fn run_standalone_srun(args: &SrunArgs, hooks: &HooksConfig, work_dir: &str) -> Result<()> {
+    let io = resolve_io_paths(args);
+    let channel = spur_client::connect_channel(&args.controller)
+        .await
+        .context("failed to connect to spurctld")?;
+    let mut client = SlurmControllerClient::new(channel);
+    let user = whoami::username().unwrap_or_else(|_| "unknown".into());
+
+    let job_spec = build_srun_job_spec(args, work_dir, &io)?;
+    let job_id = client
+        .submit_job(SubmitJobRequest {
+            spec: Some(job_spec),
+        })
+        .await
+        .context("job submission failed")?
+        .into_inner()
+        .job_id;
+
+    eprintln!("srun: Pending job allocation {}...", job_id);
+
+    let nodelist = wait_for_job_running(&mut client, job_id).await?;
+    if !nodelist.is_empty() {
+        eprintln!("srun: job {} running on {}", job_id, nodelist);
+    }
+
+    let job = client
+        .get_job(GetJobRequest { job_id })
+        .await
+        .context("failed to get job after allocation")?
+        .into_inner();
+
+    if job.srun_step_dispatch {
+        let dispatch_result =
+            dispatch_step_cancellable(&mut client, args, job_id, &user, work_dir, &io, true).await;
+        let exit_code = match &dispatch_result {
+            Ok(result) => result.exit_code,
+            Err(_) => 1,
+        };
+        release_srun_allocation(&mut client, job_id, &user, exit_code).await;
+        let result = dispatch_result?;
+        let state = if result.exit_code == 0 {
+            JobState::JobCompleted
+        } else {
+            JobState::JobFailed
+        };
+        handle_terminal_state(
+            state,
+            job_id,
+            result.exit_code,
+            work_dir,
+            &io.stdout,
+            hooks,
+            true,
+        )
+        .await;
+    }
+
+    install_ctrl_c_cancel(client.clone(), job_id, user.clone());
+
+    let output_streamed = if io.stdout.is_empty() {
+        try_stream_output(&mut client, &nodelist, job_id).await
+    } else {
+        false
+    };
+    poll_for_completion(
+        &mut client,
+        job_id,
+        work_dir,
+        &io.stdout,
+        hooks,
+        output_streamed,
+    )
+    .await;
+
+    Ok(())
+}
+
+/// Client-side output path resolution, mirroring the agent's logic.
+fn resolve_output_path_client(pattern: &str, job_id: u32, work_dir: &str) -> String {
+    let resolved = if pattern.is_empty() {
+        format!("spur-{}.out", job_id)
+    } else {
+        pattern
+            .replace("%j", &job_id.to_string())
+            .replace("%J", &job_id.to_string())
+    };
+
+    if std::path::Path::new(&resolved).is_absolute() {
+        resolved
+    } else {
+        std::path::PathBuf::from(work_dir)
+            .join(resolved)
+            .to_string_lossy()
+            .into()
+    }
+}
+
+/// Wrap the command argv in a bash script for batch submission.
+///
+/// Each argv element is shell-escaped so metacharacters (spaces, quotes, `;`,
+/// `>`, `$`, globs) stay literal arguments instead of being reinterpreted by
+/// the wrapper shell. This matches Slurm's semantics, where `srun` execs the
+/// argv directly with no shell: `srun touch "my file"` creates one file, and
+/// `srun bash -c 'a; b'` passes the whole script as a single `-c` argument.
+fn build_command_script(command: &[String]) -> Result<String> {
+    let cmd_line = shlex::try_join(command.iter().map(String::as_str))
+        .context("command contains a NUL byte and cannot be run")?;
+    Ok(format!("#!/bin/bash\n{cmd_line}\n"))
+}
+
 async fn try_stream_output(
     controller: &mut SlurmControllerClient<tonic::transport::Channel>,
     nodelist: &str,
@@ -582,7 +821,7 @@ async fn try_stream_output(
         return false;
     }
 
-    let agent_addr = format!("http://{}:6818", first_node);
+    let agent_addr = format!("http://{first_node}:6818");
 
     let mut agent = match SlurmAgentClient::connect(agent_addr).await {
         Ok(c) => c
@@ -619,7 +858,6 @@ async fn try_stream_output(
     }
 }
 
-/// Poll-based fallback for agents that don't support streaming.
 async fn poll_for_completion(
     client: &mut SlurmControllerClient<tonic::transport::Channel>,
     job_id: u32,
@@ -683,7 +921,6 @@ async fn handle_terminal_state(
     hooks: &HooksConfig,
     output_streamed: bool,
 ) -> ! {
-    // SrunEpilog: run locally after job reaches terminal state
     if let Some(ref srun_epilog) = hooks.srun_epilog {
         let ctx = srun_hook_context("epilog_srun", work_dir);
         if let Err(e) = spur_core::hooks::run_hook(srun_epilog, &ctx).await {
@@ -730,73 +967,14 @@ async fn handle_terminal_state(
     }
 }
 
-/// Print job output file to stdout (best-effort).
 async fn print_job_output(work_dir: &str, stdout_path: &str, job_id: u32) {
     let path = resolve_output_path_client(stdout_path, job_id, work_dir);
     if let Ok(content) = tokio::fs::read_to_string(&path).await {
-        print!("{}", content);
+        print!("{content}");
     }
 }
 
-/// Client-side output path resolution, mirroring the agent's logic.
-fn resolve_output_path_client(pattern: &str, job_id: u32, work_dir: &str) -> String {
-    let resolved = if pattern.is_empty() {
-        format!("spur-{}.out", job_id)
-    } else {
-        pattern
-            .replace("%j", &job_id.to_string())
-            .replace("%J", &job_id.to_string())
-    };
-
-    if std::path::Path::new(&resolved).is_absolute() {
-        resolved
-    } else {
-        std::path::PathBuf::from(work_dir)
-            .join(resolved)
-            .to_string_lossy()
-            .into()
-    }
-}
-
-struct ResolvedIoPaths {
-    stdout: String,
-    stderr: String,
-    stdin: String,
-}
-
-/// Wrap the command argv in a bash script for batch submission.
-///
-/// Each argv element is shell-escaped so metacharacters (spaces, quotes, `;`,
-/// `>`, `$`, globs) stay literal arguments instead of being reinterpreted by
-/// the wrapper shell. This matches Slurm's semantics, where `srun` execs the
-/// argv directly with no shell: `srun touch "my file"` creates one file, and
-/// `srun bash -c 'a; b'` passes the whole script as a single `-c` argument.
-fn build_command_script(command: &[String]) -> Result<String> {
-    let cmd_line = shlex::try_join(command.iter().map(String::as_str))
-        .context("command contains a NUL byte and cannot be run")?;
-    Ok(format!("#!/bin/bash\n{}\n", cmd_line))
-}
-
-/// Resolve I/O paths from CLI args. When `-o` is set but `-e` is not,
-/// stderr follows stdout (Slurm default behavior).
-fn resolve_io_paths(args: &SrunArgs) -> ResolvedIoPaths {
-    let stdout = args.output.clone().unwrap_or_default();
-    let stderr = args.error.clone().unwrap_or_else(|| {
-        if stdout.is_empty() {
-            String::new()
-        } else {
-            stdout.clone()
-        }
-    });
-    let stdin = args.input.clone().unwrap_or_default();
-    ResolvedIoPaths {
-        stdout,
-        stderr,
-        stdin,
-    }
-}
-
-/// Write step output to a file, used by `run_as_step` for both stdout and stderr.
+/// Write step output to a file, used by step dispatch for stdout and stderr.
 async fn write_step_file(content: &str, pattern: &str, job_id: u32, work_dir: &str, append: bool) {
     let resolved = resolve_output_path_client(pattern, job_id, work_dir);
     if let Some(parent) = std::path::Path::new(&resolved).parent() {
@@ -823,92 +1001,48 @@ async fn write_step_file(content: &str, pattern: &str, job_id: u32, work_dir: &s
 
 /// When srun runs inside an allocation (SPUR_JOB_ID is set, e.g. inside an
 /// `salloc` interactive shell or sbatch script on the submit host), it
-/// dispatches the command to one of the allocation's nodes via the
-/// controller's RunStep RPC. The controller picks an allocated node and
-/// forwards to that agent's RunCommand RPC.
-///
-/// Closes #146 — previously this ran the command locally, so `srun hostname`
-/// inside `salloc` printed the controller's hostname instead of the
-/// allocated compute node's.
+/// dispatches the command to the allocation's nodes via the controller's
+/// RunStep RPC, which fans out to each agent's RunCommand RPC.
+fn warn_unsupported_cpu_bind(environment: &HashMap<String, String>) {
+    if let Some(cpu_bind) = spur_core::task_launch::unsupported_cpu_bind(environment) {
+        eprintln!(
+            "srun: warning: --cpu-bind={cpu_bind} is not applied in step mode \
+             (supported: rank, map_cpu, mask_cpu)"
+        );
+    }
+}
+
 async fn run_as_step(
     args: &SrunArgs,
     job_id: u32,
     hooks: &HooksConfig,
     work_dir: &str,
 ) -> Result<()> {
-    use spur_proto::proto::RunStepRequest;
-
     let channel = spur_client::connect_channel(&args.controller)
         .await
         .context("failed to connect to spurctld")?;
-    let mut client = spur_proto::controller_client(channel);
-
-    // Create a step on the controller for tracking; capture the assigned
-    // step_id so the completion (and thus DerivedExitCode) records against it.
-    let step_id = client
-        .create_job_step(CreateJobStepRequest {
-            job_id,
-            command: args.command.clone(),
-            num_tasks: args.ntasks,
-            cpus_per_task: args.cpus_per_task,
-        })
-        .await
-        .context("failed to create job step")?
-        .into_inner()
-        .step_id;
-
-    if args.input.is_some() {
-        eprintln!("srun: warning: --input is not supported in step mode, ignoring");
-    }
-
+    let mut client = SlurmControllerClient::new(channel);
     let io = resolve_io_paths(args);
+    let user = whoami::username().unwrap_or_else(|_| "unknown".into());
 
-    let env: std::collections::HashMap<String, String> = std::env::vars().collect();
+    let dispatch_result =
+        dispatch_step_cancellable(&mut client, args, job_id, &user, work_dir, &io, false).await?;
 
-    let resp = client
-        .run_step(RunStepRequest {
-            job_id,
-            command: args.command.clone(),
-            uid: nix::unistd::geteuid().as_raw(),
-            gid: nix::unistd::getegid().as_raw(),
-            work_dir: work_dir.to_string(),
-            environment: env,
-            step_id,
-        })
-        .await
-        .context("RunStep dispatch failed")?
-        .into_inner();
-
-    if !resp.node.is_empty() {
-        eprintln!("srun: dispatched to node {}", resp.node);
-    }
-
-    let stderr_appends = !io.stderr.is_empty() && io.stderr == io.stdout;
-
-    if !resp.stdout.is_empty() {
-        if io.stdout.is_empty() {
-            print!("{}", resp.stdout);
-        } else {
-            write_step_file(&resp.stdout, &io.stdout, job_id, work_dir, false).await;
-        }
-    }
-    if !resp.stderr.is_empty() {
-        if io.stderr.is_empty() {
-            eprint!("{}", resp.stderr);
-        } else {
-            write_step_file(&resp.stderr, &io.stderr, job_id, work_dir, stderr_appends).await;
-        }
-    }
-
-    // SrunEpilog: run locally after step completes (failure logged only)
-    if let Some(ref srun_epilog) = hooks.srun_epilog {
-        let ctx = srun_hook_context("epilog_srun", work_dir);
-        if let Err(e) = spur_core::hooks::run_hook(srun_epilog, &ctx).await {
-            eprintln!("srun: warning: SrunEpilog failed: {}", e);
-        }
-    }
-
-    std::process::exit(resp.exit_code);
+    let state = if dispatch_result.exit_code == 0 {
+        JobState::JobCompleted
+    } else {
+        JobState::JobFailed
+    };
+    handle_terminal_state(
+        state,
+        job_id,
+        dispatch_result.exit_code,
+        work_dir,
+        &io.stdout,
+        hooks,
+        true,
+    )
+    .await;
 }
 
 fn parse_memory_mb(s: &str) -> Result<u64> {
@@ -1099,6 +1233,24 @@ mod tests {
             .trim_end();
         let reparsed = shlex::split(body).expect("generated script must be shell-parseable");
         assert_eq!(reparsed, command, "argv did not round-trip: {body:?}");
+    }
+
+    #[test]
+    fn build_srun_job_spec_sets_srun_job_and_command_script() {
+        let args =
+            SrunArgs::try_parse_from(["srun", "-N", "2", "-n", "4", "hostname"]).expect("parse");
+        let io = ResolvedIoPaths {
+            stdout: String::new(),
+            stderr: String::new(),
+            stdin: String::new(),
+        };
+        let spec = build_srun_job_spec(&args, "/tmp/work", &io).expect("spec");
+        assert!(spec.srun_job);
+        assert_eq!(spec.num_nodes, 2);
+        assert_eq!(spec.num_tasks, 4);
+        assert_eq!(spec.work_dir, "/tmp/work");
+        assert!(spec.script.starts_with("#!/bin/bash\n"));
+        assert!(spec.script.contains("hostname"));
     }
 
     #[test]

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -424,6 +424,10 @@ pub struct JobSpec {
     pub exclusive: bool,
     pub hold: bool,
     pub interactive: bool,
+    /// Standalone srun: reserve nodes without a batch script; user command
+    /// runs as a job step after allocation.
+    #[serde(default)]
+    pub srun_job: bool,
     pub mail_type: Vec<String>,
     pub mail_user: Option<String>,
     pub comment: Option<String>,
@@ -517,6 +521,7 @@ impl Default for JobSpec {
             exclusive: false,
             hold: false,
             interactive: false,
+            srun_job: false,
             mail_type: Vec::new(),
             mail_user: None,
             comment: None,
@@ -632,6 +637,10 @@ pub struct Job {
     #[serde(default)]
     pub node_completions: HashMap<String, NodeCompletion>,
 
+    /// Standalone srun: native step dispatch after allocation registration.
+    #[serde(default)]
+    pub srun_step_dispatch: bool,
+
     /// Wall-clock instant the job entered Suspended (None unless currently suspended).
     #[serde(default)]
     pub suspended_at: Option<DateTime<Utc>>,
@@ -686,6 +695,7 @@ impl Job {
             suspended_at: None,
             suspended_secs: 0,
             bb_stage_state: BbStageState::None,
+            srun_step_dispatch: false,
         }
     }
 

--- a/crates/spur-core/src/lib.rs
+++ b/crates/spur-core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod job;
 pub mod k0s;
 pub mod node;
 pub mod partition;
+pub mod process;
 pub mod qos;
 pub mod reservation;
 pub mod resource;

--- a/crates/spur-core/src/lib.rs
+++ b/crates/spur-core/src/lib.rs
@@ -20,6 +20,7 @@ pub mod reservation;
 pub mod resource;
 pub mod spur_env;
 pub mod step;
+pub mod task_launch;
 pub mod topology;
 pub mod version;
 pub mod wal;

--- a/crates/spur-core/src/process.rs
+++ b/crates/spur-core/src/process.rs
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Exit code suitable for shell / srun step return: normal exit status, or `128 + signal` when signaled.
+pub fn shell_exit_code(status: &std::process::ExitStatus) -> i32 {
+    if let Some(code) = status.code() {
+        return code;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        status.signal().map(|s| 128 + s).unwrap_or(-1)
+    }
+    #[cfg(not(unix))]
+    {
+        -1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    #[test]
+    fn shell_exit_code_returns_process_status() {
+        let status = Command::new("true").status().unwrap();
+        assert_eq!(shell_exit_code(&status), 0);
+
+        let status = Command::new("false").status().unwrap();
+        assert_eq!(shell_exit_code(&status), 1);
+    }
+}

--- a/crates/spur-core/src/spur_env.rs
+++ b/crates/spur-core/src/spur_env.rs
@@ -64,6 +64,47 @@ impl SpurEnv {
             "  export SLURM_PROCID=$((SPUR_TASK_OFFSET + LOCAL_RANK))\n",
         )
     }
+
+    /// Step-scoped variables shared by every task in an srun step.
+    pub fn apply_step_scope(
+        senv: &mut SpurEnv,
+        job_id: u32,
+        step_id: u32,
+        step_num_tasks: u32,
+        node_id: u32,
+        num_nodes: u32,
+    ) {
+        senv.set_with_slurm_twin("SPUR_STEP_ID", step_id);
+        senv.set_with_slurm_twin("SPUR_STEPID", step_id);
+        senv.set_with_slurm_twin("SPUR_STEP_NUM_TASKS", step_num_tasks);
+        senv.set_with_slurm_twin("SPUR_NTASKS", step_num_tasks);
+        senv.set_with_slurm_twin("SPUR_NPROCS", step_num_tasks);
+        senv.set_with_slurm_twin("SPUR_NODEID", node_id);
+        senv.set_with_slurm_twin("SPUR_NNODES", num_nodes);
+        senv.set_with_slurm_twin("SPUR_JOB_NUM_NODES", num_nodes);
+        senv.set_with_slurm_twin("SPUR_JOB_ID", job_id);
+        senv.set_with_slurm_twin("SPUR_JOBID", job_id);
+    }
+
+    /// Per-task rank variables for a single-process step or batch launch.
+    pub fn apply_task_rank(
+        senv: &mut SpurEnv,
+        task_offset: u32,
+        local_rank: u32,
+        tasks_on_node: u32,
+    ) {
+        let procid = task_offset + local_rank;
+        senv.set("SPUR_TASK_OFFSET", task_offset);
+        senv.set("LOCAL_RANK", local_rank);
+        senv.set("LOCAL_WORLD_SIZE", tasks_on_node);
+        senv.set("NPROC_PER_NODE", tasks_on_node);
+        senv.set_with_slurm_twin("SPUR_LOCALID", local_rank);
+        senv.set_with_slurm_twin("SPUR_PROCID", procid);
+        senv.set("PMI_RANK", procid);
+        senv.set("PMIX_RANK", procid);
+        senv.set("OMPI_COMM_WORLD_RANK", procid);
+        senv.set("OMPI_COMM_WORLD_LOCAL_RANK", local_rank);
+    }
 }
 
 impl Default for SpurEnv {
@@ -159,5 +200,29 @@ mod tests {
         assert!(exports.contains("SLURM_LOCALID"));
         assert!(exports.contains("SPUR_PROCID"));
         assert!(exports.contains("SLURM_PROCID"));
+    }
+
+    #[test]
+    fn apply_task_rank_sets_procid_twins() {
+        let mut env = SpurEnv::new();
+        SpurEnv::apply_task_rank(&mut env, 1, 0, 1);
+        let map = env.into_map();
+        assert_eq!(map["SPUR_PROCID"], "1");
+        assert_eq!(map["SLURM_PROCID"], "1");
+        assert_eq!(map["SPUR_LOCALID"], "0");
+        assert_eq!(map["SLURM_LOCALID"], "0");
+    }
+
+    #[test]
+    fn apply_step_scope_sets_step_id_twins() {
+        let mut env = SpurEnv::new();
+        SpurEnv::apply_step_scope(&mut env, 42, 3, 8, 1, 2);
+        let map = env.into_map();
+        assert_eq!(map["SPUR_STEP_ID"], "3");
+        assert_eq!(map["SLURM_STEP_ID"], "3");
+        assert_eq!(map["SPUR_NTASKS"], "8");
+        assert_eq!(map["SLURM_NTASKS"], "8");
+        assert_eq!(map["SPUR_NODEID"], "1");
+        assert_eq!(map["SPUR_NNODES"], "2");
     }
 }

--- a/crates/spur-core/src/task_launch.rs
+++ b/crates/spur-core/src/task_launch.rs
@@ -159,7 +159,7 @@ fn cpu_bind_bash_prefix(bind: &CpuBind, map_cpus: &[&str]) -> String {
             )
         }
         CpuBind::Map(_) => String::new(),
-        CpuBind::Mask(mask) => format!("taskset -m {mask} "),
+        CpuBind::Mask(mask) => format!("taskset {mask} "),
         CpuBind::None | CpuBind::Cores | CpuBind::Threads | CpuBind::Sockets | CpuBind::Ldoms => {
             String::new()
         }
@@ -199,8 +199,7 @@ pub fn wrap_command_with_cpu_bind(
         }
         CpuBind::Mask(mask) => (
             "taskset".into(),
-            std::iter::once("-m".to_string())
-                .chain(std::iter::once(mask))
+            std::iter::once(mask)
                 .chain(std::iter::once(program.to_string()))
                 .chain(args.iter().cloned())
                 .collect(),
@@ -267,6 +266,26 @@ pub fn build_multi_task_wrapper(
     wrapper.push_str("  fi\n");
     wrapper.push_str("done\nwait\n");
     wrapper
+}
+
+/// Bash wrapper for a single labeled task (one task per node in fan-out steps).
+pub fn build_labeled_single_task_wrapper(
+    user_script_path: &str,
+    procid: u32,
+    environment: Option<&HashMap<String, String>>,
+) -> String {
+    let escaped = user_script_path.replace('"', "\\\"");
+    let bind = environment.map(parse_cpu_bind).unwrap_or(CpuBind::None);
+    let map_cpus: Vec<&str> = match &bind {
+        CpuBind::Map(list) => list
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .collect(),
+        _ => Vec::new(),
+    };
+    let taskset_prefix = cpu_bind_bash_prefix(&bind, &map_cpus);
+    format!("#!/bin/bash\n{taskset_prefix}bash \"{escaped}\" 2>&1 | sed \"s/^/[{procid}] /\"\n")
 }
 
 #[cfg(test)]
@@ -398,6 +417,21 @@ mod tests {
         let (program, args) = wrap_command_with_cpu_bind("hostname", &[], &env, 1);
         assert_eq!(program, "taskset");
         assert_eq!(args, vec!["-c", "4", "hostname"]);
+    }
+
+    #[test]
+    fn wrap_command_with_cpu_bind_mask_uses_hex_mask() {
+        let mut env = HashMap::new();
+        env.insert("SPUR_CPU_BIND".into(), "mask_cpu:0x3".into());
+        let (program, args) = wrap_command_with_cpu_bind("hostname", &[], &env, 0);
+        assert_eq!(program, "taskset");
+        assert_eq!(args, vec!["0x3", "hostname"]);
+    }
+
+    #[test]
+    fn labeled_single_task_wrapper_applies_sed_prefix() {
+        let script = build_labeled_single_task_wrapper("/tmp/step.sh", 4, None);
+        assert!(script.contains("sed \"s/^/[4] /\""));
     }
 
     #[test]

--- a/crates/spur-core/src/task_launch.rs
+++ b/crates/spur-core/src/task_launch.rs
@@ -1,0 +1,411 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared helpers for multi-task and multi-node step launch.
+//!
+//! Used by batch `launch_job` and srun step dispatch on agents.
+
+use std::collections::HashMap;
+
+use crate::spur_env::SpurEnv;
+use crate::step::{distribute_tasks, CpuBind, GpuBind, TaskDistribution};
+
+/// Per-node task launch parameters derived from a step's task distribution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeStepTasks {
+    pub node_index: u32,
+    pub task_offset: u32,
+    pub tasks_on_node: u32,
+}
+
+/// Compute how many tasks each node runs and the global rank offset of the
+/// first task on that node.
+pub fn build_step_task_plan(
+    num_tasks: u32,
+    num_nodes: u32,
+    distribution: TaskDistribution,
+) -> Vec<NodeStepTasks> {
+    if num_tasks == 0 {
+        return Vec::new();
+    }
+
+    let num_nodes = num_nodes.max(1);
+    let mapping = distribute_tasks(num_tasks, num_nodes, distribution);
+    let mut plan = Vec::new();
+
+    for node_index in 0..num_nodes {
+        let task_ids: Vec<u32> = mapping
+            .iter()
+            .enumerate()
+            .filter(|(_, node)| **node == node_index)
+            .map(|(task_id, _)| task_id as u32)
+            .collect();
+        if task_ids.is_empty() {
+            continue;
+        }
+        plan.push(NodeStepTasks {
+            node_index,
+            task_offset: task_ids[0],
+            tasks_on_node: task_ids.len() as u32,
+        });
+    }
+
+    plan
+}
+
+/// Apply GPU bind directives from the request environment into step launch env.
+///
+/// Honors `map_gpu` / `mask_gpu` overrides. `closest` and `none` keep the
+/// controller-assigned device list.
+pub fn apply_gpu_bind_env(
+    target: &mut HashMap<String, String>,
+    source: &HashMap<String, String>,
+    allocated: &[u32],
+) {
+    let Some(bind_str) = source
+        .get("SPUR_GPU_BIND")
+        .or_else(|| source.get("SLURM_GPU_BIND"))
+    else {
+        return;
+    };
+    let bind = bind_str.parse::<GpuBind>().unwrap_or(GpuBind::None);
+    let visible = match bind {
+        GpuBind::Map(ids) => ids,
+        GpuBind::Mask(mask) => mask,
+        GpuBind::Closest | GpuBind::None => allocated
+            .iter()
+            .map(|id| id.to_string())
+            .collect::<Vec<_>>()
+            .join(","),
+    };
+    if visible.is_empty() {
+        return;
+    }
+    target.insert("SPUR_JOB_GPUS".into(), visible.clone());
+    target.insert("ROCR_VISIBLE_DEVICES".into(), visible.clone());
+    target.insert("CUDA_VISIBLE_DEVICES".into(), visible.clone());
+    target.insert("GPU_DEVICE_ORDINAL".into(), visible);
+}
+
+/// Return the CPU bind string when step mode cannot enforce topology-based binds.
+pub fn unsupported_cpu_bind(source: &HashMap<String, String>) -> Option<String> {
+    let bind_str = source
+        .get("SPUR_CPU_BIND")
+        .or_else(|| source.get("SLURM_CPU_BIND"))?;
+    if bind_str.eq_ignore_ascii_case("none") || bind_str.is_empty() {
+        return None;
+    }
+    let bind = bind_str.parse::<CpuBind>().unwrap_or(CpuBind::None);
+    match bind {
+        CpuBind::Cores | CpuBind::Threads | CpuBind::Sockets | CpuBind::Ldoms => {
+            Some(bind_str.clone())
+        }
+        CpuBind::None | CpuBind::Rank | CpuBind::Map(_) | CpuBind::Mask(_) => None,
+    }
+}
+
+fn parse_cpu_bind(source: &HashMap<String, String>) -> CpuBind {
+    source
+        .get("SPUR_CPU_BIND")
+        .or_else(|| source.get("SLURM_CPU_BIND"))
+        .map(|s| s.parse().unwrap_or(CpuBind::None))
+        .unwrap_or(CpuBind::None)
+}
+
+fn parse_map_cpu_list(list: &str) -> Vec<String> {
+    list.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// Returns an error message when `map_cpu` lists fewer CPUs than `num_tasks`.
+pub fn map_cpu_bind_error(source: &HashMap<String, String>, num_tasks: u32) -> Option<String> {
+    if num_tasks == 0 {
+        return None;
+    }
+    let bind = parse_cpu_bind(source);
+    let CpuBind::Map(list) = bind else {
+        return None;
+    };
+    let cpus = parse_map_cpu_list(&list);
+    let need = num_tasks as usize;
+    if cpus.len() < need {
+        Some(format!(
+            "map_cpu lists {} CPU(s) but the step requires {} task(s)",
+            cpus.len(),
+            need
+        ))
+    } else {
+        None
+    }
+}
+
+/// Bash prefix that pins a task to CPUs per `map_cpu`, `mask_cpu`, or `rank`.
+fn cpu_bind_bash_prefix(bind: &CpuBind, map_cpus: &[&str]) -> String {
+    match bind {
+        CpuBind::Rank => "taskset -c $((SPUR_TASK_OFFSET + LOCAL_RANK)) ".to_string(),
+        CpuBind::Map(_) if !map_cpus.is_empty() => {
+            let entries = map_cpus.join(" ");
+            format!(
+                "_CPU_MAP=({entries})\n  \
+                 _CPU_IDX=$((SPUR_TASK_OFFSET + LOCAL_RANK))\n  \
+                 if [ \"$_CPU_IDX\" -ge ${{#_CPU_MAP[@]}} ]; then\n    \
+                   echo \"map_cpu: rank $_CPU_IDX exceeds CPU map (len ${{#_CPU_MAP[@]}})\" >&2\n    \
+                   exit 1\n  \
+                 fi\n  \
+                 taskset -c ${{_CPU_MAP[$_CPU_IDX]}} "
+            )
+        }
+        CpuBind::Map(_) => String::new(),
+        CpuBind::Mask(mask) => format!("taskset -m {mask} "),
+        CpuBind::None | CpuBind::Cores | CpuBind::Threads | CpuBind::Sockets | CpuBind::Ldoms => {
+            String::new()
+        }
+    }
+}
+
+/// Prefix argv with `taskset` when an explicit CPU bind applies to one task.
+pub fn wrap_command_with_cpu_bind(
+    program: &str,
+    args: &[String],
+    source: &HashMap<String, String>,
+    global_rank: u32,
+) -> (String, Vec<String>) {
+    let bind = parse_cpu_bind(source);
+    match bind {
+        CpuBind::Rank => (
+            "taskset".into(),
+            std::iter::once("-c".to_string())
+                .chain(std::iter::once(global_rank.to_string()))
+                .chain(std::iter::once(program.to_string()))
+                .chain(args.iter().cloned())
+                .collect(),
+        ),
+        CpuBind::Map(list) => {
+            let cpus = parse_map_cpu_list(&list);
+            let Some(cpu) = cpus.get(global_rank as usize) else {
+                return (program.to_string(), args.to_vec());
+            };
+            (
+                "taskset".into(),
+                std::iter::once("-c".to_string())
+                    .chain(std::iter::once(cpu.clone()))
+                    .chain(std::iter::once(program.to_string()))
+                    .chain(args.iter().cloned())
+                    .collect(),
+            )
+        }
+        CpuBind::Mask(mask) => (
+            "taskset".into(),
+            std::iter::once("-m".to_string())
+                .chain(std::iter::once(mask))
+                .chain(std::iter::once(program.to_string()))
+                .chain(args.iter().cloned())
+                .collect(),
+        ),
+        CpuBind::None | CpuBind::Cores | CpuBind::Threads | CpuBind::Sockets | CpuBind::Ldoms => {
+            (program.to_string(), args.to_vec())
+        }
+    }
+}
+
+/// Build a bash wrapper that forks `tasks_on_node` copies of `user_script_path`,
+/// assigning distinct `LOCAL_RANK` / `SLURM_PROCID` values in each fork.
+///
+/// Output labeling is controlled at runtime via the `SPUR_LABEL=1` environment
+/// variable (matching batch `launch_job` and srun `-l`).
+pub fn build_multi_task_wrapper(
+    user_script_path: &str,
+    tasks_on_node: u32,
+    environment: Option<&HashMap<String, String>>,
+) -> String {
+    let escaped = user_script_path.replace('"', "\\\"");
+    let bind = environment.map(parse_cpu_bind).unwrap_or(CpuBind::None);
+    let map_cpus: Vec<&str> = match &bind {
+        CpuBind::Map(list) => list
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .collect(),
+        _ => Vec::new(),
+    };
+    let taskset_prefix = cpu_bind_bash_prefix(&bind, &map_cpus);
+    let mut wrapper = String::from("#!/bin/bash\n");
+    wrapper.push_str(&format!(
+        "_TASKS_ON_NODE={tasks_on_node}\nSPUR_TASK_OFFSET=${{SPUR_TASK_OFFSET:-0}}\n"
+    ));
+    wrapper.push_str("for LOCAL_RANK in $(seq 0 $((_TASKS_ON_NODE - 1))); do\n");
+    wrapper.push_str("  export LOCAL_RANK\n");
+    wrapper.push_str(SpurEnv::per_task_bash_exports());
+    wrapper.push_str("  export PMI_RANK=$SPUR_PROCID\n");
+    wrapper.push_str("  export PMIX_RANK=$SPUR_PROCID\n");
+    wrapper.push_str("  export OMPI_COMM_WORLD_RANK=$SPUR_PROCID\n");
+    wrapper.push_str("  export OMPI_COMM_WORLD_LOCAL_RANK=$LOCAL_RANK\n");
+
+    wrapper.push_str("  if [ -n \"$SPUR_JOB_GPUS\" ]; then\n");
+    wrapper.push_str("    IFS=',' read -ra _ALL_GPUS <<< \"$SPUR_JOB_GPUS\"\n");
+    wrapper.push_str("    _GPUS_PER_TASK=$(( ${#_ALL_GPUS[@]} / _TASKS_ON_NODE ))\n");
+    wrapper.push_str("    if [ $_GPUS_PER_TASK -gt 0 ]; then\n");
+    wrapper.push_str("      _START=$((LOCAL_RANK * _GPUS_PER_TASK))\n");
+    wrapper.push_str(
+        "      _TASK_GPUS=$(echo \"${_ALL_GPUS[@]:$_START:$_GPUS_PER_TASK}\" | tr ' ' ',')\n",
+    );
+    wrapper.push_str("      export ROCR_VISIBLE_DEVICES=$_TASK_GPUS\n");
+    wrapper.push_str("      export CUDA_VISIBLE_DEVICES=$_TASK_GPUS\n");
+    wrapper.push_str("      export GPU_DEVICE_ORDINAL=$_TASK_GPUS\n");
+    wrapper.push_str("    fi\n");
+    wrapper.push_str("  fi\n");
+
+    wrapper.push_str("  if [ \"$SPUR_LABEL\" = \"1\" ]; then\n");
+    wrapper.push_str(&format!(
+        "    {taskset_prefix}bash \"{escaped}\" 2>&1 | sed \"s/^/[$SPUR_PROCID] /\" &\n"
+    ));
+    wrapper.push_str("  else\n");
+    wrapper.push_str(&format!("    {taskset_prefix}bash \"{escaped}\" &\n"));
+    wrapper.push_str("  fi\n");
+    wrapper.push_str("done\nwait\n");
+    wrapper
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn step_plan_one_task_per_node() {
+        let plan = build_step_task_plan(2, 2, TaskDistribution::Block);
+        assert_eq!(
+            plan,
+            vec![
+                NodeStepTasks {
+                    node_index: 0,
+                    task_offset: 0,
+                    tasks_on_node: 1,
+                },
+                NodeStepTasks {
+                    node_index: 1,
+                    task_offset: 1,
+                    tasks_on_node: 1,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn step_plan_two_tasks_per_node() {
+        let plan = build_step_task_plan(4, 2, TaskDistribution::Block);
+        assert_eq!(
+            plan,
+            vec![
+                NodeStepTasks {
+                    node_index: 0,
+                    task_offset: 0,
+                    tasks_on_node: 2,
+                },
+                NodeStepTasks {
+                    node_index: 1,
+                    task_offset: 2,
+                    tasks_on_node: 2,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn step_plan_single_node_multi_task() {
+        let plan = build_step_task_plan(4, 1, TaskDistribution::Block);
+        assert_eq!(
+            plan,
+            vec![NodeStepTasks {
+                node_index: 0,
+                task_offset: 0,
+                tasks_on_node: 4,
+            }]
+        );
+    }
+
+    #[test]
+    fn multi_task_wrapper_exports_procid() {
+        let script = build_multi_task_wrapper("/tmp/work.sh", 2, None);
+        assert!(script.contains("SPUR_PROCID"));
+        assert!(script.contains("SLURM_PROCID"));
+        assert!(script.contains("_TASKS_ON_NODE=2"));
+        assert!(script.contains("/tmp/work.sh"));
+    }
+
+    #[test]
+    fn multi_task_wrapper_applies_map_cpu_bind() {
+        let mut env = HashMap::new();
+        env.insert("SPUR_CPU_BIND".into(), "map_cpu:0,4".into());
+        let script = build_multi_task_wrapper("/tmp/work.sh", 2, Some(&env));
+        assert!(script.contains("_CPU_MAP=(0 4)"));
+        assert!(script.contains("_CPU_IDX\" -ge"));
+        assert!(script.contains("taskset -c ${_CPU_MAP[$_CPU_IDX]}"));
+    }
+
+    #[test]
+    fn multi_task_wrapper_honors_spur_label_env() {
+        let script = build_multi_task_wrapper("/tmp/work.sh", 1, None);
+        assert!(script.contains("SPUR_LABEL"));
+        assert!(script.contains("sed \"s/^/[$SPUR_PROCID] /\""));
+    }
+
+    #[test]
+    fn apply_gpu_bind_map_override() {
+        let mut env = HashMap::new();
+        env.insert("SPUR_GPU_BIND".into(), "map_gpu:2,3".into());
+        let mut target = HashMap::new();
+        apply_gpu_bind_env(&mut target, &env, &[0, 1]);
+        assert_eq!(target.get("ROCR_VISIBLE_DEVICES").unwrap(), "2,3");
+        assert_eq!(target.get("SPUR_JOB_GPUS").unwrap(), "2,3");
+    }
+
+    #[test]
+    fn wrap_command_with_cpu_bind_rank() {
+        let mut env = HashMap::new();
+        env.insert("SPUR_CPU_BIND".into(), "rank".into());
+        let (program, args) = wrap_command_with_cpu_bind("hostname", &[], &env, 3);
+        assert_eq!(program, "taskset");
+        assert_eq!(args, vec!["-c", "3", "hostname"]);
+    }
+
+    #[test]
+    fn unsupported_cpu_bind_flags_topology_modes() {
+        let mut env = HashMap::new();
+        env.insert("SPUR_CPU_BIND".into(), "cores".into());
+        assert_eq!(unsupported_cpu_bind(&env).as_deref(), Some("cores"));
+        env.insert("SPUR_CPU_BIND".into(), "map_cpu:0,1".into());
+        assert_eq!(unsupported_cpu_bind(&env), None);
+    }
+
+    #[test]
+    fn map_cpu_bind_error_when_map_shorter_than_tasks() {
+        let mut env = HashMap::new();
+        env.insert("SPUR_CPU_BIND".into(), "map_cpu:0,1".into());
+        assert_eq!(
+            map_cpu_bind_error(&env, 3).as_deref(),
+            Some("map_cpu lists 2 CPU(s) but the step requires 3 task(s)")
+        );
+        assert_eq!(map_cpu_bind_error(&env, 2), None);
+    }
+
+    #[test]
+    fn wrap_command_with_cpu_bind_map_uses_list_entry() {
+        let mut env = HashMap::new();
+        env.insert("SPUR_CPU_BIND".into(), "map_cpu:2,4".into());
+        let (program, args) = wrap_command_with_cpu_bind("hostname", &[], &env, 1);
+        assert_eq!(program, "taskset");
+        assert_eq!(args, vec!["-c", "4", "hostname"]);
+    }
+
+    #[test]
+    fn wrap_command_with_cpu_bind_map_skips_taskset_when_rank_oob() {
+        let mut env = HashMap::new();
+        env.insert("SPUR_CPU_BIND".into(), "map_cpu:0".into());
+        let (program, args) = wrap_command_with_cpu_bind("hostname", &[], &env, 2);
+        assert_eq!(program, "hostname");
+        assert!(args.is_empty());
+    }
+}

--- a/crates/spur-core/src/task_launch.rs
+++ b/crates/spur-core/src/task_launch.rs
@@ -120,6 +120,29 @@ fn parse_map_cpu_list(list: &str) -> Vec<String> {
         .collect()
 }
 
+fn parse_mask_cpu_list(mask: &str) -> Vec<String> {
+    parse_map_cpu_list(mask)
+}
+
+fn mask_cpu_bind_bash_prefix(masks: &[&str]) -> String {
+    if masks.len() > 1 {
+        let entries = masks.join(" ");
+        format!(
+            "_CPU_MASK=({entries})\n  \
+             _CPU_IDX=$((SPUR_TASK_OFFSET + LOCAL_RANK))\n  \
+             if [ \"$_CPU_IDX\" -ge ${{#_CPU_MASK[@]}} ]; then\n    \
+               echo \"mask_cpu: rank $_CPU_IDX exceeds CPU mask list (len ${{#_CPU_MASK[@]}})\" >&2\n    \
+               exit 1\n  \
+             fi\n  \
+             taskset ${{_CPU_MASK[$_CPU_IDX]}} "
+        )
+    } else if let Some(mask) = masks.first() {
+        format!("taskset {mask} ")
+    } else {
+        String::new()
+    }
+}
+
 /// Returns an error message when `map_cpu` lists fewer CPUs than `num_tasks`.
 pub fn map_cpu_bind_error(source: &HashMap<String, String>, num_tasks: u32) -> Option<String> {
     if num_tasks == 0 {
@@ -135,6 +158,31 @@ pub fn map_cpu_bind_error(source: &HashMap<String, String>, num_tasks: u32) -> O
         Some(format!(
             "map_cpu lists {} CPU(s) but the step requires {} task(s)",
             cpus.len(),
+            need
+        ))
+    } else {
+        None
+    }
+}
+
+/// Returns an error message when comma-separated `mask_cpu` lists fewer masks than `num_tasks`.
+pub fn mask_cpu_bind_error(source: &HashMap<String, String>, num_tasks: u32) -> Option<String> {
+    if num_tasks == 0 {
+        return None;
+    }
+    let bind = parse_cpu_bind(source);
+    let CpuBind::Mask(mask) = bind else {
+        return None;
+    };
+    let masks = parse_mask_cpu_list(&mask);
+    if masks.len() <= 1 {
+        return None;
+    }
+    let need = num_tasks as usize;
+    if masks.len() < need {
+        Some(format!(
+            "mask_cpu lists {} CPU mask(s) but the step requires {} task(s)",
+            masks.len(),
             need
         ))
     } else {
@@ -159,7 +207,14 @@ fn cpu_bind_bash_prefix(bind: &CpuBind, map_cpus: &[&str]) -> String {
             )
         }
         CpuBind::Map(_) => String::new(),
-        CpuBind::Mask(mask) => format!("taskset {mask} "),
+        CpuBind::Mask(mask) => {
+            let masks: Vec<&str> = mask
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .collect();
+            mask_cpu_bind_bash_prefix(&masks)
+        }
         CpuBind::None | CpuBind::Cores | CpuBind::Threads | CpuBind::Sockets | CpuBind::Ldoms => {
             String::new()
         }
@@ -197,13 +252,24 @@ pub fn wrap_command_with_cpu_bind(
                     .collect(),
             )
         }
-        CpuBind::Mask(mask) => (
-            "taskset".into(),
-            std::iter::once(mask)
-                .chain(std::iter::once(program.to_string()))
-                .chain(args.iter().cloned())
-                .collect(),
-        ),
+        CpuBind::Mask(mask) => {
+            let masks = parse_mask_cpu_list(&mask);
+            let mask_arg = if masks.len() > 1 {
+                let Some(m) = masks.get(global_rank as usize) else {
+                    return (program.to_string(), args.to_vec());
+                };
+                m.clone()
+            } else {
+                masks.first().cloned().unwrap_or_else(|| mask.clone())
+            };
+            (
+                "taskset".into(),
+                std::iter::once(mask_arg)
+                    .chain(std::iter::once(program.to_string()))
+                    .chain(args.iter().cloned())
+                    .collect(),
+            )
+        }
         CpuBind::None | CpuBind::Cores | CpuBind::Threads | CpuBind::Sockets | CpuBind::Ldoms => {
             (program.to_string(), args.to_vec())
         }
@@ -224,6 +290,11 @@ pub fn build_multi_task_wrapper(
     let bind = environment.map(parse_cpu_bind).unwrap_or(CpuBind::None);
     let map_cpus: Vec<&str> = match &bind {
         CpuBind::Map(list) => list
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .collect(),
+        CpuBind::Mask(mask) => mask
             .split(',')
             .map(str::trim)
             .filter(|s| !s.is_empty())
@@ -278,6 +349,11 @@ pub fn build_labeled_single_task_wrapper(
     let bind = environment.map(parse_cpu_bind).unwrap_or(CpuBind::None);
     let map_cpus: Vec<&str> = match &bind {
         CpuBind::Map(list) => list
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .collect(),
+        CpuBind::Mask(mask) => mask
             .split(',')
             .map(str::trim)
             .filter(|s| !s.is_empty())
@@ -411,6 +487,24 @@ mod tests {
     }
 
     #[test]
+    fn mask_cpu_bind_error_when_mask_list_shorter_than_tasks() {
+        let mut env = HashMap::new();
+        env.insert("SPUR_CPU_BIND".into(), "mask_cpu:0x3,0xc".into());
+        assert_eq!(
+            mask_cpu_bind_error(&env, 3).as_deref(),
+            Some("mask_cpu lists 2 CPU mask(s) but the step requires 3 task(s)")
+        );
+        assert_eq!(mask_cpu_bind_error(&env, 2), None);
+    }
+
+    #[test]
+    fn mask_cpu_bind_error_allows_single_mask_for_all_tasks() {
+        let mut env = HashMap::new();
+        env.insert("SPUR_CPU_BIND".into(), "mask_cpu:0x3".into());
+        assert_eq!(mask_cpu_bind_error(&env, 4), None);
+    }
+
+    #[test]
     fn wrap_command_with_cpu_bind_map_uses_list_entry() {
         let mut env = HashMap::new();
         env.insert("SPUR_CPU_BIND".into(), "map_cpu:2,4".into());
@@ -426,6 +520,14 @@ mod tests {
         let (program, args) = wrap_command_with_cpu_bind("hostname", &[], &env, 0);
         assert_eq!(program, "taskset");
         assert_eq!(args, vec!["0x3", "hostname"]);
+    }
+
+    #[test]
+    fn wrap_command_with_cpu_bind_mask_uses_per_rank_entry() {
+        let mut env = HashMap::new();
+        env.insert("SPUR_CPU_BIND".into(), "mask_cpu:0x3,0xc".into());
+        let (_, args) = wrap_command_with_cpu_bind("hostname", &[], &env, 1);
+        assert_eq!(args, vec!["0xc", "hostname"]);
     }
 
     #[test]

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -42,6 +42,9 @@ pub enum WalOperation {
         /// Per-node allocation slices (device IDs are node-local).
         #[serde(default)]
         per_node_alloc: HashMap<String, ResourceAllocations>,
+        /// Standalone srun: native step dispatch (false = K8s batch fallback).
+        #[serde(default)]
+        srun_step_dispatch: bool,
     },
     JobComplete {
         job_id: JobId,
@@ -60,6 +63,10 @@ pub enum WalOperation {
         job_id: JobId,
         step_id: u32,
         exit_code: i32,
+    },
+    /// Record a job step at creation so `run_step` survives controller restart.
+    JobStepCreate {
+        step: Box<crate::step::JobStep>,
     },
     JobPriorityChange {
         job_id: JobId,
@@ -212,6 +219,22 @@ impl WalOperation {
             new_state: JobState::Pending,
             pending_reason: Some(reason),
             pending_priority: Some(0),
+        }
+    }
+
+    /// Record node allocation at job start (batch/sbatch and K8s srun fallback).
+    pub fn job_start(
+        job_id: JobId,
+        nodes: Vec<String>,
+        resources: ResourceAllocations,
+        per_node_alloc: HashMap<String, ResourceAllocations>,
+    ) -> Self {
+        Self::JobStart {
+            job_id,
+            nodes,
+            resources,
+            per_node_alloc,
+            srun_step_dispatch: false,
         }
     }
 }
@@ -499,6 +522,7 @@ mod suspend_wal_tests {
 #[cfg(test)]
 mod evict_wal_tests {
     use super::*;
+    use crate::step::{JobStep, StepState, TaskDistribution};
 
     #[test]
     fn job_evict_op_round_trips() {
@@ -507,6 +531,37 @@ mod evict_wal_tests {
         let back: WalOperation = serde_json::from_str(&json).unwrap();
         match back {
             WalOperation::JobEvict { job_id } => assert_eq!(job_id, 9),
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn job_step_create_op_round_trips() {
+        let step = JobStep {
+            job_id: 7,
+            step_id: 1,
+            name: "hostname".into(),
+            state: StepState::Running,
+            num_tasks: 2,
+            cpus_per_task: 1,
+            resources: Default::default(),
+            nodes: vec!["n1".into(), "n2".into()],
+            distribution: TaskDistribution::Block,
+            start_time: None,
+            end_time: None,
+            exit_code: None,
+        };
+        let op = WalOperation::JobStepCreate {
+            step: Box::new(step.clone()),
+        };
+        let json = serde_json::to_string(&op).unwrap();
+        let back: WalOperation = serde_json::from_str(&json).unwrap();
+        match back {
+            WalOperation::JobStepCreate { step: restored } => {
+                assert_eq!(restored.job_id, 7);
+                assert_eq!(restored.step_id, 1);
+                assert_eq!(restored.name, "hostname");
+            }
             _ => panic!("wrong variant"),
         }
     }

--- a/crates/spur-k8s/src/agent.rs
+++ b/crates/spur-k8s/src/agent.rs
@@ -598,15 +598,20 @@ impl SlurmAgent for VirtualAgent {
         &self,
         _request: Request<RunCommandRequest>,
     ) -> Result<Response<RunCommandResponse>, Status> {
-        // #146: srun-in-salloc step dispatch. The K8s virtual agent does
-        // not currently support one-shot commands outside the job pod's
-        // lifecycle — salloc + srun-in-allocation is not a common K8s
-        // workflow. Implementations that need it could spawn a transient
-        // pod (e.g. via PodSpec with the same image as the allocation
-        // template), but that's a non-trivial design choice and the
-        // user-facing path uses the native spurd agent.
+        // Srun step dispatch. The K8s virtual agent does not currently support
+        // one-shot commands outside the job pod's lifecycle — salloc plus
+        // srun-in-allocation is not a common K8s workflow.
         Err(Status::unimplemented(
             "RunCommand is not yet supported by the K8s virtual agent",
+        ))
+    }
+
+    async fn register_job_allocation(
+        &self,
+        _request: Request<RegisterJobAllocationRequest>,
+    ) -> Result<Response<RegisterJobAllocationResponse>, Status> {
+        Err(Status::unimplemented(
+            "RegisterJobAllocation is not yet supported by the K8s virtual agent",
         ))
     }
 

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -812,6 +812,7 @@ fn core_job_spec_to_proto(spec: &spur_core::job::JobSpec) -> spur_proto::proto::
         mail_type: Vec::new(),
         mail_user: String::new(),
         interactive: false,
+        srun_job: spec.srun_job,
         begin_time: spec.begin_time.map(|dt| prost_types::Timestamp {
             seconds: dt.timestamp(),
             nanos: dt.timestamp_subsec_nanos() as i32,

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -224,6 +224,7 @@ impl SlurmAccounting for AccountingService {
                 array_task_id: 0,
                 reservation: r.reservation.clone(),
                 comment: String::new(),
+                srun_step_dispatch: false,
             })
             .collect();
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -79,6 +79,43 @@ pub enum SubmitError {
     Internal(String),
 }
 
+/// Errors from completing a standalone srun allocation.
+#[derive(Debug)]
+pub enum SrunCompleteError {
+    NotFound(JobId),
+    NotSrunJob(JobId),
+    NotStepDispatch(JobId),
+    AlreadyTerminal { job_id: JobId, state: JobState },
+    NotOwner { job_id: JobId, user: String },
+    Internal { job_id: JobId, message: String },
+}
+
+impl std::fmt::Display for SrunCompleteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound(id) => write!(f, "job {id} not found"),
+            Self::NotSrunJob(id) => write!(f, "job {id} is not an srun allocation"),
+            Self::NotStepDispatch(id) => {
+                write!(
+                    f,
+                    "job {id} does not use native step dispatch (CompleteJob is not valid)"
+                )
+            }
+            Self::AlreadyTerminal { job_id, state } => {
+                write!(f, "job {job_id} is already {state:?}")
+            }
+            Self::NotOwner { job_id, user } => {
+                write!(f, "user {user} is not permitted to complete job {job_id}")
+            }
+            Self::Internal { job_id, message } => {
+                write!(f, "job {job_id}: {message}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SrunCompleteError {}
+
 impl std::fmt::Display for SubmitError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -594,6 +631,54 @@ impl ClusterManager {
         Ok(())
     }
 
+    /// Complete a standalone srun allocation after its step finishes.
+    pub fn finish_srun_job(
+        &self,
+        job_id: JobId,
+        exit_code: i32,
+        user: &str,
+    ) -> Result<Job, SrunCompleteError> {
+        let job = {
+            let jobs = self.jobs.read();
+            let job = jobs
+                .get(&job_id)
+                .ok_or(SrunCompleteError::NotFound(job_id))?;
+            if !job.spec.srun_job {
+                return Err(SrunCompleteError::NotSrunJob(job_id));
+            }
+            if !job.srun_step_dispatch {
+                return Err(SrunCompleteError::NotStepDispatch(job_id));
+            }
+            if job.state.is_terminal() {
+                return Err(SrunCompleteError::AlreadyTerminal {
+                    job_id,
+                    state: job.state,
+                });
+            }
+            Self::check_job_owner(user, &job.spec.user, "complete").map_err(|_| {
+                SrunCompleteError::NotOwner {
+                    job_id,
+                    user: user.to_string(),
+                }
+            })?;
+            job.clone()
+        };
+
+        let state = if exit_code == 0 {
+            JobState::Completed
+        } else {
+            JobState::Failed
+        };
+        self.complete_job(job_id, exit_code, state).map_err(|e| {
+            warn!(job_id, error = %e, "finish_srun_job: complete_job failed");
+            SrunCompleteError::Internal {
+                job_id,
+                message: e.to_string(),
+            }
+        })?;
+        Ok(job)
+    }
+
     /// Suspend a running job: validate state, record through Raft. Allocation is retained.
     /// The requesting `user` must be the job owner, root, or empty (trusted internal calls).
     pub fn suspend_job(&self, job_id: JobId, user: &str) -> anyhow::Result<()> {
@@ -644,6 +729,17 @@ impl ClusterManager {
         resources: ResourceAllocations,
         per_node_alloc: std::collections::HashMap<String, ResourceAllocations>,
     ) -> anyhow::Result<()> {
+        self.start_job_impl(job_id, node_names, resources, per_node_alloc, false)
+    }
+
+    pub(crate) fn start_job_impl(
+        &self,
+        job_id: JobId,
+        node_names: Vec<String>,
+        resources: ResourceAllocations,
+        per_node_alloc: std::collections::HashMap<String, ResourceAllocations>,
+        srun_step_dispatch: bool,
+    ) -> anyhow::Result<()> {
         for name in &node_names {
             if !per_node_alloc.contains_key(name) {
                 anyhow::bail!(
@@ -682,6 +778,7 @@ impl ClusterManager {
             nodes: node_names.clone(),
             resources: resources.clone(),
             per_node_alloc: per_node_alloc.clone(),
+            srun_step_dispatch,
         })?;
 
         let node_count = node_names.len().max(1) as u32;
@@ -694,21 +791,25 @@ impl ClusterManager {
                     resources.memory_mb / node_count as u64,
                 )
             });
-        let batch_step = JobStep {
-            job_id,
-            step_id: STEP_BATCH,
-            name: "batch".into(),
-            state: StepState::Running,
-            num_tasks: 1,
-            cpus_per_task: per_node.cpus,
-            resources: per_node,
-            nodes: node_names,
-            distribution: spur_core::step::TaskDistribution::Block,
-            start_time: Some(Utc::now()),
-            end_time: None,
-            exit_code: None,
-        };
-        self.create_step(job_id, STEP_BATCH, batch_step);
+        if !srun_step_dispatch {
+            let batch_step = JobStep {
+                job_id,
+                step_id: STEP_BATCH,
+                name: "batch".into(),
+                state: StepState::Running,
+                num_tasks: 1,
+                cpus_per_task: per_node.cpus,
+                resources: per_node,
+                nodes: node_names,
+                distribution: spur_core::step::TaskDistribution::Block,
+                start_time: Some(Utc::now()),
+                end_time: None,
+                exit_code: None,
+            };
+            if let Err(e) = self.create_step(batch_step) {
+                warn!(job_id, error = %e, "failed to record batch step");
+            }
+        }
 
         if spec_for_notify
             .mail_type
@@ -1679,10 +1780,15 @@ impl ClusterManager {
         Ok(resp.jobs_finalized)
     }
 
-    /// Create a job step.
-    pub fn create_step(&self, job_id: JobId, step_id: u32, step: JobStep) {
-        self.steps.write().insert((job_id, step_id), step);
+    /// Create a job step durably via Raft.
+    pub fn create_step(&self, step: JobStep) -> anyhow::Result<()> {
+        let job_id = step.job_id;
+        let step_id = step.step_id;
+        self.propose(WalOperation::JobStepCreate {
+            step: Box::new(step),
+        })?;
         debug!(job_id, step_id, "step created");
+        Ok(())
     }
 
     /// Record an srun step's completion via Raft so the step exit code and the
@@ -3206,6 +3312,7 @@ impl ClusterManager {
                 nodes: node_names,
                 resources,
                 per_node_alloc,
+                srun_step_dispatch,
             } => {
                 if let Some(job) = jobs.get_mut(job_id) {
                     job.start_time = Some(timestamp);
@@ -3213,6 +3320,7 @@ impl ClusterManager {
                     job.allocated_resources = Some(resources.clone());
                     job.per_node_alloc = per_node_alloc.clone();
                     job.pending_reason = PendingReason::None;
+                    job.srun_step_dispatch = *srun_step_dispatch;
                 }
                 let node_count = node_names.len().max(1) as u32;
                 for name in node_names {
@@ -3467,6 +3575,29 @@ impl ClusterManager {
                     }
                 }
             }
+            WalOperation::JobStepCreate { step } => match jobs.get(&step.job_id) {
+                None => {
+                    warn!(
+                        job_id = step.job_id,
+                        step_id = step.step_id,
+                        "JobStepCreate: skipping step for unknown job"
+                    );
+                }
+                Some(job) if job.state.is_terminal() => {
+                    warn!(
+                        job_id = step.job_id,
+                        step_id = step.step_id,
+                        state = ?job.state,
+                        "JobStepCreate: skipping step for terminal job"
+                    );
+                }
+                Some(_) => {
+                    let mut steps = self.steps.write();
+                    steps
+                        .entry((step.job_id, step.step_id))
+                        .or_insert_with(|| (**step).clone());
+                }
+            },
             WalOperation::JobPriorityChange {
                 job_id,
                 new_priority,
@@ -4575,6 +4706,12 @@ mod tests {
         }
     }
 
+    fn srun_spec(name: &str) -> JobSpec {
+        let mut spec = basic_spec(name);
+        spec.srun_job = true;
+        spec
+    }
+
     fn scalar_alloc(cpus: u32, memory_mb: u64) -> ResourceAllocations {
         ResourceAllocations::with_scalar(cpus, memory_mb)
     }
@@ -4710,6 +4847,7 @@ mod tests {
             nodes: vec!["node1".into()],
             resources: resources.clone(),
             per_node_alloc: per_node_for(&["node1"], resources),
+            srun_step_dispatch: false,
         });
 
         let job = cm.get_job(1).unwrap();
@@ -4744,6 +4882,7 @@ mod tests {
             nodes: vec!["node1".into()],
             resources: alloc.clone(),
             per_node_alloc: per_node_for(&["node1"], alloc),
+            srun_step_dispatch: false,
         });
 
         cm.apply_operation(&WalOperation::JobComplete {
@@ -5231,6 +5370,7 @@ mod tests {
             nodes: vec!["worker1".into()],
             resources: alloc.clone(),
             per_node_alloc: per_node_for(&["worker1"], alloc),
+            srun_step_dispatch: false,
         });
 
         cm.apply_operation(&WalOperation::JobNodeComplete {
@@ -5272,6 +5412,7 @@ mod tests {
             nodes: vec!["worker1".into()],
             resources: alloc.clone(),
             per_node_alloc: per_node_for(&["worker1"], alloc),
+            srun_step_dispatch: false,
         });
 
         cm.apply_operation(&WalOperation::JobNodeComplete {
@@ -5314,6 +5455,7 @@ mod tests {
             nodes: vec!["n1".into(), "n2".into(), "n3".into()],
             resources: scalar_alloc(6, 12000),
             per_node_alloc: per_node_for(&["n1", "n2", "n3"], alloc),
+            srun_step_dispatch: false,
         });
 
         cm.apply_operation(&WalOperation::JobNodeComplete {
@@ -5379,6 +5521,7 @@ mod tests {
             nodes: vec!["n1".into()],
             resources: scalar_alloc(4, 8000),
             per_node_alloc: per_node_for(&["n1"], scalar_alloc(4, 8000)),
+            srun_step_dispatch: false,
         });
 
         // Three srun steps exit 7, 3, 2 (in that order). DerivedExitCode tracks
@@ -5471,6 +5614,7 @@ mod tests {
             nodes: vec!["n1".into(), "n2".into()],
             resources: scalar_alloc(4, 8000),
             per_node_alloc: per_node_for(&["n1", "n2"], alloc),
+            srun_step_dispatch: false,
         });
 
         let r1 = cm.apply_operation(&WalOperation::JobNodeComplete {
@@ -5521,6 +5665,7 @@ mod tests {
             nodes: vec!["worker1".into()],
             resources: alloc.clone(),
             per_node_alloc: per_node_for(&["worker1"], alloc),
+            srun_step_dispatch: false,
         });
 
         let resp = cm.apply_operation(&WalOperation::JobComplete {
@@ -5560,6 +5705,7 @@ mod tests {
             nodes: vec!["worker1".into()],
             resources: alloc.clone(),
             per_node_alloc: per_node_for(&["worker1"], alloc),
+            srun_step_dispatch: false,
         });
 
         let first = cm.apply_operation(&WalOperation::JobComplete {
@@ -5617,6 +5763,7 @@ mod tests {
             nodes: vec!["n1".into(), "n2".into(), "n3".into()],
             resources: scalar_alloc(6, 12000),
             per_node_alloc: per_node_for(&["n1", "n2", "n3"], alloc),
+            srun_step_dispatch: false,
         });
         cm.apply_operation(&WalOperation::JobNodeComplete {
             job_id: 1,
@@ -5653,6 +5800,7 @@ mod tests {
             nodes: vec!["n1".into()],
             resources: scalar_alloc(6, 12000),
             per_node_alloc: per_node_for(&["n1"], scalar_alloc(6, 12000)),
+            srun_step_dispatch: false,
         });
 
         cm.node_complete(1, "n1", 0, 9).unwrap();
@@ -5695,6 +5843,7 @@ mod tests {
             nodes: vec!["n1".into()],
             resources: scalar_alloc(6, 12000),
             per_node_alloc: per_node_for(&["n1"], scalar_alloc(6, 12000)),
+            srun_step_dispatch: false,
         });
 
         // Step 2: the call the RPC makes after validation (wire state dropped).
@@ -5730,6 +5879,7 @@ mod tests {
             nodes: vec!["n1".into()],
             resources: scalar_alloc(6, 12000),
             per_node_alloc: per_node_for(&["n1"], scalar_alloc(6, 12000)),
+            srun_step_dispatch: false,
         });
 
         cm.node_complete(1, "n1", 42, 0).unwrap();
@@ -5769,6 +5919,7 @@ mod tests {
             nodes: vec!["n1".into(), "n2".into(), "n3".into()],
             resources: scalar_alloc(6, 12000),
             per_node_alloc: per_node_for(&["n1", "n2", "n3"], alloc),
+            srun_step_dispatch: false,
         });
 
         cm.apply_operation(&WalOperation::JobNodeComplete {
@@ -5836,6 +5987,7 @@ mod tests {
             nodes: vec!["n1".into(), "n2".into(), "n3".into()],
             resources: scalar_alloc(6, 12000),
             per_node_alloc: per_node_for(&["n1", "n2", "n3"], alloc),
+            srun_step_dispatch: false,
         });
         cm.apply_operation(&WalOperation::JobNodeComplete {
             job_id: 1,
@@ -6186,6 +6338,7 @@ mod tests {
             nodes: vec!["worker1".into()],
             resources: alloc.clone(),
             per_node_alloc: per_node_for(&["worker1"], alloc),
+            srun_step_dispatch: false,
         });
         cm.apply_operation(&WalOperation::JobComplete {
             job_id: 1,
@@ -6279,6 +6432,7 @@ mod tests {
             nodes: vec!["worker1".into()],
             resources: alloc.clone(),
             per_node_alloc: per_node_for(&["worker1"], alloc),
+            srun_step_dispatch: false,
         });
         assert_eq!(cm.get_node("worker1").unwrap().alloc_resources.cpus, 2);
 
@@ -10836,6 +10990,24 @@ mod tests {
             nodes: vec![node.into()],
             resources: scalar_alloc(1, 1000),
             per_node_alloc: per_node_for(&[node], scalar_alloc(1, 1000)),
+            srun_step_dispatch: false,
+        });
+    }
+
+    fn start_srun_job_on(cm: &ClusterManager, id: JobId, node: &str) {
+        cm.apply_operation(&WalOperation::JobStateChange {
+            job_id: id,
+            old_state: JobState::Pending,
+            new_state: JobState::Running,
+            pending_reason: None,
+            pending_priority: None,
+        });
+        cm.apply_operation(&WalOperation::JobStart {
+            job_id: id,
+            nodes: vec![node.into()],
+            resources: scalar_alloc(1, 1000),
+            per_node_alloc: per_node_for(&[node], scalar_alloc(1, 1000)),
+            srun_step_dispatch: true,
         });
     }
 
@@ -11231,5 +11403,91 @@ mod tests {
         );
 
         assert_eq!(nodes["n1"].state, NodeState::Drain);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn finish_srun_job_completes_running_allocation() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 4, 8000);
+        let id = submit_and_wait(&cm, srun_spec("srun-alloc"));
+        start_srun_job_on(&cm, id, "n1");
+
+        let returned = cm.finish_srun_job(id, 0, "testuser").unwrap();
+        assert_eq!(returned.job_id, id);
+        settle(&cm, id, JobState::Completed);
+        assert_eq!(cm.get_job(id).unwrap().exit_code, Some(0));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn finish_srun_job_rejects_non_srun_job() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 4, 8000);
+        let id = submit_and_wait(&cm, basic_spec("batch"));
+        start_job_on(&cm, id, "n1");
+
+        assert!(matches!(
+            cm.finish_srun_job(id, 0, "testuser"),
+            Err(SrunCompleteError::NotSrunJob(j)) if j == id
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn finish_srun_job_rejects_terminal_job() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 4, 8000);
+        let id = submit_and_wait(&cm, srun_spec("srun-done"));
+        start_srun_job_on(&cm, id, "n1");
+        cm.finish_srun_job(id, 0, "testuser").unwrap();
+        settle(&cm, id, JobState::Completed);
+
+        assert!(matches!(
+            cm.finish_srun_job(id, 0, "testuser"),
+            Err(SrunCompleteError::AlreadyTerminal {
+                job_id,
+                state: JobState::Completed,
+            }) if job_id == id
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn finish_srun_job_rejects_wrong_user() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 4, 8000);
+        let id = submit_and_wait(&cm, srun_spec("srun-owner"));
+        start_srun_job_on(&cm, id, "n1");
+
+        assert!(matches!(
+            cm.finish_srun_job(id, 0, "otheruser"),
+            Err(SrunCompleteError::NotOwner { job_id, user }) if job_id == id && user == "otheruser"
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn finish_srun_job_rejects_batch_fallback_srun() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 4, 8000);
+        let id = submit_and_wait(&cm, srun_spec("srun-batch-fallback"));
+        start_job_on(&cm, id, "n1");
+
+        assert!(matches!(
+            cm.finish_srun_job(id, 0, "testuser"),
+            Err(SrunCompleteError::NotStepDispatch(j)) if j == id
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn finish_srun_job_not_found() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        assert!(matches!(
+            cm.finish_srun_job(999, 0, "testuser"),
+            Err(SrunCompleteError::NotFound(999))
+        ));
     }
 }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -282,6 +282,7 @@ impl ClusterManager {
     /// Submit a new job. If it has an array spec, expand into individual tasks.
     pub fn submit_job(&self, mut spec: JobSpec) -> Result<JobId, SubmitError> {
         apply_default_partition(&mut spec, &self.partitions.read());
+        apply_default_time_limit(&mut spec, &self.partitions.read());
         apply_default_account(&mut spec, &self.association_cache);
         validate_user_account(&spec, &self.association_cache)?;
         self.validate_partition(&spec)?;
@@ -4457,6 +4458,21 @@ fn apply_default_partition(spec: &mut JobSpec, partitions: &[Partition]) {
         } else if let Some(first) = partitions.first() {
             spec.partition = Some(first.name.clone());
         }
+    }
+}
+
+fn apply_default_time_limit(spec: &mut JobSpec, partitions: &[Partition]) {
+    if spec.time_limit.is_some() {
+        return;
+    }
+    let partition = spec
+        .partition
+        .as_deref()
+        .and_then(|name| partitions.iter().find(|p| p.name == name))
+        .or_else(|| partitions.iter().find(|p| p.is_default))
+        .or_else(|| partitions.first());
+    if let Some(minutes) = partition.and_then(|p| p.default_time_minutes) {
+        spec.time_limit = Some(chrono::Duration::minutes(minutes as i64));
     }
 }
 
@@ -9902,6 +9918,47 @@ mod tests {
         ];
         super::apply_default_partition(&mut spec, &partitions);
         assert_eq!(spec.partition.as_deref(), Some("gpu"));
+    }
+
+    #[test]
+    fn apply_default_time_limit_uses_partition_default() {
+        let mut spec = basic_spec("j");
+        spec.partition = Some("gpu".into());
+        spec.time_limit = None;
+        let partitions = vec![Partition {
+            name: "gpu".into(),
+            default_time_minutes: Some(30),
+            ..Default::default()
+        }];
+        super::apply_default_time_limit(&mut spec, &partitions);
+        assert_eq!(spec.time_limit, Some(chrono::Duration::minutes(30)));
+    }
+
+    #[test]
+    fn apply_default_time_limit_noop_when_set() {
+        let mut spec = basic_spec("j");
+        spec.time_limit = Some(chrono::Duration::minutes(5));
+        let partitions = vec![Partition {
+            name: "gpu".into(),
+            default_time_minutes: Some(30),
+            ..Default::default()
+        }];
+        super::apply_default_time_limit(&mut spec, &partitions);
+        assert_eq!(spec.time_limit, Some(chrono::Duration::minutes(5)));
+    }
+
+    #[test]
+    fn apply_default_time_limit_skips_when_partition_has_no_default() {
+        let mut spec = basic_spec("j");
+        spec.partition = Some("gpu".into());
+        spec.time_limit = None;
+        let partitions = vec![Partition {
+            name: "gpu".into(),
+            default_time_minutes: None,
+            ..Default::default()
+        }];
+        super::apply_default_time_limit(&mut spec, &partitions);
+        assert!(spec.time_limit.is_none());
     }
 
     #[test]

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -8,11 +8,12 @@ use std::time::{Duration, Instant};
 use chrono::Utc;
 use tracing::{debug, error, info, warn};
 
+use spur_core::node::NodeSource;
 use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{
     AgentCancelJobRequest, AgentSuspendJobRequest, JobSpec as ProtoJobSpec, LaunchJobRequest,
-    SubmitJobRequest,
+    RegisterJobAllocationRequest, SubmitJobRequest,
 };
 use spur_sched::backfill::{self, BackfillScheduler};
 use spur_sched::traits::{ClusterState, Scheduler};
@@ -205,13 +206,83 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
             let resources =
                 compute_job_allocation(&job, &assignment.nodes, &assignment.per_node_alloc);
 
+            let job_id = assignment.job_id;
+            let spec = job.spec.clone();
+            let all_nodes = assignment.nodes.clone();
+            let per_node_allocs = assignment.per_node_alloc.clone();
+            let dispatch_nodes = all_nodes.clone();
+            let allocated_nodelist = all_nodes.join(",");
+
+            let srun_step_dispatch = spec.srun_job
+                && dispatch_nodes.iter().all(|name| {
+                    cluster
+                        .get_node(name)
+                        .is_some_and(|n| n.source == NodeSource::NativeHost)
+                });
+
+            if spec.srun_job
+                && !srun_step_dispatch
+                && spec.script.as_deref().unwrap_or("").is_empty()
+            {
+                warn!(
+                    job_id,
+                    "srun batch fallback requires a script in the job spec"
+                );
+                if let Err(e) = cluster.requeue_job(job_id) {
+                    error!(job_id, error = %e, "failed to requeue srun job without script");
+                }
+                continue;
+            }
+
+            if spec.srun_job && srun_step_dispatch {
+                match register_allocation_on_nodes(
+                    cluster.clone(),
+                    job_id,
+                    dispatch_nodes.clone(),
+                    &spec,
+                    per_node_allocs.clone(),
+                    allocated_nodelist.clone(),
+                )
+                .await
+                {
+                    AllocationRegisterOutcome::AllFailed => {
+                        if let Err(e) = cluster.requeue_job(job_id) {
+                            error!(job_id, error = %e, "failed to requeue after registration failure");
+                        }
+                        continue;
+                    }
+                    AllocationRegisterOutcome::PartialFailed { succeeded_nodes } => {
+                        cancel_job_on_nodes(&cluster, job_id, &succeeded_nodes, 9).await;
+                        if let Err(e) = cluster.requeue_job(job_id) {
+                            error!(job_id, error = %e, "failed to requeue after partial registration");
+                        }
+                        continue;
+                    }
+                    AllocationRegisterOutcome::AllSucceeded => {}
+                }
+            }
+
             // Transition job to Running
-            if let Err(e) = cluster.start_job(
-                assignment.job_id,
-                assignment.nodes.clone(),
-                resources,
-                assignment.per_node_alloc.clone(),
-            ) {
+            let start_result = if srun_step_dispatch {
+                cluster.start_job_impl(
+                    job_id,
+                    assignment.nodes.clone(),
+                    resources,
+                    assignment.per_node_alloc.clone(),
+                    true,
+                )
+            } else {
+                cluster.start_job(
+                    job_id,
+                    assignment.nodes.clone(),
+                    resources,
+                    assignment.per_node_alloc.clone(),
+                )
+            };
+            if let Err(e) = start_result {
+                if spec.srun_job && srun_step_dispatch {
+                    cancel_job_on_nodes(&cluster, job_id, &dispatch_nodes, 0).await;
+                }
                 debug!(
                     job_id = assignment.job_id,
                     error = %e,
@@ -240,6 +311,9 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
                         error = %e,
                         "PrologSlurmctld failed"
                     );
+                    if spec.srun_job && srun_step_dispatch && !job.spec.interactive {
+                        cancel_job_on_nodes(&cluster, job_id, &dispatch_nodes, 0).await;
+                    }
                     if job.spec.interactive {
                         if let Err(ce) = cluster.cancel_job(assignment.job_id, &job.spec.user) {
                             error!(job_id = assignment.job_id, error = %ce, "failed to cancel job after PrologSlurmctld failure");
@@ -254,12 +328,6 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
             }
 
             jobs_started_cycle += 1;
-
-            // Dispatch job to ALL assigned nodes
-            let job_id = assignment.job_id;
-            let spec = job.spec.clone();
-            let all_nodes = assignment.nodes.clone();
-            let per_node_allocs = assignment.per_node_alloc.clone();
 
             // Build peer_nodes list with addresses for cross-node communication
             let peer_addrs: Vec<String> = all_nodes
@@ -277,20 +345,34 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
                 (spec.num_tasks / spec.num_nodes.max(1)).max(1)
             };
 
-            // Collect dispatch tasks to track success/failure
             let cluster_ref = cluster.clone();
-            let dispatch_nodes = all_nodes.clone();
-            let allocated_nodelist = all_nodes.join(",");
-            tokio::spawn(dispatch_job_to_nodes(
-                cluster_ref,
-                job_id,
-                dispatch_nodes,
-                spec,
-                peer_addrs,
-                per_node_allocs,
-                allocated_nodelist,
-                tasks_per_node,
-            ));
+            if spec.srun_job {
+                if !srun_step_dispatch {
+                    let mut batch_spec = spec;
+                    batch_spec.srun_job = false;
+                    tokio::spawn(dispatch_job_to_nodes(
+                        cluster_ref,
+                        job_id,
+                        dispatch_nodes,
+                        batch_spec,
+                        peer_addrs,
+                        per_node_allocs,
+                        allocated_nodelist,
+                        tasks_per_node,
+                    ));
+                }
+            } else {
+                tokio::spawn(dispatch_job_to_nodes(
+                    cluster_ref,
+                    job_id,
+                    dispatch_nodes,
+                    spec,
+                    peer_addrs,
+                    per_node_allocs,
+                    allocated_nodelist,
+                    tasks_per_node,
+                ));
+            }
         }
 
         let cycle_time_us = cycle_start.elapsed().as_micros().min(u64::MAX as u128) as u64;
@@ -630,6 +712,7 @@ fn core_spec_to_proto(s: &spur_core::job::JobSpec) -> ProtoJobSpec {
         exclusive: s.exclusive,
         hold: s.hold,
         interactive: s.interactive,
+        srun_job: s.srun_job,
         mail_type: s.mail_type.clone(),
         mail_user: s.mail_user.clone().unwrap_or_default(),
         comment: s.comment.clone().unwrap_or_default(),
@@ -727,6 +810,7 @@ async fn dispatch_to_agent(
         exclusive: spec.exclusive,
         hold: spec.hold,
         interactive: spec.interactive,
+        srun_job: spec.srun_job,
         comment: spec.comment.clone().unwrap_or_default(),
         wckey: spec.wckey.clone().unwrap_or_default(),
         container_image: spec.container_image.clone().unwrap_or_default(),
@@ -785,6 +869,155 @@ async fn dispatch_to_agent(
     }
 
     Ok(())
+}
+
+/// Outcome of parallel RegisterJobAllocation RPCs for a standalone srun job.
+pub(crate) enum AllocationRegisterOutcome {
+    AllSucceeded,
+    AllFailed,
+    PartialFailed { succeeded_nodes: Vec<String> },
+}
+
+/// Parameters for registering a srun-only allocation on a single node agent.
+struct AllocationRegisterParams {
+    job_id: u32,
+    partition: String,
+    uid: u32,
+    gid: u32,
+    mpi: String,
+    allocated_nodelist: String,
+    allocated: spur_core::resource::ResourceAllocations,
+}
+
+/// Register a srun-only allocation on a node agent without launching a batch process.
+async fn register_allocation_to_agent(
+    agent_addr: &str,
+    params: &AllocationRegisterParams,
+) -> anyhow::Result<()> {
+    let mut client = SlurmAgentClient::connect(agent_addr.to_string())
+        .await?
+        .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
+        .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE);
+
+    client
+        .register_job_allocation(RegisterJobAllocationRequest {
+            job_id: params.job_id,
+            partition: params.partition.clone(),
+            nodelist: params.allocated_nodelist.clone(),
+            uid: params.uid,
+            gid: params.gid,
+            cpus: params.allocated.cpus,
+            memory_mb: params.allocated.memory_mb,
+            gpu_devices: params
+                .allocated
+                .device_ids("gpu")
+                .into_iter()
+                .map(|id| id.to_string())
+                .collect(),
+            allocated: Some(crate::server::allocations_to_proto(&params.allocated)),
+            mpi: params.mpi.clone(),
+        })
+        .await?;
+
+    info!(
+        job_id = params.job_id,
+        "srun allocation registered on agent successfully"
+    );
+
+    Ok(())
+}
+
+/// Register a srun-only allocation on every assigned node.
+#[allow(clippy::too_many_arguments)]
+async fn register_allocation_on_nodes(
+    cluster: Arc<ClusterManager>,
+    job_id: spur_core::job::JobId,
+    dispatch_nodes: Vec<String>,
+    spec: &spur_core::job::JobSpec,
+    per_node_allocs: std::collections::HashMap<String, spur_core::resource::ResourceAllocations>,
+    allocated_nodelist: String,
+) -> AllocationRegisterOutcome {
+    let mut successes = 0u32;
+    let mut failures = 0u32;
+    let mut succeeded_nodes: Vec<String> = Vec::new();
+    let total = dispatch_nodes.len() as u32;
+
+    let mut set = tokio::task::JoinSet::new();
+    for node_name in &dispatch_nodes {
+        let node_info = cluster.get_node(node_name);
+        let (addr, port) = match node_info {
+            Some(ref n) if n.address.is_some() => (n.address.clone().unwrap(), n.port),
+            _ => {
+                warn!(
+                    job_id,
+                    node = %node_name,
+                    "no agent address for node, skipping allocation registration"
+                );
+                failures += 1;
+                continue;
+            }
+        };
+
+        let agent_addr = format!("http://{}:{}", addr, port);
+        let result_node = node_name.clone();
+        let allocated = per_node_allocs.get(node_name).cloned().unwrap_or_default();
+        let params = AllocationRegisterParams {
+            job_id,
+            partition: spec.partition.clone().unwrap_or_default(),
+            uid: spec.uid,
+            gid: spec.gid,
+            mpi: spec.mpi.clone().unwrap_or_default(),
+            allocated_nodelist: allocated_nodelist.clone(),
+            allocated,
+        };
+        set.spawn(async move {
+            let result = register_allocation_to_agent(&agent_addr, &params).await;
+            (result_node, result)
+        });
+    }
+
+    while let Some(result) = set.join_next().await {
+        match result {
+            Ok((node_name, Ok(()))) => {
+                successes += 1;
+                succeeded_nodes.push(node_name);
+            }
+            Ok((node_name, Err(e))) => {
+                error!(
+                    job_id,
+                    node = %node_name,
+                    error = %e,
+                    "allocation registration on agent failed"
+                );
+                failures += 1;
+            }
+            Err(e) => {
+                error!(job_id, error = %e, "allocation registration task panicked");
+                failures += 1;
+            }
+        }
+    }
+
+    if successes == 0 && total > 0 {
+        error!(job_id, failures, "all allocation registrations failed");
+        AllocationRegisterOutcome::AllFailed
+    } else if failures > 0 {
+        warn!(
+            job_id,
+            successes, failures, "partial allocation registration failure"
+        );
+        AllocationRegisterOutcome::PartialFailed { succeeded_nodes }
+    } else {
+        AllocationRegisterOutcome::AllSucceeded
+    }
+}
+
+/// Release standalone srun allocations on agents after CompleteJob.
+pub async fn release_srun_allocation_on_agents(
+    cluster: &Arc<ClusterManager>,
+    job: &spur_core::job::Job,
+) {
+    send_cancel_to_agents(cluster, job, 0).await;
 }
 
 /// Dispatch a job to every assigned node and act on the aggregate result:
@@ -1745,6 +1978,16 @@ mod tests {
                 _request: tonic::Request<spur_proto::proto::RunCommandRequest>,
             ) -> Result<tonic::Response<spur_proto::proto::RunCommandResponse>, tonic::Status>
             {
+                Ok(tonic::Response::new(Default::default()))
+            }
+
+            async fn register_job_allocation(
+                &self,
+                _request: tonic::Request<spur_proto::proto::RegisterJobAllocationRequest>,
+            ) -> Result<
+                tonic::Response<spur_proto::proto::RegisterJobAllocationResponse>,
+                tonic::Status,
+            > {
                 Ok(tonic::Response::new(Default::default()))
             }
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -13,6 +13,7 @@ use tracing::{info, warn};
 
 use spur_core::job::NodeCompleteError;
 use spur_core::reservation::Reservation;
+use spur_core::task_launch::build_step_task_plan;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::slurm_controller_server::SlurmController;
 use spur_proto::proto::*;
@@ -308,6 +309,62 @@ impl SlurmController for ControllerService {
                 crate::scheduler_loop::send_cancel_to_agents(&cluster, &job, 0).await;
             });
         }
+
+        Ok(Response::new(()))
+    }
+
+    async fn complete_job(
+        &self,
+        request: Request<CompleteJobRequest>,
+    ) -> Result<Response<()>, Status> {
+        if let Err(status) = self.check_leader(&request) {
+            let proxy = &self.leader_proxy;
+            match proxy.get_leader_client().await {
+                Ok(mut client) => {
+                    let mut fwd = Request::new(request.into_inner());
+                    *fwd.metadata_mut() = Self::forwarded_metadata();
+                    return client.complete_job(fwd).await;
+                }
+                Err(e) => {
+                    warn!("failed to forward complete_job to leader: {e}");
+                    return Err(status);
+                }
+            }
+        }
+
+        let req = request.into_inner();
+        let job = self
+            .cluster
+            .finish_srun_job(req.job_id, req.exit_code, &req.user)
+            .map_err(|e| match e {
+                crate::cluster::SrunCompleteError::NotFound(id) => {
+                    Status::not_found(format!("job {id} not found"))
+                }
+                crate::cluster::SrunCompleteError::NotSrunJob(id) => {
+                    Status::failed_precondition(format!("job {id} is not an srun allocation"))
+                }
+                crate::cluster::SrunCompleteError::NotStepDispatch(id) => {
+                    Status::failed_precondition(format!(
+                        "job {id} does not use native step dispatch"
+                    ))
+                }
+                crate::cluster::SrunCompleteError::AlreadyTerminal { job_id, state } => {
+                    Status::failed_precondition(format!("job {job_id} is already {state:?}"))
+                }
+                crate::cluster::SrunCompleteError::NotOwner { job_id, user } => {
+                    Status::permission_denied(format!(
+                        "user {user} is not permitted to complete job {job_id}"
+                    ))
+                }
+                crate::cluster::SrunCompleteError::Internal { job_id, message } => {
+                    Status::internal(format!("job {job_id}: {message}"))
+                }
+            })?;
+
+        let cluster = self.cluster.clone();
+        tokio::spawn(async move {
+            crate::scheduler_loop::release_srun_allocation_on_agents(&cluster, &job).await;
+        });
 
         Ok(Response::new(()))
     }
@@ -1176,7 +1233,9 @@ impl SlurmController for ControllerService {
             exit_code: None,
         };
 
-        self.cluster.create_step(job_id, step_id, step);
+        self.cluster
+            .create_step(step)
+            .map_err(|e| Status::internal(format!("failed to create job step: {e}")))?;
 
         Ok(Response::new(CreateJobStepResponse { step_id }))
     }
@@ -1393,9 +1452,9 @@ impl SlurmController for ControllerService {
         Ok(resp)
     }
 
-    /// #146: route a step from `srun-in-salloc` to one of the job's
-    /// allocated nodes. Unlike ExecInJob, the job may not have a tracked
-    /// process — salloc allocations only exist as scheduler bookkeeping.
+    /// Route a step from srun to the job's allocated nodes. Unlike ExecInJob,
+    /// the job may not have a tracked process — salloc allocations only exist
+    /// as scheduler bookkeeping.
     async fn run_step(
         &self,
         request: Request<RunStepRequest>,
@@ -1425,58 +1484,140 @@ impl SlurmController for ControllerService {
             )));
         }
 
-        let node_name = job.allocated_nodes[0].clone();
-        let node = self
+        let step = self
             .cluster
-            .get_node(&node_name)
-            .ok_or_else(|| Status::not_found(format!("node {} not found", node_name)))?;
-        let addr = node
-            .address
-            .as_ref()
-            .ok_or_else(|| Status::internal(format!("node {} has no agent address", node_name)))?;
-        let agent_addr = format!("http://{}:{}", addr, node.port);
+            .get_steps(job_id)
+            .into_iter()
+            .find(|s| s.step_id == req.step_id)
+            .ok_or_else(|| {
+                Status::not_found(format!("step {} not found for job {}", req.step_id, job_id))
+            })?;
 
-        let mut agent = SlurmAgentClient::connect(agent_addr.clone())
-            .await
-            .map_err(|e| {
-                Status::unavailable(format!("cannot reach agent at {}: {}", agent_addr, e))
-            })?
-            .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
-            .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE);
+        let num_nodes = job.allocated_nodes.len() as u32;
+        let plan = build_step_task_plan(step.num_tasks, num_nodes, step.distribution);
+        if plan.is_empty() {
+            return Err(Status::failed_precondition(format!(
+                "step {} for job {} has no tasks to run",
+                req.step_id, job_id
+            )));
+        }
 
-        let agent_resp = agent
-            .run_command(RunCommandRequest {
-                command: req.command,
-                uid: req.uid,
-                gid: req.gid,
-                work_dir: req.work_dir,
-                environment: req.environment,
-                job_id: req.job_id,
-            })
-            .await
-            .map_err(|e| Status::internal(format!("run_command failed: {}", e)))?
-            .into_inner();
+        let step_num_tasks = step.num_tasks;
+        let command = req.command.clone();
+        let work_dir = req.work_dir.clone();
+        let environment = req.environment.clone();
+        let uid = req.uid;
+        let gid = req.gid;
+        let step_id = req.step_id;
+        let label = req.label;
 
-        // Record the step's exit code durably (Raft) so the job's live
-        // DerivedExitCode (running max over steps) is consistent and survives
-        // restart. Best-effort: a failure here doesn't fail the step itself.
-        if let Err(e) =
-            self.cluster
-                .record_step_complete(req.job_id, req.step_id, agent_resp.exit_code)
-        {
+        let mut set = tokio::task::JoinSet::new();
+        for node_tasks in plan {
+            let node_name = job
+                .allocated_nodes
+                .get(node_tasks.node_index as usize)
+                .ok_or_else(|| {
+                    Status::internal(format!(
+                        "step plan references node index {} but job {} has {} nodes",
+                        node_tasks.node_index,
+                        job_id,
+                        job.allocated_nodes.len()
+                    ))
+                })?
+                .clone();
+            let node = self
+                .cluster
+                .get_node(&node_name)
+                .ok_or_else(|| Status::not_found(format!("node {} not found", node_name)))?;
+            let addr = node.address.as_ref().ok_or_else(|| {
+                Status::internal(format!("node {} has no agent address", node_name))
+            })?;
+            let agent_addr = format!("http://{}:{}", addr, node.port);
+
+            let command = command.clone();
+            let work_dir = work_dir.clone();
+            let environment = environment.clone();
+            set.spawn(async move {
+                let mut agent = SlurmAgentClient::connect(agent_addr.clone())
+                    .await
+                    .map_err(|e| {
+                        Status::unavailable(format!("cannot reach agent at {}: {}", agent_addr, e))
+                    })?
+                    .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
+                    .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE);
+
+                let agent_resp = agent
+                    .run_command(RunCommandRequest {
+                        command: command.clone(),
+                        uid,
+                        gid,
+                        work_dir: work_dir.clone(),
+                        environment: environment.clone(),
+                        job_id,
+                        num_tasks: node_tasks.tasks_on_node,
+                        task_offset: node_tasks.task_offset,
+                        step_id,
+                        step_num_tasks,
+                        label,
+                    })
+                    .await
+                    .map_err(|e| {
+                        Status::internal(format!("run_command on {} failed: {}", node_name, e))
+                    })?
+                    .into_inner();
+
+                Ok::<_, Status>((node_name, agent_resp))
+            });
+        }
+
+        let mut max_exit = 0i32;
+        let mut stdout = String::new();
+        let mut stderr = String::new();
+        let mut ran_nodes = Vec::new();
+        let mut dispatch_errors = Vec::new();
+
+        while let Some(result) = set.join_next().await {
+            match result {
+                Ok(Ok((node_name, agent_resp))) => {
+                    max_exit = max_exit.max(agent_resp.exit_code);
+                    stdout.push_str(&agent_resp.stdout);
+                    stderr.push_str(&agent_resp.stderr);
+                    ran_nodes.push(node_name);
+                }
+                Ok(Err(e)) => {
+                    warn!(job_id, step_id, error = %e, "step dispatch failed on one node");
+                    dispatch_errors.push(e.to_string());
+                    max_exit = max_exit.max(1);
+                }
+                Err(e) => {
+                    warn!(job_id, step_id, error = %e, "step dispatch task panicked");
+                    dispatch_errors.push(format!("step dispatch task panicked: {e}"));
+                    max_exit = max_exit.max(1);
+                }
+            }
+        }
+
+        if !dispatch_errors.is_empty() {
+            stderr.push_str(&format!(
+                "srun step dispatch errors:\n{}\n",
+                dispatch_errors.join("\n")
+            ));
+        }
+
+        if let Err(e) = self.cluster.record_step_complete(job_id, step_id, max_exit) {
             warn!(
-                job_id = req.job_id,
-                step_id = req.step_id,
+                job_id,
+                step_id,
                 error = %e,
                 "failed to record step completion"
             );
         }
 
         Ok(Response::new(RunStepResponse {
-            exit_code: agent_resp.exit_code,
-            stdout: agent_resp.stdout,
-            stderr: agent_resp.stderr,
-            node: node_name,
+            exit_code: max_exit,
+            stdout,
+            stderr,
+            node: ran_nodes.join(","),
         }))
     }
 
@@ -1778,6 +1919,7 @@ fn proto_to_job_spec(spec: JobSpec) -> Result<spur_core::job::JobSpec, Status> {
         exclusive: spec.exclusive,
         hold: spec.hold,
         interactive: spec.interactive,
+        srun_job: spec.srun_job,
         mail_type: spec.mail_type,
         mail_user: if spec.mail_user.is_empty() {
             None
@@ -1934,6 +2076,7 @@ fn job_to_proto(job: &spur_core::job::Job) -> JobInfo {
         array_task_id: job.spec.array_task_id.unwrap_or(0),
         reservation: job.spec.reservation.clone().unwrap_or_default(),
         comment: job.spec.comment.clone().unwrap_or_default(),
+        srun_step_dispatch: job.srun_step_dispatch,
     }
 }
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1511,29 +1511,48 @@ impl SlurmController for ControllerService {
         let step_id = req.step_id;
         let label = req.label;
 
-        let mut set = tokio::task::JoinSet::new();
+        struct NodeDispatch {
+            node_name: String,
+            agent_addr: String,
+            node_tasks: spur_core::task_launch::NodeStepTasks,
+        }
+
+        let mut dispatches = Vec::new();
+        let mut dispatch_errors = Vec::new();
+
         for node_tasks in plan {
-            let node_name = job
-                .allocated_nodes
-                .get(node_tasks.node_index as usize)
-                .ok_or_else(|| {
-                    Status::internal(format!(
+            let node_name = match job.allocated_nodes.get(node_tasks.node_index as usize) {
+                Some(name) => name.clone(),
+                None => {
+                    dispatch_errors.push(format!(
                         "step plan references node index {} but job {} has {} nodes",
                         node_tasks.node_index,
                         job_id,
                         job.allocated_nodes.len()
-                    ))
-                })?
-                .clone();
-            let node = self
-                .cluster
-                .get_node(&node_name)
-                .ok_or_else(|| Status::not_found(format!("node {} not found", node_name)))?;
-            let addr = node.address.as_ref().ok_or_else(|| {
-                Status::internal(format!("node {} has no agent address", node_name))
-            })?;
-            let agent_addr = format!("http://{}:{}", addr, node.port);
+                    ));
+                    continue;
+                }
+            };
+            let Some(node) = self.cluster.get_node(&node_name) else {
+                dispatch_errors.push(format!("node {node_name} not found"));
+                continue;
+            };
+            let Some(addr) = node.address.as_ref() else {
+                dispatch_errors.push(format!("node {node_name} has no agent address"));
+                continue;
+            };
+            dispatches.push(NodeDispatch {
+                node_name,
+                agent_addr: format!("http://{}:{}", addr, node.port),
+                node_tasks,
+            });
+        }
 
+        let mut set = tokio::task::JoinSet::new();
+        for dispatch in dispatches {
+            let node_name = dispatch.node_name;
+            let agent_addr = dispatch.agent_addr;
+            let node_tasks = dispatch.node_tasks;
             let command = command.clone();
             let work_dir = work_dir.clone();
             let environment = environment.clone();
@@ -1574,7 +1593,6 @@ impl SlurmController for ControllerService {
         let mut stdout = String::new();
         let mut stderr = String::new();
         let mut ran_nodes = Vec::new();
-        let mut dispatch_errors = Vec::new();
 
         while let Some(result) = set.join_next().await {
             match result {
@@ -1598,6 +1616,7 @@ impl SlurmController for ControllerService {
         }
 
         if !dispatch_errors.is_empty() {
+            max_exit = max_exit.max(1);
             stderr.push_str(&format!(
                 "srun step dispatch errors:\n{}\n",
                 dispatch_errors.join("\n")

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -22,6 +22,7 @@ use spur_spank::{SpankContext, SpankHandle, SpankHook, SpankHost};
 
 use spur_core::config::HooksConfig;
 use spur_core::spur_env::SpurEnv;
+use spur_core::task_launch::build_multi_task_wrapper;
 use spur_devices::DeviceRegistry;
 
 use crate::executor;
@@ -42,6 +43,7 @@ struct TrackedJob {
     cpus: u32,
     memory_mb: u64,
     nodelist: String,
+    mpi: String,
 }
 
 struct CompletedJob {
@@ -369,6 +371,16 @@ mod completion_report_tests {
     }
 }
 
+/// Build a bash script that execs a command vector without shell interpretation.
+fn build_one_shot_command_script(command: &[String]) -> String {
+    let quoted: Vec<String> = command
+        .iter()
+        .map(|arg| shlex::try_quote(arg).unwrap_or_else(|_| std::borrow::Cow::Borrowed(arg)))
+        .map(|c| c.into_owned())
+        .collect();
+    format!("#!/bin/bash\nexec {}\n", quoted.join(" "))
+}
+
 /// Build the bash job script for a launch request.
 ///
 /// A non-empty `script` is used verbatim. Otherwise `argv` is a literal
@@ -594,8 +606,16 @@ impl SlurmAgent for AgentService {
         }
 
         // Spur-only vars
-        senv.set("SPUR_TASK_OFFSET", task_offset);
         senv.set("SPUR_NODE_RANK", node_rank);
+        if tasks_per_node == 1 {
+            SpurEnv::apply_task_rank(&mut senv, task_offset, 0, 1);
+        } else {
+            senv.set("SPUR_TASK_OFFSET", task_offset);
+            senv.set("LOCAL_RANK", "0");
+            senv.set("LOCAL_WORLD_SIZE", tasks_per_node);
+            senv.set("NPROC_PER_NODE", tasks_per_node);
+            senv.set("PMI_RANK", task_offset);
+        }
         if !peer_nodes.is_empty() {
             senv.set("SPUR_PEER_NODES", peer_nodes.join(","));
         }
@@ -607,15 +627,19 @@ impl SlurmAgent for AgentService {
         }
 
         // Third-party distributed training / MPI env vars
-        senv.set("LOCAL_RANK", "0");
-        senv.set("LOCAL_WORLD_SIZE", tasks_per_node);
-        senv.set("NPROC_PER_NODE", tasks_per_node);
+        if tasks_per_node > 1 {
+            senv.set("LOCAL_RANK", "0");
+            senv.set("LOCAL_WORLD_SIZE", tasks_per_node);
+            senv.set("NPROC_PER_NODE", tasks_per_node);
+        }
         senv.set("NODE_RANK", node_rank);
 
         senv.set("PMI_SIZE", spec.num_tasks);
         senv.set("PMI_UNIVERSE_SIZE", spec.num_tasks);
         senv.set("PMI_APPNUM", "0");
-        senv.set("PMI_RANK", task_offset);
+        if tasks_per_node > 1 {
+            senv.set("PMI_RANK", task_offset);
+        }
 
         if spec.mpi == "pmix" {
             senv.set("PMIX_SIZE", spec.num_tasks);
@@ -767,47 +791,7 @@ impl SlurmAgent for AgentService {
             }
 
             // Build the wrapper that launches N tasks with GPU partitioning
-            let mut wrapper = String::from("#!/bin/bash\n");
-            wrapper.push_str(&format!(
-                "_TASKS_ON_NODE={}\nSPUR_TASK_OFFSET=${{SPUR_TASK_OFFSET:-0}}\n",
-                tasks_per_node
-            ));
-            wrapper.push_str("for LOCAL_RANK in $(seq 0 $((_TASKS_ON_NODE - 1))); do\n");
-            wrapper.push_str("  export LOCAL_RANK\n");
-            wrapper.push_str(SpurEnv::per_task_bash_exports());
-            wrapper.push_str("  export PMI_RANK=$SPUR_PROCID\n");
-            wrapper.push_str("  export PMIX_RANK=$SPUR_PROCID\n");
-            wrapper.push_str("  export OMPI_COMM_WORLD_RANK=$SPUR_PROCID\n");
-            wrapper.push_str("  export OMPI_COMM_WORLD_LOCAL_RANK=$LOCAL_RANK\n");
-
-            // Partition GPUs across tasks if GPUs are allocated
-            wrapper.push_str("  if [ -n \"$SPUR_JOB_GPUS\" ]; then\n");
-            wrapper.push_str("    IFS=',' read -ra _ALL_GPUS <<< \"$SPUR_JOB_GPUS\"\n");
-            wrapper.push_str("    _GPUS_PER_TASK=$(( ${#_ALL_GPUS[@]} / _TASKS_ON_NODE ))\n");
-            wrapper.push_str("    if [ $_GPUS_PER_TASK -gt 0 ]; then\n");
-            wrapper.push_str("      _START=$((LOCAL_RANK * _GPUS_PER_TASK))\n");
-            wrapper.push_str(
-                "      _TASK_GPUS=$(echo \"${_ALL_GPUS[@]:$_START:$_GPUS_PER_TASK}\" | tr ' ' ',')\n",
-            );
-            wrapper.push_str("      export ROCR_VISIBLE_DEVICES=$_TASK_GPUS\n");
-            wrapper.push_str("      export CUDA_VISIBLE_DEVICES=$_TASK_GPUS\n");
-            wrapper.push_str("      export GPU_DEVICE_ORDINAL=$_TASK_GPUS\n");
-            wrapper.push_str("    fi\n");
-            wrapper.push_str("  fi\n");
-
-            wrapper.push_str("  if [ \"$SPUR_LABEL\" = \"1\" ]; then\n");
-            wrapper.push_str(&format!(
-                "    bash \"{}\" 2>&1 | sed \"s/^/[$SPUR_PROCID] /\" &\n",
-                user_script_path.replace('"', "\\\"")
-            ));
-            wrapper.push_str("  else\n");
-            wrapper.push_str(&format!(
-                "    bash \"{}\" &\n",
-                user_script_path.replace('"', "\\\"")
-            ));
-            wrapper.push_str("  fi\n");
-            wrapper.push_str("done\nwait\n");
-            wrapper
+            build_multi_task_wrapper(&user_script_path, tasks_per_node, None)
         } else {
             launch_script
         };
@@ -913,6 +897,7 @@ impl SlurmAgent for AgentService {
                         cpus: launch_cfg.cpus,
                         memory_mb: launch_cfg.memory_mb,
                         nodelist: launch_cfg.nodelist,
+                        mpi: spec.mpi.clone(),
                     },
                 );
                 Ok(Response::new(LaunchJobResponse {
@@ -1039,10 +1024,93 @@ impl SlurmAgent for AgentService {
         }))
     }
 
-    /// #146: run a one-shot command on this node, used by `srun` inside an
-    /// `salloc` interactive shell. Unlike ExecInJob, this does not require
-    /// a tracked job process — salloc allocations don't run anything until
-    /// `srun` dispatches a step.
+    /// Record a standalone-srun allocation on this node without launching a
+    /// batch script.
+    async fn register_job_allocation(
+        &self,
+        request: Request<RegisterJobAllocationRequest>,
+    ) -> Result<Response<RegisterJobAllocationResponse>, Status> {
+        let req = request.into_inner();
+        if req.job_id == 0 {
+            return Err(Status::invalid_argument("job_id is required"));
+        }
+
+        {
+            let jobs = self.running.lock().await;
+            if jobs.contains_key(&req.job_id) {
+                return Err(Status::already_exists(format!(
+                    "job {} already registered on this node",
+                    req.job_id
+                )));
+            }
+        }
+
+        let allocated = req.allocated.as_ref();
+        let mut controller_gpu_ids: Vec<u32> = allocated
+            .and_then(|a| a.devices.get("gpu"))
+            .map(|d| d.devices.iter().map(|dev| dev.device_id).collect())
+            .unwrap_or_default();
+        if controller_gpu_ids.is_empty() {
+            controller_gpu_ids = req
+                .gpu_devices
+                .iter()
+                .filter_map(|s| s.parse().ok())
+                .collect();
+        }
+
+        let cpus = allocated.map(|a| a.cpus).unwrap_or(req.cpus).max(1);
+        let memory_mb = allocated.map(|a| a.memory_mb).unwrap_or(req.memory_mb);
+
+        {
+            let mut alloc = self.allocation.lock().await;
+            alloc
+                .allocate_for_job(req.job_id, cpus, memory_mb, &controller_gpu_ids)
+                .map_err(|e| match e {
+                    AllocError::GpusUnavailable => Status::resource_exhausted(
+                        "controller-allocated GPUs unavailable on this node",
+                    ),
+                    AllocError::DuplicateJob => Status::already_exists(format!(
+                        "job {} already registered on this node",
+                        req.job_id
+                    )),
+                })?;
+            alloc.commit_job(req.job_id);
+        }
+
+        info!(
+            job_id = req.job_id,
+            cpus,
+            memory_mb,
+            gpus = ?controller_gpu_ids,
+            "registered srun allocation"
+        );
+
+        self.running.lock().await.insert(
+            req.job_id,
+            TrackedJob {
+                job: executor::RunningJob::AllocationOnly,
+                rootfs_mode: crate::container::RootfsMode::Extracted,
+                stdout_path: String::new(),
+                stderr_path: String::new(),
+                has_pid_namespace: false,
+                work_dir: String::new(),
+                uid: req.uid,
+                gid: req.gid,
+                partition: req.partition,
+                gpu_devices: controller_gpu_ids,
+                cpus,
+                memory_mb,
+                nodelist: req.nodelist,
+                mpi: req.mpi,
+            },
+        );
+
+        Ok(Response::new(RegisterJobAllocationResponse {}))
+    }
+
+    /// Run a one-shot command on this node, used by srun inside an allocation.
+    /// Unlike ExecInJob, this does not require a tracked job process — salloc
+    /// allocations don't run anything until srun dispatches a step.
     async fn run_command(
         &self,
         request: Request<RunCommandRequest>,
@@ -1063,7 +1131,15 @@ impl SlurmAgent for AgentService {
             return Err(Status::invalid_argument("job_id is required"));
         }
 
-        let (gpu_devices, partition, cpus, memory_mb, nodelist) = {
+        let num_tasks = req.num_tasks.max(1);
+        let step_num_tasks = if req.step_num_tasks > 0 {
+            req.step_num_tasks
+        } else {
+            num_tasks
+        };
+        let step_id = req.step_id;
+
+        let (gpu_devices, partition, cpus, memory_mb, nodelist, mpi, num_tasks_total) = {
             let jobs = self.running.lock().await;
             let tracked = jobs.get(&job_id).ok_or_else(|| {
                 Status::not_found(format!("job {} not running on this node", job_id))
@@ -1081,8 +1157,17 @@ impl SlurmAgent for AgentService {
                 tracked.cpus,
                 tracked.memory_mb,
                 nodelist,
+                tracked.mpi.clone(),
+                step_num_tasks,
             )
         };
+
+        let hostname = hostname::get()
+            .map(|h| h.to_string_lossy().to_string())
+            .unwrap_or_else(|_| "localhost".into());
+        let node_names: Vec<&str> = nodelist.split(',').filter(|s| !s.is_empty()).collect();
+        let num_nodes = node_names.len().max(1) as u32;
+        let node_id = node_names.iter().position(|n| *n == hostname).unwrap_or(0) as u32;
 
         let gpu_env = if gpu_devices.is_empty() {
             HashMap::new()
@@ -1107,9 +1192,86 @@ impl SlurmAgent for AgentService {
         senv.set_with_slurm_twin("SPUR_JOB_NODELIST", &nodelist);
         senv.set_with_slurm_twin("SPUR_CPUS_ON_NODE", cpus);
         senv.extend(&gpu_env);
+        let mut bind_env = HashMap::new();
+        spur_core::task_launch::apply_gpu_bind_env(&mut bind_env, &req.environment, &gpu_devices);
+        senv.extend(&bind_env);
+        if let Some(cpu_bind) = spur_core::task_launch::unsupported_cpu_bind(&req.environment) {
+            warn!(
+                job_id,
+                cpu_bind = %cpu_bind,
+                "topology CPU bind modes are not applied in srun step mode"
+            );
+        }
+        if let Some(err) =
+            spur_core::task_launch::map_cpu_bind_error(&req.environment, step_num_tasks)
+        {
+            return Err(Status::invalid_argument(err));
+        }
+        SpurEnv::apply_step_scope(
+            &mut senv,
+            job_id,
+            step_id,
+            step_num_tasks,
+            node_id,
+            num_nodes,
+        );
+        if req.label {
+            senv.set("SPUR_LABEL", "1");
+        }
 
-        let mut cmd = tokio::process::Command::new(&req.command[0]);
-        cmd.args(&req.command[1..]).current_dir(&work_dir);
+        let tasks_per_node = num_tasks;
+        senv.set("PMI_SIZE", num_tasks_total);
+        senv.set("PMI_UNIVERSE_SIZE", num_tasks_total);
+        senv.set("PMI_APPNUM", "0");
+        if mpi == "pmix" {
+            senv.set("PMIX_SIZE", num_tasks_total);
+            senv.set("PMIX_NAMESPACE", format!("spur.{job_id}"));
+            senv.set("OMPI_COMM_WORLD_SIZE", num_tasks_total);
+            senv.set("OMPI_COMM_WORLD_NODE_RANK", node_id);
+            senv.set("OMPI_COMM_WORLD_LOCAL_SIZE", tasks_per_node);
+        }
+
+        let (program, program_args) = if num_tasks > 1 {
+            let user_script_path = format!("{work_dir}/.spur_step_{job_id}_{step_id}_{node_id}.sh");
+            let user_script = build_one_shot_command_script(&req.command);
+            std::fs::write(&user_script_path, &user_script)
+                .map_err(|e| Status::internal(format!("failed to write step script: {}", e)))?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = std::fs::set_permissions(
+                    &user_script_path,
+                    std::fs::Permissions::from_mode(0o755),
+                );
+            }
+
+            let wrapper_path =
+                format!("{work_dir}/.spur_step_wrapper_{job_id}_{step_id}_{node_id}.sh");
+            let wrapper =
+                build_multi_task_wrapper(&user_script_path, num_tasks, Some(&req.environment));
+            std::fs::write(&wrapper_path, &wrapper)
+                .map_err(|e| Status::internal(format!("failed to write step wrapper: {}", e)))?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ =
+                    std::fs::set_permissions(&wrapper_path, std::fs::Permissions::from_mode(0o755));
+            }
+
+            senv.set("SPUR_TASK_OFFSET", req.task_offset);
+            ("bash".to_string(), vec![wrapper_path])
+        } else {
+            SpurEnv::apply_task_rank(&mut senv, req.task_offset, 0, 1);
+            spur_core::task_launch::wrap_command_with_cpu_bind(
+                &req.command[0],
+                &req.command[1..],
+                &req.environment,
+                req.task_offset,
+            )
+        };
+
+        let mut cmd = tokio::process::Command::new(&program);
+        cmd.args(&program_args).current_dir(&work_dir);
         for (k, v) in senv.into_map() {
             cmd.env(k, v);
         }
@@ -1133,12 +1295,13 @@ impl SlurmAgent for AgentService {
 
         info!(
             command = ?req.command,
+            num_tasks,
+            task_offset = req.task_offset,
             uid = req.uid,
             work_dir = %work_dir,
-            "RunCommand: executing one-shot step"
+            "RunCommand: executing step"
         );
 
-        // TaskProlog: run before the step command
         if let Some(ref task_prolog) = self.hooks.task_prolog {
             let ctx = spur_core::hooks::HookContext {
                 job_id,
@@ -1162,7 +1325,6 @@ impl SlurmAgent for AgentService {
             .await
             .map_err(|e| Status::internal(format!("command failed: {}", e)))?;
 
-        // TaskEpilog: run after the step command (failure logged, not fatal)
         if let Some(ref task_epilog) = self.hooks.task_epilog {
             let ctx = spur_core::hooks::HookContext {
                 job_id,
@@ -1635,6 +1797,12 @@ impl SlurmAgent for AgentService {
 }
 
 impl AgentService {
+    async fn drop_tracked_job(&self, job_id: u32) {
+        if self.running.lock().await.remove(&job_id).is_some() {
+            self.allocation.lock().await.release_job(job_id);
+        }
+    }
+
     /// Record controller-allocated GPUs and allocate local CPU/memory resources.
     async fn allocate_local_resources(
         &self,
@@ -1721,6 +1889,16 @@ impl AgentService {
 
     /// Send a user-specified signal to a running job.
     async fn send_explicit_signal(&self, job_id: u32, signal: i32) {
+        let is_allocation_only = {
+            let jobs = self.running.lock().await;
+            jobs.get(&job_id)
+                .is_some_and(|tracked| tracked.job.is_allocation_only())
+        };
+        if is_allocation_only {
+            self.drop_tracked_job(job_id).await;
+            return;
+        }
+
         let jobs = self.running.lock().await;
         let Some(tracked) = jobs.get(&job_id) else {
             return;
@@ -1748,6 +1926,16 @@ impl AgentService {
 
     /// SIGTERM now, escalate to SIGKILL after a 5-second grace period.
     async fn graceful_cancel(&self, job_id: u32) {
+        let is_allocation_only = {
+            let jobs = self.running.lock().await;
+            jobs.get(&job_id)
+                .is_some_and(|tracked| tracked.job.is_allocation_only())
+        };
+        if is_allocation_only {
+            self.drop_tracked_job(job_id).await;
+            return;
+        }
+
         {
             let jobs = self.running.lock().await;
             let Some(tracked) = jobs.get(&job_id) else {
@@ -1813,6 +2001,7 @@ impl TrackedJob {
             cpus: 1,
             memory_mb: 0,
             nodelist: String::new(),
+            mpi: String::new(),
         }
     }
 }
@@ -1993,7 +2182,7 @@ mod tests {
         assert_eq!(err.code(), tonic::Code::NotFound);
     }
 
-    // --- #146: srun-in-salloc step dispatch via RunCommand ---
+    // --- srun step dispatch via RunCommand ---
     //
     // Regression: srun's run_as_step previously called
     //   tokio::process::Command::new(args.command[0]).status()
@@ -2015,6 +2204,7 @@ mod tests {
             work_dir: String::new(),
             environment: HashMap::new(),
             job_id,
+            ..Default::default()
         });
         let resp = svc.run_command(req).await.unwrap().into_inner();
         assert_eq!(resp.exit_code, 0);
@@ -2032,6 +2222,7 @@ mod tests {
             work_dir: String::new(),
             environment: HashMap::new(),
             job_id,
+            ..Default::default()
         });
         let resp = svc.run_command(req).await.unwrap().into_inner();
         assert_eq!(resp.exit_code, 1, "false exits 1");
@@ -2049,6 +2240,7 @@ mod tests {
             work_dir: String::new(),
             environment: env,
             job_id,
+            ..Default::default()
         });
         let resp = svc.run_command(req).await.unwrap().into_inner();
         assert_eq!(resp.exit_code, 0);
@@ -2070,6 +2262,7 @@ mod tests {
             work_dir: String::new(),
             environment: HashMap::new(),
             job_id: 0,
+            ..Default::default()
         });
         let err = svc.run_command(req).await.unwrap_err();
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
@@ -2090,6 +2283,7 @@ mod tests {
             work_dir: String::new(),
             environment: HashMap::new(),
             job_id: 0,
+            ..Default::default()
         });
         let err = svc.run_command(req).await.unwrap_err();
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
@@ -2110,6 +2304,7 @@ mod tests {
             work_dir: String::new(),
             environment: HashMap::new(),
             job_id: 999,
+            ..Default::default()
         });
         let err = svc.run_command(req).await.unwrap_err();
         assert_eq!(err.code(), tonic::Code::NotFound);
@@ -2133,6 +2328,7 @@ mod tests {
             work_dir: tmp_canonical.to_string_lossy().into_owned(),
             environment: HashMap::new(),
             job_id,
+            ..Default::default()
         });
         let resp = svc.run_command(req).await.unwrap().into_inner();
         assert_eq!(resp.exit_code, 0);
@@ -2298,6 +2494,7 @@ mod tests {
             work_dir: String::new(),
             environment: HashMap::new(),
             job_id,
+            ..Default::default()
         });
         let resp = svc.run_command(req).await.unwrap().into_inner();
         assert_eq!(resp.exit_code, 0);
@@ -2384,6 +2581,7 @@ mod tests {
             cpus: 1,
             memory_mb: 0,
             nodelist: String::new(),
+            mpi: String::new(),
         };
         svc.insert_test_job(job_id, tracked).await;
 

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -372,13 +372,10 @@ mod completion_report_tests {
 }
 
 /// Build a bash script that execs a command vector without shell interpretation.
-fn build_one_shot_command_script(command: &[String]) -> String {
-    let quoted: Vec<String> = command
-        .iter()
-        .map(|arg| shlex::try_quote(arg).unwrap_or_else(|_| std::borrow::Cow::Borrowed(arg)))
-        .map(|c| c.into_owned())
-        .collect();
-    format!("#!/bin/bash\nexec {}\n", quoted.join(" "))
+fn build_one_shot_command_script(command: &[String]) -> Result<String, Status> {
+    let joined = shlex::try_join(command.iter().map(String::as_str))
+        .map_err(|e| Status::invalid_argument(format!("command is not shell-safe: {e}")))?;
+    Ok(format!("#!/bin/bash\nexec {joined}\n"))
 }
 
 /// Build the bash job script for a launch request.
@@ -1162,12 +1159,13 @@ impl SlurmAgent for AgentService {
             )
         };
 
-        let hostname = hostname::get()
-            .map(|h| h.to_string_lossy().to_string())
-            .unwrap_or_else(|_| "localhost".into());
+        let agent_hostname = self.reporter.hostname.clone();
         let node_names: Vec<&str> = nodelist.split(',').filter(|s| !s.is_empty()).collect();
         let num_nodes = node_names.len().max(1) as u32;
-        let node_id = node_names.iter().position(|n| *n == hostname).unwrap_or(0) as u32;
+        let node_id = node_names
+            .iter()
+            .position(|n| *n == agent_hostname)
+            .unwrap_or(0) as u32;
 
         let gpu_env = if gpu_devices.is_empty() {
             HashMap::new()
@@ -1231,9 +1229,9 @@ impl SlurmAgent for AgentService {
             senv.set("OMPI_COMM_WORLD_LOCAL_SIZE", tasks_per_node);
         }
 
-        let (program, program_args) = if num_tasks > 1 {
+        let (program, program_args) = if num_tasks > 1 || req.label {
             let user_script_path = format!("{work_dir}/.spur_step_{job_id}_{step_id}_{node_id}.sh");
-            let user_script = build_one_shot_command_script(&req.command);
+            let user_script = build_one_shot_command_script(&req.command)?;
             std::fs::write(&user_script_path, &user_script)
                 .map_err(|e| Status::internal(format!("failed to write step script: {}", e)))?;
             #[cfg(unix)]
@@ -1247,8 +1245,15 @@ impl SlurmAgent for AgentService {
 
             let wrapper_path =
                 format!("{work_dir}/.spur_step_wrapper_{job_id}_{step_id}_{node_id}.sh");
-            let wrapper =
-                build_multi_task_wrapper(&user_script_path, num_tasks, Some(&req.environment));
+            let wrapper = if num_tasks > 1 {
+                build_multi_task_wrapper(&user_script_path, num_tasks, Some(&req.environment))
+            } else {
+                spur_core::task_launch::build_labeled_single_task_wrapper(
+                    &user_script_path,
+                    req.task_offset,
+                    Some(&req.environment),
+                )
+            };
             std::fs::write(&wrapper_path, &wrapper)
                 .map_err(|e| Status::internal(format!("failed to write step wrapper: {}", e)))?;
             #[cfg(unix)]
@@ -1258,7 +1263,11 @@ impl SlurmAgent for AgentService {
                     std::fs::set_permissions(&wrapper_path, std::fs::Permissions::from_mode(0o755));
             }
 
-            senv.set("SPUR_TASK_OFFSET", req.task_offset);
+            if num_tasks > 1 {
+                senv.set("SPUR_TASK_OFFSET", req.task_offset);
+            } else {
+                SpurEnv::apply_task_rank(&mut senv, req.task_offset, 0, 1);
+            }
             ("bash".to_string(), vec![wrapper_path])
         } else {
             SpurEnv::apply_task_rank(&mut senv, req.task_offset, 0, 1);

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -378,6 +378,26 @@ fn build_one_shot_command_script(command: &[String]) -> Result<String, Status> {
     Ok(format!("#!/bin/bash\nexec {joined}\n"))
 }
 
+fn cleanup_step_scripts(dir: &std::path::Path, paths: &[&std::path::Path]) {
+    for path in paths {
+        let _ = std::fs::remove_file(path);
+    }
+    let _ = std::fs::remove_dir(dir);
+}
+
+struct StepScriptCleanup {
+    dir: std::path::PathBuf,
+    paths: Vec<std::path::PathBuf>,
+}
+
+impl Drop for StepScriptCleanup {
+    fn drop(&mut self) {
+        let path_refs: Vec<&std::path::Path> =
+            self.paths.iter().map(std::path::PathBuf::as_path).collect();
+        cleanup_step_scripts(&self.dir, &path_refs);
+    }
+}
+
 /// Build the bash job script for a launch request.
 ///
 /// A non-empty `script` is used verbatim. Otherwise `argv` is a literal
@@ -1201,7 +1221,9 @@ impl SlurmAgent for AgentService {
             );
         }
         if let Some(err) =
-            spur_core::task_launch::map_cpu_bind_error(&req.environment, step_num_tasks)
+            spur_core::task_launch::map_cpu_bind_error(&req.environment, step_num_tasks).or_else(
+                || spur_core::task_launch::mask_cpu_bind_error(&req.environment, step_num_tasks),
+            )
         {
             return Err(Status::invalid_argument(err));
         }
@@ -1229,55 +1251,59 @@ impl SlurmAgent for AgentService {
             senv.set("OMPI_COMM_WORLD_LOCAL_SIZE", tasks_per_node);
         }
 
-        let (program, program_args) = if num_tasks > 1 || req.label {
-            let user_script_path = format!("{work_dir}/.spur_step_{job_id}_{step_id}_{node_id}.sh");
-            let user_script = build_one_shot_command_script(&req.command)?;
-            std::fs::write(&user_script_path, &user_script)
-                .map_err(|e| Status::internal(format!("failed to write step script: {}", e)))?;
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                let _ = std::fs::set_permissions(
-                    &user_script_path,
-                    std::fs::Permissions::from_mode(0o755),
-                );
-            }
+        let (program, program_args, step_script_cleanup) = if num_tasks > 1 || req.label {
+            let step_dir =
+                crate::executor::prepare_step_script_dir(&work_dir, job_id, req.uid, req.gid)
+                    .map_err(|e| {
+                        Status::internal(format!("failed to create step script dir: {e}"))
+                    })?;
+            let mut guard = StepScriptCleanup {
+                dir: step_dir.clone(),
+                paths: Vec::new(),
+            };
 
-            let wrapper_path =
-                format!("{work_dir}/.spur_step_wrapper_{job_id}_{step_id}_{node_id}.sh");
+            let user_script_path = step_dir.join(format!("cmd_{node_id}.sh"));
+            let user_script = build_one_shot_command_script(&req.command)?;
+            crate::executor::write_job_scratch(&user_script_path, &user_script, req.uid, req.gid)
+                .map_err(|e| Status::internal(format!("failed to write step script: {e}")))?;
+            guard.paths.push(user_script_path.clone());
+
+            let wrapper_path = step_dir.join(format!("wrapper_{node_id}.sh"));
             let wrapper = if num_tasks > 1 {
-                build_multi_task_wrapper(&user_script_path, num_tasks, Some(&req.environment))
+                build_multi_task_wrapper(
+                    user_script_path.to_string_lossy().as_ref(),
+                    num_tasks,
+                    Some(&req.environment),
+                )
             } else {
                 spur_core::task_launch::build_labeled_single_task_wrapper(
-                    &user_script_path,
+                    user_script_path.to_string_lossy().as_ref(),
                     req.task_offset,
                     Some(&req.environment),
                 )
             };
-            std::fs::write(&wrapper_path, &wrapper)
-                .map_err(|e| Status::internal(format!("failed to write step wrapper: {}", e)))?;
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                let _ =
-                    std::fs::set_permissions(&wrapper_path, std::fs::Permissions::from_mode(0o755));
-            }
+            crate::executor::write_job_scratch(&wrapper_path, &wrapper, req.uid, req.gid)
+                .map_err(|e| Status::internal(format!("failed to write step wrapper: {e}")))?;
+            guard.paths.push(wrapper_path.clone());
 
             if num_tasks > 1 {
                 senv.set("SPUR_TASK_OFFSET", req.task_offset);
             } else {
                 SpurEnv::apply_task_rank(&mut senv, req.task_offset, 0, 1);
             }
-            ("bash".to_string(), vec![wrapper_path])
+            let wrapper_path_string = wrapper_path.to_string_lossy().into_owned();
+            ("bash".to_string(), vec![wrapper_path_string], Some(guard))
         } else {
             SpurEnv::apply_task_rank(&mut senv, req.task_offset, 0, 1);
-            spur_core::task_launch::wrap_command_with_cpu_bind(
+            let (program, args) = spur_core::task_launch::wrap_command_with_cpu_bind(
                 &req.command[0],
                 &req.command[1..],
                 &req.environment,
                 req.task_offset,
-            )
+            );
+            (program, args, None)
         };
+        let _step_script_guard = step_script_cleanup;
 
         let mut cmd = tokio::process::Command::new(&program);
         cmd.args(&program_args).current_dir(&work_dir);
@@ -1353,7 +1379,7 @@ impl SlurmAgent for AgentService {
         }
 
         Ok(Response::new(RunCommandResponse {
-            exit_code: output.status.code().unwrap_or(-1),
+            exit_code: spur_core::process::shell_exit_code(&output.status),
             stdout: String::from_utf8_lossy(&output.stdout).to_string(),
             stderr: String::from_utf8_lossy(&output.stderr).to_string(),
         }))

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -104,6 +104,8 @@ pub enum RunningJob {
         cgroup_path: Option<PathBuf>,
         reaped: bool,
     },
+    /// Allocation registered without a batch process (standalone srun).
+    AllocationOnly,
 }
 
 /// Split a finished process's wait status into (exit_code, signal).
@@ -158,7 +160,12 @@ impl RunningJob {
         match self {
             RunningJob::Managed { child, .. } => child.id(),
             RunningJob::Forked { pid, .. } => Some(*pid as u32),
+            RunningJob::AllocationOnly => None,
         }
+    }
+
+    pub fn is_allocation_only(&self) -> bool {
+        matches!(self, RunningJob::AllocationOnly)
     }
 
     /// Non-blocking check for process exit. Returns (exit_code, signal) if done.
@@ -193,6 +200,7 @@ impl RunningJob {
                     Err(e) => Err(e.into()),
                 }
             }
+            RunningJob::AllocationOnly => Ok(None),
         }
     }
 
@@ -220,6 +228,7 @@ impl RunningJob {
                 kill_process_tree(*pid, sig);
                 Ok(())
             }
+            RunningJob::AllocationOnly => Ok(()),
         }
     }
 
@@ -227,6 +236,7 @@ impl RunningJob {
         match self {
             RunningJob::Managed { cgroup_path, .. } => cgroup_path.take(),
             RunningJob::Forked { cgroup_path, .. } => cgroup_path.take(),
+            RunningJob::AllocationOnly => None,
         }
     }
 }

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -990,11 +990,38 @@ fn create_job_spool_dir(job_id: JobId, uid: u32, gid: u32) -> anyhow::Result<Pat
     bail!("failed to create job spool dir: {last_err:?}")
 }
 
+/// Private per-job directory for srun step scripts under the step work dir.
+pub(crate) fn prepare_step_script_dir(
+    work_dir: &str,
+    job_id: JobId,
+    uid: u32,
+    gid: u32,
+) -> anyhow::Result<PathBuf> {
+    let dir = PathBuf::from(work_dir).join(format!(".spur_step_{job_id}"));
+    std::fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700))?;
+        if should_run_as_user(uid) {
+            use nix::unistd::{Gid, Uid};
+            nix::unistd::chown(&dir, Some(Uid::from_raw(uid)), Some(Gid::from_raw(gid)))
+                .with_context(|| format!("chown {}", dir.display()))?;
+        }
+    }
+    Ok(dir)
+}
+
 /// Write a scratch file (job script, namespace wrapper) executable. When spurd
 /// is root and the job targets a user, hand ownership to that user and keep the
 /// file private (0700), so only the job and root can read it — matching Slurm's
 /// batch script handling.
-fn write_job_scratch(path: &Path, content: &str, uid: u32, gid: u32) -> anyhow::Result<()> {
+pub(crate) fn write_job_scratch(
+    path: &Path,
+    content: &str,
+    uid: u32,
+    gid: u32,
+) -> anyhow::Result<()> {
     use std::os::unix::fs::PermissionsExt;
     std::fs::write(path, content).with_context(|| format!("write {}", path.display()))?;
     std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))?;

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -160,6 +160,10 @@ message JobSpec {
   map<string, string> container_env = 76; // Extra env vars for container
   string container_entrypoint = 77; // Override entrypoint
   bool container_remap_root = 78;  // Remap user to root inside container
+
+  // Standalone srun: reserve an allocation without launching a batch script;
+  // the user command runs as a job step after nodes are registered.
+  bool srun_job = 82;
 }
 
 message JobInfo {
@@ -204,6 +208,12 @@ message JobInfo {
   string reservation = 52;
 
   string comment = 53;
+
+  // True when standalone srun uses native step dispatch (not K8s batch fallback).
+  // Requires a matching spur CLI: clients that ignore this field against a
+  // step-dispatch controller will poll for batch completion while agents hold
+  // allocation-only state.
+  bool srun_step_dispatch = 54;
 }
 
 message NodeInfo {
@@ -268,6 +278,8 @@ service SlurmController {
   rpc GetJobs(GetJobsRequest) returns (GetJobsResponse);
   rpc GetJob(GetJobRequest) returns (JobInfo);
   rpc CancelJob(CancelJobRequest) returns (google.protobuf.Empty);
+  // Finish a standalone srun allocation after its step completes.
+  rpc CompleteJob(CompleteJobRequest) returns (google.protobuf.Empty);
   rpc SuspendJob(SuspendJobRequest) returns (google.protobuf.Empty);
   rpc ResumeJob(ResumeJobRequest) returns (google.protobuf.Empty);
   rpc UpdateJob(UpdateJobRequest) returns (google.protobuf.Empty);
@@ -324,9 +336,8 @@ service SlurmController {
   // Exec a command inside a running job's container (proxies to correct agent)
   rpc ExecInJob(ExecInJobRequest) returns (ExecInJobResponse);
 
-  // Run a step on one of an allocation's nodes — used by `srun` inside an
-  // `salloc` interactive shell. The controller picks an allocated node and
-  // proxies to its agent's RunCommand RPC (#146).
+  // Run a step across an allocation's nodes — used by srun inside sbatch/salloc
+  // and standalone srun. Fans out tasks via agent RunCommand RPCs.
   rpc RunStep(RunStepRequest) returns (RunStepResponse);
 
   // -- Native cluster (k0s) lifecycle: SPUR owns the k0s cluster --
@@ -344,8 +355,10 @@ service SlurmAgent {
   rpc SuspendJob(AgentSuspendJobRequest) returns (google.protobuf.Empty);
   rpc GetNodeResources(google.protobuf.Empty) returns (NodeResourcesResponse);
   rpc ExecInJob(ExecInJobRequest) returns (ExecInJobResponse);
-  // Run a one-shot command on this node (for srun-in-salloc step dispatch, #146)
+  // Run a one-shot command on this node (for srun step dispatch).
   rpc RunCommand(RunCommandRequest) returns (RunCommandResponse);
+  // Record an allocation on this node without launching a batch process.
+  rpc RegisterJobAllocation(RegisterJobAllocationRequest) returns (RegisterJobAllocationResponse);
   rpc StreamJobOutput(StreamJobOutputRequest) returns (stream StreamJobOutputChunk);
   // Interactive attach: bidirectional streaming for stdin/stdout forwarding
   rpc AttachJob(stream AttachJobInput) returns (stream AttachJobOutput);
@@ -430,6 +443,12 @@ message GetJobRequest {
 message CancelJobRequest {
   uint32 job_id = 1;
   int32 signal = 2;  // 0 = cancel, else signal number
+  string user = 3;   // For authorization
+}
+
+message CompleteJobRequest {
+  uint32 job_id = 1;
+  int32 exit_code = 2;
   string user = 3;   // For authorization
 }
 
@@ -673,8 +692,8 @@ message ExecInJobResponse {
 }
 
 // Controller-side request: run a step inside an allocation. The controller
-// selects a node from the allocation's allocated_nodes and forwards to that
-// agent's RunCommand RPC. Used for srun-in-salloc (#146).
+// fans out tasks across the allocation's nodes via each agent's RunCommand
+// RPC. Used by srun inside sbatch/salloc and standalone srun.
 message RunStepRequest {
   uint32 job_id = 1;
   repeated string command = 2;
@@ -683,13 +702,14 @@ message RunStepRequest {
   string work_dir = 5;
   map<string, string> environment = 6;
   uint32 step_id = 7;  // Step id from CreateJobStep, for recording completion
+  bool label = 8;      // Prefix output lines with [rank] (srun -l)
 }
 
 message RunStepResponse {
-  int32 exit_code = 1;
-  string stdout = 2;
-  string stderr = 3;
-  string node = 4;  // Hostname of the allocated node the command ran on
+  int32 exit_code = 1;   // Max exit code across all tasks in the step
+  string stdout = 2;     // Aggregated stdout from all tasks/nodes
+  string stderr = 3;     // Aggregated stderr from all tasks/nodes
+  string node = 4;       // Comma-separated hostnames that ran tasks
 }
 
 // -- Native cluster (k0s) lifecycle messages --
@@ -812,7 +832,28 @@ message RunCommandRequest {
   string work_dir = 4;
   map<string, string> environment = 5;
   uint32 job_id = 6;
+  uint32 num_tasks = 7;        // Tasks to launch on this node (default 1)
+  uint32 task_offset = 8;      // Global rank of the first local task
+  uint32 step_id = 9;
+  uint32 step_num_tasks = 10;  // Total tasks in the step (SLURM_NTASKS)
+  bool label = 11;             // Prefix output with [rank] inside wrapper
 }
+
+// Register a srun-only allocation on an agent without starting a batch process.
+message RegisterJobAllocationRequest {
+  uint32 job_id = 1;
+  string partition = 2;
+  string nodelist = 3;
+  uint32 uid = 4;
+  uint32 gid = 5;
+  uint32 cpus = 6;
+  uint64 memory_mb = 7;
+  repeated string gpu_devices = 8;
+  ResourceAllocations allocated = 9;
+  string mpi = 10;
+}
+
+message RegisterJobAllocationResponse {}
 
 message RunCommandResponse {
   int32 exit_code = 1;

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -10,6 +10,7 @@ and CLI wrappers for interacting with the running cluster.
 
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import time
@@ -352,11 +353,11 @@ class SpurCluster:
     def srun_with_exit(self, args: list[str]) -> tuple[int, str]:
         """Run srun and return (exit_code, combined stdout+stderr)."""
         cmd_parts = [
-            f"SPUR_CONTROLLER_ADDR='{self.controller_addr}'",
-            f"PATH='{self.bin_dir}':$PATH",
-            f"'{self.bin_dir}/srun'",
+            f"SPUR_CONTROLLER_ADDR={shlex.quote(self.controller_addr)}",
+            f"PATH={shlex.quote(self.bin_dir)}:$PATH",
+            shlex.quote(f"{self.bin_dir}/srun"),
         ]
-        cmd_parts.extend(f"'{a}'" for a in args)
+        cmd_parts.extend(shlex.quote(a) for a in args)
         _, stdout, stderr = self.nodes[0].client.exec_command(" ".join(cmd_parts))
         code = stdout.channel.recv_exit_status()
         return code, stdout.read().decode() + stderr.read().decode()
@@ -366,6 +367,20 @@ class SpurCluster:
 
     def squeue_all(self) -> str:
         return self.cli(["squeue", "-t", "all"])
+
+    def running_job_ids_by_name(self, name: str) -> list[int]:
+        """Return running job IDs matching *name* (uses server-side name filter)."""
+        out = self.squeue(["-n", name, "-t", "R", "-h", "-o", "%i"])
+        ids: list[int] = []
+        for line in out.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                ids.append(int(line.split()[0]))
+            except ValueError:
+                continue
+        return ids
 
     def sinfo(self) -> str:
         return self.cli(["sinfo"])

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -349,6 +349,18 @@ class SpurCluster:
     def sbatch(self, args: list[str]) -> str:
         return self.cli(["sbatch"] + args)
 
+    def srun_with_exit(self, args: list[str]) -> tuple[int, str]:
+        """Run srun and return (exit_code, combined stdout+stderr)."""
+        cmd_parts = [
+            f"SPUR_CONTROLLER_ADDR='{self.controller_addr}'",
+            f"PATH='{self.bin_dir}':$PATH",
+            f"'{self.bin_dir}/srun'",
+        ]
+        cmd_parts.extend(f"'{a}'" for a in args)
+        _, stdout, stderr = self.nodes[0].client.exec_command(" ".join(cmd_parts))
+        code = stdout.channel.recv_exit_status()
+        return code, stdout.read().decode() + stderr.read().decode()
+
     def squeue(self, args: list[str]) -> str:
         return self.cli(["squeue"] + args)
 

--- a/tests/native_host/e2e/test_srun_multi_node.py
+++ b/tests/native_host/e2e/test_srun_multi_node.py
@@ -4,6 +4,7 @@
 """E2E tests for standalone and step-mode srun task fan-out."""
 
 import re
+import shlex
 import time
 
 from cluster import job_state, parse_job_id, wait_job, wait_job_state
@@ -37,23 +38,50 @@ class TestStandaloneSrun:
     def test_srun_holds_allocation_until_step_finishes(self, multi_node_cluster):
         cluster = multi_node_cluster
         log = f"{cluster.remote_dir}/srun-hold.log"
-        cmd = (
-            f"SPUR_CONTROLLER_ADDR='{cluster.controller_addr}' "
-            f"PATH='{cluster.bin_dir}':$PATH "
-            f"nohup '{cluster.bin_dir}/srun' -N 2 sleep 8 > '{log}' 2>&1 & echo $!"
+        srun_cmd = " ".join(
+            [
+                f"SPUR_CONTROLLER_ADDR={shlex.quote(cluster.controller_addr)}",
+                f"PATH={shlex.quote(cluster.bin_dir)}:$PATH",
+                "nohup",
+                shlex.quote(f"{cluster.bin_dir}/srun"),
+                "-J",
+                "srun-hold",
+                "-N",
+                "2",
+                "-n",
+                "2",
+                "sleep",
+                "8",
+                ">",
+                shlex.quote(log),
+                "2>&1",
+                "&",
+                "echo",
+                "$!",
+            ]
         )
-        cluster.nodes[0].exec(cmd)
+        pid_out = cluster.nodes[0].exec(srun_cmd).strip()
+        assert pid_out.isdigit(), f"expected background srun pid, got: {pid_out!r}"
         time.sleep(2)
 
-        sq = cluster.squeue_all()
-        running = [
-            int(m.group(1))
-            for m in re.finditer(r"(\d+)\s+\S+\s+\S+\s+\S+\s+R\b", sq)
-        ]
-        assert running, f"expected a running srun allocation in squeue:\n{sq}"
-        job_id = running[0]
+        job_ids = cluster.running_job_ids_by_name("srun-hold")
+        assert job_ids, (
+            "expected running srun-hold job in squeue:\n"
+            f"{cluster.squeue(['-n', 'srun-hold', '-t', 'all'])}"
+        )
+        job_id = job_ids[0]
 
         wait_job_state(cluster, job_id, "R", timeout=30)
+        show = cluster.scontrol("show", "job", str(job_id))
+        assert "JobState=RUNNING" in show, f"expected RUNNING job:\n{show}"
+        num_nodes_match = re.search(r"NumNodes=(\d+)", show)
+        assert num_nodes_match, f"missing NumNodes in scontrol output:\n{show}"
+        assert int(num_nodes_match.group(1)) == 2, (
+            f"expected 2-node allocation while srun sleep runs:\n{show}"
+        )
+        assert re.search(r"NodeList=\S+", show), (
+            f"missing NodeList in scontrol output:\n{show}"
+        )
         sinfo = cluster.sinfo()
         assert not cluster._cluster_is_ready(sinfo), (
             f"expected allocated nodes while srun sleep runs, sinfo:\n{sinfo}"
@@ -82,6 +110,6 @@ class TestSrunInBatch:
         assert job_id is not None
 
         wait_job(cluster, job_id, timeout=90)
-        content = cluster.read_output_all_nodes(out_path)
-        lines = [ln for ln in content.splitlines() if ln.startswith("host=")]
+        content = cluster.read_output_on_any_node(out_path)
+        lines = sorted({ln for ln in content.splitlines() if ln.startswith("host=")})
         assert len(lines) == 2, f"expected 2 step task lines in batch output:\n{content}"

--- a/tests/native_host/e2e/test_srun_multi_node.py
+++ b/tests/native_host/e2e/test_srun_multi_node.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for standalone and step-mode srun task fan-out."""
+
+import re
+import time
+
+from cluster import job_state, parse_job_id, wait_job, wait_job_state
+
+
+class TestStandaloneSrun:
+    def test_srun_two_nodes_two_tasks(self, multi_node_cluster):
+        cluster = multi_node_cluster
+        code, out = cluster.srun_with_exit(
+            [
+                "-N",
+                "2",
+                "-n",
+                "2",
+                "bash",
+                "-c",
+                'echo "host=$(hostname) rank=${SPUR_PROCID}"',
+            ]
+        )
+        assert code == 0, f"srun failed (exit {code}):\n{out}"
+
+        lines = [ln for ln in out.splitlines() if ln.startswith("host=")]
+        assert len(lines) == 2, f"expected 2 task lines, got {len(lines)}:\n{out}"
+
+        hosts = {ln.split("host=")[1].split()[0] for ln in lines}
+        assert len(hosts) == 2, f"expected 2 distinct hosts, got {hosts}:\n{out}"
+
+        ranks = {ln.split("rank=")[1].strip() for ln in lines}
+        assert ranks == {"0", "1"}, f"expected ranks 0 and 1, got {ranks}:\n{out}"
+
+    def test_srun_holds_allocation_until_step_finishes(self, multi_node_cluster):
+        cluster = multi_node_cluster
+        log = f"{cluster.remote_dir}/srun-hold.log"
+        cmd = (
+            f"SPUR_CONTROLLER_ADDR='{cluster.controller_addr}' "
+            f"PATH='{cluster.bin_dir}':$PATH "
+            f"nohup '{cluster.bin_dir}/srun' -N 2 sleep 8 > '{log}' 2>&1 & echo $!"
+        )
+        cluster.nodes[0].exec(cmd)
+        time.sleep(2)
+
+        sq = cluster.squeue_all()
+        running = [
+            int(m.group(1))
+            for m in re.finditer(r"(\d+)\s+\S+\s+\S+\s+\S+\s+R\b", sq)
+        ]
+        assert running, f"expected a running srun allocation in squeue:\n{sq}"
+        job_id = running[0]
+
+        wait_job_state(cluster, job_id, "R", timeout=30)
+        sinfo = cluster.sinfo()
+        assert not cluster._cluster_is_ready(sinfo), (
+            f"expected allocated nodes while srun sleep runs, sinfo:\n{sinfo}"
+        )
+
+        wait_job(cluster, job_id, timeout=60)
+        deadline = time.time() + 60
+        while time.time() < deadline:
+            if cluster._cluster_is_ready(cluster.sinfo()):
+                return
+            time.sleep(2)
+        raise TimeoutError("nodes did not return to idle after srun completed")
+
+
+class TestSrunInBatch:
+    def test_sbatch_srun_hostname_on_allocated_nodes(self, multi_node_cluster):
+        cluster = multi_node_cluster
+        out_path = f"{cluster.remote_dir}/srun-step.out"
+        script = cluster.write_file(
+            "srun-in-batch.sh",
+            "#!/bin/bash\n"
+            "srun -n 2 bash -c 'echo host=$(hostname) rank=${SPUR_PROCID}'\n",
+        )
+        sb = cluster.sbatch(["-J", "srun-step", "-N", "2", "-n", "2", "-o", out_path, script])
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+
+        wait_job(cluster, job_id, timeout=90)
+        content = cluster.read_output_all_nodes(out_path)
+        lines = [ln for ln in content.splitlines() if ln.startswith("host=")]
+        assert len(lines) == 2, f"expected 2 step task lines in batch output:\n{content}"


### PR DESCRIPTION
## Summary

Fixes multi-node / multi-task `srun` fan-out (#460).

- **Standalone `srun` (native nodes):** submit an `srun_job` allocation, register it on agents via `RegisterJobAllocation` (no batch script launch), dispatch the user command as a job step with per-node `RunCommand` fan-out, then release the allocation with `CompleteJob`.
- **Standalone `srun` (K8s nodes):** fall back to the existing batch launch path when any allocated node is non-native; the CLI reads `JobInfo.srun_step_dispatch` and polls for batch completion instead of using the step-dispatch path.
- **Step mode (`SPUR_JOB_ID`):** `RunStep` fans out across allocated nodes using `build_step_task_plan`, with partial-failure aggregation instead of fail-fast on the first node error.
- **Shared launch helpers:** `spur-core::task_launch` centralizes step task planning, multi-task bash wrappers, and GPU/CPU bind env for batch and step paths.
- **Durability:** job steps are recorded via `WalOperation::JobStepCreate`; `srun_step_dispatch` is persisted on `JobStart` and exposed on `JobInfo`.

## Approach

Native standalone srun splits allocation from execution:

1. Scheduler registers the allocation on each native agent (`RegisterJobAllocation`) **before** transitioning the job to `Running`.
2. CLI creates a step, calls `RunStep`, and on completion calls `CompleteJob` (with `cancel_job` fallback if release fails).
3. Agents track allocation-only jobs (`RunningJob::AllocationOnly`) until cleanup.

`CompleteJob` is rejected unless `srun_step_dispatch` is true, so K8s batch-fallback jobs cannot be completed while batch processes are still running.

Ctrl+C in standalone native srun cancels the allocation job; Ctrl+C in step mode (inside sbatch/salloc) interrupts the step without cancelling the parent allocation.

GPU bind (`map_gpu` / `mask_gpu`) and explicit CPU bind (`rank`, `map_cpu`, `mask_cpu`) are applied in step mode; topology CPU bind modes (`cores`, `threads`, etc.) warn and are skipped. `map_cpu` validates list length against task count before dispatch.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --exclude spur-ffi --all-targets --locked`
- [x] `cargo test --locked`
- [x] Unit: `build_step_task_plan`, `finish_srun_job_*`, `JobStepCreate` WAL round-trip, CPU/GPU bind helpers
- [x] Native e2e: `tests/native_host/e2e/test_srun_multi_node.py` (standalone 2-node fan-out, allocation hold, sbatch+srun step)