### PR TITLE
feat(quota): Kubernetes quota-enforcement — M1 (tenancy + hard quotas + scoped kubeconfig)

### DIFF
--- a/crates/spur-cli/src/k8s.rs
+++ b/crates/spur-cli/src/k8s.rs
@@ -44,8 +44,13 @@ pub enum K8sCommand {
     },
     /// Show cluster phase + per-node component status.
     Status,
-    /// Print the admin kubeconfig to stdout.
-    Kubeconfig,
+    /// Print a kubeconfig to stdout. Default: the cluster-admin kubeconfig. With `--user`, a
+    /// namespace-scoped kubeconfig (a ServiceAccount token in that user's account namespace).
+    Kubeconfig {
+        /// Mint a scoped kubeconfig for this SPUR user instead of the admin one.
+        #[arg(long)]
+        user: Option<String>,
+    },
     /// Download + install the k0s binary on THIS node (local; no controller needed).
     /// Run as root for the default /usr/local/bin path.
     InstallK0s {
@@ -72,7 +77,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         K8sCommand::Up { control_plane_node } => cmd_up(&controller, control_plane_node).await,
         K8sCommand::Down { reset } => cmd_down(&controller, reset).await,
         K8sCommand::Status => cmd_status(&controller).await,
-        K8sCommand::Kubeconfig => cmd_kubeconfig(&controller).await,
+        K8sCommand::Kubeconfig { user } => cmd_kubeconfig(&controller, user).await,
         K8sCommand::InstallK0s {
             version,
             path,
@@ -149,10 +154,12 @@ async fn cmd_status(controller: &str) -> Result<()> {
     Ok(())
 }
 
-async fn cmd_kubeconfig(controller: &str) -> Result<()> {
+async fn cmd_kubeconfig(controller: &str, user: Option<String>) -> Result<()> {
     let mut client = SlurmControllerClient::new(spur_client::connect_channel(controller).await?);
     let resp = client
-        .cluster_kubeconfig(ClusterKubeconfigRequest {})
+        .cluster_kubeconfig(ClusterKubeconfigRequest {
+            user: user.unwrap_or_default(),
+        })
         .await?
         .into_inner();
     // stdout = data (the YAML), so it can be redirected to a kubeconfig file.

--- a/crates/spur-core/src/lib.rs
+++ b/crates/spur-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod node;
 pub mod partition;
 pub mod process;
 pub mod qos;
+pub mod quota_names;
 pub mod reservation;
 pub mod resource;
 pub mod spur_env;

--- a/crates/spur-core/src/quota_names.rs
+++ b/crates/spur-core/src/quota_names.rs
@@ -7,20 +7,36 @@
 //! per-user ServiceAccount; spurctld mints a scoped kubeconfig into that same namespace/SA. They
 //! must agree on the exact names, so the convention lives here in spur-core (both depend on it).
 
-/// Kubernetes namespace for a SPUR account (DNS-1123 label safe).
+/// Max length of a DNS-1123 label (k8s namespace / ServiceAccount name limit).
+const DNS_LABEL_MAX: usize = 63;
+const NS_PREFIX: &str = "spur-acct-";
+const SA_PREFIX: &str = "spur-user-";
+
+/// Kubernetes namespace for a SPUR account (DNS-1123 label safe, prefix included in the length cap).
 pub fn account_namespace(account: &str) -> String {
-    format!("spur-acct-{}", sanitize_dns_label(account))
+    prefixed_dns_label(NS_PREFIX, account)
 }
 
 /// Per-user ServiceAccount name within the account namespace — what `spur k8s kubeconfig --user`
 /// mints a token for and what the account RoleBinding grants.
 pub fn user_service_account(user: &str) -> String {
-    format!("spur-user-{}", sanitize_dns_label(user))
+    prefixed_dns_label(SA_PREFIX, user)
+}
+
+/// `<prefix><sanitized>` capped at 63 chars total, so the returned name is always a valid DNS-1123
+/// label. The sanitized part is truncated to leave room for the prefix (which is itself DNS-safe).
+fn prefixed_dns_label(prefix: &str, s: &str) -> String {
+    let budget = DNS_LABEL_MAX.saturating_sub(prefix.len());
+    format!("{prefix}{}", sanitize_dns_label_capped(s, budget))
 }
 
 /// Lower-case, replace any char that isn't `[a-z0-9-]` with `-`, collapse/trim leading-trailing `-`,
 /// and cap at 63 chars — a DNS-1123 label. Empty input yields "x" so a name is always valid.
 pub fn sanitize_dns_label(s: &str) -> String {
+    sanitize_dns_label_capped(s, DNS_LABEL_MAX)
+}
+
+fn sanitize_dns_label_capped(s: &str, max: usize) -> String {
     let mut out = String::with_capacity(s.len());
     for c in s.chars() {
         let c = c.to_ascii_lowercase();
@@ -31,7 +47,7 @@ pub fn sanitize_dns_label(s: &str) -> String {
         }
     }
     let trimmed = out.trim_matches('-');
-    let capped: String = trimmed.chars().take(63).collect();
+    let capped: String = trimmed.chars().take(max).collect();
     let capped = capped.trim_matches('-').to_string();
     if capped.is_empty() {
         "x".to_string()
@@ -51,5 +67,31 @@ mod tests {
         assert_eq!(account_namespace("__weird__"), "spur-acct-weird");
         assert_eq!(sanitize_dns_label(""), "x");
         assert!(sanitize_dns_label(&"a".repeat(200)).len() <= 63);
+    }
+
+    #[test]
+    fn distinct_names_can_collide_after_sanitization() {
+        // Known M1 limitation: the sanitizer is not injective, so account names differing only in
+        // non-DNS characters map to the same namespace. Documented here so a change is deliberate.
+        assert_eq!(
+            account_namespace("physics_lab"),
+            account_namespace("physics.lab")
+        );
+        assert_eq!(
+            account_namespace("Physics-Lab"),
+            account_namespace("physics-lab")
+        );
+    }
+
+    #[test]
+    fn prefixed_names_stay_within_dns_limit() {
+        // The prefix must count toward the 63-char cap, and the result stays a valid label.
+        let ns = account_namespace(&"a".repeat(200));
+        assert!(ns.len() <= 63, "namespace too long: {} chars", ns.len());
+        assert!(ns.starts_with("spur-acct-"));
+        assert!(!ns.ends_with('-'));
+        let sa = user_service_account(&"b".repeat(200));
+        assert!(sa.len() <= 63, "sa too long: {} chars", sa.len());
+        assert!(sa.starts_with("spur-user-"));
     }
 }

--- a/crates/spur-core/src/quota_names.rs
+++ b/crates/spur-core/src/quota_names.rs
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared naming for the SPUR quota layer.
+//!
+//! The operator's quota reconciler creates a per-account Namespace and grants each member a
+//! per-user ServiceAccount; spurctld mints a scoped kubeconfig into that same namespace/SA. They
+//! must agree on the exact names, so the convention lives here in spur-core (both depend on it).
+
+/// Kubernetes namespace for a SPUR account (DNS-1123 label safe).
+pub fn account_namespace(account: &str) -> String {
+    format!("spur-acct-{}", sanitize_dns_label(account))
+}
+
+/// Per-user ServiceAccount name within the account namespace — what `spur k8s kubeconfig --user`
+/// mints a token for and what the account RoleBinding grants.
+pub fn user_service_account(user: &str) -> String {
+    format!("spur-user-{}", sanitize_dns_label(user))
+}
+
+/// Lower-case, replace any char that isn't `[a-z0-9-]` with `-`, collapse/trim leading-trailing `-`,
+/// and cap at 63 chars — a DNS-1123 label. Empty input yields "x" so a name is always valid.
+pub fn sanitize_dns_label(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        let c = c.to_ascii_lowercase();
+        if c.is_ascii_alphanumeric() {
+            out.push(c);
+        } else if !out.ends_with('-') {
+            out.push('-');
+        }
+    }
+    let trimmed = out.trim_matches('-');
+    let capped: String = trimmed.chars().take(63).collect();
+    let capped = capped.trim_matches('-').to_string();
+    if capped.is_empty() {
+        "x".to_string()
+    } else {
+        capped
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn names_are_dns_safe() {
+        assert_eq!(account_namespace("Physics_Lab"), "spur-acct-physics-lab");
+        assert_eq!(user_service_account("Alice.Smith"), "spur-user-alice-smith");
+        assert_eq!(account_namespace("__weird__"), "spur-acct-weird");
+        assert_eq!(sanitize_dns_label(""), "x");
+        assert!(sanitize_dns_label(&"a".repeat(200)).len() <= 63);
+    }
+}

--- a/crates/spur-k8s/src/agent.rs
+++ b/crates/spur-k8s/src/agent.rs
@@ -726,10 +726,10 @@ impl SlurmAgent for VirtualAgent {
         ))
     }
 
-    async fn get_admin_kubeconfig(
+    async fn get_kubeconfig(
         &self,
-        _request: Request<GetAdminKubeconfigRequest>,
-    ) -> Result<Response<GetAdminKubeconfigResponse>, Status> {
+        _request: Request<GetKubeconfigRequest>,
+    ) -> Result<Response<GetKubeconfigResponse>, Status> {
         Err(Status::unimplemented(
             "cluster components not supported for K8s agent",
         ))

--- a/crates/spur-k8s/src/lib.rs
+++ b/crates/spur-k8s/src/lib.rs
@@ -7,3 +7,4 @@ pub mod health;
 pub mod heartbeat;
 pub mod job_controller;
 pub mod node_watcher;
+pub mod quota;

--- a/crates/spur-k8s/src/lib.rs
+++ b/crates/spur-k8s/src/lib.rs
@@ -8,3 +8,4 @@ pub mod heartbeat;
 pub mod job_controller;
 pub mod node_watcher;
 pub mod quota;
+pub mod quota_controller;

--- a/crates/spur-k8s/src/main.rs
+++ b/crates/spur-k8s/src/main.rs
@@ -7,6 +7,8 @@ mod health;
 mod heartbeat;
 mod job_controller;
 mod node_watcher;
+mod quota;
+mod quota_controller;
 
 use std::net::SocketAddr;
 use std::time::Duration;
@@ -43,6 +45,11 @@ struct Args {
     /// K8s node label selector
     #[arg(long, default_value = "spur.amd.com/managed=true")]
     node_selector: String,
+
+    /// Enable the quota policy reconciler: project SPUR accounts into per-account Namespace +
+    /// ResourceQuota + LimitRange + RBAC. Off by default (opt-in policy plane).
+    #[arg(long, default_value_t = false)]
+    enable_quota: bool,
 
     /// HTTP health/metrics server address
     #[arg(long, default_value = "[::]:8080")]
@@ -168,6 +175,21 @@ async fn main() -> anyhow::Result<()> {
         })
         .await;
     });
+
+    // Spawn the quota policy reconciler (opt-in): projects SPUR accounts into per-account k8s
+    // Namespace + ResourceQuota + LimitRange + RBAC, and drift-corrects them.
+    if args.enable_quota {
+        let q_client = client.clone();
+        let q_ctrl_addr = args.controller_addr.clone();
+        tokio::spawn(async move {
+            run_with_retry("quota reconciler", || {
+                let c = q_client.clone();
+                let ctrl = q_ctrl_addr.clone();
+                Box::pin(quota_controller::run(c, ctrl))
+            })
+            .await;
+        });
+    }
 
     // Start virtual agent gRPC server
     let virtual_agent = agent::VirtualAgent::new(client);

--- a/crates/spur-k8s/src/quota.rs
+++ b/crates/spur-k8s/src/quota.rs
@@ -16,6 +16,10 @@ use k8s_openapi::api::rbac::v1::{PolicyRule, Role, RoleBinding, RoleRef, Subject
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use spur_core::accounting::{TresRecord, TresType};
+// Namespace + ServiceAccount naming lives in spur-core so spurctld's `kubeconfig --user` path agrees
+// with what this reconciler creates.
+use spur_core::quota_names::sanitize_dns_label;
+pub use spur_core::quota_names::{account_namespace, user_service_account};
 
 /// Value of the `app.kubernetes.io/managed-by` label stamped on every object this reconciler owns.
 /// The controller finds + drift-corrects its objects by this label and it encodes the
@@ -40,17 +44,6 @@ pub struct AccountQuota {
     /// Users associated with the account. Each becomes a RoleBinding subject via their per-namespace
     /// ServiceAccount (minted by `spur k8s kubeconfig --user`).
     pub members: Vec<String>,
-}
-
-/// Kubernetes namespace for a SPUR account (DNS-1123 label safe).
-pub fn account_namespace(account: &str) -> String {
-    format!("spur-acct-{}", sanitize_dns_label(account))
-}
-
-/// Per-user ServiceAccount name within the account namespace — what `kubeconfig --user` mints and
-/// what the RoleBinding grants.
-pub fn user_service_account(user: &str) -> String {
-    format!("spur-user-{}", sanitize_dns_label(user))
 }
 
 fn managed_labels(account: &str) -> BTreeMap<String, String> {
@@ -207,28 +200,6 @@ pub fn role_binding(aq: &AccountQuota) -> RoleBinding {
     }
 }
 
-/// Lower-case, replace any char that isn't `[a-z0-9-]` with `-`, collapse/trim leading-trailing `-`,
-/// and cap at 63 chars — a DNS-1123 label. Empty input yields "x" so a name is always valid.
-fn sanitize_dns_label(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        let c = c.to_ascii_lowercase();
-        if c.is_ascii_alphanumeric() {
-            out.push(c);
-        } else if !out.ends_with('-') {
-            out.push('-');
-        }
-    }
-    let trimmed = out.trim_matches('-');
-    let capped: String = trimmed.chars().take(63).collect();
-    let capped = capped.trim_matches('-').to_string();
-    if capped.is_empty() {
-        "x".to_string()
-    } else {
-        capped
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -269,16 +240,6 @@ mod tests {
         t.set(TresType::Node, 3);
         t.set(TresType::Billing, 100);
         assert!(quota_hard(&t).is_empty());
-    }
-
-    #[test]
-    fn namespace_and_sa_names_are_dns_safe() {
-        assert_eq!(account_namespace("Physics_Lab"), "spur-acct-physics-lab");
-        assert_eq!(user_service_account("Alice.Smith"), "spur-user-alice-smith");
-        // leading/trailing junk trimmed; empty -> valid.
-        assert_eq!(account_namespace("__weird__"), "spur-acct-weird");
-        assert_eq!(sanitize_dns_label(""), "x");
-        assert!(sanitize_dns_label("a".repeat(200).as_str()).len() <= 63);
     }
 
     #[test]

--- a/crates/spur-k8s/src/quota.rs
+++ b/crates/spur-k8s/src/quota.rs
@@ -4,7 +4,7 @@
 //! Projects a SPUR account's allocation into the native Kubernetes objects that ENFORCE it:
 //! a Namespace (tenancy), a ResourceQuota (hard caps from the account's `grp_tres` allocation),
 //! a LimitRange (default requests so unset-request pods can't dodge the quota), and RBAC (a Role
-//! + a RoleBinding to the account's members). Pure — no I/O — so the whole mapping is unit-tested
+//! and a RoleBinding to the account's members). Pure — no I/O — so the whole mapping is unit-tested
 //! here; the quota controller applies what these return and drift-corrects.
 
 use std::collections::BTreeMap;

--- a/crates/spur-k8s/src/quota.rs
+++ b/crates/spur-k8s/src/quota.rs
@@ -68,7 +68,7 @@ fn meta(name: &str, namespace: Option<&str>, account: &str) -> ObjectMeta {
     }
 }
 
-/// Map the account allocation to ResourceQuota `hard` entries. CPU (cores) and memory (MB→Mi) are
+/// Map the account allocation to ResourceQuota `hard` entries. CPU (cores) and memory (MB) are
 /// capped on both requests and limits; GPUs go on `requests.amd.com/gpu` (an extended resource). A
 /// dimension left at 0 is omitted (uncapped). Node/Energy/Billing have no pod-level quota analog.
 pub fn quota_hard(grp_tres: &TresRecord) -> BTreeMap<String, Quantity> {
@@ -80,8 +80,9 @@ pub fn quota_hard(grp_tres: &TresRecord) -> BTreeMap<String, Quantity> {
     }
     let mem_mb = grp_tres.get(TresType::Memory);
     if mem_mb > 0 {
-        hard.insert("requests.memory".into(), Quantity(format!("{mem_mb}Mi")));
-        hard.insert("limits.memory".into(), Quantity(format!("{mem_mb}Mi")));
+        // TRES mem is base-10 MB; `M` (not `Mi`) keeps the quota equal to the allocation.
+        hard.insert("requests.memory".into(), Quantity(format!("{mem_mb}M")));
+        hard.insert("limits.memory".into(), Quantity(format!("{mem_mb}M")));
     }
     let gpu = grp_tres.get(TresType::Gpu);
     if gpu > 0 {
@@ -111,17 +112,15 @@ pub fn resource_quota(aq: &AccountQuota) -> ResourceQuota {
     }
 }
 
-/// A LimitRange giving every container a default request, so a pod that omits requests still counts
-/// against the ResourceQuota (otherwise unset-request pods dodge the cap).
+/// A LimitRange giving every container a default *request*, so a pod that omits requests still
+/// counts against the ResourceQuota (otherwise unset-request pods dodge the cap). Deliberately no
+/// default *limit*: forcing an arbitrary small limit would reject ordinary larger pods that omit
+/// limits — the account's ResourceQuota is what actually bounds usage.
 pub fn limit_range(account: &str) -> LimitRange {
     let ns = account_namespace(account);
     let default_request = BTreeMap::from([
         ("cpu".to_string(), Quantity("100m".into())),
         ("memory".to_string(), Quantity("128Mi".into())),
-    ]);
-    let default_limit = BTreeMap::from([
-        ("cpu".to_string(), Quantity("1".into())),
-        ("memory".to_string(), Quantity("1Gi".into())),
     ]);
     LimitRange {
         metadata: meta(LIMITS_NAME, Some(&ns), account),
@@ -129,7 +128,6 @@ pub fn limit_range(account: &str) -> LimitRange {
             limits: vec![LimitRangeItem {
                 type_: "Container".to_string(),
                 default_request: Some(default_request),
-                default: Some(default_limit),
                 ..Default::default()
             }],
         }),
@@ -223,8 +221,8 @@ mod tests {
         let h = quota_hard(&tres(16, 32768, 8));
         assert_eq!(h["requests.cpu"].0, "16");
         assert_eq!(h["limits.cpu"].0, "16");
-        assert_eq!(h["requests.memory"].0, "32768Mi");
-        assert_eq!(h["limits.memory"].0, "32768Mi");
+        assert_eq!(h["requests.memory"].0, "32768M");
+        assert_eq!(h["limits.memory"].0, "32768M");
         assert_eq!(h["requests.amd.com/gpu"].0, "8");
     }
 
@@ -283,6 +281,8 @@ mod tests {
         let item = &lr.spec.unwrap().limits[0];
         assert_eq!(item.type_, "Container");
         assert_eq!(item.default_request.as_ref().unwrap()["cpu"].0, "100m");
-        assert_eq!(item.default.as_ref().unwrap()["memory"].0, "1Gi");
+        assert_eq!(item.default_request.as_ref().unwrap()["memory"].0, "128Mi");
+        // No default limit: it would reject ordinary pods that omit limits.
+        assert!(item.default.is_none());
     }
 }

--- a/crates/spur-k8s/src/quota.rs
+++ b/crates/spur-k8s/src/quota.rs
@@ -122,7 +122,7 @@ pub fn limit_range(account: &str) -> LimitRange {
     let ns = account_namespace(account);
     let default_request = BTreeMap::from([
         ("cpu".to_string(), Quantity("100m".into())),
-        ("memory".to_string(), Quantity("128Mi".into())),
+        ("memory".to_string(), Quantity("128M".into())),
     ]);
     LimitRange {
         metadata: meta(LIMITS_NAME, Some(&ns), account),
@@ -284,7 +284,7 @@ mod tests {
         let item = &lr.spec.unwrap().limits[0];
         assert_eq!(item.type_, "Container");
         assert_eq!(item.default_request.as_ref().unwrap()["cpu"].0, "100m");
-        assert_eq!(item.default_request.as_ref().unwrap()["memory"].0, "128Mi");
+        assert_eq!(item.default_request.as_ref().unwrap()["memory"].0, "128M");
         // No default limit: it would reject ordinary pods that omit limits.
         assert!(item.default.is_none());
     }

--- a/crates/spur-k8s/src/quota.rs
+++ b/crates/spur-k8s/src/quota.rs
@@ -1,0 +1,327 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Projects a SPUR account's allocation into the native Kubernetes objects that ENFORCE it:
+//! a Namespace (tenancy), a ResourceQuota (hard caps from the account's `grp_tres` allocation),
+//! a LimitRange (default requests so unset-request pods can't dodge the quota), and RBAC (a Role
+//! + a RoleBinding to the account's members). Pure — no I/O — so the whole mapping is unit-tested
+//! here; the quota controller applies what these return and drift-corrects.
+
+use std::collections::BTreeMap;
+
+use k8s_openapi::api::core::v1::{
+    LimitRange, LimitRangeItem, LimitRangeSpec, Namespace, ResourceQuota, ResourceQuotaSpec,
+};
+use k8s_openapi::api::rbac::v1::{PolicyRule, Role, RoleBinding, RoleRef, Subject};
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use spur_core::accounting::{TresRecord, TresType};
+
+/// Value of the `app.kubernetes.io/managed-by` label stamped on every object this reconciler owns.
+/// The controller finds + drift-corrects its objects by this label and it encodes the
+/// "SPUR-managed" contract (an admin hand-edit is reverted).
+pub const MANAGED_BY: &str = "spur-quota";
+
+/// Name of the (single) ResourceQuota / LimitRange / Role per account namespace.
+const QUOTA_NAME: &str = "spur-account-quota";
+const LIMITS_NAME: &str = "spur-account-defaults";
+const ROLE_NAME: &str = "spur-account-editor";
+const BINDING_NAME: &str = "spur-account-members";
+
+/// A SPUR account's projected allocation. The controller builds this from `ListAccounts` (the
+/// account's `grp_tres` allocation) joined with `ListUsers` (its member users).
+#[derive(Debug, Clone)]
+pub struct AccountQuota {
+    /// SPUR account name (e.g. "physics").
+    pub account: String,
+    /// The account's resource allocation. Only Cpu/Memory/Gpu map to a ResourceQuota; a 0/unset
+    /// dimension is left uncapped (a 0 cap would block every pod).
+    pub grp_tres: TresRecord,
+    /// Users associated with the account. Each becomes a RoleBinding subject via their per-namespace
+    /// ServiceAccount (minted by `spur k8s kubeconfig --user`).
+    pub members: Vec<String>,
+}
+
+/// Kubernetes namespace for a SPUR account (DNS-1123 label safe).
+pub fn account_namespace(account: &str) -> String {
+    format!("spur-acct-{}", sanitize_dns_label(account))
+}
+
+/// Per-user ServiceAccount name within the account namespace — what `kubeconfig --user` mints and
+/// what the RoleBinding grants.
+pub fn user_service_account(user: &str) -> String {
+    format!("spur-user-{}", sanitize_dns_label(user))
+}
+
+fn managed_labels(account: &str) -> BTreeMap<String, String> {
+    BTreeMap::from([
+        (
+            "app.kubernetes.io/managed-by".to_string(),
+            MANAGED_BY.to_string(),
+        ),
+        (
+            "spur.amd.com/account".to_string(),
+            sanitize_dns_label(account),
+        ),
+    ])
+}
+
+fn meta(name: &str, namespace: Option<&str>, account: &str) -> ObjectMeta {
+    ObjectMeta {
+        name: Some(name.to_string()),
+        namespace: namespace.map(str::to_string),
+        labels: Some(managed_labels(account)),
+        ..Default::default()
+    }
+}
+
+/// Map the account allocation to ResourceQuota `hard` entries. CPU (cores) and memory (MB→Mi) are
+/// capped on both requests and limits; GPUs go on `requests.amd.com/gpu` (an extended resource). A
+/// dimension left at 0 is omitted (uncapped). Node/Energy/Billing have no pod-level quota analog.
+pub fn quota_hard(grp_tres: &TresRecord) -> BTreeMap<String, Quantity> {
+    let mut hard = BTreeMap::new();
+    let cpu = grp_tres.get(TresType::Cpu);
+    if cpu > 0 {
+        hard.insert("requests.cpu".into(), Quantity(cpu.to_string()));
+        hard.insert("limits.cpu".into(), Quantity(cpu.to_string()));
+    }
+    let mem_mb = grp_tres.get(TresType::Memory);
+    if mem_mb > 0 {
+        hard.insert("requests.memory".into(), Quantity(format!("{mem_mb}Mi")));
+        hard.insert("limits.memory".into(), Quantity(format!("{mem_mb}Mi")));
+    }
+    let gpu = grp_tres.get(TresType::Gpu);
+    if gpu > 0 {
+        hard.insert("requests.amd.com/gpu".into(), Quantity(gpu.to_string()));
+    }
+    hard
+}
+
+/// The account's Namespace.
+pub fn namespace(account: &str) -> Namespace {
+    Namespace {
+        metadata: meta(&account_namespace(account), None, account),
+        ..Default::default()
+    }
+}
+
+/// The account's ResourceQuota (hard caps from its allocation).
+pub fn resource_quota(aq: &AccountQuota) -> ResourceQuota {
+    let ns = account_namespace(&aq.account);
+    ResourceQuota {
+        metadata: meta(QUOTA_NAME, Some(&ns), &aq.account),
+        spec: Some(ResourceQuotaSpec {
+            hard: Some(quota_hard(&aq.grp_tres)),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+/// A LimitRange giving every container a default request, so a pod that omits requests still counts
+/// against the ResourceQuota (otherwise unset-request pods dodge the cap).
+pub fn limit_range(account: &str) -> LimitRange {
+    let ns = account_namespace(account);
+    let default_request = BTreeMap::from([
+        ("cpu".to_string(), Quantity("100m".into())),
+        ("memory".to_string(), Quantity("128Mi".into())),
+    ]);
+    let default_limit = BTreeMap::from([
+        ("cpu".to_string(), Quantity("1".into())),
+        ("memory".to_string(), Quantity("1Gi".into())),
+    ]);
+    LimitRange {
+        metadata: meta(LIMITS_NAME, Some(&ns), account),
+        spec: Some(LimitRangeSpec {
+            limits: vec![LimitRangeItem {
+                type_: "Container".to_string(),
+                default_request: Some(default_request),
+                default: Some(default_limit),
+                ..Default::default()
+            }],
+        }),
+    }
+}
+
+/// A namespace-scoped Role granting the account's members ordinary workload management (no cluster
+/// resources, no quota/RBAC self-editing — those stay SPUR-managed).
+pub fn role(account: &str) -> Role {
+    let ns = account_namespace(account);
+    let rule = |api_groups: &[&str], resources: &[&str], verbs: &[&str]| PolicyRule {
+        api_groups: Some(api_groups.iter().map(|s| s.to_string()).collect()),
+        resources: Some(resources.iter().map(|s| s.to_string()).collect()),
+        verbs: verbs.iter().map(|s| s.to_string()).collect(),
+        ..Default::default()
+    };
+    let rw = &["get", "list", "watch", "create", "update", "patch", "delete"];
+    Role {
+        metadata: meta(ROLE_NAME, Some(&ns), account),
+        rules: Some(vec![
+            rule(
+                &[""],
+                &[
+                    "pods",
+                    "pods/log",
+                    "pods/exec",
+                    "pods/attach",
+                    "pods/portforward",
+                    "services",
+                    "configmaps",
+                    "secrets",
+                    "persistentvolumeclaims",
+                ],
+                rw,
+            ),
+            rule(&[""], &["events"], &["get", "list", "watch"]),
+            rule(&["batch"], &["jobs", "cronjobs"], rw),
+            rule(
+                &["apps"],
+                &["deployments", "replicasets", "statefulsets", "daemonsets"],
+                rw,
+            ),
+        ]),
+    }
+}
+
+/// The RoleBinding granting the account Role to each member's per-namespace ServiceAccount.
+pub fn role_binding(aq: &AccountQuota) -> RoleBinding {
+    let ns = account_namespace(&aq.account);
+    let subjects: Vec<Subject> = aq
+        .members
+        .iter()
+        .map(|user| Subject {
+            kind: "ServiceAccount".to_string(),
+            name: user_service_account(user),
+            namespace: Some(ns.clone()),
+            api_group: None,
+        })
+        .collect();
+    RoleBinding {
+        metadata: meta(BINDING_NAME, Some(&ns), &aq.account),
+        role_ref: RoleRef {
+            api_group: Some("rbac.authorization.k8s.io".to_string()),
+            kind: "Role".to_string(),
+            name: ROLE_NAME.to_string(),
+        },
+        subjects: Some(subjects),
+    }
+}
+
+/// Lower-case, replace any char that isn't `[a-z0-9-]` with `-`, collapse/trim leading-trailing `-`,
+/// and cap at 63 chars — a DNS-1123 label. Empty input yields "x" so a name is always valid.
+fn sanitize_dns_label(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        let c = c.to_ascii_lowercase();
+        if c.is_ascii_alphanumeric() {
+            out.push(c);
+        } else if !out.ends_with('-') {
+            out.push('-');
+        }
+    }
+    let trimmed = out.trim_matches('-');
+    let capped: String = trimmed.chars().take(63).collect();
+    let capped = capped.trim_matches('-').to_string();
+    if capped.is_empty() {
+        "x".to_string()
+    } else {
+        capped
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tres(cpu: u64, mem_mb: u64, gpu: u64) -> TresRecord {
+        let mut t = TresRecord::new();
+        if cpu > 0 {
+            t.set(TresType::Cpu, cpu);
+        }
+        if mem_mb > 0 {
+            t.set(TresType::Memory, mem_mb);
+        }
+        if gpu > 0 {
+            t.set(TresType::Gpu, gpu);
+        }
+        t
+    }
+
+    #[test]
+    fn quota_hard_maps_cpu_mem_gpu() {
+        let h = quota_hard(&tres(16, 32768, 8));
+        assert_eq!(h["requests.cpu"].0, "16");
+        assert_eq!(h["limits.cpu"].0, "16");
+        assert_eq!(h["requests.memory"].0, "32768Mi");
+        assert_eq!(h["limits.memory"].0, "32768Mi");
+        assert_eq!(h["requests.amd.com/gpu"].0, "8");
+    }
+
+    #[test]
+    fn quota_hard_omits_zero_dimensions() {
+        // GPU-only allocation: cpu/mem uncapped (no key), gpu capped.
+        let h = quota_hard(&tres(0, 0, 4));
+        assert!(!h.contains_key("requests.cpu"));
+        assert!(!h.contains_key("requests.memory"));
+        assert_eq!(h["requests.amd.com/gpu"].0, "4");
+        // Node/Energy/Billing never map even when set.
+        let mut t = TresRecord::new();
+        t.set(TresType::Node, 3);
+        t.set(TresType::Billing, 100);
+        assert!(quota_hard(&t).is_empty());
+    }
+
+    #[test]
+    fn namespace_and_sa_names_are_dns_safe() {
+        assert_eq!(account_namespace("Physics_Lab"), "spur-acct-physics-lab");
+        assert_eq!(user_service_account("Alice.Smith"), "spur-user-alice-smith");
+        // leading/trailing junk trimmed; empty -> valid.
+        assert_eq!(account_namespace("__weird__"), "spur-acct-weird");
+        assert_eq!(sanitize_dns_label(""), "x");
+        assert!(sanitize_dns_label("a".repeat(200).as_str()).len() <= 63);
+    }
+
+    #[test]
+    fn resource_quota_carries_hard_caps_and_managed_label() {
+        let aq = AccountQuota {
+            account: "physics".into(),
+            grp_tres: tres(16, 1024, 2),
+            members: vec![],
+        };
+        let rq = resource_quota(&aq);
+        assert_eq!(rq.metadata.namespace.as_deref(), Some("spur-acct-physics"));
+        assert_eq!(rq.metadata.name.as_deref(), Some(QUOTA_NAME));
+        assert_eq!(
+            rq.metadata.labels.as_ref().unwrap()["app.kubernetes.io/managed-by"],
+            MANAGED_BY
+        );
+        let hard = rq.spec.unwrap().hard.unwrap();
+        assert_eq!(hard["requests.amd.com/gpu"].0, "2");
+    }
+
+    #[test]
+    fn role_binding_has_a_service_account_subject_per_member() {
+        let aq = AccountQuota {
+            account: "physics".into(),
+            grp_tres: tres(1, 0, 0),
+            members: vec!["alice".into(), "bob".into()],
+        };
+        let rb = role_binding(&aq);
+        let subs = rb.subjects.unwrap();
+        assert_eq!(subs.len(), 2);
+        assert!(subs.iter().all(|s| s.kind == "ServiceAccount"
+            && s.namespace.as_deref() == Some("spur-acct-physics")));
+        assert_eq!(subs[0].name, "spur-user-alice");
+        assert_eq!(rb.role_ref.name, ROLE_NAME);
+        assert_eq!(rb.role_ref.kind, "Role");
+    }
+
+    #[test]
+    fn limit_range_defaults_requests_so_pods_count_against_quota() {
+        let lr = limit_range("physics");
+        let item = &lr.spec.unwrap().limits[0];
+        assert_eq!(item.type_, "Container");
+        assert_eq!(item.default_request.as_ref().unwrap()["cpu"].0, "100m");
+        assert_eq!(item.default.as_ref().unwrap()["memory"].0, "1Gi");
+    }
+}

--- a/crates/spur-k8s/src/quota.rs
+++ b/crates/spur-k8s/src/quota.rs
@@ -69,20 +69,22 @@ fn meta(name: &str, namespace: Option<&str>, account: &str) -> ObjectMeta {
 }
 
 /// Map the account allocation to ResourceQuota `hard` entries. CPU (cores) and memory (MB) are
-/// capped on both requests and limits; GPUs go on `requests.amd.com/gpu` (an extended resource). A
-/// dimension left at 0 is omitted (uncapped). Node/Energy/Billing have no pod-level quota analog.
+/// capped on `requests.*`; GPUs go on `requests.amd.com/gpu` (an extended resource). A dimension
+/// left at 0 is omitted (uncapped). Node/Energy/Billing have no pod-level quota analog.
+///
+/// Only `requests.*` is capped, never `limits.*`: a `limits.cpu`/`limits.memory` quota key forces
+/// every pod to declare a limit (or inherit a LimitRange default), so unset-limit pods would fail
+/// admission. `limit_range` supplies only a default *request*, matching this requests-only cap.
 pub fn quota_hard(grp_tres: &TresRecord) -> BTreeMap<String, Quantity> {
     let mut hard = BTreeMap::new();
     let cpu = grp_tres.get(TresType::Cpu);
     if cpu > 0 {
         hard.insert("requests.cpu".into(), Quantity(cpu.to_string()));
-        hard.insert("limits.cpu".into(), Quantity(cpu.to_string()));
     }
     let mem_mb = grp_tres.get(TresType::Memory);
     if mem_mb > 0 {
         // TRES mem is base-10 MB; `M` (not `Mi`) keeps the quota equal to the allocation.
         hard.insert("requests.memory".into(), Quantity(format!("{mem_mb}M")));
-        hard.insert("limits.memory".into(), Quantity(format!("{mem_mb}M")));
     }
     let gpu = grp_tres.get(TresType::Gpu);
     if gpu > 0 {
@@ -220,10 +222,11 @@ mod tests {
     fn quota_hard_maps_cpu_mem_gpu() {
         let h = quota_hard(&tres(16, 32768, 8));
         assert_eq!(h["requests.cpu"].0, "16");
-        assert_eq!(h["limits.cpu"].0, "16");
         assert_eq!(h["requests.memory"].0, "32768M");
-        assert_eq!(h["limits.memory"].0, "32768M");
         assert_eq!(h["requests.amd.com/gpu"].0, "8");
+        // Never cap limits.* — that would reject pods that omit limits.
+        assert!(!h.contains_key("limits.cpu"));
+        assert!(!h.contains_key("limits.memory"));
     }
 
     #[test]

--- a/crates/spur-k8s/src/quota.rs
+++ b/crates/spur-k8s/src/quota.rs
@@ -146,7 +146,9 @@ pub fn role(account: &str) -> Role {
         verbs: verbs.iter().map(|s| s.to_string()).collect(),
         ..Default::default()
     };
-    let rw = &["get", "list", "watch", "create", "update", "patch", "delete"];
+    let rw = &[
+        "get", "list", "watch", "create", "update", "patch", "delete",
+    ];
     Role {
         metadata: meta(ROLE_NAME, Some(&ns), account),
         rules: Some(vec![
@@ -271,8 +273,10 @@ mod tests {
         let rb = role_binding(&aq);
         let subs = rb.subjects.unwrap();
         assert_eq!(subs.len(), 2);
-        assert!(subs.iter().all(|s| s.kind == "ServiceAccount"
-            && s.namespace.as_deref() == Some("spur-acct-physics")));
+        assert!(subs
+            .iter()
+            .all(|s| s.kind == "ServiceAccount"
+                && s.namespace.as_deref() == Some("spur-acct-physics")));
         assert_eq!(subs[0].name, "spur-user-alice");
         assert_eq!(rb.role_ref.name, ROLE_NAME);
         assert_eq!(rb.role_ref.kind, "Role");

--- a/crates/spur-k8s/src/quota_controller.rs
+++ b/crates/spur-k8s/src/quota_controller.rs
@@ -74,7 +74,14 @@ async fn reconcile_once(
             .context("ListUsers RPC")?
             .into_inner()
             .users;
-        let aq = build_account_quota(&a, &users);
+        // A malformed allocation must not silently uncap the namespace; skip the account instead.
+        let aq = match build_account_quota(&a, &users) {
+            Ok(aq) => aq,
+            Err(e) => {
+                warn!(account = %a.name, error = %e, "skipping account with invalid grp_tres");
+                continue;
+            }
+        };
         // Isolate per-account failures so one bad account can't stall the rest of the reconcile.
         if let Err(e) = apply_account(client, &aq).await {
             warn!(account = %a.name, error = %e, "failed to reconcile account quota");
@@ -84,14 +91,23 @@ async fn reconcile_once(
 }
 
 /// Build the account's projected quota from its `AccountInfo` (the `grp_tres` allocation) and its
-/// member users. Pure — unit-tested.
-pub fn build_account_quota(account: &AccountInfo, users: &[UserInfo]) -> AccountQuota {
-    AccountQuota {
+/// member users. Pure — unit-tested. An empty allocation is uncapped; a non-empty but unparseable
+/// one is an error (fail closed — never silently uncap a namespace).
+pub fn build_account_quota(
+    account: &AccountInfo,
+    users: &[UserInfo],
+) -> anyhow::Result<AccountQuota> {
+    let grp_tres = if account.grp_tres.is_empty() {
+        TresRecord::default()
+    } else {
+        TresRecord::parse(&account.grp_tres)
+            .map_err(|e| anyhow::anyhow!("invalid grp_tres {:?}: {e}", account.grp_tres))?
+    };
+    Ok(AccountQuota {
         account: account.name.clone(),
-        // A malformed allocation string leaves the account uncapped rather than stalling the loop.
-        grp_tres: TresRecord::parse(&account.grp_tres).unwrap_or_default(),
+        grp_tres,
         members: users.iter().map(|u| u.name.clone()).collect(),
-    }
+    })
 }
 
 /// Apply the Namespace + ResourceQuota + LimitRange + Role + RoleBinding for one account. The
@@ -176,7 +192,8 @@ mod tests {
         let aq = build_account_quota(
             &account("physics", "cpu=16,mem=32768,gres/gpu=8"),
             &[user("alice", "physics"), user("bob", "physics")],
-        );
+        )
+        .unwrap();
         assert_eq!(aq.account, "physics");
         assert_eq!(aq.grp_tres.get(TresType::Cpu), 16);
         assert_eq!(aq.grp_tres.get(TresType::Memory), 32768);
@@ -187,9 +204,16 @@ mod tests {
     #[test]
     fn empty_grp_tres_yields_uncapped_allocation() {
         // An account with no allocation string -> empty TresRecord -> ResourceQuota with no caps.
-        let aq = build_account_quota(&account("open", ""), &[]);
+        let aq = build_account_quota(&account("open", ""), &[]).unwrap();
         assert_eq!(aq.grp_tres.get(TresType::Cpu), 0);
         assert!(quota::quota_hard(&aq.grp_tres).is_empty());
         assert!(aq.members.is_empty());
+    }
+
+    #[test]
+    fn malformed_grp_tres_is_an_error_not_uncapped() {
+        // A non-empty but unparseable allocation must fail closed, never silently uncap.
+        let err = build_account_quota(&account("bad", "cpu=notanumber"), &[]);
+        assert!(err.is_err());
     }
 }

--- a/crates/spur-k8s/src/quota_controller.rs
+++ b/crates/spur-k8s/src/quota_controller.rs
@@ -1,0 +1,195 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Quota policy reconciler.
+//!
+//! Projects every SPUR account into the native Kubernetes tenancy + quota objects that enforce it
+//! (Namespace, ResourceQuota, LimitRange, Role, RoleBinding — the mapping is in [`crate::quota`]).
+//! Reads accounts (with their `grp_tres` allocation) and members over the SlurmAccounting gRPC, then
+//! server-side-applies the objects with `force`, so the reconciler both fills drift and reverts an
+//! admin's hand-edit (the "SPUR-managed" contract). Runs on a level-triggered interval loop; a
+//! converged cluster re-applies the same objects (a no-op) and self-heals otherwise.
+
+use std::time::Duration;
+
+use anyhow::Context;
+use k8s_openapi::api::core::v1::{LimitRange, Namespace, ResourceQuota};
+use k8s_openapi::api::rbac::v1::{Role, RoleBinding};
+use kube::api::{Patch, PatchParams};
+use kube::{Api, Client, Resource};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use serde_json::json;
+use tonic::transport::Channel;
+use tracing::{info, warn};
+
+use spur_core::accounting::TresRecord;
+use spur_proto::proto::slurm_accounting_client::SlurmAccountingClient;
+use spur_proto::proto::{AccountInfo, ListAccountsRequest, ListUsersRequest, UserInfo};
+
+use crate::quota::{self, AccountQuota, MANAGED_BY};
+
+const RECONCILE_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Reconcile loop. Returns `Err` only on a fatal connect error so the caller (`run_with_retry`)
+/// restarts it with backoff; per-tick failures are logged and retried on the next interval.
+pub async fn run(client: Client, controller_addr: String) -> anyhow::Result<()> {
+    let url = if controller_addr.starts_with("http") {
+        controller_addr
+    } else {
+        format!("http://{controller_addr}")
+    };
+    let mut acct = SlurmAccountingClient::connect(url)
+        .await
+        .context("connect to spurctld accounting service")?;
+    info!("quota reconciler started");
+
+    let mut interval = tokio::time::interval(RECONCILE_INTERVAL);
+    loop {
+        interval.tick().await;
+        if let Err(e) = reconcile_once(&client, &mut acct).await {
+            warn!(error = %e, "quota reconcile tick failed; retrying next interval");
+        }
+    }
+}
+
+/// One reconcile pass: project every account into its k8s objects.
+async fn reconcile_once(
+    client: &Client,
+    acct: &mut SlurmAccountingClient<Channel>,
+) -> anyhow::Result<()> {
+    let accounts = acct
+        .list_accounts(ListAccountsRequest {})
+        .await
+        .context("ListAccounts RPC")?
+        .into_inner()
+        .accounts;
+
+    for a in accounts {
+        let users = acct
+            .list_users(ListUsersRequest {
+                account: a.name.clone(),
+            })
+            .await
+            .context("ListUsers RPC")?
+            .into_inner()
+            .users;
+        let aq = build_account_quota(&a, &users);
+        // Isolate per-account failures so one bad account can't stall the rest of the reconcile.
+        if let Err(e) = apply_account(client, &aq).await {
+            warn!(account = %a.name, error = %e, "failed to reconcile account quota");
+        }
+    }
+    Ok(())
+}
+
+/// Build the account's projected quota from its `AccountInfo` (the `grp_tres` allocation) and its
+/// member users. Pure — unit-tested.
+pub fn build_account_quota(account: &AccountInfo, users: &[UserInfo]) -> AccountQuota {
+    AccountQuota {
+        account: account.name.clone(),
+        // A malformed allocation string leaves the account uncapped rather than stalling the loop.
+        grp_tres: TresRecord::parse(&account.grp_tres).unwrap_or_default(),
+        members: users.iter().map(|u| u.name.clone()).collect(),
+    }
+}
+
+/// Apply the Namespace + ResourceQuota + LimitRange + Role + RoleBinding for one account. The
+/// Namespace is applied first so the namespaced objects have a home on a fresh cluster.
+async fn apply_account(client: &Client, aq: &AccountQuota) -> anyhow::Result<()> {
+    let ns = quota::account_namespace(&aq.account);
+    apply(
+        &Api::<Namespace>::all(client.clone()),
+        &quota::namespace(&aq.account),
+    )
+    .await?;
+    apply(
+        &Api::<ResourceQuota>::namespaced(client.clone(), &ns),
+        &quota::resource_quota(aq),
+    )
+    .await?;
+    apply(
+        &Api::<LimitRange>::namespaced(client.clone(), &ns),
+        &quota::limit_range(&aq.account),
+    )
+    .await?;
+    apply(
+        &Api::<Role>::namespaced(client.clone(), &ns),
+        &quota::role(&aq.account),
+    )
+    .await?;
+    apply(
+        &Api::<RoleBinding>::namespaced(client.clone(), &ns),
+        &quota::role_binding(aq),
+    )
+    .await?;
+    Ok(())
+}
+
+/// Server-side apply one object (create-or-update; `force` reverts drift from other field managers).
+/// k8s-openapi types don't serialize their `apiVersion`/`kind`, which SSA requires in the body, so
+/// they're injected from the type's `Resource` metadata.
+async fn apply<K>(api: &Api<K>, obj: &K) -> anyhow::Result<()>
+where
+    K: Resource<DynamicType = ()> + Serialize + DeserializeOwned + Clone + std::fmt::Debug,
+{
+    let name = obj
+        .meta()
+        .name
+        .clone()
+        .context("SPUR quota object has no name")?;
+    let mut body = serde_json::to_value(obj)?;
+    body["apiVersion"] = json!(K::api_version(&()).into_owned());
+    body["kind"] = json!(K::kind(&()).into_owned());
+    api.patch(
+        &name,
+        &PatchParams::apply(MANAGED_BY).force(),
+        &Patch::Apply(body),
+    )
+    .await
+    .with_context(|| format!("server-side apply {name}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spur_core::accounting::TresType;
+
+    fn account(name: &str, grp_tres: &str) -> AccountInfo {
+        AccountInfo {
+            name: name.into(),
+            grp_tres: grp_tres.into(),
+            ..Default::default()
+        }
+    }
+    fn user(name: &str, account: &str) -> UserInfo {
+        UserInfo {
+            name: name.into(),
+            account: account.into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn builds_account_quota_from_grp_tres_and_members() {
+        let aq = build_account_quota(
+            &account("physics", "cpu=16,mem=32768,gres/gpu=8"),
+            &[user("alice", "physics"), user("bob", "physics")],
+        );
+        assert_eq!(aq.account, "physics");
+        assert_eq!(aq.grp_tres.get(TresType::Cpu), 16);
+        assert_eq!(aq.grp_tres.get(TresType::Memory), 32768);
+        assert_eq!(aq.grp_tres.get(TresType::Gpu), 8);
+        assert_eq!(aq.members, vec!["alice".to_string(), "bob".to_string()]);
+    }
+
+    #[test]
+    fn empty_grp_tres_yields_uncapped_allocation() {
+        // An account with no allocation string -> empty TresRecord -> ResourceQuota with no caps.
+        let aq = build_account_quota(&account("open", ""), &[]);
+        assert_eq!(aq.grp_tres.get(TresType::Cpu), 0);
+        assert!(quota::quota_hard(&aq.grp_tres).is_empty());
+        assert!(aq.members.is_empty());
+    }
+}

--- a/crates/spur-k8s/src/quota_controller.rs
+++ b/crates/spur-k8s/src/quota_controller.rs
@@ -10,6 +10,7 @@
 //! admin's hand-edit (the "SPUR-managed" contract). Runs on a level-triggered interval loop; a
 //! converged cluster re-applies the same objects (a no-op) and self-heals otherwise.
 
+use std::collections::HashMap;
 use std::time::Duration;
 
 use anyhow::Context;
@@ -65,17 +66,24 @@ async fn reconcile_once(
         .into_inner()
         .accounts;
 
+    // One ListUsers (empty account = all) grouped client-side, instead of one RPC per account.
+    let all_users = acct
+        .list_users(ListUsersRequest {
+            account: String::new(),
+        })
+        .await
+        .context("ListUsers RPC")?
+        .into_inner()
+        .users;
+    let users_by_account = group_users_by_account(all_users);
+
     for a in accounts {
-        let users = acct
-            .list_users(ListUsersRequest {
-                account: a.name.clone(),
-            })
-            .await
-            .context("ListUsers RPC")?
-            .into_inner()
-            .users;
+        let users = users_by_account
+            .get(&a.name)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
         // A malformed allocation must not silently uncap the namespace; skip the account instead.
-        let aq = match build_account_quota(&a, &users) {
+        let aq = match build_account_quota(&a, users) {
             Ok(aq) => aq,
             Err(e) => {
                 warn!(account = %a.name, error = %e, "skipping account with invalid grp_tres");
@@ -88,6 +96,16 @@ async fn reconcile_once(
         }
     }
     Ok(())
+}
+
+/// Group all users by their account. Pure — lets the reconciler fetch users in one RPC and look
+/// each account's members up locally instead of a ListUsers call per account.
+fn group_users_by_account(users: Vec<UserInfo>) -> HashMap<String, Vec<UserInfo>> {
+    let mut by_account: HashMap<String, Vec<UserInfo>> = HashMap::new();
+    for u in users {
+        by_account.entry(u.account.clone()).or_default().push(u);
+    }
+    by_account
 }
 
 /// Build the account's projected quota from its `AccountInfo` (the `grp_tres` allocation) and its
@@ -215,5 +233,17 @@ mod tests {
         // A non-empty but unparseable allocation must fail closed, never silently uncap.
         let err = build_account_quota(&account("bad", "cpu=notanumber"), &[]);
         assert!(err.is_err());
+    }
+
+    #[test]
+    fn group_users_by_account_buckets_members() {
+        let grouped = group_users_by_account(vec![
+            user("alice", "physics"),
+            user("bob", "physics"),
+            user("carol", "chem"),
+        ]);
+        assert_eq!(grouped["physics"].len(), 2);
+        assert_eq!(grouped["chem"].len(), 1);
+        assert!(!grouped.contains_key("bio"));
     }
 }

--- a/crates/spur-k8s/src/quota_controller.rs
+++ b/crates/spur-k8s/src/quota_controller.rs
@@ -66,10 +66,11 @@ async fn reconcile_once(
         .into_inner()
         .accounts;
 
-    // One ListUsers (empty account = all) grouped client-side, instead of one RPC per account.
+    // One ListUsers (empty account/user = all) grouped client-side, instead of one RPC per account.
     let all_users = acct
         .list_users(ListUsersRequest {
             account: String::new(),
+            user: String::new(),
         })
         .await
         .context("ListUsers RPC")?

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -22,8 +22,8 @@ use spur_net::address::AddressPool;
 use spur_net::mesh::{MeshMembership, MeshNode};
 use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
 use spur_proto::proto::{
-    ClusterNodeStatus, CreateK0sJoinTokenRequest, GetAdminKubeconfigRequest,
-    GetClusterComponentStatusRequest, StartClusterComponentRequest, StopClusterComponentRequest,
+    ClusterNodeStatus, CreateK0sJoinTokenRequest, GetClusterComponentStatusRequest,
+    GetKubeconfigRequest, StartClusterComponentRequest, StopClusterComponentRequest,
 };
 
 use crate::cluster::ClusterManager;
@@ -383,9 +383,9 @@ async fn mint_worker_token(cluster: &ClusterManager) -> anyhow::Result<String> {
 pub async fn fetch_admin_kubeconfig(cluster: &ClusterManager) -> anyhow::Result<String> {
     let mut client = connect_control_plane(cluster).await?;
     let resp = client
-        .get_admin_kubeconfig(GetAdminKubeconfigRequest::default())
+        .get_kubeconfig(GetKubeconfigRequest::default())
         .await
-        .map_err(|e| anyhow::anyhow!("get_admin_kubeconfig RPC failed: {e}"))?;
+        .map_err(|e| anyhow::anyhow!("get_kubeconfig RPC failed: {e}"))?;
     Ok(resp.into_inner().kubeconfig)
 }
 
@@ -400,13 +400,13 @@ pub async fn fetch_user_kubeconfig(
 ) -> anyhow::Result<String> {
     let mut client = connect_control_plane(cluster).await?;
     let resp = client
-        .get_admin_kubeconfig(GetAdminKubeconfigRequest {
+        .get_kubeconfig(GetKubeconfigRequest {
             user: user.to_string(),
             namespace: namespace.to_string(),
             service_account: service_account.to_string(),
         })
         .await
-        .map_err(|e| anyhow::anyhow!("get_admin_kubeconfig (scoped) RPC failed: {e}"))?;
+        .map_err(|e| anyhow::anyhow!("get_kubeconfig (scoped) RPC failed: {e}"))?;
     Ok(resp.into_inner().kubeconfig)
 }
 

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -383,9 +383,30 @@ async fn mint_worker_token(cluster: &ClusterManager) -> anyhow::Result<String> {
 pub async fn fetch_admin_kubeconfig(cluster: &ClusterManager) -> anyhow::Result<String> {
     let mut client = connect_control_plane(cluster).await?;
     let resp = client
-        .get_admin_kubeconfig(GetAdminKubeconfigRequest {})
+        .get_admin_kubeconfig(GetAdminKubeconfigRequest::default())
         .await
         .map_err(|e| anyhow::anyhow!("get_admin_kubeconfig RPC failed: {e}"))?;
+    Ok(resp.into_inner().kubeconfig)
+}
+
+/// Mint a namespace-scoped kubeconfig for a SPUR user: the control-plane agent ensures the
+/// ServiceAccount exists in the account namespace and mints a bound token. `namespace` + `sa` are
+/// derived by the caller from the user's account via `spur_core::quota_names`.
+pub async fn fetch_user_kubeconfig(
+    cluster: &ClusterManager,
+    user: &str,
+    namespace: &str,
+    service_account: &str,
+) -> anyhow::Result<String> {
+    let mut client = connect_control_plane(cluster).await?;
+    let resp = client
+        .get_admin_kubeconfig(GetAdminKubeconfigRequest {
+            user: user.to_string(),
+            namespace: namespace.to_string(),
+            service_account: service_account.to_string(),
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("get_admin_kubeconfig (scoped) RPC failed: {e}"))?;
     Ok(resp.into_inner().kubeconfig)
 }
 

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -2092,10 +2092,10 @@ mod tests {
                 Err(tonic::Status::unimplemented("not used in tests"))
             }
 
-            async fn get_admin_kubeconfig(
+            async fn get_kubeconfig(
                 &self,
-                _request: tonic::Request<spur_proto::proto::GetAdminKubeconfigRequest>,
-            ) -> Result<tonic::Response<spur_proto::proto::GetAdminKubeconfigResponse>, tonic::Status>
+                _request: tonic::Request<spur_proto::proto::GetKubeconfigRequest>,
+            ) -> Result<tonic::Response<spur_proto::proto::GetKubeconfigResponse>, tonic::Status>
             {
                 Err(tonic::Status::unimplemented("not used in tests"))
             }

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1782,8 +1782,15 @@ impl SlurmController for ControllerService {
             };
         }
         // Scoped kubeconfig: resolve the user's account -> its namespace + per-user ServiceAccount,
-        // then have the control-plane agent mint a bound token there.
-        let (account, _qos) = self.cluster.association_cache().resolve(&req.user, None);
+        // then have the control-plane agent mint a bound token there. Fail closed if associations
+        // aren't loaded yet — the cache resolves fail-open, which would mint an unscoped token.
+        let cache = self.cluster.association_cache();
+        if !cache.is_loaded() {
+            return Err(Status::unavailable(
+                "associations not loaded yet; retry shortly",
+            ));
+        }
+        let (account, _qos) = cache.resolve(&req.user, None);
         let account = account.ok_or_else(|| {
             Status::not_found(format!(
                 "user '{}' is not associated with any account",

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -169,6 +169,28 @@ impl ControllerService {
     }
 }
 
+/// Resolve a user to the (namespace, ServiceAccount) its scoped kubeconfig must be bound to.
+/// Fails closed if associations aren't loaded yet — the cache resolves fail-open, which would
+/// otherwise mint an unscoped token — and rejects a user with no account.
+fn resolve_user_namespace_sa(
+    cache: &crate::association_cache::AssociationCache,
+    user: &str,
+) -> Result<(String, String), Status> {
+    if !cache.is_loaded() {
+        return Err(Status::unavailable(
+            "associations not loaded yet; retry shortly",
+        ));
+    }
+    let (account, _qos, _allowed_qos) = cache.resolve(user, None);
+    let account = account.ok_or_else(|| {
+        Status::not_found(format!("user '{user}' is not associated with any account"))
+    })?;
+    Ok((
+        spur_core::quota_names::account_namespace(&account),
+        spur_core::quota_names::user_service_account(user),
+    ))
+}
+
 #[tonic::async_trait]
 impl SlurmController for ControllerService {
     async fn submit_job(
@@ -1782,23 +1804,9 @@ impl SlurmController for ControllerService {
             };
         }
         // Scoped kubeconfig: resolve the user's account -> its namespace + per-user ServiceAccount,
-        // then have the control-plane agent mint a bound token there. Fail closed if associations
-        // aren't loaded yet — the cache resolves fail-open, which would mint an unscoped token.
-        let cache = self.cluster.association_cache();
-        if !cache.is_loaded() {
-            return Err(Status::unavailable(
-                "associations not loaded yet; retry shortly",
-            ));
-        }
-        let (account, _qos) = cache.resolve(&req.user, None);
-        let account = account.ok_or_else(|| {
-            Status::not_found(format!(
-                "user '{}' is not associated with any account",
-                req.user
-            ))
-        })?;
-        let namespace = spur_core::quota_names::account_namespace(&account);
-        let sa = spur_core::quota_names::user_service_account(&req.user);
+        // then have the control-plane agent mint a bound token there.
+        let (namespace, sa) =
+            resolve_user_namespace_sa(self.cluster.association_cache(), &req.user)?;
         match crate::cluster_k8s::fetch_user_kubeconfig(&self.cluster, &req.user, &namespace, &sa)
             .await
         {
@@ -2406,6 +2414,32 @@ mod tests {
     use spur_core::job::{JobState, NodeCompleteError};
     use spur_core::reservation::ReservationFlags;
     use tonic::Code;
+
+    #[test]
+    fn resolve_user_namespace_sa_fails_closed_on_cold_cache() {
+        // A not-yet-loaded cache resolves fail-open, so the scoped-kubeconfig path
+        // must reject rather than mint an unscoped (cluster-wide) token.
+        let cache = crate::association_cache::AssociationCache::new();
+        let err = resolve_user_namespace_sa(&cache, "alice").unwrap_err();
+        assert_eq!(err.code(), Code::Unavailable);
+    }
+
+    #[test]
+    fn resolve_user_namespace_sa_rejects_unassociated_user() {
+        let cache = crate::association_cache::AssociationCache::new();
+        cache.set_loaded_without_associations();
+        let err = resolve_user_namespace_sa(&cache, "alice").unwrap_err();
+        assert_eq!(err.code(), Code::NotFound);
+    }
+
+    #[test]
+    fn resolve_user_namespace_sa_derives_namespace_and_sa() {
+        let cache = crate::association_cache::AssociationCache::new();
+        cache.insert_default_account("alice", "physics");
+        let (namespace, sa) = resolve_user_namespace_sa(&cache, "alice").unwrap();
+        assert_eq!(namespace, "spur-acct-physics");
+        assert_eq!(sa, "spur-user-alice");
+    }
 
     #[test]
     fn submit_rpc_status_maps_invalid_argument() {

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1771,11 +1771,34 @@ impl SlurmController for ControllerService {
             *fwd.metadata_mut() = Self::forwarded_metadata();
             return client.cluster_kubeconfig(fwd).await;
         }
-        // Ask the control-plane node's agent to run `k0s kubeconfig admin`.
-        match crate::cluster_k8s::fetch_admin_kubeconfig(&self.cluster).await {
+        let req = request.into_inner();
+        if req.user.is_empty() {
+            // Cluster-admin kubeconfig (`k0s kubeconfig admin` on the control-plane agent).
+            return match crate::cluster_k8s::fetch_admin_kubeconfig(&self.cluster).await {
+                Ok(kubeconfig) => Ok(Response::new(ClusterKubeconfigResponse { kubeconfig })),
+                Err(e) => Err(Status::unavailable(format!(
+                    "could not fetch admin kubeconfig from the control-plane agent: {e}"
+                ))),
+            };
+        }
+        // Scoped kubeconfig: resolve the user's account -> its namespace + per-user ServiceAccount,
+        // then have the control-plane agent mint a bound token there.
+        let (account, _qos) = self.cluster.association_cache().resolve(&req.user, None);
+        let account = account.ok_or_else(|| {
+            Status::not_found(format!(
+                "user '{}' is not associated with any account",
+                req.user
+            ))
+        })?;
+        let namespace = spur_core::quota_names::account_namespace(&account);
+        let sa = spur_core::quota_names::user_service_account(&req.user);
+        match crate::cluster_k8s::fetch_user_kubeconfig(&self.cluster, &req.user, &namespace, &sa)
+            .await
+        {
             Ok(kubeconfig) => Ok(Response::new(ClusterKubeconfigResponse { kubeconfig })),
             Err(e) => Err(Status::unavailable(format!(
-                "could not fetch admin kubeconfig from the control-plane agent: {e}"
+                "could not mint a scoped kubeconfig for user '{}': {e}",
+                req.user
             ))),
         }
     }

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1682,13 +1682,21 @@ impl SlurmAgent for AgentService {
 
     async fn get_admin_kubeconfig(
         &self,
-        _request: Request<GetAdminKubeconfigRequest>,
+        request: Request<GetAdminKubeconfigRequest>,
     ) -> Result<Response<GetAdminKubeconfigResponse>, Status> {
-        match self.k0s.admin_kubeconfig().await {
+        let req = request.into_inner();
+        // Empty user -> cluster-admin kubeconfig; set -> a scoped kubeconfig (SA + bound token in the
+        // user's account namespace).
+        let result = if req.user.is_empty() {
+            self.k0s.admin_kubeconfig().await
+        } else {
+            self.k0s
+                .user_kubeconfig(&req.user, &req.namespace, &req.service_account)
+                .await
+        };
+        match result {
             Ok(kubeconfig) => Ok(Response::new(GetAdminKubeconfigResponse { kubeconfig })),
-            Err(e) => Err(Status::internal(format!(
-                "k0s kubeconfig admin failed: {e}"
-            ))),
+            Err(e) => Err(Status::internal(format!("get kubeconfig failed: {e}"))),
         }
     }
 

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1680,10 +1680,10 @@ impl SlurmAgent for AgentService {
         }
     }
 
-    async fn get_admin_kubeconfig(
+    async fn get_kubeconfig(
         &self,
-        request: Request<GetAdminKubeconfigRequest>,
-    ) -> Result<Response<GetAdminKubeconfigResponse>, Status> {
+        request: Request<GetKubeconfigRequest>,
+    ) -> Result<Response<GetKubeconfigResponse>, Status> {
         let req = request.into_inner();
         // Empty user -> cluster-admin kubeconfig; set -> a scoped kubeconfig (SA + bound token in the
         // user's account namespace).
@@ -1695,7 +1695,7 @@ impl SlurmAgent for AgentService {
                 .await
         };
         match result {
-            Ok(kubeconfig) => Ok(Response::new(GetAdminKubeconfigResponse { kubeconfig })),
+            Ok(kubeconfig) => Ok(Response::new(GetKubeconfigResponse { kubeconfig })),
             Err(e) => Err(Status::internal(format!("get kubeconfig failed: {e}"))),
         }
     }

--- a/crates/spurd/src/cluster.rs
+++ b/crates/spurd/src/cluster.rs
@@ -365,6 +365,87 @@ fn parse_execstart(exec: &str) -> anyhow::Result<ClusterConfig> {
     })
 }
 
+/// Extract the cluster CA (base64) + server URL from an admin kubeconfig YAML. k0s's admin
+/// kubeconfig has exactly one cluster, so a dependency-free line scan is sufficient.
+fn parse_cluster_ca_server(admin: &str) -> anyhow::Result<(String, String)> {
+    let mut ca = None;
+    let mut server = None;
+    for line in admin.lines() {
+        let t = line.trim();
+        if let Some(v) = t.strip_prefix("certificate-authority-data:") {
+            ca = Some(v.trim().to_string());
+        } else if let Some(v) = t.strip_prefix("server:") {
+            server = Some(v.trim().to_string());
+        }
+    }
+    match (ca, server) {
+        (Some(ca), Some(server)) => Ok((ca, server)),
+        _ => anyhow::bail!("admin kubeconfig missing certificate-authority-data or server"),
+    }
+}
+
+/// Template a namespace-scoped kubeconfig. `name` (the ServiceAccount name) is DNS-safe and the
+/// ca/server/token carry no YAML-breaking characters, so plain interpolation is safe.
+fn build_scoped_kubeconfig(
+    ca: &str,
+    server: &str,
+    token: &str,
+    name: &str,
+    namespace: &str,
+) -> String {
+    format!(
+        r#"apiVersion: v1
+kind: Config
+clusters:
+- name: spur
+  cluster:
+    certificate-authority-data: {ca}
+    server: {server}
+contexts:
+- name: {name}
+  context:
+    cluster: spur
+    namespace: {namespace}
+    user: {name}
+current-context: {name}
+users:
+- name: {name}
+  user:
+    token: {token}
+"#
+    )
+}
+
+#[cfg(test)]
+mod scoped_kubeconfig_tests {
+    use super::{build_scoped_kubeconfig, parse_cluster_ca_server};
+
+    #[test]
+    fn parses_ca_and_server() {
+        let admin = "clusters:\n- cluster:\n    certificate-authority-data: QUJD\n    server: https://10.0.0.1:6443\n  name: k0s\n";
+        let (ca, server) = parse_cluster_ca_server(admin).unwrap();
+        assert_eq!(ca, "QUJD");
+        assert_eq!(server, "https://10.0.0.1:6443");
+        assert!(parse_cluster_ca_server("apiVersion: v1\n").is_err());
+    }
+
+    #[test]
+    fn builds_scoped_kubeconfig_yaml() {
+        let kc = build_scoped_kubeconfig(
+            "QUJD",
+            "https://x:6443",
+            "tok123",
+            "spur-user-alice",
+            "spur-acct-physics",
+        );
+        assert!(kc.starts_with("apiVersion: v1\nkind: Config\n"));
+        assert!(kc.contains("namespace: spur-acct-physics"));
+        assert!(kc.contains("token: tok123"));
+        assert!(kc.contains("certificate-authority-data: QUJD"));
+        assert!(kc.contains("current-context: spur-user-alice"));
+    }
+}
+
 /// Write a bearer-secret file (0600). Content is never logged.
 async fn write_secret_file(path: &Path, content: &[u8]) -> anyhow::Result<()> {
     use tokio::io::AsyncWriteExt;
@@ -686,6 +767,72 @@ impl K0sAgent {
             anyhow::bail!("k0s kubeconfig admin returned empty output");
         }
         Ok(kubeconfig)
+    }
+
+    /// Mint a namespace-scoped kubeconfig on this (control-plane) node: ensure `service_account`
+    /// exists in `namespace`, mint a bound token for it (`k0s kubectl create token`), and template a
+    /// kubeconfig with the admin cluster CA + server scoped to that namespace. The namespace + its
+    /// RBAC are expected to exist (created by the operator's quota reconciler). Token never logged.
+    pub async fn user_kubeconfig(
+        &self,
+        user: &str,
+        namespace: &str,
+        service_account: &str,
+    ) -> anyhow::Result<String> {
+        // Ensure the ServiceAccount exists — idempotent (an already-existing SA is fine).
+        let create = Command::new(&self.k0s_binary)
+            .args([
+                "kubectl",
+                "create",
+                "serviceaccount",
+                service_account,
+                "-n",
+                namespace,
+            ])
+            .output()
+            .await?;
+        if !create.status.success() {
+            let err = String::from_utf8_lossy(&create.stderr);
+            if !err.contains("AlreadyExists") && !err.contains("already exists") {
+                anyhow::bail!(
+                    "create serviceaccount {service_account} in {namespace} failed: {}",
+                    err.trim()
+                );
+            }
+        }
+        // Mint a bound (rotatable) token for the ServiceAccount.
+        let tok = Command::new(&self.k0s_binary)
+            .args([
+                "kubectl",
+                "create",
+                "token",
+                service_account,
+                "-n",
+                namespace,
+                "--duration=8760h",
+            ])
+            .output()
+            .await?;
+        if !tok.status.success() {
+            anyhow::bail!(
+                "create token for {service_account} in {namespace} failed: {}",
+                String::from_utf8_lossy(&tok.stderr).trim()
+            );
+        }
+        let token = String::from_utf8_lossy(&tok.stdout).trim().to_string();
+        if token.is_empty() {
+            anyhow::bail!("k0s kubectl create token returned empty output");
+        }
+        // Reuse the admin kubeconfig for the cluster CA + server URL.
+        let (ca, server) = parse_cluster_ca_server(&self.admin_kubeconfig().await?)?;
+        info!(user, namespace, service_account, "minted scoped kubeconfig");
+        Ok(build_scoped_kubeconfig(
+            &ca,
+            &server,
+            &token,
+            service_account,
+            namespace,
+        ))
     }
 
     /// (role, active_state, enabled) for the node's component. When there is no tracked component,

--- a/crates/spurd/src/cluster.rs
+++ b/crates/spurd/src/cluster.rs
@@ -779,6 +779,13 @@ impl K0sAgent {
         namespace: &str,
         service_account: &str,
     ) -> anyhow::Result<String> {
+        // Fail closed: this is the token-minting boundary. Empty inputs must never reach kubectl,
+        // where they could scope a token to an unintended namespace/SA.
+        if user.is_empty() || namespace.is_empty() || service_account.is_empty() {
+            anyhow::bail!(
+                "user_kubeconfig requires non-empty user, namespace, and service_account"
+            );
+        }
         // Ensure the ServiceAccount exists — idempotent (an already-existing SA is fine).
         let create = Command::new(&self.k0s_binary)
             .args([
@@ -1044,5 +1051,24 @@ mod tests {
             sup.unit_status_is(&["is-active"], "active").await,
             "active again after re-write"
         );
+    }
+
+    #[tokio::test]
+    async fn user_kubeconfig_fails_closed_on_empty_inputs() {
+        let agent = K0sAgent::from_config(&spur_core::config::ClusterConfig::default());
+        for (user, ns, sa) in [
+            ("", "spur-acct-x", "spur-user-y"),
+            ("u", "", "spur-user-y"),
+            ("u", "spur-acct-x", ""),
+        ] {
+            let err = agent
+                .user_kubeconfig(user, ns, sa)
+                .await
+                .expect_err("empty input must fail closed before minting a token");
+            assert!(
+                err.to_string().contains("non-empty"),
+                "unexpected error: {err}"
+            );
+        }
     }
 }

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -814,9 +814,10 @@ message CreateK0sJoinTokenResponse {
 }
 
 message GetAdminKubeconfigRequest {
-  // All empty -> the cluster-admin kubeconfig. When `user` is set, the control-plane node mints a
-  // scoped kubeconfig: a bound token for `service_account` in `namespace` (created if absent), with
-  // the admin cluster CA + server. spurctld resolves the SPUR user -> account namespace + SA name.
+  // Empty `user` -> the cluster-admin kubeconfig (namespace/service_account ignored). When `user` is
+  // set, the control-plane node mints a scoped kubeconfig: a bound token for `service_account` in
+  // `namespace` (created if absent), with the admin cluster CA + server. spurctld resolves the SPUR
+  // user -> account namespace + SA name.
   string user = 1;
   string namespace = 2;
   string service_account = 3;

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -759,9 +759,14 @@ message ClusterNodeStatus {
   bool enabled = 4;
 }
 
-message ClusterKubeconfigRequest {}
+message ClusterKubeconfigRequest {
+  // Empty -> the cluster-admin kubeconfig. Set -> a namespace-scoped kubeconfig for this SPUR user
+  // (a ServiceAccount + bound token in the user's account namespace).
+  string user = 1;
+}
 message ClusterKubeconfigResponse {
-  // Admin kubeconfig YAML (server rewritten to the control-plane's mesh IP).
+  // Admin kubeconfig YAML (server rewritten to the control-plane's mesh IP), or the scoped kubeconfig
+  // when `user` was set.
   string kubeconfig = 1;
 }
 
@@ -808,9 +813,16 @@ message CreateK0sJoinTokenResponse {
   string join_token = 1;
 }
 
-message GetAdminKubeconfigRequest {}
+message GetAdminKubeconfigRequest {
+  // All empty -> the cluster-admin kubeconfig. When `user` is set, the control-plane node mints a
+  // scoped kubeconfig: a bound token for `service_account` in `namespace` (created if absent), with
+  // the admin cluster CA + server. spurctld resolves the SPUR user -> account namespace + SA name.
+  string user = 1;
+  string namespace = 2;
+  string service_account = 3;
+}
 message GetAdminKubeconfigResponse {
-  // Admin kubeconfig YAML read from the control-plane node.
+  // Admin (or scoped) kubeconfig YAML read/minted on the control-plane node.
   string kubeconfig = 1;
 }
 

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -376,10 +376,11 @@ service SlurmAgent {
 
   // -- Control-plane-only cluster admin: the controller calls these on
   //    the control-plane node's agent, which shells `k0s` against the running
-  //    controller. Worker joins need a fresh token; ClusterKubeconfig needs the
-  //    admin kubeconfig. Erroring on a non-control-plane node is expected. --
+  //    controller. Worker joins need a fresh token; GetKubeconfig returns either
+  //    the admin kubeconfig or a scoped per-user token. Erroring on a
+  //    non-control-plane node is expected. --
   rpc CreateK0sJoinToken(CreateK0sJoinTokenRequest) returns (CreateK0sJoinTokenResponse);
-  rpc GetAdminKubeconfig(GetAdminKubeconfigRequest) returns (GetAdminKubeconfigResponse);
+  rpc GetKubeconfig(GetKubeconfigRequest) returns (GetKubeconfigResponse);
 
   // Apply the full-mesh WireGuard membership on this node: the controller pushes the
   // authoritative peer set so a native-routing CNI (Calico bird) can ride the mesh. Additive +
@@ -813,7 +814,7 @@ message CreateK0sJoinTokenResponse {
   string join_token = 1;
 }
 
-message GetAdminKubeconfigRequest {
+message GetKubeconfigRequest {
   // Empty `user` -> the cluster-admin kubeconfig (namespace/service_account ignored). When `user` is
   // set, the control-plane node mints a scoped kubeconfig: a bound token for `service_account` in
   // `namespace` (created if absent), with the admin cluster CA + server. spurctld resolves the SPUR
@@ -822,7 +823,7 @@ message GetAdminKubeconfigRequest {
   string namespace = 2;
   string service_account = 3;
 }
-message GetAdminKubeconfigResponse {
+message GetKubeconfigResponse {
   // Admin (or scoped) kubeconfig YAML read/minted on the control-plane node.
   string kubeconfig = 1;
 }


### PR DESCRIPTION
## What

Implements **M1** of the Kubernetes quota-enforcement design ([#444 RFC](https://github.com/ROCm/spur/pull/444)): the **tenancy + hard-quota** layer that projects SPUR accounts onto native Kubernetes objects, plus per-user scoped kubeconfigs — so a cluster looks like a normal Kubernetes deployment to its users while SPUR is the invisible policy plane.

Picks up the work from #471 (which was stacked on #432). Rebased cleanly onto `main` — the diff here is exactly the 4 quota commits, no `#432` dependency, plus one review-fix commit (below).

## End-to-end flow

```
sacctmgr add account name=physics grptres=cpu=64,mem=131072,gres/gpu=8
  → the operator's quota reconciler (opt-in --enable-quota) projects it to:
      namespace spur-acct-physics
      + ResourceQuota (requests.cpu, requests.memory, requests.amd.com/gpu)
      + LimitRange (default requests so unset-request pods still count)
      + Role + RoleBinding (the account's members)

spur k8s kubeconfig --user alice
  → spurctld resolves alice → physics → its namespace; the control-plane agent
    mints a ServiceAccount + bound token there → a namespace-scoped kubeconfig
    (no cluster-admin credential ever handed out)
```

## Increments (each independently reviewable)

| Commit | Increment |
|---|---|
| projection module | Pure `account → Namespace/ResourceQuota/LimitRange/RBAC` mapping (`spur-k8s/quota.rs`), unit-tested |
| persist `grp_tres` | Account-level TRES allocation through DB (column + migration) + proto + gRPC + `sacctmgr` |
| reconciler | `quota_controller` in the operator: lists accounts+members over gRPC, server-side-applies with `force` (drift-correcting), opt-in `--enable-quota` |
| `kubeconfig --user` | Shared naming in `spur-core`, scoped kubeconfig minted by the control-plane agent, CLI flag |
| review fixes | mem units, DNS name cap, fail-closed paths (see below) |

## Design decision

Per the RFC, SPUR persists resource caps on **QoS**, not accounts. M1 wires **account-level allocations** (`grp_tres` on the `Account`) so each account/namespace has a definite ResourceQuota — the cleanest tenancy model, and it gives the GPU cluster the GPU quota it lacks today.

## Review fixes applied

A round of review surfaced several correctness/safety issues, all fixed here:

- **Memory units**: TRES `mem` is base-10 MB, but the ResourceQuota emitted `Mi` (mebibytes) → ~4.86% over-allocation. Now emits `M`.
- **DNS name length**: the 63-char cap was applied to the label *before* the `spur-acct-`/`spur-user-` prefix, so long names produced invalid (>63-char) namespace/SA names. The cap now includes the prefix.
- **Fail closed on malformed allocation**: a non-empty but unparseable `grp_tres` used to silently leave the namespace *uncapped*; the reconciler now skips such an account.
- **Fail closed on cold cache**: the scoped-kubeconfig path now refuses when associations aren't loaded (the association cache resolves fail-open, which could have minted an unscoped token).
- **LimitRange**: dropped the default *limit* (kept the default *request*) — a forced small limit would reject ordinary pods that omit limits; the ResourceQuota is what bounds usage.
- **ResourceQuota caps requests only**: dropped the `limits.cpu`/`limits.memory` hard keys — with no default limit those keys would reject any pod that omits limits at admission. The cap is enforced on `requests.*` (matching the requests-only LimitRange).
- **Account `grp_tres` validated on create**: `create_account` now runs `validate_tres` (as add/modify user already did), so an invalid allocation is rejected with `invalid_argument` instead of being stored and later skipped by the reconciler.
- **Reconciler user lookup batched**: replaced the per-account `ListUsers` (N+1) with a single `ListUsers` grouped client-side by account.

## Known limitations (M1 scope)

- **No GC of deleted accounts**: deleting a SPUR account leaves its namespace/quota/RBAC in place (objects are labelled `app.kubernetes.io/managed-by=spur-quota`, so a prune pass is a natural follow-up).
- **Token lifetime / revocation**: scoped tokens are long-lived and not revoked on member removal (RBAC subjects do shrink on the next reconcile). Shortening TTL + SA-deletion on removal is follow-up work.
- **Name collisions**: the DNS sanitizer is not injective (e.g. `physics_lab` and `physics.lab` collapse to the same namespace). Documented with a test; a hash-suffix disambiguation is a follow-up.
- **`sacctmgr modify account`** is a full-resend upsert, so it clears fields not restated (a pre-existing behavior across all account fields, not specific to `grp_tres`). Out of scope here; worth a dedicated fix.
- The whole client gRPC surface is unauthenticated today; this PR adds an RPC that mints bearer tokens, so caller-identity enforcement is important future work.

## Testing

`cargo build` / `clippy -D warnings` / `fmt` green across the workspace (excl. spur-ffi). `spur-k8s` (146) + `spur-core` (339) unit tests pass, including the new mem-unit, prefixed-name-length, sanitizer-collision, and malformed-`grp_tres` tests. DB round-trip test is `#[ignore]` (runs in CI's Postgres).

Also validated end-to-end on an isolated 2-node deployment: `sacctmgr add account ... grptres=...` persists through gRPC → Postgres and reads back; the `grp_tres` migration applies cleanly (`ADD COLUMN IF NOT EXISTS`); and `k8s kubeconfig --user` fails closed for unknown users / unresolved accounts and never falls back to the admin kubeconfig. (Cluster-side SA/token minting still needs a live k0s control plane — that path is integration-level.)

