### PR TITLE
fix(spurctld): drop stale completion reports from preempted-and-requeued runs

### DIFF
--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -625,6 +625,11 @@ pub struct Job {
     #[serde(default)]
     pub preempt_requeue_count: u32,
 
+    /// Monotonic run epoch, bumped on each dispatch (first dispatch = 1). Lets
+    /// the controller drop a completion report from a superseded run.
+    #[serde(default)]
+    pub run_attempt: u32,
+
     // Heterogeneous job support
     /// Links het job components to the first component's job ID.
     #[serde(default)]
@@ -689,6 +694,7 @@ impl Job {
             derived_exit_code: 0,
             requeue_count: 0,
             preempt_requeue_count: 0,
+            run_attempt: 0,
             het_job_id: None,
             het_group: None,
             node_completions: HashMap::new(),

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -45,6 +45,9 @@ pub enum WalOperation {
         /// Standalone srun: native step dispatch (false = K8s batch fallback).
         #[serde(default)]
         srun_step_dispatch: bool,
+        /// Run epoch for this dispatch (0 for pre-upgrade entries).
+        #[serde(default)]
+        run_attempt: u32,
     },
     JobComplete {
         job_id: JobId,
@@ -235,6 +238,7 @@ impl WalOperation {
             resources,
             per_node_alloc,
             srun_step_dispatch: false,
+            run_attempt: 0,
         }
     }
 }

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -524,6 +524,9 @@ async fn watch_pods(ctx: Arc<JobControllerCtx>) -> anyhow::Result<()> {
                     drain_node: false,
                     drain_reason: String::new(),
                     reporting_node,
+                    // K8s operator doesn't track run epochs; 0 disables the
+                    // controller-side staleness check for this report.
+                    run_attempt: 0,
                 };
                 if let Err(e) = ctrl.report_job_status(req).await {
                     error!(job_id, error = %e, "failed to report job status");

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -48,6 +48,9 @@ pub enum NodeCompleteResult {
     AllDone { state: JobState, exit_code: i32 },
     /// Job was already in a terminal state (duplicate or race with cancel/timeout).
     AlreadyTerminal,
+    /// Report came from a superseded run (older `run_attempt`); ignored so it
+    /// cannot fail a job that has since been requeued and re-dispatched.
+    StaleReport,
 }
 
 /// Reservation CRUD errors for the gRPC boundary.
@@ -729,13 +732,15 @@ impl ClusterManager {
     }
 
     /// Start a job on specific nodes.
+    /// Transition a pending job to Running and record its allocation. Returns
+    /// the run epoch assigned to this dispatch (threaded into the launch RPC).
     pub fn start_job(
         &self,
         job_id: JobId,
         node_names: Vec<String>,
         resources: ResourceAllocations,
         per_node_alloc: std::collections::HashMap<String, ResourceAllocations>,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<u32> {
         self.start_job_impl(job_id, node_names, resources, per_node_alloc, false)
     }
 
@@ -746,7 +751,7 @@ impl ClusterManager {
         resources: ResourceAllocations,
         per_node_alloc: std::collections::HashMap<String, ResourceAllocations>,
         srun_step_dispatch: bool,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<u32> {
         for name in &node_names {
             if !per_node_alloc.contains_key(name) {
                 anyhow::bail!(
@@ -761,6 +766,7 @@ impl ClusterManager {
         let old_state;
         let spec_for_notify;
         let submit_time_for_notify;
+        let run_attempt;
         {
             let jobs = self.jobs.read();
             let job = jobs
@@ -769,6 +775,8 @@ impl ClusterManager {
             old_state = job.state;
             spec_for_notify = job.spec.clone();
             submit_time_for_notify = job.submit_time;
+            // Next run epoch (first dispatch = 1), threaded to the agents.
+            run_attempt = job.run_attempt.saturating_add(1);
             if job.state != JobState::Pending {
                 anyhow::bail!("job {} cannot start from state {:?}", job_id, job.state);
             }
@@ -786,6 +794,7 @@ impl ClusterManager {
             resources: resources.clone(),
             per_node_alloc: per_node_alloc.clone(),
             srun_step_dispatch,
+            run_attempt,
         })?;
 
         let node_count = node_names.len().max(1) as u32;
@@ -844,7 +853,7 @@ impl ClusterManager {
         }
 
         debug!(job_id, "job started");
-        Ok(())
+        Ok(run_attempt)
     }
 
     /// Record completion from one allocated node (multi-node COMPLETING flow).
@@ -854,6 +863,7 @@ impl ClusterManager {
         node_name: &str,
         exit_code: i32,
         signal: i32,
+        run_attempt: u32,
     ) -> Result<NodeCompleteResult, NodeCompleteError> {
         {
             let jobs = self.jobs.read();
@@ -862,6 +872,12 @@ impl ClusterManager {
                 .ok_or(NodeCompleteError::JobNotFound { job_id })?;
             if job.state.is_terminal() {
                 return Ok(NodeCompleteResult::AlreadyTerminal);
+            }
+            // Drop a report from a superseded run (older epoch); e.g. the
+            // delayed SIGKILL of a preemption-requeued process. Epoch 0 on
+            // either side (legacy) disables the check.
+            if run_attempt != 0 && job.run_attempt != 0 && run_attempt < job.run_attempt {
+                return Ok(NodeCompleteResult::StaleReport);
             }
             if !job.allocated_nodes.iter().any(|n| n == node_name) {
                 return Err(NodeCompleteError::NodeNotAllocated {
@@ -3342,6 +3358,7 @@ impl ClusterManager {
                 resources,
                 per_node_alloc,
                 srun_step_dispatch,
+                run_attempt,
             } => {
                 if let Some(job) = jobs.get_mut(job_id) {
                     job.start_time = Some(timestamp);
@@ -3350,6 +3367,7 @@ impl ClusterManager {
                     job.per_node_alloc = per_node_alloc.clone();
                     job.pending_reason = PendingReason::None;
                     job.srun_step_dispatch = *srun_step_dispatch;
+                    job.run_attempt = *run_attempt;
                 }
                 let node_count = node_names.len().max(1) as u32;
                 for name in node_names {
@@ -4892,6 +4910,7 @@ mod tests {
             resources: resources.clone(),
             per_node_alloc: per_node_for(&["node1"], resources),
             srun_step_dispatch: false,
+            run_attempt: 0,
         });
 
         let job = cm.get_job(1).unwrap();
@@ -4927,6 +4946,7 @@ mod tests {
             resources: alloc.clone(),
             per_node_alloc: per_node_for(&["node1"], alloc),
             srun_step_dispatch: false,
+            run_attempt: 0,
         });
 
         cm.apply_operation(&WalOperation::JobComplete {
@@ -5415,6 +5435,7 @@ mod tests {
             resources: alloc.clone(),
             per_node_alloc: per_node_for(&["worker1"], alloc),
             srun_step_dispatch: false,
+            run_attempt: 0,
         });
 
         cm.apply_operation(&WalOperation::JobNodeComplete {
@@ -5457,6 +5478,7 @@ mod tests {
             resources: alloc.clone(),
             per_node_alloc: per_node_for(&["worker1"], alloc),
             srun_step_dispatch: false,
+            run_attempt: 0,
         });
 
         cm.apply_operation(&WalOperation::JobNodeComplete {
@@ -5500,6 +5522,7 @@ mod tests {
             resources: scalar_alloc(6, 12000),
             per_node_alloc: per_node_for(&["n1", "n2", "n3"], alloc),
             srun_step_dispatch: false,
+            run_attempt: 0,
         });
 
         cm.apply_operation(&WalOperation::JobNodeComplete {
@@ -5566,6 +5589,7 @@ mod tests {
             resources: scalar_alloc(4, 8000),
             per_node_alloc: per_node_for(&["n1"], scalar_alloc(4, 8000)),
             srun_step_dispatch: false,
+            run_attempt: 0,
         });
 
         // Three srun steps exit 7, 3, 2 (in that order). DerivedExitCode tracks
@@ -5659,6 +5683,7 @@ mod tests {
             resources: scalar_alloc(4, 8000),
             per_node_alloc: per_node_for(&["n1", "n2"], alloc),
             srun_step_dispatch: false,
+            run_attempt: 0,
         });
 
         let r1 = cm.apply_operation(&WalOperation::JobNodeComplete {
@@ -5710,6 +5735,7 @@ mod tests {
             resources: alloc.clone(),
             per_node_alloc: per_node_for(&["worker1"], alloc),
             srun_step_dispatch: false,
+            run_attempt: 0,
         });
 
         let resp = cm.apply_operation(&WalOperation::JobComplete {
@@ -5750,6 +5776,7 @@ mod tests {
             resources: alloc.clone(),
             per_node_alloc: per_node_for(&["worker1"], alloc),
             srun_step_dispatch: false,
+            run_attempt: 0,
         });
 
         let first = cm.apply_operation(&WalOperation::JobComplete {
@@ -5808,6 +5835,7 @@ mod tests {
             resources: scalar_alloc(6, 12000),
             per_node_alloc: per_node_for(&["n1", "n2", "n3"], alloc),
             srun_step_dispatch: false,
+            run_attempt: 0,
         });
         cm.apply_operation(&WalOperation::JobNodeComplete {
             job_id: 1,
@@ -5816,7 +5844,7 @@ mod tests {
             signal: 0,
         });
 
-        let result = cm.node_complete(1, "n2", 0, 0).unwrap();
+        let result = cm.node_complete(1, "n2", 0, 0, 0).unwrap();
         assert_eq!(result, NodeCompleteResult::Completing);
         assert_eq!(cm.get_job(1).unwrap().state, JobState::Completing);
     }
@@ -5845,9 +5873,10 @@ mod tests {
             resources: scalar_alloc(6, 12000),
             per_node_alloc: per_node_for(&["n1"], scalar_alloc(6, 12000)),
             srun_step_dispatch: false,
+            run_attempt: 0,
         });
 
-        cm.node_complete(1, "n1", 0, 9).unwrap();
+        cm.node_complete(1, "n1", 0, 9, 0).unwrap();
         let job = cm.get_job(1).unwrap();
         assert_eq!(job.state, JobState::Failed);
         assert_eq!(job.exit_code, Some(0));
@@ -5888,10 +5917,11 @@ mod tests {
             resources: scalar_alloc(6, 12000),
             per_node_alloc: per_node_for(&["n1"], scalar_alloc(6, 12000)),
             srun_step_dispatch: false,
+            run_attempt: 0,
         });
 
         // Step 2: the call the RPC makes after validation (wire state dropped).
-        cm.node_complete(1, "n1", 0, 9).unwrap();
+        cm.node_complete(1, "n1", 0, 9, 0).unwrap();
 
         let job = cm.get_job(1).unwrap();
         assert_eq!(job.state, JobState::Failed);
@@ -5924,9 +5954,10 @@ mod tests {
             resources: scalar_alloc(6, 12000),
             per_node_alloc: per_node_for(&["n1"], scalar_alloc(6, 12000)),
             srun_step_dispatch: false,
+            run_attempt: 0,
         });
 
-        cm.node_complete(1, "n1", 42, 0).unwrap();
+        cm.node_complete(1, "n1", 42, 0, 0).unwrap();
         let job = cm.get_job(1).unwrap();
         assert_eq!(job.state, JobState::Failed);
         assert_eq!(job.exit_code, Some(42));
@@ -5935,6 +5966,46 @@ mod tests {
         // exit (42) surfaces as ExitCode, not DerivedExitCode.
         assert_eq!(job.derived_exit_code, 0);
         assert_eq!(job.pending_reason, PendingReason::NonZeroExitCode);
+    }
+
+    // A completion report from a superseded run (older epoch) must be dropped,
+    // not fail the re-dispatched run. Reproduces the preempt-requeue race.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn node_complete_drops_stale_run_report() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("stale-job")),
+        });
+        cm.apply_operation(&WalOperation::JobStateChange {
+            job_id: 1,
+            old_state: JobState::Pending,
+            new_state: JobState::Running,
+            pending_reason: None,
+            pending_priority: None,
+        });
+        // Re-dispatched run: current epoch is 2.
+        cm.apply_operation(&WalOperation::JobStart {
+            job_id: 1,
+            nodes: vec!["n1".into()],
+            resources: scalar_alloc(6, 12000),
+            per_node_alloc: per_node_for(&["n1"], scalar_alloc(6, 12000)),
+            srun_step_dispatch: false,
+            run_attempt: 2,
+        });
+
+        // Stale SIGKILL report from epoch 1 must be ignored.
+        let res = cm.node_complete(1, "n1", 0, 9, 1).unwrap();
+        assert!(matches!(res, NodeCompleteResult::StaleReport));
+        let job = cm.get_job(1).unwrap();
+        assert_eq!(job.state, JobState::Running);
+
+        // Current-epoch report is applied normally.
+        cm.node_complete(1, "n1", 0, 9, 2).unwrap();
+        assert_eq!(cm.get_job(1).unwrap().state, JobState::Failed);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -5964,6 +6035,7 @@ mod tests {
             resources: scalar_alloc(6, 12000),
             per_node_alloc: per_node_for(&["n1", "n2", "n3"], alloc),
             srun_step_dispatch: false,
+            run_attempt: 0,
         });
 
         cm.apply_operation(&WalOperation::JobNodeComplete {
@@ -6032,6 +6104,7 @@ mod tests {
             resources: scalar_alloc(6, 12000),
             per_node_alloc: per_node_for(&["n1", "n2", "n3"], alloc),
             srun_step_dispatch: false,
+            run_attempt: 0,
         });
         cm.apply_operation(&WalOperation::JobNodeComplete {
             job_id: 1,
@@ -6043,7 +6116,7 @@ mod tests {
         cm.cancel_job(1, "testuser").unwrap();
         settle(&cm, 1, JobState::Cancelled);
 
-        let result = cm.node_complete(1, "n2", 0, 0).unwrap();
+        let result = cm.node_complete(1, "n2", 0, 0, 0).unwrap();
         assert_eq!(result, NodeCompleteResult::AlreadyTerminal);
         assert_eq!(cm.get_job(1).unwrap().state, JobState::Cancelled);
     }
@@ -6383,6 +6456,7 @@ mod tests {
             resources: alloc.clone(),
             per_node_alloc: per_node_for(&["worker1"], alloc),
             srun_step_dispatch: false,
+            run_attempt: 0,
         });
         cm.apply_operation(&WalOperation::JobComplete {
             job_id: 1,
@@ -6477,6 +6551,7 @@ mod tests {
             resources: alloc.clone(),
             per_node_alloc: per_node_for(&["worker1"], alloc),
             srun_step_dispatch: false,
+            run_attempt: 0,
         });
         assert_eq!(cm.get_node("worker1").unwrap().alloc_resources.cpus, 2);
 
@@ -11192,6 +11267,7 @@ mod tests {
             resources: scalar_alloc(1, 1000),
             per_node_alloc: per_node_for(&[node], scalar_alloc(1, 1000)),
             srun_step_dispatch: false,
+            run_attempt: 0,
         });
     }
 
@@ -11209,6 +11285,7 @@ mod tests {
             resources: scalar_alloc(1, 1000),
             per_node_alloc: per_node_for(&[node], scalar_alloc(1, 1000)),
             srun_step_dispatch: true,
+            run_attempt: 0,
         });
     }
 

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -279,17 +279,20 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
                     assignment.per_node_alloc.clone(),
                 )
             };
-            if let Err(e) = start_result {
-                if spec.srun_job && srun_step_dispatch {
-                    cancel_job_on_nodes(&cluster, job_id, &dispatch_nodes, 0).await;
+            let run_attempt = match start_result {
+                Ok(attempt) => attempt,
+                Err(e) => {
+                    if spec.srun_job && srun_step_dispatch {
+                        cancel_job_on_nodes(&cluster, job_id, &dispatch_nodes, 0).await;
+                    }
+                    debug!(
+                        job_id = assignment.job_id,
+                        error = %e,
+                        "failed to start job"
+                    );
+                    continue;
                 }
-                debug!(
-                    job_id = assignment.job_id,
-                    error = %e,
-                    "failed to start job"
-                );
-                continue;
-            }
+            };
 
             // Run PrologSlurmctld if configured
             if let Some(ref prolog_ctld) = cluster.config.hooks.prolog_slurmctld {
@@ -359,6 +362,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
                         per_node_allocs,
                         allocated_nodelist,
                         tasks_per_node,
+                        run_attempt,
                     ));
                 }
             } else {
@@ -371,6 +375,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
                     per_node_allocs,
                     allocated_nodelist,
                     tasks_per_node,
+                    run_attempt,
                 ));
             }
         }
@@ -755,6 +760,7 @@ struct AgentDispatchParams<'a> {
     target_node: &'a str,
     allocated: &'a spur_core::resource::ResourceAllocations,
     allocated_nodelist: &'a str,
+    run_attempt: u32,
 }
 
 /// Send a LaunchJob RPC to a node agent.
@@ -855,6 +861,7 @@ async fn dispatch_to_agent(
             // Controller-assigned at array expansion; consumed agent-side.
             array_job_id: spec.array_job_id.unwrap_or(0),
             array_task_id: spec.array_task_id.unwrap_or(0),
+            run_attempt: params.run_attempt,
         })
         .await?;
 
@@ -1034,6 +1041,7 @@ async fn dispatch_job_to_nodes(
     per_node_allocs: std::collections::HashMap<String, spur_core::resource::ResourceAllocations>,
     allocated_nodelist: String,
     tasks_per_node: u32,
+    run_attempt: u32,
 ) {
     let mut successes = 0u32;
     let mut failures = 0u32;
@@ -1075,6 +1083,7 @@ async fn dispatch_job_to_nodes(
                     target_node: &target_node,
                     allocated: &allocated,
                     allocated_nodelist: &allocated_nodelist,
+                    run_attempt,
                 },
             )
             .await;
@@ -2234,13 +2243,14 @@ mod tests {
                 .iter()
                 .map(|n| (n.clone(), ResourceAllocations::with_scalar(1, 0)))
                 .collect();
-            cm.start_job(
-                job_id,
-                nodes.clone(),
-                ResourceAllocations::with_scalar(2, 0),
-                per_node_allocs.clone(),
-            )
-            .unwrap();
+            let run_attempt = cm
+                .start_job(
+                    job_id,
+                    nodes.clone(),
+                    ResourceAllocations::with_scalar(2, 0),
+                    per_node_allocs.clone(),
+                )
+                .unwrap();
             settle(&cm, job_id, JobState::Running);
 
             // This calls the exact same function `run()` spawns per assignment:
@@ -2256,6 +2266,7 @@ mod tests {
                 per_node_allocs,
                 "n1,n2".into(),
                 1,
+                run_attempt,
             )
             .await;
 
@@ -2330,6 +2341,7 @@ mod tests {
                 Vec::new(),
                 per_node_allocs,
                 "n1,n2".into(),
+                1,
                 1,
             )
             .await;

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -958,6 +958,7 @@ impl SlurmController for ControllerService {
                 &req.reporting_node,
                 req.exit_code,
                 req.signal,
+                req.run_attempt,
             ))
         } else {
             None
@@ -993,6 +994,15 @@ impl SlurmController for ControllerService {
                     job_id = req.job_id,
                     node = %req.reporting_node,
                     "duplicate completion report for terminal job"
+                );
+                Ok(Response::new(()))
+            }
+            Some(Ok(NodeCompleteResult::StaleReport)) => {
+                warn!(
+                    job_id = req.job_id,
+                    node = %req.reporting_node,
+                    run_attempt = req.run_attempt,
+                    "ignoring completion report from superseded run"
                 );
                 Ok(Response::new(()))
             }

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -44,12 +44,15 @@ struct TrackedJob {
     memory_mb: u64,
     nodelist: String,
     mpi: String,
+    /// Run epoch; echoed on completion and guards the grace-period SIGKILL.
+    run_attempt: u32,
 }
 
 struct CompletedJob {
     job_id: u32,
     exit_code: i32,
     signal: i32,
+    run_attempt: u32,
     rootfs_mode: crate::container::RootfsMode,
     cgroup: Option<std::path::PathBuf>,
     work_dir: String,
@@ -205,6 +208,7 @@ impl AgentService {
                                 job_id: *job_id,
                                 exit_code,
                                 signal,
+                                run_attempt: tracked.run_attempt,
                                 rootfs_mode: tracked.rootfs_mode.clone(),
                                 cgroup,
                                 work_dir: tracked.work_dir.clone(),
@@ -313,6 +317,7 @@ impl AgentService {
                         c.job_id,
                         c.exit_code,
                         c.signal,
+                        c.run_attempt,
                         &local_hostname,
                         drain.as_ref(),
                     )
@@ -453,6 +458,7 @@ async fn report_completion(
     job_id: u32,
     exit_code: i32,
     signal: i32,
+    run_attempt: u32,
     reporting_node: &str,
     drain: Option<&DrainRequest>,
 ) {
@@ -477,6 +483,7 @@ async fn report_completion(
                     drain_node: drain.is_some(),
                     drain_reason: drain.as_ref().map(|d| d.reason.clone()).unwrap_or_default(),
                     reporting_node: reporting_node.to_string(),
+                    run_attempt,
                 };
                 match client.report_job_status(req).await {
                     Ok(_) => {
@@ -544,6 +551,7 @@ impl SlurmAgent for AgentService {
         // not part of the (user-supplied) job spec.
         let array_job_id = req.array_job_id;
         let array_task_id = req.array_task_id;
+        let run_attempt = req.run_attempt;
         let spec = req
             .spec
             .ok_or_else(|| Status::invalid_argument("missing job spec"))?;
@@ -898,6 +906,15 @@ impl SlurmAgent for AgentService {
                 // `launching` (which would let reconcile reclaim it).
                 self.allocation.lock().await.commit_job(job_id);
                 info!(job_id, gpus = ?launch_cfg.gpu_devices, "job launched successfully");
+                // Re-dispatch onto the same node reuses job_id. If an older run
+                // is still tracked (its process ignored SIGTERM and outlived the
+                // requeue), the insert would drop its Child without killing it —
+                // an orphaned runaway. SIGKILL it before overwriting.
+                if let Some(old) = jobs.get(&job_id) {
+                    if old.run_attempt < run_attempt {
+                        let _ = old.job.kill_signal(nix::sys::signal::Signal::SIGKILL);
+                    }
+                }
                 jobs.insert(
                     job_id,
                     TrackedJob {
@@ -915,6 +932,7 @@ impl SlurmAgent for AgentService {
                         memory_mb: launch_cfg.memory_mb,
                         nodelist: launch_cfg.nodelist,
                         mpi: spec.mpi.clone(),
+                        run_attempt,
                     },
                 );
                 Ok(Response::new(LaunchJobResponse {
@@ -937,8 +955,16 @@ impl SlurmAgent for AgentService {
                         let drain = DrainRequest {
                             reason: drain_reason.clone(),
                         };
-                        report_completion(&controller, job_id, -1, 0, &node_name, Some(&drain))
-                            .await;
+                        report_completion(
+                            &controller,
+                            job_id,
+                            -1,
+                            0,
+                            run_attempt,
+                            &node_name,
+                            Some(&drain),
+                        )
+                        .await;
                     });
                 }
 
@@ -1119,6 +1145,9 @@ impl SlurmAgent for AgentService {
                 memory_mb,
                 nodelist: req.nodelist,
                 mpi: req.mpi,
+                // srun allocation-only jobs use their own cancel lifecycle;
+                // epoch 0 leaves the stale-report guard disabled for them.
+                run_attempt: 0,
             },
         );
 
@@ -1971,20 +2000,27 @@ impl AgentService {
             return;
         }
 
-        {
+        // Epoch of the run we're cancelling; the delayed SIGKILL below must not
+        // touch a newer run that reused this job_id after a requeue.
+        let cancel_attempt = {
             let jobs = self.running.lock().await;
             let Some(tracked) = jobs.get(&job_id) else {
                 return;
             };
             info!(job_id, "graceful cancel: SIGTERM → 5s grace → SIGKILL");
             let _ = tracked.job.kill_signal(nix::sys::signal::Signal::SIGTERM);
-        }
+            tracked.run_attempt
+        };
 
         let running = self.running.clone();
         tokio::spawn(async move {
             tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
             let jobs = running.lock().await;
             if let Some(tracked) = jobs.get(&job_id) {
+                // Skip if job_id was reused by a newer run after requeue.
+                if tracked.run_attempt != cancel_attempt {
+                    return;
+                }
                 info!(job_id, "grace period expired, sending SIGKILL");
                 let _ = tracked.job.kill_signal(nix::sys::signal::Signal::SIGKILL);
                 // Job stays in `running` and monitor loop reaps it and does full cleanup.
@@ -2037,6 +2073,7 @@ impl TrackedJob {
             memory_mb: 0,
             nodelist: String::new(),
             mpi: String::new(),
+            run_attempt: 0,
         }
     }
 }
@@ -2617,6 +2654,7 @@ mod tests {
             memory_mb: 0,
             nodelist: String::new(),
             mpi: String::new(),
+            run_attempt: 0,
         };
         svc.insert_test_job(job_id, tracked).await;
 
@@ -2627,6 +2665,84 @@ mod tests {
             wait_job_reaped(&svc, job_id, 10_000).await,
             "monitor should reap job after SIGKILL escalation"
         );
+    }
+
+    // The grace-period SIGKILL must not fire if job_id was reused by a newer
+    // run (epoch bumped) after a requeue. Guards the preempt-requeue race.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn graceful_cancel_skips_sigkill_for_reused_job_id() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        // No monitor: this test asserts the grace timer's epoch guard directly,
+        // so nothing should reap the job out from under it.
+
+        // SIGTERM-trapping process so epoch 1 survives its cancel; built inline
+        // (not via dummy(), which would leak its own sleep child).
+        fn spawn_trap(run_attempt: u32) -> (TrackedJob, i32) {
+            let child = tokio::process::Command::new("/bin/sh")
+                .args(["-c", "trap '' TERM; while true; do sleep 1; done"])
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .process_group(0)
+                .spawn()
+                .expect("spawn trap process");
+            let pid = child.id().expect("pid") as i32;
+            let t = TrackedJob {
+                job: executor::RunningJob::Managed {
+                    child,
+                    cgroup_path: None,
+                },
+                rootfs_mode: crate::container::RootfsMode::Extracted,
+                stdout_path: "/dev/null".into(),
+                stderr_path: "/dev/null".into(),
+                has_pid_namespace: false,
+                work_dir: "/tmp".into(),
+                uid: 0,
+                gid: 0,
+                partition: String::new(),
+                gpu_devices: Vec::new(),
+                cpus: 1,
+                memory_mb: 0,
+                nodelist: String::new(),
+                mpi: String::new(),
+                run_attempt,
+            };
+            (t, pid)
+        }
+        let alive = |pid: i32| std::path::Path::new(&format!("/proc/{pid}")).exists();
+
+        let job_id = 902;
+        let (run1, pid1) = spawn_trap(1);
+        svc.insert_test_job(job_id, run1).await;
+
+        // Cancel epoch 1 (SIGTERM; trapped, survives) and spawn the grace timer.
+        svc.graceful_cancel(job_id).await;
+
+        // Simulate requeue + re-dispatch: same job_id, newer epoch.
+        let (run2, pid2) = spawn_trap(2);
+        svc.insert_test_job(job_id, run2).await;
+
+        // Wait past the 5s grace period; the guard must skip the SIGKILL, so the
+        // epoch-2 process stays alive.
+        tokio::time::sleep(tokio::time::Duration::from_secs(6)).await;
+        assert!(
+            alive(pid2),
+            "grace-period SIGKILL wrongly killed the re-dispatched run"
+        );
+
+        // Cleanup: both trap processes ignore SIGTERM, so SIGKILL by pid.
+        for pid in [pid1, pid2] {
+            let _ = nix::sys::signal::kill(
+                nix::unistd::Pid::from_raw(pid),
+                nix::sys::signal::Signal::SIGKILL,
+            );
+        }
+        svc.running.lock().await.remove(&job_id);
     }
 
     fn proc_state(pid: i32) -> char {

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -2714,8 +2714,6 @@ mod tests {
             };
             (t, pid)
         }
-        let alive = |pid: i32| std::path::Path::new(&format!("/proc/{pid}")).exists();
-
         let job_id = 902;
         let (run1, pid1) = spawn_trap(1);
         svc.insert_test_job(job_id, run1).await;
@@ -2728,17 +2726,21 @@ mod tests {
         svc.insert_test_job(job_id, run2).await;
 
         // Wait past the 5s grace period; the guard must skip the SIGKILL, so the
-        // epoch-2 process stays alive.
+        // epoch-2 process stays alive. Assert a live state ('S'/'R'), not mere
+        // /proc existence — a wrongly-killed unreaped child would be a zombie
+        // ('Z'), which still has /proc and would false-pass an existence check.
         tokio::time::sleep(tokio::time::Duration::from_secs(6)).await;
+        let state = proc_state(pid2);
         assert!(
-            alive(pid2),
-            "grace-period SIGKILL wrongly killed the re-dispatched run"
+            matches!(state, 'S' | 'R' | 'D'),
+            "grace-period SIGKILL wrongly killed the re-dispatched run (state {state})"
         );
 
-        // Cleanup: both trap processes ignore SIGTERM, so SIGKILL by pid.
+        // Cleanup: trap processes ignore SIGTERM; SIGKILL each process group
+        // (negative pid) so the inner sleep child is reaped too.
         for pid in [pid1, pid2] {
             let _ = nix::sys::signal::kill(
-                nix::unistd::Pid::from_raw(pid),
+                nix::unistd::Pid::from_raw(-pid),
                 nix::sys::signal::Signal::SIGKILL,
             );
         }

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -376,6 +376,20 @@ mod completion_report_tests {
     }
 }
 
+/// Reap an already-killed displaced run. Polls `try_wait` so both executor
+/// variants are collected: a `Managed` child via tokio, a `Forked` container's
+/// raw pid via `waitpid`. Once a displaced run leaves the `running` map the
+/// monitor loop no longer polls it, so without this a killed `Forked` run would
+/// linger as a zombie until spurd exits.
+async fn reap_killed_job(mut job: executor::RunningJob) {
+    loop {
+        match job.try_wait() {
+            Ok(Some(_)) | Err(_) => break,
+            Ok(None) => tokio::time::sleep(std::time::Duration::from_millis(50)).await,
+        }
+    }
+}
+
 /// Build a bash script that execs a command vector without shell interpretation.
 fn build_one_shot_command_script(command: &[String]) -> Result<String, Status> {
     let joined = shlex::try_join(command.iter().map(String::as_str))
@@ -931,14 +945,10 @@ impl SlurmAgent for AgentService {
                 // older run. If its process ignored SIGTERM and outlived the
                 // requeue, kill and reap it here — the monitor loop no longer
                 // tracks it, so without this it would leak as an orphan/zombie.
-                if let Some(mut old) = displaced {
+                if let Some(old) = displaced {
                     if old.run_attempt < run_attempt {
                         let _ = old.job.kill_signal(nix::sys::signal::Signal::SIGKILL);
-                        tokio::spawn(async move {
-                            if let executor::RunningJob::Managed { child, .. } = &mut old.job {
-                                let _ = child.wait().await;
-                            }
-                        });
+                        tokio::spawn(reap_killed_job(old.job));
                     }
                 }
                 Ok(Response::new(LaunchJobResponse {
@@ -2775,6 +2785,40 @@ mod tests {
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
         proc_state(pid)
+    }
+
+    /// A displaced `Forked` run (root/container path) holds a raw pid that
+    /// spurd must reap itself. `reap_killed_job` must collect it via `waitpid`;
+    /// otherwise it lingers as a zombie once it leaves the monitor loop's map.
+    #[tokio::test]
+    async fn reap_killed_job_reaps_forked_variant() {
+        // Fork a child that exits immediately, leaving it unreaped (a zombie)
+        // until something waits on it — exactly the displaced-run situation.
+        let pid = match unsafe { nix::unistd::fork() }.expect("fork") {
+            nix::unistd::ForkResult::Child => unsafe { libc::_exit(0) },
+            nix::unistd::ForkResult::Parent { child } => child.as_raw(),
+        };
+
+        // Let the child exit so it is a zombie before we reap it.
+        assert_eq!(
+            await_proc_state(pid, &['Z']).await,
+            'Z',
+            "forked child should be an unreaped zombie before reap_killed_job"
+        );
+
+        let job = executor::RunningJob::Forked {
+            pid,
+            _pidfd: None,
+            cgroup_path: None,
+            reaped: false,
+        };
+        reap_killed_job(job).await;
+
+        // After reaping, the pid is gone from the process table entirely.
+        assert!(
+            !std::path::Path::new(&format!("/proc/{pid}")).exists(),
+            "reap_killed_job must reap the Forked child (pid {pid} still present)"
+        );
     }
 
     #[tokio::test]

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -906,16 +906,7 @@ impl SlurmAgent for AgentService {
                 // `launching` (which would let reconcile reclaim it).
                 self.allocation.lock().await.commit_job(job_id);
                 info!(job_id, gpus = ?launch_cfg.gpu_devices, "job launched successfully");
-                // Re-dispatch onto the same node reuses job_id. If an older run
-                // is still tracked (its process ignored SIGTERM and outlived the
-                // requeue), the insert would drop its Child without killing it —
-                // an orphaned runaway. SIGKILL it before overwriting.
-                if let Some(old) = jobs.get(&job_id) {
-                    if old.run_attempt < run_attempt {
-                        let _ = old.job.kill_signal(nix::sys::signal::Signal::SIGKILL);
-                    }
-                }
-                jobs.insert(
+                let displaced = jobs.insert(
                     job_id,
                     TrackedJob {
                         job: result.job,
@@ -935,6 +926,21 @@ impl SlurmAgent for AgentService {
                         run_attempt,
                     },
                 );
+                drop(jobs);
+                // Re-dispatch onto the same node reuses job_id and displaces an
+                // older run. If its process ignored SIGTERM and outlived the
+                // requeue, kill and reap it here — the monitor loop no longer
+                // tracks it, so without this it would leak as an orphan/zombie.
+                if let Some(mut old) = displaced {
+                    if old.run_attempt < run_attempt {
+                        let _ = old.job.kill_signal(nix::sys::signal::Signal::SIGKILL);
+                        tokio::spawn(async move {
+                            if let executor::RunningJob::Managed { child, .. } = &mut old.job {
+                                let _ = child.wait().await;
+                            }
+                        });
+                    }
+                }
                 Ok(Response::new(LaunchJobResponse {
                     success: true,
                     error: String::new(),

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -657,6 +657,9 @@ message LaunchJobRequest {
   // array_job_id is the parent id (0 = not an array task); exported as SLURM_ARRAY_*.
   uint32 array_job_id = 7;
   uint32 array_task_id = 8;
+  // Run epoch for this dispatch; agent echoes it in ReportJobStatusRequest so
+  // the controller can drop stale-run reports. 0 = unset (legacy), check off.
+  uint32 run_attempt = 9;
 }
 
 message LaunchJobResponse {
@@ -967,6 +970,9 @@ message ReportJobStatusRequest {
   string drain_reason = 6; // Reason for drain request
   string reporting_node = 7; // Hostname of the reporting agent (for drain targeting)
   int32 signal = 8;  // Terminating signal of the reporting node's process (0 = none)
+  // Echoed from LaunchJobRequest.run_attempt; controller drops this report if
+  // older than the job's current epoch. 0 = unset (legacy), check off.
+  uint32 run_attempt = 9;
 }
 
 // ============================================================


### PR DESCRIPTION
## What this fixes

A batch job in a `preempt_mode=requeue` partition could land in `FAILED` / `RaisedSignal:9` after preemption instead of returning to `RUNNING`, intermittently. This is the product bug behind the flaky `test_chronic_preemption_never_holds_job` e2e (see the recurring native-host E2E failure: https://github.com/ROCm/spur/actions/runs/29723193165/job/88290371845). A prior change (#466) only raised the test's reschedule timeout; because the job ends terminal, no timeout can make it pass — the failure kept recurring.

## Root cause

The requeue **eligibility hold** is `interval_secs*2+3` (≥ 5s) and the agent's **graceful-cancel grace period** is a fixed 5s — they coincide. On preemption:

1. The controller requeues the low-priority job (clears its allocation, sets a ~5s `begin_time` hold) and tells the agent to graceful-cancel.
2. The job's process dies on SIGTERM; the agent's completion report is correctly rejected (allocation already cleared).
3. ~5s later the hold expires, the job is re-dispatched onto the **same** node (it's `--exclusive` and the other node is busy), and goes `Running` again.
4. At the same ~5s mark the agent's grace timer fires a **SIGKILL** and reports completion **signal=9** — but the report is keyed only by `job_id` with no notion of *which run*, so it is applied to the freshly re-dispatched run and flips it to `FAILED`.

Two gaps combine: the agent's grace-timer SIGKILL matched on `job_id` alone, and completion reports carried no run identity, so the controller couldn't tell a prior run's report from the current one.

## The fix

Introduce a monotonic per-dispatch **run epoch** (`run_attempt`) threaded `JobStart` → `LaunchJobRequest` → `ReportJobStatusRequest`:

- The controller assigns `run_attempt = prev + 1` at each dispatch, persists it on the job (and in the `JobStart` WAL op), and sends it to the agent.
- The agent stores it per tracked job, echoes it on the completion report, and its grace-period SIGKILL now fires **only if the still-tracked run's epoch matches** the one it SIGTERM'd — so it can't kill a re-dispatched run that reused the `job_id`.
- The controller **drops a node completion whose epoch is older** than the job's current run (new `NodeCompleteResult::StaleReport`), so a late report from a superseded run can't fail the current one.
- On same-node re-dispatch, `launch_job` SIGKILLs an older-epoch tracked run before overwriting it, closing a pre-existing gap where a SIGTERM-ignoring prior process could be orphaned.

`run_attempt == 0` (legacy agent or controller, or a pre-upgrade WAL entry) disables both checks, so the change is backward compatible. Proto additions are new fields only (no renumbering, package unchanged); the new WAL field uses `#[serde(default)]`.

## Compatibility note

The race is only fully closed when **both** the controller and agents are upgraded — a legacy component reports/sees epoch 0, which disables the guard. Mixed-version clusters retain the prior behavior until both sides are updated.

## Testing

- `cargo fmt --all --check`, `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` — clean.
- `cargo test --locked` — all pass, including two new unit tests: the controller dropping a stale-epoch completion (`node_complete_drops_stale_run_report`) and the agent grace timer skipping SIGKILL for a reused `job_id` (`graceful_cancel_skips_sigkill_for_reused_job_id`).
- Reviewed by independent passes plus an adversarial cross-validation; findings addressed (superseded-run kill on re-dispatch; hardened the epoch test against a zombie false-pass).
- Manually reproduced on a 2-node cluster: the pre-fix build hit `FAILED` on the first preemption cycle; the fixed build ran repeated preemption cycles with the low-priority job returning to `RUNNING` every time and no grace-period SIGKILL escalations.

## Follow-ups

- The reschedule after requeue currently waits for the next scheduler tick because job completion doesn't wake the scheduler; a completion-triggered wake would reduce latency (out of scope here).