### PR TITLE
feat(spur-cli): persist and display account-level grp_tres allocation

### DIFF
--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -128,8 +128,8 @@ const QOS_KEYS: &[&str] = &[
 ];
 
 /// Input keys the `add`/`modify account` handlers read (names + aliases). Gates
-/// mistyped fields the same way `QOS_KEYS` does, so a dropped limit can't read
-/// as "set" but never enforce.
+/// mistyped fields the same way `QOS_KEYS` does, so an unsupported field errors
+/// loudly instead of being silently dropped.
 const ACCOUNT_KEYS: &[&str] = &[
     "name",
     "account",

--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -127,6 +127,21 @@ const QOS_KEYS: &[&str] = &[
     "grpwall",
 ];
 
+/// Input keys the `add`/`modify account` handlers read (names + aliases). Gates
+/// mistyped fields the same way `QOS_KEYS` does, so a dropped limit can't read
+/// as "set" but never enforce.
+const ACCOUNT_KEYS: &[&str] = &[
+    "name",
+    "account",
+    "description",
+    "organization",
+    "parent",
+    "fairshare",
+    "maxrunningjobs",
+    "maxjobs",
+    "grptres",
+];
+
 /// Reject keys the command does not understand, so a mistyped or unsupported
 /// field errors loudly instead of being silently dropped (a dropped limit
 /// reads as "set" but never enforces).
@@ -239,6 +254,7 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
 
     match entity.to_lowercase().as_str() {
         "account" => {
+            reject_unknown_keys(&p, ACCOUNT_KEYS)?;
             let name = p
                 .get("name")
                 .or_else(|| p.get("account"))
@@ -256,6 +272,7 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
                 .map(|v| parse_limit("maxjobs", v))
                 .transpose()?
                 .unwrap_or(0);
+            let grp_tres = p.get("grptres").cloned().unwrap_or_default();
 
             let mut client = connect(addr).await?;
             client
@@ -266,6 +283,7 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
                     parent_account: parent.clone(),
                     fairshare_weight: fairshare,
                     max_running_jobs: max_jobs,
+                    grp_tres,
                 })
                 .await
                 .context("CreateAccount RPC failed")?;
@@ -473,6 +491,7 @@ async fn modify(entity: &str, params: &[String], addr: &str) -> Result<()> {
     // Modify is an upsert — same RPCs as add, just re-sends the record
     match entity.to_lowercase().as_str() {
         "account" => {
+            reject_unknown_keys(&p, ACCOUNT_KEYS)?;
             let name = p
                 .get("name")
                 .or_else(|| p.get("account"))
@@ -495,6 +514,7 @@ async fn modify(entity: &str, params: &[String], addr: &str) -> Result<()> {
                         .map(|v| parse_limit("maxjobs", v))
                         .transpose()?
                         .unwrap_or(0),
+                    grp_tres: p.get("grptres").cloned().unwrap_or_default(),
                 })
                 .await
                 .context("CreateAccount (modify) RPC failed")?;
@@ -616,15 +636,15 @@ async fn show(entity: &str, params: &[String], addr: &str) -> Result<()> {
             let accounts = resp.into_inner().accounts;
 
             println!(
-                "{:<20} {:<30} {:<15} {:<10} {:<10}",
-                "Account", "Descr", "Org", "Parent", "Share"
+                "{:<20} {:<30} {:<15} {:<10} {:<10} {:<10}",
+                "Account", "Descr", "Org", "Parent", "Share", "GrpTRES"
             );
-            println!("{}", "-".repeat(85));
+            println!("{}", "-".repeat(100));
 
             if accounts.is_empty() {
                 println!(
-                    "{:<20} {:<30} {:<15} {:<10} {:<10}",
-                    "(no accounts configured)", "", "", "", ""
+                    "{:<20} {:<30} {:<15} {:<10} {:<10} {:<10}",
+                    "(no accounts configured)", "", "", "", "", ""
                 );
             } else {
                 for a in &accounts {
@@ -634,8 +654,13 @@ async fn show(entity: &str, params: &[String], addr: &str) -> Result<()> {
                         &a.parent_account
                     };
                     println!(
-                        "{:<20} {:<30} {:<15} {:<10} {:<10}",
-                        a.name, a.description, a.organization, parent, a.fairshare_weight as u32,
+                        "{:<20} {:<30} {:<15} {:<10} {:<10} {:<10}",
+                        a.name,
+                        a.description,
+                        a.organization,
+                        parent,
+                        a.fairshare_weight as u32,
+                        a.grp_tres,
                     );
                 }
             }
@@ -941,6 +966,52 @@ mod tests {
         let p = parse_params(&["name=testuser".into(), "account=testacct".into()]);
         let fields = build_add_user_request(&p).unwrap();
         assert_eq!(fields.default_qos, "");
+    }
+
+    #[test]
+    fn reject_unknown_keys_accepts_every_parsed_account_field() {
+        // Every key the add/modify account handlers read must be allowlisted,
+        // otherwise reject_unknown_keys bounces it (the grpwall regression class).
+        let parsed_fields = [
+            "name",
+            "account",
+            "description",
+            "organization",
+            "parent",
+            "fairshare",
+            "maxrunningjobs",
+            "maxjobs",
+            "grptres",
+        ];
+        for field in parsed_fields {
+            let p = parse_params(&["name=acct".into(), format!("{field}=1")]);
+            assert!(
+                reject_unknown_keys(&p, ACCOUNT_KEYS).is_ok(),
+                "account field '{field}' is read by the handler but missing from ACCOUNT_KEYS"
+            );
+        }
+    }
+
+    #[test]
+    fn reject_unknown_keys_flags_mistyped_account_grptres() {
+        // A typo'd limit key must error, not be silently dropped.
+        let p = parse_params(&["name=acct".into(), "grptre=cpu=8".into()]);
+        let err = reject_unknown_keys(&p, ACCOUNT_KEYS).unwrap_err();
+        assert!(err.to_string().contains("unknown field 'grptre'"));
+    }
+
+    #[test]
+    fn parse_params_keeps_account_grptres_value_intact() {
+        // The comma-separated TRES value must survive as a single value (the `add
+        // account` handler reads p["grptres"] and forwards it to the RPC verbatim).
+        let p = parse_params(&[
+            "name=physics".into(),
+            "grptres=cpu=16,mem=32768,gres/gpu=8".into(),
+        ]);
+        assert_eq!(
+            p.get("grptres").map(String::as_str),
+            Some("cpu=16,mem=32768,gres/gpu=8")
+        );
     }
 
     #[test]

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -46,6 +46,7 @@ CREATE TABLE IF NOT EXISTS accounts (
     parent_account  TEXT,
     fairshare_weight INTEGER NOT NULL DEFAULT 1,
     max_running_jobs INTEGER,
+    grp_tres        TEXT,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
@@ -125,6 +126,7 @@ ALTER TABLE jobs ADD COLUMN IF NOT EXISTS reservation TEXT NOT NULL DEFAULT '';
 -- default) must degrade gracefully at read time, not be blocked here.
 ALTER TABLE associations ADD COLUMN IF NOT EXISTS default_qos TEXT;
 ALTER TABLE qos ADD COLUMN IF NOT EXISTS grp_wall_min INTEGER;
+ALTER TABLE accounts ADD COLUMN IF NOT EXISTS grp_tres TEXT;
 "#;
 
 /// Record a job start in the database.
@@ -482,7 +484,9 @@ use chrono::Timelike;
 // Account / User / QOS management (sacctmgr operations)
 // ============================================================
 
-/// Create or update an account.
+/// Create or update an account. Like `upsert_qos`/`add_user`, this is a full
+/// resend on modify, not a partial patch: a `None` `grp_tres` clears it.
+#[allow(clippy::too_many_arguments)]
 pub async fn upsert_account(
     pool: &PgPool,
     name: &str,
@@ -491,18 +495,19 @@ pub async fn upsert_account(
     parent: Option<&str>,
     fairshare: i32,
     max_running_jobs: Option<i32>,
+    grp_tres: Option<&str>,
 ) -> anyhow::Result<()> {
     sqlx::query(
         r#"
-        INSERT INTO accounts (name, description, organization, parent_account, fairshare_weight, max_running_jobs)
-        VALUES ($1, $2, $3, $4, $5, $6)
+        INSERT INTO accounts (name, description, organization, parent_account, fairshare_weight, max_running_jobs, grp_tres)
+        VALUES ($1, $2, $3, $4, $5, $6, $7)
         ON CONFLICT (name) DO UPDATE SET
             description = $2, organization = $3, parent_account = $4,
-            fairshare_weight = $5, max_running_jobs = $6
+            fairshare_weight = $5, max_running_jobs = $6, grp_tres = $7
         "#,
     )
     .bind(name).bind(description).bind(organization)
-    .bind(parent).bind(fairshare).bind(max_running_jobs)
+    .bind(parent).bind(fairshare).bind(max_running_jobs).bind(grp_tres)
     .execute(pool).await?;
     Ok(())
 }
@@ -519,7 +524,7 @@ pub async fn delete_account(pool: &PgPool, name: &str) -> anyhow::Result<()> {
 /// List all accounts.
 pub async fn list_accounts(pool: &PgPool) -> anyhow::Result<Vec<AccountRecord>> {
     let rows = sqlx::query(
-        "SELECT name, description, organization, parent_account, fairshare_weight, max_running_jobs FROM accounts ORDER BY name"
+        "SELECT name, description, organization, parent_account, fairshare_weight, max_running_jobs, grp_tres FROM accounts ORDER BY name"
     ).fetch_all(pool).await?;
 
     Ok(rows
@@ -531,6 +536,7 @@ pub async fn list_accounts(pool: &PgPool) -> anyhow::Result<Vec<AccountRecord>> 
             parent: r.get("parent_account"),
             fairshare_weight: r.get("fairshare_weight"),
             max_running_jobs: r.get("max_running_jobs"),
+            grp_tres: r.get("grp_tres"),
         })
         .collect())
 }
@@ -543,6 +549,8 @@ pub struct AccountRecord {
     pub parent: Option<String>,
     pub fairshare_weight: i32,
     pub max_running_jobs: Option<i32>,
+    /// Account resource allocation as a TRES string; None = unlimited.
+    pub grp_tres: Option<String>,
 }
 
 /// Add a user-account association. Like `upsert_account`/`upsert_qos`, this
@@ -1208,7 +1216,7 @@ mod job_history_tests {
             .execute(&pool)
             .await?;
 
-        upsert_account(&pool, &account, "d", "o", None, 1, None).await?;
+        upsert_account(&pool, &account, "d", "o", None, 1, None, None).await?;
         upsert_qos(
             &pool, &qos_name, "d", 0, "off", 1.0, None, None, None, None, None, None, None,
         )
@@ -1278,7 +1286,7 @@ mod job_history_tests {
             .execute(&pool)
             .await?;
 
-        upsert_account(&pool, &account, "d", "o", None, 1, None).await?;
+        upsert_account(&pool, &account, "d", "o", None, 1, None, None).await?;
 
         add_user(
             &pool,
@@ -1388,7 +1396,7 @@ mod job_history_tests {
             .execute(&pool)
             .await?;
 
-        upsert_account(&pool, &account, "d", "o", None, 1, None).await?;
+        upsert_account(&pool, &account, "d", "o", None, 1, None, None).await?;
 
         add_user(
             &pool, &user, &account, "none", true, "", None, None, None, None, None,
@@ -1464,7 +1472,7 @@ mod job_history_tests {
             .execute(&pool)
             .await?;
 
-        upsert_account(&pool, &account, "d", "o", None, 1, None).await?;
+        upsert_account(&pool, &account, "d", "o", None, 1, None, None).await?;
         sqlx::query("INSERT INTO users (name, account, admin_level) VALUES ($1, $2, 'none')")
             .bind(&user)
             .bind(&account)
@@ -1518,7 +1526,7 @@ mod job_history_tests {
             .execute(&pool)
             .await?;
 
-        upsert_account(&pool, &account, "d", "o", None, 1, None).await?;
+        upsert_account(&pool, &account, "d", "o", None, 1, None, None).await?;
         sqlx::query(
             "INSERT INTO associations \
              (user_name, account, max_running_jobs, max_submit_jobs, max_tres_per_job, grp_tres, max_wall_min) \
@@ -1544,6 +1552,50 @@ mod job_history_tests {
             .bind(&user)
             .execute(&pool)
             .await?;
+        sqlx::query("DELETE FROM accounts WHERE name = $1")
+            .bind(&account)
+            .execute(&pool)
+            .await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL and PostgreSQL"]
+    async fn account_grp_tres_round_trips_and_clears() -> anyhow::Result<()> {
+        let pool = test_pool().await?;
+        let account = format!("spur_acct_grptres_{}", std::process::id());
+        sqlx::query("DELETE FROM accounts WHERE name = $1")
+            .bind(&account)
+            .execute(&pool)
+            .await?;
+
+        upsert_account(
+            &pool,
+            &account,
+            "d",
+            "o",
+            None,
+            1,
+            None,
+            Some("cpu=16,mem=32768,gres/gpu=8"),
+        )
+        .await?;
+        let got = list_accounts(&pool)
+            .await?
+            .into_iter()
+            .find(|a| a.name == account)
+            .expect("account present");
+        assert_eq!(got.grp_tres.as_deref(), Some("cpu=16,mem=32768,gres/gpu=8"));
+
+        // Full-resend upsert with no allocation clears it (same contract as qos/user).
+        upsert_account(&pool, &account, "d", "o", None, 1, None, None).await?;
+        let got = list_accounts(&pool)
+            .await?
+            .into_iter()
+            .find(|a| a.name == account)
+            .expect("account present");
+        assert_eq!(got.grp_tres, None);
+
         sqlx::query("DELETE FROM accounts WHERE name = $1")
             .bind(&account)
             .execute(&pool)

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -291,6 +291,7 @@ impl SlurmAccounting for AccountingService {
         request: Request<CreateAccountRequest>,
     ) -> Result<Response<()>, Status> {
         let req = request.into_inner();
+        validate_tres("grptres", &req.grp_tres)?;
         let parent = if req.parent_account.is_empty() {
             None
         } else {
@@ -301,6 +302,11 @@ impl SlurmAccounting for AccountingService {
         } else {
             Some(req.max_running_jobs as i32)
         };
+        let grp_tres = if req.grp_tres.is_empty() {
+            None
+        } else {
+            Some(req.grp_tres.as_str())
+        };
         db::upsert_account(
             &self.pool,
             &req.name,
@@ -309,6 +315,7 @@ impl SlurmAccounting for AccountingService {
             parent,
             req.fairshare_weight as i32,
             max_running,
+            grp_tres,
         )
         .await
         .map_err(|e| Status::internal(e.to_string()))?;
@@ -343,6 +350,7 @@ impl SlurmAccounting for AccountingService {
                 parent_account: r.parent.unwrap_or_default(),
                 fairshare_weight: r.fairshare_weight as f64,
                 max_running_jobs: r.max_running_jobs.unwrap_or(0) as u32,
+                grp_tres: r.grp_tres.unwrap_or_default(),
             })
             .collect();
 

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -980,6 +980,7 @@ message CreateAccountRequest {
   string parent_account = 4;
   double fairshare_weight = 5;
   uint32 max_running_jobs = 6;
+  string grp_tres = 7;
 }
 
 message DeleteAccountRequest {
@@ -999,6 +1000,7 @@ message AccountInfo {
   string parent_account = 4;
   double fairshare_weight = 5;
   uint32 max_running_jobs = 6;
+  string grp_tres = 7;
 }
 
 message AddUserRequest {


### PR DESCRIPTION
## What

Adds an account-level resource allocation (`grp_tres`) to the accounting stack and surfaces it in `sacctmgr`, so an admin can set a per-account cap (`cpu`, `mem`, `node`, `gres/gpu`, …) and see it from the CLI.

Previously SPUR persisted TRES caps only on **QoS** and **user/association** records. There was no way to record — or view — a resource allocation on an **account**. In particular `sacctmgr show account` only printed `Account / Descr / Org / Parent / Share`, so account allocations (e.g. how many nodes an account is allotted) were not visible at all.

## Changes

- **proto**: `grp_tres` field on `CreateAccountRequest` and `AccountInfo`.
- **db**: `accounts.grp_tres` column + `ADD COLUMN IF NOT EXISTS` migration for existing databases; `upsert_account` / `list_accounts` / `AccountRecord` carry it.
- **gRPC**: `create_account` validates the TRES string (`validate_tres`) and persists it; `list_accounts` returns it.
- **cli**: `sacctmgr add|modify account grptres=cpu=16,mem=32768,gres/gpu=8`; `sacctmgr show account` gains a `GrpTRES` column. Adds an `ACCOUNT_KEYS` allowlist so a mistyped field (e.g. `grptre=`) errors loudly instead of being silently dropped — matching the existing QoS behavior.

This mirrors the existing QoS/user `grp_tres` handling (same validation, same empty→unset mapping). Persistence + display only — no scheduler enforcement of the account cap is included here.

## Example

```
$ sacctmgr add account name=physics grptres=cpu=16,mem=32768,gres/gpu=8
$ sacctmgr show account
Account              Descr                          Org             Parent     Share      GrpTRES
----------------------------------------------------------------------------------------------------
physics                                                                        1          cpu=16,mem=32768,gres/gpu=8
```

## Known limitations

- `sacctmgr modify account` is a full-resend upsert (consistent with `modify qos`/`modify user`): a field not restated is cleared. So `modify account name=X set fairshare=2` also clears a previously-set `grp_tres`. This is the pre-existing contract for every account field (description/org/parent/maxjobs), not specific to `grp_tres`; making `modify` a true partial patch is a separate, broader change.
- The account cap is persisted and displayed but not yet enforced by the scheduler.

## Testing

`cargo build` / `clippy -D warnings` / `fmt` green. New unit tests: a DB round-trip that covers both set and clear-on-empty (`#[ignore]`, runs against CI's Postgres), a CLI parse test that the comma-separated TRES value survives intact, and allowlist tests (every account field is accepted; a typo is rejected).

Also validated end-to-end on an isolated deployment: `add account ... grptres=...` persists through gRPC to Postgres and reads back; the `GrpTRES` column renders the full value; `modify` updates and clears as described; a typo'd key and an invalid TRES value are both rejected.
