### PR TITLE
feat(spur-cli): accept --qos for srun

### DIFF
--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -30,6 +30,10 @@ pub struct SrunArgs {
     #[arg(short = 'A', long)]
     pub account: Option<String>,
 
+    /// QoS
+    #[arg(short = 'q', long)]
+    pub qos: Option<String>,
+
     /// Number of nodes
     #[arg(short = 'N', long, default_value = "1")]
     pub nodes: u32,
@@ -250,6 +254,12 @@ fn resolve_srun_env(matches: &ArgMatches, args: &mut SrunArgs) -> Result<()> {
         ],
         &mut args.account,
     );
+    apply_str(
+        matches,
+        "qos",
+        &["SPUR_QOS", "SPUR_JOB_QOS", "SLURM_QOS", "SLURM_JOB_QOS"],
+        &mut args.qos,
+    );
     apply_num(
         matches,
         "nodes",
@@ -458,6 +468,7 @@ fn build_srun_job_spec(args: &SrunArgs, work_dir: &str, io: &ResolvedIoPaths) ->
             .unwrap_or_else(|| args.command[0].clone()),
         partition: args.partition.clone().unwrap_or_default(),
         account: args.account.clone().unwrap_or_default(),
+        qos: args.qos.clone().unwrap_or_default(),
         user: whoami::username().unwrap_or_else(|_| "unknown".into()),
         uid: nix::unistd::getuid().as_raw(),
         gid: nix::unistd::getgid().as_raw(),
@@ -1274,6 +1285,41 @@ mod tests {
     }
 
     #[test]
+    fn parses_qos_short_and_long() {
+        let short =
+            SrunArgs::try_parse_from(["srun", "-q", "high", "hostname"]).expect("parse short qos");
+        assert_eq!(short.qos.as_deref(), Some("high"));
+
+        let long =
+            SrunArgs::try_parse_from(["srun", "--qos=normal", "hostname"]).expect("parse long qos");
+        assert_eq!(long.qos.as_deref(), Some("normal"));
+    }
+
+    #[test]
+    fn build_srun_job_spec_sets_qos() {
+        let args = SrunArgs::try_parse_from(["srun", "--qos", "high", "hostname"]).expect("parse");
+        let io = ResolvedIoPaths {
+            stdout: String::new(),
+            stderr: String::new(),
+            stdin: String::new(),
+        };
+        let spec = build_srun_job_spec(&args, "/tmp/work", &io).expect("spec");
+        assert_eq!(spec.qos, "high");
+    }
+
+    #[test]
+    fn build_srun_job_spec_qos_defaults_empty() {
+        let args = SrunArgs::try_parse_from(["srun", "hostname"]).expect("parse");
+        let io = ResolvedIoPaths {
+            stdout: String::new(),
+            stderr: String::new(),
+            stdin: String::new(),
+        };
+        let spec = build_srun_job_spec(&args, "/tmp/work", &io).expect("spec");
+        assert!(spec.qos.is_empty());
+    }
+
+    #[test]
     fn build_command_script_simple_argv() {
         assert_eq!(
             build_command_script(&["hostname".to_string()]).unwrap(),
@@ -1358,6 +1404,59 @@ mod tests {
         env.set("SLURM_PARTITION", "from-slurm");
         let args = resolve_from(&["srun", "hostname"]);
         assert_eq!(args.partition.as_deref(), Some("from-spur"));
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn qos_env_default_and_cli_override() {
+        let env = EnvGuard::new();
+        env.set("SLURM_QOS", "high");
+        assert_eq!(
+            resolve_from(&["srun", "hostname"]).qos.as_deref(),
+            Some("high")
+        );
+
+        // CLI wins over env.
+        assert_eq!(
+            resolve_from(&["srun", "--qos=low", "hostname"])
+                .qos
+                .as_deref(),
+            Some("low")
+        );
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn qos_spur_alias_precedes_slurm_twin() {
+        let env = EnvGuard::new();
+        env.set("SPUR_QOS", "from-spur");
+        env.set("SLURM_QOS", "from-slurm");
+        assert_eq!(
+            resolve_from(&["srun", "hostname"]).qos.as_deref(),
+            Some("from-spur")
+        );
+    }
+
+    /// An allocation exports QoS under the `*_JOB_QOS` twin, so srun inside a
+    /// Spur allocation inherits it; the direct input var still takes precedence.
+    #[test]
+    #[serial(env_injection)]
+    fn qos_inherits_allocation_twin() {
+        let env = EnvGuard::new();
+        env.set("SLURM_JOB_QOS", "alloc-qos");
+        assert_eq!(
+            resolve_from(&["srun", "hostname"]).qos.as_deref(),
+            Some("alloc-qos")
+        );
+
+        env.set("SLURM_QOS", "input-qos");
+        assert_eq!(
+            resolve_from(&["srun", "hostname"]).qos.as_deref(),
+            Some("input-qos")
+        );
+
+        let overridden = resolve_from(&["srun", "-q", "cli-qos", "hostname"]);
+        assert_eq!(overridden.qos.as_deref(), Some("cli-qos"));
     }
 
     #[test]

--- a/tests/native_host/e2e/test_srun_qos.py
+++ b/tests/native_host/e2e/test_srun_qos.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E test for srun --qos (SPUR-77).
+
+Proves an explicit `srun --qos` reaches the controller and is recorded on the
+job. Requires Postgres on node 0 (the accounting_cluster fixture) because an
+explicit QOS must exist in the controller's QOS cache to be accepted.
+"""
+
+import shlex
+import time
+
+from cluster import wait_job_state
+
+
+class TestSrunQos:
+    def test_srun_qos_applied_to_job(self, accounting_cluster):
+        c = accounting_cluster
+        c.sacctmgr(["add", "qos", "name=srunqos"])
+        # Wait past the QoS cache refresh floor (10s) before submitting.
+        time.sleep(15)
+
+        log = f"{c.remote_dir}/srun-qos.log"
+        srun_cmd = " ".join(
+            [
+                f"SPUR_CONTROLLER_ADDR={shlex.quote(c.controller_addr)}",
+                f"PATH={shlex.quote(c.bin_dir)}:$PATH",
+                "nohup",
+                shlex.quote(f"{c.bin_dir}/srun"),
+                "-J", "srun-qos",
+                "-q", "srunqos",
+                "sleep", "30",
+                ">", shlex.quote(log), "2>&1", "&",
+                "echo", "$!",
+            ]
+        )
+        pid_out = c.nodes[0].exec(srun_cmd).strip()
+        assert pid_out.isdigit(), f"expected background srun pid, got: {pid_out!r}"
+
+        job_ids = []
+        deadline = time.time() + 30
+        while time.time() < deadline and not job_ids:
+            job_ids = c.running_job_ids_by_name("srun-qos")
+            if not job_ids:
+                time.sleep(1)
+        assert job_ids, (
+            "expected running srun-qos job in squeue:\n"
+            f"{c.squeue(['-n', 'srun-qos', '-t', 'all'])}"
+        )
+        job_id = job_ids[0]
+
+        try:
+            wait_job_state(c, job_id, "R", timeout=30)
+            show = c.scontrol("show", "job", str(job_id))
+            assert "QOS=srunqos" in show, f"expected QOS=srunqos in job:\n{show}"
+        finally:
+            c.cli_allow_fail(["scancel", str(job_id)])


### PR DESCRIPTION
## What

`srun` did not accept a `--qos` flag, even though `sbatch` does and `JobSpec` already carries a `qos` field. This adds `--qos`/`-q` support to `srun`, on par with the other job-submission commands.

## Approach

Mirrors how `srun` already handles `--partition` and `--account`:
- New `-q`/`--qos` clap arg on `SrunArgs`.
- Environment-default resolution over `SPUR_QOS`, `SPUR_JOB_QOS`, `SLURM_QOS`, `SLURM_JOB_QOS` (SPUR-native alias precedes the SLURM twin; the direct input var precedes the allocation `*_JOB_QOS` twin). This lets an `srun` launched inside a Spur allocation inherit the allocation's QoS, while an explicit CLI value still wins.
- The resolved QoS is carried into the submitted `JobSpec.qos`, so it flows through the existing submit path (the same one `sbatch --qos` uses, including the controller's "QOS does not exist" validation and the QoS's effect on priority, limits, and preemption).

## Behavior in step mode (matches Slurm)

When `srun` runs inside an existing allocation it dispatches a *step* rather than submitting a new job. QoS is a job-level attribute fixed by the parent allocation, so the step inherits the allocation's QoS and an explicit step-level `--qos` has no effect. This matches Slurm exactly: Slurm's step-create request carries no QoS field, and its `srun` likewise accepts `--qos` in an allocation but the step still runs under the allocation's QoS (independent of whether accounting is enabled). The `--qos` flag takes effect on the standalone path, where `srun` submits a new job.

## Tests

- Unit tests for CLI parsing (short/long), env-var precedence (default, CLI override, SPUR-before-SLURM, allocation-twin inheritance), and `JobSpec` wiring (set + empty default).
- A native-host e2e that defines a QoS, submits an `srun --qos` job, and asserts the job reports that QoS.
- Validated end-to-end on an isolated 2-node deployment: an `srun --qos <known>` job runs and the QoS is recorded on the job; an unknown QoS is rejected identically to `sbatch`.