### PR TITLE
feat(spur-cli): interactive PTY sessions via srun --pty and sattach

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.104"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arraydeque"
@@ -501,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.3"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -511,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -523,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.3"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -659,6 +659,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.13.0",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,7 +793,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -960,7 +985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1709,7 +1734,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link",
 ]
@@ -1776,7 +1801,7 @@ dependencies = [
  "jsonptr",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1789,7 +1814,7 @@ dependencies = [
  "pest_derive",
  "regex",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1873,7 +1898,7 @@ dependencies = [
  "serde",
  "serde-saphyr",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
@@ -1898,7 +1923,7 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1936,7 +1961,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1982,6 +2007,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2085,6 +2116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -2239,7 +2271,7 @@ dependencies = [
  "once_cell",
  "shell-escape",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -2625,7 +2657,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -2648,7 +2680,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2665,7 +2697,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2964,6 +2996,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2971,8 +3016,8 @@ dependencies = [
  "bitflags 2.13.0",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys 0.52.0",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3030,7 +3075,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3158,9 +3203,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -3197,22 +3242,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3228,9 +3273,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.151"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -3375,6 +3420,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3423,7 +3489,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -3468,6 +3534,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "crossterm",
  "flate2",
  "libc",
  "nix",
@@ -3483,7 +3550,7 @@ dependencies = [
  "spur-update",
  "tar",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -3519,7 +3586,7 @@ dependencies = [
  "spur-proto",
  "subtle",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "toml",
  "tracing",
@@ -3574,7 +3641,7 @@ dependencies = [
  "serde_json",
  "spur-core",
  "spur-proto",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -3604,7 +3671,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tar",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -3636,7 +3703,7 @@ dependencies = [
  "anyhow",
  "libloading",
  "spur-core",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -3788,7 +3855,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -3831,7 +3898,7 @@ dependencies = [
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn 2.0.118",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
@@ -3859,7 +3926,7 @@ dependencies = [
  "sha1 0.11.0",
  "sha2 0.11.0",
  "sqlx-core",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
 ]
@@ -3895,7 +3962,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
  "whoami",
@@ -3921,7 +3988,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "sqlx-core",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tracing",
  "url",
  "uuid",
@@ -3979,17 +4046,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4033,10 +4089,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
- "rustix",
- "windows-sys 0.52.0",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4056,11 +4112,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -4076,13 +4132,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4151,9 +4207,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.53.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -4227,9 +4283,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -4272,9 +4328,9 @@ dependencies = [
 
 [[package]]
 name = "toml_writer"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -4530,7 +4586,7 @@ dependencies = [
  "log",
  "rand 0.9.4",
  "sha1 0.10.6",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4640,9 +4696,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -4858,13 +4914,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -5044,7 +5122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ k8s-openapi = { version = "0.28", features = ["latest", "schemars"] }
 schemars = "1"
 
 # Unix
-nix = { version = "0.31", features = ["process", "signal", "fs", "user", "sched", "mount", "socket"] }
+nix = { version = "0.31", features = ["process", "signal", "fs", "user", "sched", "mount", "socket", "term"] }
 
 # Auth
 jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }

--- a/crates/spur-cli/Cargo.toml
+++ b/crates/spur-cli/Cargo.toml
@@ -28,6 +28,7 @@ tokio-stream = "0.1"
 whoami = "2.1.1"
 nix = { workspace = true, features = ["user"] }
 libc = "0.2"
+crossterm = "0.28"
 flate2 = { workspace = true }
 tar = { workspace = true }
 shlex = "2"

--- a/crates/spur-cli/src/interactive.rs
+++ b/crates/spur-cli/src/interactive.rs
@@ -8,6 +8,16 @@ use std::collections::HashMap;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::signal::unix::{signal, SignalKind};
 
+/// Connect to a spurd agent, applying the standard gRPC size limits.
+pub async fn connect_agent(addr: &str) -> Result<SlurmAgentClient<tonic::transport::Channel>> {
+    let channel = spur_client::connect_channel(addr)
+        .await
+        .context("cannot connect to agent")?;
+    Ok(SlurmAgentClient::new(channel)
+        .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
+        .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE))
+}
+
 pub fn get_terminal_size() -> spur_proto::proto::WindowSize {
     let (cols, rows) = crossterm::terminal::size().unwrap_or((80, 24));
     spur_proto::proto::WindowSize {
@@ -18,16 +28,23 @@ pub fn get_terminal_size() -> spur_proto::proto::WindowSize {
     }
 }
 
-/// Run a full interactive PTY session over the InteractiveSession RPC.
-/// Returns the remote exit code.
-pub async fn run_interactive_session(
+/// Established interactive session: the input sender and output stream.
+pub struct InteractiveSessionHandle {
+    pub in_tx: tokio::sync::mpsc::Sender<InteractiveInput>,
+    pub out_stream: tonic::Streaming<spur_proto::proto::InteractiveOutput>,
+}
+
+/// Open the InteractiveSession RPC, returning the raw handle.
+///
+/// Returns `Err(tonic::Status)` on RPC failure.
+pub async fn open_interactive_session(
     agent: &mut SlurmAgentClient<tonic::transport::Channel>,
     job_id: u32,
     step_id: u32,
     argv: Vec<String>,
     winsize: spur_proto::proto::WindowSize,
     overlap: bool,
-) -> Result<i32> {
+) -> std::result::Result<InteractiveSessionHandle, tonic::Status> {
     let init = InteractiveInput {
         msg: Some(interactive_input::Msg::Init(InitSession {
             job_id,
@@ -44,20 +61,37 @@ pub async fn run_interactive_session(
     in_tx.send(init).await.ok();
 
     let in_stream = tokio_stream::wrappers::ReceiverStream::new(in_rx);
-    let response = agent
-        .interactive_session(in_stream)
-        .await
-        .context("InteractiveSession RPC failed")?;
+    let response = agent.interactive_session(in_stream).await?;
 
-    let mut out_stream = response.into_inner();
+    Ok(InteractiveSessionHandle {
+        in_tx,
+        out_stream: response.into_inner(),
+    })
+}
 
-    let _raw_guard = RawModeGuard::enter().ok();
+/// Drive the I/O loop for an already-opened interactive session.
+/// Returns the remote exit code.
+pub async fn drive_interactive_session(handle: InteractiveSessionHandle) -> Result<i32> {
+    let InteractiveSessionHandle {
+        in_tx,
+        mut out_stream,
+    } = handle;
+
+    let _raw_guard = match RawModeGuard::enter() {
+        Ok(g) => Some(g),
+        Err(_) => {
+            eprintln!("spur: warning: raw mode unavailable (stdin is not a TTY)");
+            None
+        }
+    };
 
     let mut sigwinch = signal(SignalKind::window_change())?;
 
     let mut stdout = tokio::io::stdout();
     let mut stdin = tokio::io::stdin();
     let mut stdin_buf = vec![0u8; 4096];
+    let mut stdin_open = true;
+    let mut in_tx = Some(in_tx);
 
     let exit_code: i32 = loop {
         tokio::select! {
@@ -83,25 +117,35 @@ pub async fn run_interactive_session(
                 }
             }
 
-            n = stdin.read(&mut stdin_buf) => {
+            n = stdin.read(&mut stdin_buf), if stdin_open => {
                 match n {
-                    Ok(0) => break 0,
-                    Ok(n) => {
-                        let _ = in_tx.send(InteractiveInput {
-                            msg: Some(interactive_input::Msg::Stdin(
-                                stdin_buf[..n].to_vec(),
-                            )),
-                        }).await;
+                    Ok(0) => {
+                        stdin_open = false;
+                        in_tx.take();
                     }
-                    Err(_) => break 1,
+                    Ok(n) => {
+                        if let Some(ref tx) = in_tx {
+                            let _ = tx.send(InteractiveInput {
+                                msg: Some(interactive_input::Msg::Stdin(
+                                    stdin_buf[..n].to_vec(),
+                                )),
+                            }).await;
+                        }
+                    }
+                    Err(_) => {
+                        stdin_open = false;
+                        in_tx.take();
+                    }
                 }
             }
 
-            _ = sigwinch.recv() => {
+            _ = sigwinch.recv(), if stdin_open => {
                 let ws = get_terminal_size();
-                let _ = in_tx.send(InteractiveInput {
-                    msg: Some(interactive_input::Msg::Resize(ws)),
-                }).await;
+                if let Some(ref tx) = in_tx {
+                    let _ = tx.send(InteractiveInput {
+                        msg: Some(interactive_input::Msg::Resize(ws)),
+                    }).await;
+                }
             }
         }
     };
@@ -109,6 +153,22 @@ pub async fn run_interactive_session(
     drop(_raw_guard);
 
     Ok(exit_code)
+}
+
+/// Run a full interactive PTY session over the InteractiveSession RPC.
+/// Returns the remote exit code.
+pub async fn run_interactive_session(
+    agent: &mut SlurmAgentClient<tonic::transport::Channel>,
+    job_id: u32,
+    step_id: u32,
+    argv: Vec<String>,
+    winsize: spur_proto::proto::WindowSize,
+    overlap: bool,
+) -> Result<i32> {
+    let handle = open_interactive_session(agent, job_id, step_id, argv, winsize, overlap)
+        .await
+        .map_err(|status| anyhow::anyhow!("InteractiveSession RPC failed: {}", status.message()))?;
+    drive_interactive_session(handle).await
 }
 
 /// RAII guard that puts the terminal into raw mode and restores it on drop.

--- a/crates/spur-cli/src/interactive.rs
+++ b/crates/spur-cli/src/interactive.rs
@@ -77,6 +77,12 @@ pub async fn drive_interactive_session(handle: InteractiveSessionHandle) -> Resu
         mut out_stream,
     } = handle;
 
+    let prev_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = crossterm::terminal::disable_raw_mode();
+        prev_hook(info);
+    }));
+
     let _raw_guard = match RawModeGuard::enter() {
         Ok(g) => Some(g),
         Err(_) => {
@@ -151,6 +157,7 @@ pub async fn drive_interactive_session(handle: InteractiveSessionHandle) -> Resu
     };
 
     drop(_raw_guard);
+    let _ = std::panic::take_hook(); // remove our raw-mode panic hook
 
     Ok(exit_code)
 }

--- a/crates/spur-cli/src/interactive.rs
+++ b/crates/spur-cli/src/interactive.rs
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Context, Result};
+use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
+use spur_proto::proto::{interactive_input, interactive_output, InitSession, InteractiveInput};
+use std::collections::HashMap;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::signal::unix::{signal, SignalKind};
+
+pub fn get_terminal_size() -> spur_proto::proto::WindowSize {
+    let (cols, rows) = crossterm::terminal::size().unwrap_or((80, 24));
+    spur_proto::proto::WindowSize {
+        rows: rows as u32,
+        cols: cols as u32,
+        xpixel: 0,
+        ypixel: 0,
+    }
+}
+
+/// Run a full interactive PTY session over the InteractiveSession RPC.
+/// Returns the remote exit code.
+pub async fn run_interactive_session(
+    agent: &mut SlurmAgentClient<tonic::transport::Channel>,
+    job_id: u32,
+    step_id: u32,
+    argv: Vec<String>,
+    winsize: spur_proto::proto::WindowSize,
+    overlap: bool,
+) -> Result<i32> {
+    let init = InteractiveInput {
+        msg: Some(interactive_input::Msg::Init(InitSession {
+            job_id,
+            step_id,
+            overlap,
+            pty: true,
+            winsize: Some(winsize),
+            argv,
+            env: HashMap::new(),
+        })),
+    };
+
+    let (in_tx, in_rx) = tokio::sync::mpsc::channel::<InteractiveInput>(64);
+    in_tx.send(init).await.ok();
+
+    let in_stream = tokio_stream::wrappers::ReceiverStream::new(in_rx);
+    let response = agent
+        .interactive_session(in_stream)
+        .await
+        .context("InteractiveSession RPC failed")?;
+
+    let mut out_stream = response.into_inner();
+
+    let _raw_guard = RawModeGuard::enter().ok();
+
+    let mut sigwinch = signal(SignalKind::window_change())?;
+
+    let mut stdout = tokio::io::stdout();
+    let mut stdin = tokio::io::stdin();
+    let mut stdin_buf = vec![0u8; 4096];
+
+    let exit_code: i32 = loop {
+        tokio::select! {
+            msg = out_stream.message() => {
+                match msg {
+                    Ok(Some(output)) => {
+                        match output.msg {
+                            Some(interactive_output::Msg::Data(data)) => {
+                                stdout.write_all(&data).await?;
+                                stdout.flush().await?;
+                            }
+                            Some(interactive_output::Msg::ExitStatus(code)) => {
+                                break code;
+                            }
+                            None => {}
+                        }
+                    }
+                    Ok(None) => break 1,
+                    Err(e) => {
+                        eprintln!("\r\nstream error: {e}");
+                        break 1;
+                    }
+                }
+            }
+
+            n = stdin.read(&mut stdin_buf) => {
+                match n {
+                    Ok(0) => break 0,
+                    Ok(n) => {
+                        let _ = in_tx.send(InteractiveInput {
+                            msg: Some(interactive_input::Msg::Stdin(
+                                stdin_buf[..n].to_vec(),
+                            )),
+                        }).await;
+                    }
+                    Err(_) => break 1,
+                }
+            }
+
+            _ = sigwinch.recv() => {
+                let ws = get_terminal_size();
+                let _ = in_tx.send(InteractiveInput {
+                    msg: Some(interactive_input::Msg::Resize(ws)),
+                }).await;
+            }
+        }
+    };
+
+    drop(_raw_guard);
+
+    Ok(exit_code)
+}
+
+/// RAII guard that puts the terminal into raw mode and restores it on drop.
+pub struct RawModeGuard;
+
+impl RawModeGuard {
+    pub fn enter() -> Result<Self> {
+        crossterm::terminal::enable_raw_mode().context("enable raw mode")?;
+        Ok(Self)
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        let _ = crossterm::terminal::disable_raw_mode();
+    }
+}

--- a/crates/spur-cli/src/main.rs
+++ b/crates/spur-cli/src/main.rs
@@ -6,6 +6,7 @@ mod exec;
 mod exit_fmt;
 mod format_engine;
 mod image;
+mod interactive;
 mod k8s;
 mod net;
 mod node;

--- a/crates/spur-cli/src/sattach.rs
+++ b/crates/spur-cli/src/sattach.rs
@@ -75,11 +75,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     // Connect to the first node's agent
     let first_node = nodelist.split(',').next().unwrap_or(nodelist).trim();
     let agent_addr = format!("http://{}:6818", first_node);
-    let mut agent = SlurmAgentClient::connect(agent_addr.clone())
-        .await
-        .context(format!("failed to connect to agent at {}", agent_addr))?
-        .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
-        .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE);
+    let mut agent = crate::interactive::connect_agent(&agent_addr).await?;
 
     if args.output_only {
         stream_output_only(&mut agent, job_id, &args.output).await

--- a/crates/spur-cli/src/sattach.rs
+++ b/crates/spur-cli/src/sattach.rs
@@ -4,7 +4,7 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
-use spur_proto::proto::{AttachJobInput, GetJobRequest, JobState, StreamJobOutputRequest};
+use spur_proto::proto::{GetJobRequest, JobState, StreamJobOutputRequest};
 use std::io::Write;
 
 /// Attach to a running job step's standard I/O.
@@ -82,11 +82,10 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE);
 
     if args.output_only {
-        // Output-only mode: stream stdout/stderr without stdin
         stream_output_only(&mut agent, job_id, &args.output).await
     } else {
-        // Interactive mode: bidirectional stdin/stdout forwarding
-        interactive_attach(&mut agent, job_id).await
+        let exit_code = interactive_attach(&mut agent, job_id).await?;
+        std::process::exit(exit_code);
     }
 }
 
@@ -132,176 +131,17 @@ async fn stream_output_only(
     Ok(())
 }
 
-/// Interactive attach: bidirectional stdin/stdout forwarding via AttachJob RPC.
-///
-/// Issue #64 (reopen of #54):
-/// - Put terminal into raw mode so keystrokes are forwarded immediately
-///   (not buffered until newline by the kernel's line discipline)
-/// - Restore terminal on exit via Drop guard
-/// - Previous fix only switched to per-byte reads, but the terminal was still
-///   in canonical mode, so reads blocked on newline anyway
+/// Interactive attach via InteractiveSession RPC. Returns the remote exit code.
 async fn interactive_attach(
     agent: &mut SlurmAgentClient<tonic::transport::Channel>,
     job_id: u32,
-) -> Result<()> {
-    use tokio::io::AsyncReadExt;
-
-    // Enable raw mode on stdin so keystrokes are forwarded immediately.
-    // Save original termios to restore on exit (via Drop guard).
-    let _raw_guard = RawModeGuard::enter().ok(); // Non-fatal: if stdin isn't a TTY, continue in cooked mode
-
-    let (tx, rx) = tokio::sync::mpsc::channel::<AttachJobInput>(256);
-
-    // Send first message with job_id
-    tx.send(AttachJobInput {
-        job_id,
-        data: Vec::new(),
-    })
-    .await
-    .context("failed to send initial attach message")?;
-
-    // Spawn stdin reader task — reads raw bytes for interactive use
-    let tx_stdin = tx.clone();
-    tokio::spawn(async move {
-        let mut stdin = tokio::io::stdin();
-        let mut buf = vec![0u8; 4096];
-        loop {
-            match stdin.read(&mut buf).await {
-                Ok(0) => break, // EOF
-                Ok(n) => {
-                    if tx_stdin
-                        .send(AttachJobInput {
-                            job_id,
-                            data: buf[..n].to_vec(),
-                        })
-                        .await
-                        .is_err()
-                    {
-                        break;
-                    }
-                }
-                Err(_) => break,
-            }
-        }
-        drop(tx_stdin);
-    });
-
-    // Make the bidirectional streaming call
-    let response = agent
-        .attach_job(tokio_stream::wrappers::ReceiverStream::new(rx))
-        .await
-        .context("attach_job RPC failed")?;
-
-    let mut out_stream = response.into_inner();
-    let stdout = std::io::stdout();
-    let mut handle = stdout.lock();
-
-    loop {
-        match out_stream.message().await {
-            Ok(Some(chunk)) => {
-                if chunk.eof {
-                    break;
-                }
-                if !chunk.data.is_empty() {
-                    let _ = handle.write_all(&chunk.data);
-                    let _ = handle.flush();
-                }
-            }
-            Ok(None) => break,
-            Err(e) => {
-                eprintln!("\r\nsattach: stream error: {}", e);
-                break;
-            }
-        }
-    }
-
-    Ok(())
-}
-
-/// RAII guard that sets the terminal to raw mode and restores it on drop.
-///
-/// Raw mode disables the kernel's line discipline so that:
-/// - Keystrokes are forwarded immediately (no buffering until Enter)
-/// - Special keys (Ctrl-C, Ctrl-Z) are sent as bytes instead of signals
-/// - No local echo (the remote shell handles echo)
-///
-/// RAII guard that sets the terminal to raw mode and restores it on drop.
-pub(crate) struct RawModeGuard {
-    fd: i32,
-    original: libc::termios,
-}
-
-impl RawModeGuard {
-    /// Enter raw mode on stdin. Returns Err if stdin is not a TTY.
-    pub(crate) fn enter() -> Result<Self> {
-        use std::os::unix::io::AsRawFd;
-        Self::enter_on_fd(std::io::stdin().as_raw_fd())
-    }
-
-    /// Enter raw mode on a specific file descriptor.
-    /// Exposed for testing with explicit fds (pipes, ptys).
-    pub(crate) fn enter_on_fd(fd: i32) -> Result<Self> {
-        use std::mem::MaybeUninit;
-
-        // Check fd is a TTY
-        if unsafe { libc::isatty(fd) } != 1 {
-            anyhow::bail!("fd {} is not a TTY", fd);
-        }
-
-        // Save original termios
-        let mut original = MaybeUninit::<libc::termios>::uninit();
-        if unsafe { libc::tcgetattr(fd, original.as_mut_ptr()) } != 0 {
-            anyhow::bail!("tcgetattr failed");
-        }
-        let original = unsafe { original.assume_init() };
-
-        // Set raw mode
-        let mut raw = original;
-        unsafe { libc::cfmakeraw(&mut raw) };
-        if unsafe { libc::tcsetattr(fd, libc::TCSANOW, &raw) } != 0 {
-            anyhow::bail!("tcsetattr failed");
-        }
-
-        Ok(Self { fd, original })
-    }
-}
-
-impl Drop for RawModeGuard {
-    fn drop(&mut self) {
-        unsafe { libc::tcsetattr(self.fd, libc::TCSANOW, &self.original) };
-    }
+) -> Result<i32> {
+    let winsize = crate::interactive::get_terminal_size();
+    crate::interactive::run_interactive_session(agent, job_id, 0, Vec::new(), winsize, true).await
 }
 
 fn state_name(state: i32) -> &'static str {
     spur_core::job::JobState::from_proto_i32(state)
         .map(|s| s.display())
         .unwrap_or("UNKNOWN")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn raw_mode_fails_on_pipe() {
-        // Create a pipe — a non-TTY fd — and verify RawModeGuard::enter_on_fd
-        // returns Err. This tests the REAL RawModeGuard code, not a simulation.
-        // Works identically in CI, interactive terminal, and IDE.
-        let mut fds = [0i32; 2];
-        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
-        let read_fd = fds[0];
-
-        let result = RawModeGuard::enter_on_fd(read_fd);
-        assert!(result.is_err(), "RawModeGuard should fail on a pipe fd");
-        let err_msg = format!("{}", result.err().unwrap());
-        assert!(
-            err_msg.contains("not a TTY"),
-            "error should mention TTY, got: {err_msg}"
-        );
-
-        unsafe {
-            libc::close(fds[0]);
-            libc::close(fds[1]);
-        }
-    }
 }

--- a/crates/spur-cli/src/sbatch.rs
+++ b/crates/spur-cli/src/sbatch.rs
@@ -848,6 +848,8 @@ pub async fn main_with_args(cli_args: Vec<String>) -> Result<()> {
         extra_resources: std::collections::HashMap::new(),
         open_mode: args.open_mode.unwrap_or_default(),
         srun_job: false,
+        pty: false,
+        initial_winsize: None,
     };
 
     // Submit to controller

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -486,11 +486,7 @@ fn build_srun_job_spec(args: &SrunArgs, work_dir: &str, io: &ResolvedIoPaths) ->
         cpus_per_task: args.cpus_per_task,
         memory_per_node_mb: memory_mb,
         gres,
-        script: if args.pty {
-            "#!/bin/sh\nsleep infinity\n".to_string()
-        } else {
-            build_command_script(&args.command)?
-        },
+        script: build_command_script(&args.command)?,
         work_dir: work_dir.to_string(),
         stdout_path: io.stdout.clone(),
         stderr_path: io.stderr.clone(),
@@ -526,7 +522,7 @@ fn install_ctrl_c_cancel(
     client: SlurmControllerClient<tonic::transport::Channel>,
     job_id: u32,
     user: String,
-) {
+) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut client = client;
         if tokio::signal::ctrl_c().await.is_ok() {
@@ -540,7 +536,7 @@ fn install_ctrl_c_cancel(
                 .await;
             std::process::exit(130);
         }
-    });
+    })
 }
 
 async fn wait_for_job_running(
@@ -746,7 +742,7 @@ async fn run_standalone_srun(args: &SrunArgs, hooks: &HooksConfig, work_dir: &st
 
     eprintln!("srun: Pending job allocation {}...", job_id);
 
-    install_ctrl_c_cancel(client.clone(), job_id, user.clone());
+    let ctrl_c_handle = install_ctrl_c_cancel(client.clone(), job_id, user.clone());
 
     let nodelist = wait_for_job_running(&mut client, job_id).await?;
     if !nodelist.is_empty() {
@@ -754,6 +750,7 @@ async fn run_standalone_srun(args: &SrunArgs, hooks: &HooksConfig, work_dir: &st
     }
 
     if args.pty {
+        ctrl_c_handle.abort();
         eprintln!("srun: opening interactive session on {}", nodelist);
         let result = run_interactive_pty(&args.controller, job_id, args.command.clone()).await;
         let _ = client

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -5,7 +5,6 @@ use crate::env_defaults::{apply_csv, apply_flag, apply_num, apply_str, apply_str
 use anyhow::{Context, Result};
 use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser};
 use spur_core::config::HooksConfig;
-use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{
     CancelJobRequest, CompleteJobRequest, CreateJobStepRequest, GetJobRequest, GetNodeRequest,
@@ -197,7 +196,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         if !args.overlap {
             anyhow::bail!("--jobid requires --overlap");
         }
-        let exit_code = run_interactive_overlap(&args, job_id).await?;
+        let exit_code = run_interactive_pty(&args.controller, job_id, args.command.clone()).await?;
         std::process::exit(exit_code);
     }
 
@@ -487,7 +486,11 @@ fn build_srun_job_spec(args: &SrunArgs, work_dir: &str, io: &ResolvedIoPaths) ->
         cpus_per_task: args.cpus_per_task,
         memory_per_node_mb: memory_mb,
         gres,
-        script: build_command_script(&args.command)?,
+        script: if args.pty {
+            "#!/bin/sh\nsleep infinity\n".to_string()
+        } else {
+            build_command_script(&args.command)?
+        },
         work_dir: work_dir.to_string(),
         stdout_path: io.stdout.clone(),
         stderr_path: io.stderr.clone(),
@@ -514,6 +517,7 @@ fn build_srun_job_spec(args: &SrunArgs, work_dir: &str, io: &ResolvedIoPaths) ->
             .collect(),
         container_remap_root: args.container_remap_root,
         srun_job: true,
+        pty: args.pty,
         ..Default::default()
     })
 }
@@ -749,6 +753,19 @@ async fn run_standalone_srun(args: &SrunArgs, hooks: &HooksConfig, work_dir: &st
         eprintln!("srun: job {} running on {}", job_id, nodelist);
     }
 
+    if args.pty {
+        eprintln!("srun: opening interactive session on {}", nodelist);
+        let result = run_interactive_pty(&args.controller, job_id, args.command.clone()).await;
+        let _ = client
+            .cancel_job(CancelJobRequest {
+                job_id,
+                signal: 0,
+                user: user.clone(),
+            })
+            .await;
+        std::process::exit(result?);
+    }
+
     let job = client
         .get_job(GetJobRequest { job_id })
         .await
@@ -854,10 +871,8 @@ async fn try_stream_output(
 
     let agent_addr = format!("http://{first_node}:6818");
 
-    let mut agent = match SlurmAgentClient::connect(agent_addr).await {
-        Ok(c) => c
-            .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
-            .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE),
+    let mut agent = match crate::interactive::connect_agent(&agent_addr).await {
+        Ok(c) => c,
         Err(_) => return false,
     };
 
@@ -1039,55 +1054,94 @@ fn warn_unsupported_cpu_bind(environment: &HashMap<String, String>) {
     }
 }
 
-/// Exec into a running job using the InteractiveSession RPC (--jobid --overlap).
-async fn run_interactive_overlap(args: &SrunArgs, job_id: u32) -> Result<i32> {
-    use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
-    use spur_proto::proto::CreateJobStepRequest;
-
-    let channel = spur_client::connect_channel(&args.controller)
+/// Create an interactive PTY step on a running job and attach to it.
+///
+/// Retries transient failures (job not yet visible on agent after controller
+/// reports it as Running) up to a few seconds before giving up.
+async fn run_interactive_pty(controller: &str, job_id: u32, command: Vec<String>) -> Result<i32> {
+    let channel = spur_client::connect_channel(controller)
         .await
         .context("cannot connect to controller")?;
     let mut ctrl = SlurmControllerClient::new(channel);
 
     let winsize = crate::interactive::get_terminal_size();
 
-    let step_resp = ctrl
-        .create_job_step(CreateJobStepRequest {
+    let mut last_err: Option<anyhow::Error> = None;
+    for attempt in 0..5 {
+        if attempt > 0 {
+            tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+        }
+
+        let step_resp = match ctrl
+            .create_job_step(CreateJobStepRequest {
+                job_id,
+                command: command.clone(),
+                num_tasks: 1,
+                cpus_per_task: 1,
+                overlap: true,
+                pty: true,
+                winsize: Some(winsize),
+            })
+            .await
+        {
+            Ok(resp) => resp.into_inner(),
+            Err(status) if is_retryable_status(&status) && attempt < 4 => {
+                last_err = Some(anyhow::anyhow!("CreateJobStep: {}", status.message()));
+                continue;
+            }
+            Err(status) => {
+                return Err(anyhow::anyhow!(
+                    "CreateJobStep failed: {}",
+                    status.message()
+                ))
+            }
+        };
+
+        let node_addr = if step_resp.node_addr.is_empty() {
+            anyhow::bail!(
+                "controller did not return a node address for job {}",
+                job_id
+            );
+        } else {
+            format!("http://{}", step_resp.node_addr)
+        };
+
+        let mut agent = crate::interactive::connect_agent(&node_addr).await?;
+
+        match crate::interactive::open_interactive_session(
+            &mut agent,
             job_id,
-            command: args.command.clone(),
-            num_tasks: 1,
-            cpus_per_task: 1,
-            overlap: true,
-            pty: true,
-            winsize: Some(winsize),
-        })
+            step_resp.step_id,
+            command.clone(),
+            winsize,
+            true,
+        )
         .await
-        .context("CreateJobStep failed")?
-        .into_inner();
+        {
+            Ok(handle) => {
+                return crate::interactive::drive_interactive_session(handle).await;
+            }
+            Err(status) if is_retryable_status(&status) && attempt < 4 => {
+                last_err = Some(anyhow::anyhow!("InteractiveSession: {}", status.message()));
+                continue;
+            }
+            Err(status) => {
+                return Err(anyhow::anyhow!(
+                    "InteractiveSession RPC failed: {}",
+                    status.message()
+                ));
+            }
+        }
+    }
 
-    let node_addr = if step_resp.node_addr.is_empty() {
-        anyhow::bail!(
-            "controller did not return a node address for job {}",
-            job_id
-        );
-    } else {
-        format!("http://{}", step_resp.node_addr)
-    };
+    Err(last_err.unwrap_or_else(|| anyhow::anyhow!("interactive session failed after retries")))
+}
 
-    let agent_channel = spur_client::connect_channel(&node_addr)
-        .await
-        .context("cannot connect to agent")?;
-    let mut agent = SlurmAgentClient::new(agent_channel);
-
-    crate::interactive::run_interactive_session(
-        &mut agent,
-        job_id,
-        step_resp.step_id,
-        args.command.clone(),
-        winsize,
-        true,
+fn is_retryable_status(status: &tonic::Status) -> bool {
+    matches!(
+        status.code(),
+        tonic::Code::NotFound | tonic::Code::FailedPrecondition | tonic::Code::Unavailable
     )
-    .await
 }
 
 async fn run_as_step(

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -157,6 +157,18 @@ pub struct SrunArgs {
     #[arg(long)]
     pub epilog: Option<String>,
 
+    /// Allocate a pseudo-terminal for the job
+    #[arg(long)]
+    pub pty: bool,
+
+    /// Attach to a running job (for --overlap exec-into-job)
+    #[arg(long)]
+    pub jobid: Option<u32>,
+
+    /// Share resources with the running job (requires --jobid)
+    #[arg(long)]
+    pub overlap: bool,
+
     /// Controller address
     #[arg(
         long,
@@ -179,6 +191,15 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let mut args = SrunArgs::from_arg_matches(&matches)?;
     resolve_srun_env(&matches, &mut args)?;
     args.nodelist = crate::nodelist::resolve(args.nodelist.take(), args.nodefile.take())?;
+
+    // --jobid --overlap: exec into a running job (interactive PTY session)
+    if let Some(job_id) = args.jobid {
+        if !args.overlap {
+            anyhow::bail!("--jobid requires --overlap");
+        }
+        let exit_code = run_interactive_overlap(&args, job_id).await?;
+        std::process::exit(exit_code);
+    }
 
     if args.command.is_empty() {
         eprintln!("srun: no command specified");
@@ -600,6 +621,9 @@ async fn dispatch_step(
             command: args.command.clone(),
             num_tasks: args.ntasks,
             cpus_per_task: args.cpus_per_task,
+            overlap: false,
+            pty: false,
+            winsize: None,
         })
         .await
         .context("failed to create job step")?
@@ -1006,10 +1030,6 @@ async fn write_step_file(content: &str, pattern: &str, job_id: u32, work_dir: &s
     }
 }
 
-/// When srun runs inside an allocation (SPUR_JOB_ID is set, e.g. inside an
-/// `salloc` interactive shell or sbatch script on the submit host), it
-/// dispatches the command to the allocation's nodes via the controller's
-/// RunStep RPC, which fans out to each agent's RunCommand RPC.
 fn warn_unsupported_cpu_bind(environment: &HashMap<String, String>) {
     if let Some(cpu_bind) = spur_core::task_launch::unsupported_cpu_bind(environment) {
         eprintln!(
@@ -1017,6 +1037,57 @@ fn warn_unsupported_cpu_bind(environment: &HashMap<String, String>) {
              (supported: rank, map_cpu, mask_cpu)"
         );
     }
+}
+
+/// Exec into a running job using the InteractiveSession RPC (--jobid --overlap).
+async fn run_interactive_overlap(args: &SrunArgs, job_id: u32) -> Result<i32> {
+    use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
+    use spur_proto::proto::CreateJobStepRequest;
+
+    let channel = spur_client::connect_channel(&args.controller)
+        .await
+        .context("cannot connect to controller")?;
+    let mut ctrl = SlurmControllerClient::new(channel);
+
+    let winsize = crate::interactive::get_terminal_size();
+
+    let step_resp = ctrl
+        .create_job_step(CreateJobStepRequest {
+            job_id,
+            command: args.command.clone(),
+            num_tasks: 1,
+            cpus_per_task: 1,
+            overlap: true,
+            pty: true,
+            winsize: Some(winsize),
+        })
+        .await
+        .context("CreateJobStep failed")?
+        .into_inner();
+
+    let node_addr = if step_resp.node_addr.is_empty() {
+        anyhow::bail!(
+            "controller did not return a node address for job {}",
+            job_id
+        );
+    } else {
+        format!("http://{}", step_resp.node_addr)
+    };
+
+    let agent_channel = spur_client::connect_channel(&node_addr)
+        .await
+        .context("cannot connect to agent")?;
+    let mut agent = SlurmAgentClient::new(agent_channel);
+
+    crate::interactive::run_interactive_session(
+        &mut agent,
+        job_id,
+        step_resp.step_id,
+        args.command.clone(),
+        winsize,
+        true,
+    )
+    .await
 }
 
 async fn run_as_step(
@@ -1028,7 +1099,12 @@ async fn run_as_step(
     let channel = spur_client::connect_channel(&args.controller)
         .await
         .context("failed to connect to spurctld")?;
-    let mut client = SlurmControllerClient::new(channel);
+    let mut client = spur_proto::controller_client(channel);
+
+    if args.input.is_some() {
+        eprintln!("srun: warning: --input is not supported in step mode, ignoring");
+    }
+
     let io = resolve_io_paths(args);
     let user = whoami::username().unwrap_or_else(|_| "unknown".into());
 
@@ -1529,5 +1605,22 @@ mod tests {
         // An explicit CLI value still wins over both.
         let overridden = resolve_from(&["srun", "-p", "cli-part", "hostname"]);
         assert_eq!(overridden.partition.as_deref(), Some("cli-part"));
+    }
+
+    #[tokio::test]
+    async fn jobid_without_overlap_errors() {
+        let result = main_with_args(vec![
+            "srun".into(),
+            "--jobid".into(),
+            "42".into(),
+            "hostname".into(),
+        ])
+        .await;
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains("--overlap"),
+            "expected --overlap error, got: {msg}"
+        );
     }
 }

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -555,7 +555,10 @@ async fn wait_for_job_running(
             .into_inner();
 
         match JobState::try_from(job.state) {
-            Ok(JobState::JobRunning) => return Ok(job.nodelist),
+            Ok(JobState::JobRunning) if !job.nodelist.is_empty() => {
+                return Ok(job.nodelist);
+            }
+            Ok(JobState::JobRunning) => {}
             Ok(
                 JobState::JobCompleted
                 | JobState::JobFailed
@@ -1064,43 +1067,50 @@ async fn run_interactive_pty(controller: &str, job_id: u32, command: Vec<String>
     let winsize = crate::interactive::get_terminal_size();
 
     let mut last_err: Option<anyhow::Error> = None;
+    let mut cached_step: Option<(u32, String)> = None;
+
     for attempt in 0..5 {
         if attempt > 0 {
             tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
         }
 
-        let step_resp = match ctrl
-            .create_job_step(CreateJobStepRequest {
-                job_id,
-                command: command.clone(),
-                num_tasks: 1,
-                cpus_per_task: 1,
-                overlap: true,
-                pty: true,
-                winsize: Some(winsize),
-            })
-            .await
-        {
-            Ok(resp) => resp.into_inner(),
-            Err(status) if is_retryable_status(&status) && attempt < 4 => {
-                last_err = Some(anyhow::anyhow!("CreateJobStep: {}", status.message()));
-                continue;
-            }
-            Err(status) => {
-                return Err(anyhow::anyhow!(
-                    "CreateJobStep failed: {}",
-                    status.message()
-                ))
-            }
-        };
-
-        let node_addr = if step_resp.node_addr.is_empty() {
-            anyhow::bail!(
-                "controller did not return a node address for job {}",
-                job_id
-            );
+        let (step_id, node_addr) = if let Some(ref cached) = cached_step {
+            cached.clone()
         } else {
-            format!("http://{}", step_resp.node_addr)
+            let step_resp = match ctrl
+                .create_job_step(CreateJobStepRequest {
+                    job_id,
+                    command: command.clone(),
+                    num_tasks: 1,
+                    cpus_per_task: 1,
+                    overlap: true,
+                    pty: true,
+                    winsize: Some(winsize),
+                })
+                .await
+            {
+                Ok(resp) => resp.into_inner(),
+                Err(status) if is_retryable_status(&status) && attempt < 4 => {
+                    last_err = Some(anyhow::anyhow!("CreateJobStep: {}", status.message()));
+                    continue;
+                }
+                Err(status) => {
+                    return Err(anyhow::anyhow!(
+                        "CreateJobStep failed: {}",
+                        status.message()
+                    ))
+                }
+            };
+
+            if step_resp.node_addr.is_empty() {
+                anyhow::bail!(
+                    "controller did not return a node address for job {}",
+                    job_id
+                );
+            }
+            let pair = (step_resp.step_id, format!("http://{}", step_resp.node_addr));
+            cached_step = Some(pair.clone());
+            pair
         };
 
         let mut agent = crate::interactive::connect_agent(&node_addr).await?;
@@ -1108,7 +1118,7 @@ async fn run_interactive_pty(controller: &str, job_id: u32, command: Vec<String>
         match crate::interactive::open_interactive_session(
             &mut agent,
             job_id,
-            step_resp.step_id,
+            step_id,
             command.clone(),
             winsize,
             true,

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -475,6 +475,9 @@ pub struct JobSpec {
     // Output mode
     /// How to open stdout/stderr files: "truncate" (default) or "append".
     pub open_mode: Option<String>,
+
+    // Interactive PTY
+    pub pty: bool,
 }
 
 impl Default for JobSpec {
@@ -546,6 +549,7 @@ impl Default for JobSpec {
             shm_size: None,
             extra_resources: std::collections::HashMap::new(),
             open_mode: None,
+            pty: false,
         }
     }
 }

--- a/crates/spur-k8s/src/agent.rs
+++ b/crates/spur-k8s/src/agent.rs
@@ -85,7 +85,8 @@ impl VirtualAgent {
 impl SlurmAgent for VirtualAgent {
     type StreamJobOutputStream =
         tokio_stream::wrappers::ReceiverStream<Result<StreamJobOutputChunk, Status>>;
-    type AttachJobStream = tokio_stream::wrappers::ReceiverStream<Result<AttachJobOutput, Status>>;
+    type InteractiveSessionStream =
+        tokio_stream::wrappers::ReceiverStream<Result<InteractiveOutput, Status>>;
 
     async fn launch_job(
         &self,
@@ -675,12 +676,12 @@ impl SlurmAgent for VirtualAgent {
         )))
     }
 
-    async fn attach_job(
+    async fn interactive_session(
         &self,
-        _request: Request<tonic::Streaming<AttachJobInput>>,
-    ) -> Result<Response<Self::AttachJobStream>, Status> {
+        _request: Request<tonic::Streaming<InteractiveInput>>,
+    ) -> Result<Response<Self::InteractiveSessionStream>, Status> {
         Err(Status::unimplemented(
-            "interactive attach not supported for K8s agent",
+            "interactive session not supported for K8s agent",
         ))
     }
 

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -832,6 +832,8 @@ fn core_job_spec_to_proto(spec: &spur_core::job::JobSpec) -> spur_proto::proto::
         shm_size: spec.shm_size.clone().unwrap_or_default(),
         extra_resources: spec.extra_resources.clone(),
         open_mode: spec.open_mode.clone().unwrap_or_default(),
+        pty: spec.pty,
+        initial_winsize: None,
     }
 }
 

--- a/crates/spur-tests/src/t50_core.rs
+++ b/crates/spur-tests/src/t50_core.rs
@@ -967,6 +967,94 @@ address = "http://peer-a:6817"
         assert_eq!(req.command.len(), 2);
     }
 
+    // ── Interactive session proto messages ────────────────────────
+
+    #[test]
+    fn t50_92_interactive_input_init_session() {
+        use std::collections::HashMap;
+        let msg = spur_proto::proto::InteractiveInput {
+            msg: Some(spur_proto::proto::interactive_input::Msg::Init(
+                spur_proto::proto::InitSession {
+                    job_id: 10,
+                    step_id: 0,
+                    overlap: true,
+                    pty: true,
+                    winsize: Some(spur_proto::proto::WindowSize {
+                        rows: 24,
+                        cols: 80,
+                        xpixel: 0,
+                        ypixel: 0,
+                    }),
+                    argv: vec!["/bin/bash".into()],
+                    env: HashMap::new(),
+                },
+            )),
+        };
+        match msg.msg.unwrap() {
+            spur_proto::proto::interactive_input::Msg::Init(init) => {
+                assert_eq!(init.job_id, 10);
+                assert!(init.overlap);
+                assert_eq!(init.winsize.unwrap().cols, 80);
+            }
+            _ => panic!("expected Init variant"),
+        }
+    }
+
+    #[test]
+    fn t50_92b_interactive_input_stdin_raw_bytes() {
+        let esc_seq = vec![0x1b, 0x5b, 0x41]; // ESC [ A (arrow up)
+        let msg = spur_proto::proto::InteractiveInput {
+            msg: Some(spur_proto::proto::interactive_input::Msg::Stdin(
+                esc_seq.clone(),
+            )),
+        };
+        match msg.msg.unwrap() {
+            spur_proto::proto::interactive_input::Msg::Stdin(data) => {
+                assert_eq!(data, esc_seq);
+            }
+            _ => panic!("expected Stdin variant"),
+        }
+    }
+
+    #[test]
+    fn t50_92c_interactive_output_data_and_exit() {
+        let out = spur_proto::proto::InteractiveOutput {
+            msg: Some(spur_proto::proto::interactive_output::Msg::Data(
+                b"hello\r\n".to_vec(),
+            )),
+        };
+        match out.msg.unwrap() {
+            spur_proto::proto::interactive_output::Msg::Data(d) => {
+                assert_eq!(d, b"hello\r\n");
+            }
+            _ => panic!("expected Data variant"),
+        }
+
+        let exit = spur_proto::proto::InteractiveOutput {
+            msg: Some(spur_proto::proto::interactive_output::Msg::ExitStatus(42)),
+        };
+        match exit.msg.unwrap() {
+            spur_proto::proto::interactive_output::Msg::ExitStatus(code) => {
+                assert_eq!(code, 42);
+            }
+            _ => panic!("expected ExitStatus variant"),
+        }
+    }
+
+    #[test]
+    fn t50_92d_window_size_construction() {
+        let ws = spur_proto::proto::WindowSize {
+            rows: 50,
+            cols: 200,
+            xpixel: 1024,
+            ypixel: 768,
+        };
+        assert_eq!(ws.rows, 50);
+        assert_eq!(ws.cols, 200);
+        assert_eq!(ws.xpixel, 1024);
+        assert_eq!(ws.ypixel, 768);
+    }
+
     // ── Issue #46: CLI reads config file for controller port ──────
 
     #[test]

--- a/crates/spur-tests/src/t50_core.rs
+++ b/crates/spur-tests/src/t50_core.rs
@@ -967,27 +967,6 @@ address = "http://peer-a:6817"
         assert_eq!(req.command.len(), 2);
     }
 
-    // ── Issue #45: sattach interactive attach ─────────────────────
-
-    #[test]
-    fn t50_92_attach_job_proto_messages_exist() {
-        // Issue #45: AttachJob bidirectional streaming RPC should exist
-        // with AttachJobInput and AttachJobOutput messages.
-        let input = spur_proto::proto::AttachJobInput {
-            job_id: 10,
-            data: b"ls\n".to_vec(),
-        };
-        assert_eq!(input.job_id, 10);
-        assert_eq!(input.data, b"ls\n");
-
-        let output = spur_proto::proto::AttachJobOutput {
-            data: b"hello\n".to_vec(),
-            eof: false,
-        };
-        assert!(!output.eof);
-        assert_eq!(output.data, b"hello\n");
-    }
-
     // ── Issue #46: CLI reads config file for controller port ──────
 
     #[test]
@@ -1159,27 +1138,6 @@ address = "http://peer-a:6817"
                 assert!(expected.to_str().unwrap().contains(".spur/images"));
             }
         }
-    }
-
-    // ── Issue #54 (reopen): sattach buffer sizes ─────────────────
-
-    #[test]
-    fn t50_99_attach_job_messages_support_raw_bytes() {
-        // Issue #54: AttachJobInput should carry raw bytes (not just
-        // newline-terminated lines) for interactive use.
-        let input = spur_proto::proto::AttachJobInput {
-            job_id: 42,
-            data: vec![0x1b, 0x5b, 0x41], // ESC [ A (arrow up)
-        };
-        assert_eq!(input.data.len(), 3);
-        assert_eq!(input.data[0], 0x1b); // ESC byte
-
-        let output = spur_proto::proto::AttachJobOutput {
-            data: vec![0x1b, 0x5b, 0x48], // ESC [ H (cursor home)
-            eof: false,
-        };
-        assert_eq!(output.data.len(), 3);
-        assert!(!output.eof);
     }
 
     // ── Issue #53: CLI show dispatch ─────────────────────────────

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -895,6 +895,7 @@ struct AllocationRegisterParams {
     mpi: String,
     allocated_nodelist: String,
     allocated: spur_core::resource::ResourceAllocations,
+    work_dir: String,
 }
 
 /// Register a srun-only allocation on a node agent without launching a batch process.
@@ -924,6 +925,7 @@ async fn register_allocation_to_agent(
                 .collect(),
             allocated: Some(crate::server::allocations_to_proto(&params.allocated)),
             mpi: params.mpi.clone(),
+            work_dir: params.work_dir.clone(),
         })
         .await?;
 
@@ -977,6 +979,7 @@ async fn register_allocation_on_nodes(
             mpi: spec.mpi.clone().unwrap_or_default(),
             allocated_nodelist: allocated_nodelist.clone(),
             allocated,
+            work_dir: spec.work_dir.clone(),
         };
         set.spawn(async move {
             let result = register_allocation_to_agent(&agent_addr, &params).await;

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -745,6 +745,8 @@ fn core_spec_to_proto(s: &spur_core::job::JobSpec) -> ProtoJobSpec {
         shm_size: s.shm_size.clone().unwrap_or_default(),
         extra_resources: s.extra_resources.clone(),
         open_mode: s.open_mode.clone().unwrap_or_default(),
+        pty: s.pty,
+        initial_winsize: None,
     }
 }
 
@@ -845,6 +847,8 @@ async fn dispatch_to_agent(
         shm_size: spec.shm_size.clone().unwrap_or_default(),
         extra_resources: spec.extra_resources.clone(),
         open_mode: spec.open_mode.clone().unwrap_or_default(),
+        pty: spec.pty,
+        initial_winsize: None,
     };
 
     let response = client
@@ -1935,7 +1939,8 @@ mod tests {
         impl spur_proto::proto::slurm_agent_server::SlurmAgent for MockAgent {
             type StreamJobOutputStream =
                 tonic::codegen::BoxStream<spur_proto::proto::StreamJobOutputChunk>;
-            type AttachJobStream = tonic::codegen::BoxStream<spur_proto::proto::AttachJobOutput>;
+            type InteractiveSessionStream =
+                tonic::codegen::BoxStream<spur_proto::proto::InteractiveOutput>;
 
             async fn launch_job(
                 &self,
@@ -2004,10 +2009,11 @@ mod tests {
                 Err(tonic::Status::unimplemented("not used in tests"))
             }
 
-            async fn attach_job(
+            async fn interactive_session(
                 &self,
-                _request: tonic::Request<tonic::Streaming<spur_proto::proto::AttachJobInput>>,
-            ) -> Result<tonic::Response<Self::AttachJobStream>, tonic::Status> {
+                _request: tonic::Request<tonic::Streaming<spur_proto::proto::InteractiveInput>>,
+            ) -> Result<tonic::Response<Self::InteractiveSessionStream>, tonic::Status>
+            {
                 Err(tonic::Status::unimplemented("not used in tests"))
             }
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1247,7 +1247,17 @@ impl SlurmController for ControllerService {
             .create_step(step)
             .map_err(|e| Status::internal(format!("failed to create job step: {e}")))?;
 
-        Ok(Response::new(CreateJobStepResponse { step_id }))
+        let node_addr = job
+            .allocated_nodes
+            .first()
+            .and_then(|name| self.cluster.get_node(name))
+            .map(|n| {
+                let host = n.address.as_deref().unwrap_or(&n.name);
+                format!("{}:{}", host, n.port)
+            })
+            .unwrap_or_default();
+
+        Ok(Response::new(CreateJobStepResponse { step_id, node_addr }))
     }
 
     async fn create_reservation(
@@ -2026,6 +2036,7 @@ fn proto_to_job_spec(spec: JobSpec) -> Result<spur_core::job::JobSpec, Status> {
         } else {
             Some(spec.open_mode)
         },
+        pty: spec.pty,
     })
 }
 

--- a/crates/spurd/Cargo.toml
+++ b/crates/spurd/Cargo.toml
@@ -36,6 +36,7 @@ shlex = "2"
 
 [dev-dependencies]
 tempfile = "3"
+tokio = { version = "1", features = ["test-util"] }
 
 [lints]
 workspace = true

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1166,7 +1166,6 @@ impl SlurmAgent for AgentService {
                 has_pid_namespace: false,
                 has_user_namespace: false,
                 has_mount_namespace: false,
-                rootfs: None,
                 _pty_master: None,
                 work_dir: String::new(),
                 uid: req.uid,

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -37,7 +37,6 @@ struct TrackedJob {
     has_pid_namespace: bool,
     has_user_namespace: bool,
     has_mount_namespace: bool,
-    rootfs: Option<std::path::PathBuf>,
     _pty_master: Option<std::os::fd::OwnedFd>,
     work_dir: String,
     uid: u32,
@@ -931,7 +930,6 @@ impl SlurmAgent for AgentService {
                 info!(job_id, gpus = ?launch_cfg.gpu_devices, "job launched successfully");
                 let is_root = nix::unistd::geteuid().is_root();
                 let is_container = launch_cfg.container.is_some();
-                let rootfs = launch_cfg.container.as_ref().map(|c| c.rootfs.clone());
                 let displaced = jobs.insert(
                     job_id,
                     TrackedJob {
@@ -942,7 +940,6 @@ impl SlurmAgent for AgentService {
                         has_pid_namespace: is_root || is_container,
                         has_user_namespace: is_container && !is_root,
                         has_mount_namespace: is_root || is_container,
-                        rootfs,
                         _pty_master: result.pty_master,
                         work_dir: launch_cfg.work_dir,
                         uid: launch_cfg.uid,
@@ -1934,7 +1931,6 @@ impl AgentService {
             has_pid_namespace: tracked.has_pid_namespace,
             has_user_namespace: tracked.has_user_namespace,
             has_mount_namespace: tracked.has_mount_namespace,
-            _rootfs: tracked.rootfs.clone(),
             uid: tracked.uid,
             gid: tracked.gid,
             work_dir: tracked.work_dir.clone(),
@@ -2172,12 +2168,10 @@ impl AgentService {
             cmd.pre_exec(move || raw.wire());
         }
 
-        // For non-nsenter case, drop privs via Command::uid()/gid().
-        // nsenter case already handled above via --setuid/--setgid.
-        if drop_priv && !entry.has_namespaces() {
-            cmd.gid(entry.gid);
-            cmd.uid(entry.uid);
-        }
+        debug_assert!(
+            !drop_priv || entry.has_namespaces(),
+            "root spurd always has namespaces; direct priv drop should be unreachable"
+        );
 
         let child = cmd
             .spawn()
@@ -2201,18 +2195,24 @@ impl AgentService {
 
     /// Read environment variables from a running process via /proc.
     fn read_proc_environ(pid: u32) -> Vec<(String, String)> {
+        const MAX_ENVIRON: usize = 1 << 20; // 1 MiB
         let path = format!("/proc/{}/environ", pid);
-        match std::fs::read(&path) {
-            Ok(data) => data
-                .split(|&b| b == 0)
-                .filter_map(|entry| {
-                    let s = std::str::from_utf8(entry).ok()?;
-                    let (k, v) = s.split_once('=')?;
-                    Some((k.to_string(), v.to_string()))
-                })
-                .collect(),
-            Err(_) => Vec::new(),
-        }
+        let mut buf = vec![0u8; MAX_ENVIRON];
+        let n = match std::fs::File::open(&path).and_then(|mut f| {
+            use std::io::Read;
+            f.read(&mut buf)
+        }) {
+            Ok(n) => n,
+            Err(_) => return Vec::new(),
+        };
+        buf.truncate(n);
+        buf.split(|&b| b == 0)
+            .filter_map(|entry| {
+                let s = std::str::from_utf8(entry).ok()?;
+                let (k, v) = s.split_once('=')?;
+                Some((k.to_string(), v.to_string()))
+            })
+            .collect()
     }
 }
 
@@ -2237,7 +2237,6 @@ impl TrackedJob {
             has_pid_namespace: false,
             has_user_namespace: false,
             has_mount_namespace: false,
-            rootfs: None,
             _pty_master: None,
             work_dir: "/tmp".into(),
             uid: 0,
@@ -2822,7 +2821,6 @@ mod tests {
             has_pid_namespace: false,
             has_user_namespace: false,
             has_mount_namespace: false,
-            rootfs: None,
             _pty_master: None,
             work_dir: "/tmp".into(),
             uid: 0,

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -2122,7 +2122,16 @@ impl AgentService {
             .map_err(|e| Status::internal(format!("openpty: {e}")))?;
 
         let shell = if argv.is_empty() {
-            vec!["/bin/bash".to_string()]
+            let bash_exists = if entry.has_mount_namespace {
+                std::path::Path::new(&format!("/proc/{}/root/bin/bash", entry.pid)).exists()
+            } else {
+                std::path::Path::new("/bin/bash").exists()
+            };
+            if bash_exists {
+                vec!["/bin/bash".to_string()]
+            } else {
+                vec!["/bin/sh".to_string()]
+            }
         } else {
             argv.to_vec()
         };

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1064,7 +1064,7 @@ impl SlurmAgent for AgentService {
 
         let mut cmd = if entry.has_namespaces() {
             let mut c = tokio::process::Command::new("nsenter");
-            for arg in entry.nsenter_args() {
+            for arg in entry.nsenter_args_with_priv_drop() {
                 c.arg(arg);
             }
             c.arg("--");
@@ -1081,6 +1081,8 @@ impl SlurmAgent for AgentService {
             c.current_dir(&entry.work_dir);
             c
         };
+
+        entry.apply_privilege_drop(&mut cmd);
 
         let output = cmd
             .output()
@@ -1167,7 +1169,7 @@ impl SlurmAgent for AgentService {
                 has_user_namespace: false,
                 has_mount_namespace: false,
                 _pty_master: None,
-                work_dir: String::new(),
+                work_dir: req.work_dir.clone(),
                 uid: req.uid,
                 gid: req.gid,
                 partition: req.partition,
@@ -1922,9 +1924,9 @@ impl AgentService {
         let tracked = jobs
             .get(&job_id)
             .ok_or_else(|| Status::not_found(format!("job {} not running on this node", job_id)))?;
-        let pid = tracked.job.pid().ok_or_else(|| {
-            Status::failed_precondition(format!("job {} has no tracked PID", job_id))
-        })?;
+
+        let pid = tracked.job.pid().unwrap_or(0);
+
         Ok(crate::job_entry::JobEntry {
             pid: pid as i32,
             has_pid_namespace: tracked.has_pid_namespace,
@@ -2024,7 +2026,9 @@ impl AgentService {
                             }
                         }
                         Some(Err(_)) | None => {
-                            unsafe { libc::kill(child_pid, libc::SIGHUP); }
+                            let _ = crate::pty::signal_foreground(
+                                master_raw, child_pid, libc::SIGHUP,
+                            );
                             break;
                         }
                     }
@@ -2122,7 +2126,7 @@ impl AgentService {
             .map_err(|e| Status::internal(format!("openpty: {e}")))?;
 
         let shell = if argv.is_empty() {
-            let bash_exists = if entry.has_mount_namespace {
+            let bash_exists = if entry.pid > 0 && entry.has_mount_namespace {
                 std::path::Path::new(&format!("/proc/{}/root/bin/bash", entry.pid)).exists()
             } else {
                 std::path::Path::new("/bin/bash").exists()
@@ -2136,17 +2140,8 @@ impl AgentService {
             argv.to_vec()
         };
 
-        let drop_priv = entry.uid > 0 && nix::unistd::geteuid().is_root();
-
         let (launch_cmd, launch_args) = if entry.has_namespaces() {
-            let mut args = entry.nsenter_args();
-            // nsenter needs root to open /proc/<pid>/ns/*; drop privileges
-            // inside the namespace via --setuid/--setgid instead of
-            // Command::uid()/gid() which would drop before exec.
-            if drop_priv {
-                args.push(format!("--setuid={}", entry.uid));
-                args.push(format!("--setgid={}", entry.gid));
-            }
+            let mut args = entry.nsenter_args_with_priv_drop();
             args.push("--".into());
             args.extend(shell);
             ("nsenter".to_string(), args)
@@ -2155,14 +2150,23 @@ impl AgentService {
         };
 
         let mut cmd = tokio::process::Command::new(&launch_cmd);
+        let work_dir = if entry.work_dir.is_empty() {
+            "/tmp"
+        } else {
+            &entry.work_dir
+        };
         cmd.args(&launch_args)
-            .current_dir(&entry.work_dir)
+            .current_dir(work_dir)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null());
 
-        for (k, v) in Self::read_proc_environ(entry.pid as u32) {
-            cmd.env(k, v);
+        entry.apply_privilege_drop(&mut cmd);
+
+        if entry.pid > 0 {
+            for (k, v) in Self::read_proc_environ(entry.pid as u32) {
+                cmd.env(k, v);
+            }
         }
         for (k, v) in entry.env_vars(job_id) {
             cmd.env(k, v);
@@ -2175,11 +2179,6 @@ impl AgentService {
         unsafe {
             cmd.pre_exec(move || raw.wire());
         }
-
-        debug_assert!(
-            !drop_priv || entry.has_namespaces(),
-            "root spurd always has namespaces; direct priv drop should be unreachable"
-        );
 
         let child = cmd
             .spawn()
@@ -2886,6 +2885,9 @@ mod tests {
                 stdout_path: "/dev/null".into(),
                 stderr_path: "/dev/null".into(),
                 has_pid_namespace: false,
+                has_user_namespace: false,
+                has_mount_namespace: false,
+                _pty_master: None,
                 work_dir: "/tmp".into(),
                 uid: 0,
                 gid: 0,
@@ -3111,11 +3113,9 @@ mod tests {
             .unwrap();
 
         let mut collected = Vec::new();
-        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
-        loop {
-            let remaining = deadline.duration_since(tokio::time::Instant::now());
-            match tokio::time::timeout(remaining, out_rx.recv()).await {
-                Ok(Some(Ok(msg))) => match msg.msg {
+        for _ in 0..1000 {
+            match out_rx.recv().await {
+                Some(Ok(msg)) => match msg.msg {
                     Some(interactive_output::Msg::Data(d)) => {
                         collected.extend_from_slice(&d);
                         if collected.windows(5).any(|w| w == b"hello") {
@@ -3136,11 +3136,9 @@ mod tests {
 
         drop(in_tx);
 
-        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
-        loop {
-            let remaining = deadline.duration_since(tokio::time::Instant::now());
-            match tokio::time::timeout(remaining, out_rx.recv()).await {
-                Ok(Some(Ok(msg))) => {
+        for _ in 0..1000 {
+            match out_rx.recv().await {
+                Some(Ok(msg)) => {
                     if let Some(interactive_output::Msg::ExitStatus(_code)) = msg.msg {
                         return;
                     }

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1062,10 +1062,17 @@ impl SlurmAgent for AgentService {
             "exec into running job"
         );
 
-        let mut cmd = if entry.has_namespaces() {
+        let priv_drop = crate::privdrop::PrivDrop::resolve_if_needed(entry.uid, entry.gid);
+
+        let mut cmd = if entry.has_namespaces() && entry.pid > 0 {
             let mut c = tokio::process::Command::new("nsenter");
-            for arg in entry.nsenter_args_with_priv_drop() {
+            for arg in entry.nsenter_args() {
                 c.arg(arg);
+            }
+            if let Some(ref pd) = priv_drop {
+                for arg in pd.nsenter_args() {
+                    c.arg(arg);
+                }
             }
             c.arg("--");
             c.arg(&req.command[0]);
@@ -1079,10 +1086,17 @@ impl SlurmAgent for AgentService {
                 c.arg(arg);
             }
             c.current_dir(&entry.work_dir);
+            if let Some(pd) = priv_drop {
+                unsafe {
+                    c.pre_exec(move || {
+                        pd.apply()
+                            .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
+                        Ok(())
+                    });
+                }
+            }
             c
         };
-
-        entry.apply_privilege_drop(&mut cmd);
 
         let output = cmd
             .output()
@@ -1374,17 +1388,13 @@ impl SlurmAgent for AgentService {
         }
 
         let memlock = self.memlock;
-        let drop_privilege = req.uid > 0 && nix::unistd::geteuid().is_root();
-        let target_uid = req.uid;
-        let target_gid = req.gid;
+        let priv_drop = crate::privdrop::PrivDrop::resolve_if_needed(req.uid, req.gid);
         unsafe {
             cmd.pre_exec(move || {
                 crate::executor::apply_memlock(memlock);
-                if drop_privilege {
-                    nix::unistd::setgid(nix::unistd::Gid::from_raw(target_gid))
-                        .map_err(std::io::Error::other)?;
-                    nix::unistd::setuid(nix::unistd::Uid::from_raw(target_uid))
-                        .map_err(std::io::Error::other)?;
+                if let Some(ref pd) = priv_drop {
+                    pd.apply()
+                        .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
                 }
                 Ok(())
             });
@@ -2140,13 +2150,19 @@ impl AgentService {
             argv.to_vec()
         };
 
-        let (launch_cmd, launch_args) = if entry.has_namespaces() {
-            let mut args = entry.nsenter_args_with_priv_drop();
+        let priv_drop = crate::privdrop::PrivDrop::resolve_if_needed(entry.uid, entry.gid);
+
+        let use_nsenter = entry.has_namespaces() && entry.pid > 0;
+        let (launch_cmd, launch_args, apply_priv_in_child) = if use_nsenter {
+            let mut args = entry.nsenter_args();
+            if let Some(ref pd) = priv_drop {
+                args.extend(pd.nsenter_args());
+            }
             args.push("--".into());
             args.extend(shell);
-            ("nsenter".to_string(), args)
+            ("nsenter".to_string(), args, false)
         } else {
-            (shell[0].clone(), shell[1..].to_vec())
+            (shell[0].clone(), shell[1..].to_vec(), true)
         };
 
         let mut cmd = tokio::process::Command::new(&launch_cmd);
@@ -2161,8 +2177,6 @@ impl AgentService {
             .stdout(Stdio::null())
             .stderr(Stdio::null());
 
-        entry.apply_privilege_drop(&mut cmd);
-
         if entry.pid > 0 {
             for (k, v) in Self::read_proc_environ(entry.pid as u32) {
                 cmd.env(k, v);
@@ -2171,13 +2185,32 @@ impl AgentService {
         for (k, v) in entry.env_vars(job_id) {
             cmd.env(k, v);
         }
+        if entry.uid > 0 {
+            if let Some(user) = nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(entry.uid))
+                .ok()
+                .flatten()
+            {
+                cmd.env("HOME", user.dir.to_string_lossy().as_ref());
+                cmd.env("USER", &user.name);
+                cmd.env("LOGNAME", &user.name);
+                cmd.env("SHELL", user.shell.to_string_lossy().as_ref());
+            }
+        }
 
         let raw = crate::executor::JobIoRaw::Pty {
             master: master.as_raw_fd(),
             slave: slave.as_raw_fd(),
         };
+        let priv_drop_for_child = if apply_priv_in_child { priv_drop } else { None };
         unsafe {
-            cmd.pre_exec(move || raw.wire());
+            cmd.pre_exec(move || {
+                raw.wire()?;
+                if let Some(ref pd) = priv_drop_for_child {
+                    pd.apply()
+                        .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
+                }
+                Ok(())
+            });
         }
 
         let child = cmd
@@ -2853,7 +2886,7 @@ mod tests {
 
     // The grace-period SIGKILL must not fire if job_id was reused by a newer
     // run (epoch bumped) after a requeue. Guards the preempt-requeue race.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[tokio::test(start_paused = true)]
     async fn graceful_cancel_skips_sigkill_for_reused_job_id() {
         let svc = AgentService::new(
             test_reporter(),
@@ -2912,11 +2945,12 @@ mod tests {
         let (run2, pid2) = spawn_trap(2);
         svc.insert_test_job(job_id, run2).await;
 
-        // Wait past the 5s grace period; the guard must skip the SIGKILL, so the
+        // Advance past the 5s grace period; the guard must skip the SIGKILL, so the
         // epoch-2 process stays alive. Assert a live state ('S'/'R'), not mere
         // /proc existence — a wrongly-killed unreaped child would be a zombie
         // ('Z'), which still has /proc and would false-pass an existence check.
-        tokio::time::sleep(tokio::time::Duration::from_secs(6)).await;
+        tokio::time::advance(tokio::time::Duration::from_secs(6)).await;
+        tokio::task::yield_now().await;
         let state = proc_state(pid2);
         assert!(
             matches!(state, 'S' | 'R' | 'D'),

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -35,6 +35,10 @@ struct TrackedJob {
     stdout_path: String,
     stderr_path: String,
     has_pid_namespace: bool,
+    has_user_namespace: bool,
+    has_mount_namespace: bool,
+    rootfs: Option<std::path::PathBuf>,
+    _pty_master: Option<std::os::fd::OwnedFd>,
     work_dir: String,
     uid: u32,
     gid: u32,
@@ -551,7 +555,7 @@ async fn report_completion(
 #[tonic::async_trait]
 impl SlurmAgent for AgentService {
     type StreamJobOutputStream = ReceiverStream<Result<StreamJobOutputChunk, Status>>;
-    type AttachJobStream = ReceiverStream<Result<AttachJobOutput, Status>>;
+    type InteractiveSessionStream = ReceiverStream<Result<InteractiveOutput, Status>>;
 
     async fn launch_job(
         &self,
@@ -909,6 +913,11 @@ impl SlurmAgent for AgentService {
             nodelist: spec.nodelist.clone(),
             host_device_plan: Some(host_device_plan),
             memlock: self.memlock,
+            io_mode: if spec.pty {
+                executor::LaunchIo::Pty
+            } else {
+                executor::LaunchIo::File
+            },
         };
 
         match executor::launch_job(&launch_cfg, (*self.spank).as_ref()).await {
@@ -920,6 +929,9 @@ impl SlurmAgent for AgentService {
                 // `launching` (which would let reconcile reclaim it).
                 self.allocation.lock().await.commit_job(job_id);
                 info!(job_id, gpus = ?launch_cfg.gpu_devices, "job launched successfully");
+                let is_root = nix::unistd::geteuid().is_root();
+                let is_container = launch_cfg.container.is_some();
+                let rootfs = launch_cfg.container.as_ref().map(|c| c.rootfs.clone());
                 let displaced = jobs.insert(
                     job_id,
                     TrackedJob {
@@ -927,7 +939,11 @@ impl SlurmAgent for AgentService {
                         rootfs_mode: rootfs_mode.clone(),
                         stdout_path: result.stdout_path,
                         stderr_path: result.stderr_path,
-                        has_pid_namespace: nix::unistd::geteuid().is_root(),
+                        has_pid_namespace: is_root || is_container,
+                        has_user_namespace: is_container && !is_root,
+                        has_mount_namespace: is_root || is_container,
+                        rootfs,
+                        _pty_master: result.pty_master,
                         work_dir: launch_cfg.work_dir,
                         uid: launch_cfg.uid,
                         gid: launch_cfg.gid,
@@ -1036,16 +1052,7 @@ impl SlurmAgent for AgentService {
     ) -> Result<Response<ExecInJobResponse>, Status> {
         let req = request.into_inner();
 
-        let (pid, has_pid_ns) = {
-            let jobs = self.running.lock().await;
-            let tracked = jobs.get(&req.job_id).ok_or_else(|| {
-                Status::not_found(format!("job {} not running on this node", req.job_id))
-            })?;
-            let pid = tracked.job.pid().ok_or_else(|| {
-                Status::failed_precondition(format!("job {} has no tracked PID", req.job_id))
-            })?;
-            (pid, tracked.has_pid_namespace)
-        };
+        let entry = self.job_entry(req.job_id).await?;
 
         if req.command.is_empty() {
             return Err(Status::invalid_argument("no command specified"));
@@ -1053,22 +1060,30 @@ impl SlurmAgent for AgentService {
 
         info!(
             job_id = req.job_id,
-            pid,
+            pid = entry.pid,
             command = ?req.command,
             "exec into running job"
         );
 
-        // Use nsenter to enter the job's namespace(s) and run the command
-        let mut cmd = tokio::process::Command::new("nsenter");
-        cmd.arg("--target").arg(pid.to_string()).arg("--mount");
-        if has_pid_ns {
-            cmd.arg("--pid");
-        }
-        cmd.arg("--");
-        cmd.arg(&req.command[0]);
-        for arg in &req.command[1..] {
-            cmd.arg(arg);
-        }
+        let mut cmd = if entry.has_namespaces() {
+            let mut c = tokio::process::Command::new("nsenter");
+            for arg in entry.nsenter_args() {
+                c.arg(arg);
+            }
+            c.arg("--");
+            c.arg(&req.command[0]);
+            for arg in &req.command[1..] {
+                c.arg(arg);
+            }
+            c
+        } else {
+            let mut c = tokio::process::Command::new(&req.command[0]);
+            for arg in &req.command[1..] {
+                c.arg(arg);
+            }
+            c.current_dir(&entry.work_dir);
+            c
+        };
 
         let output = cmd
             .output()
@@ -1152,6 +1167,10 @@ impl SlurmAgent for AgentService {
                 stdout_path: String::new(),
                 stderr_path: String::new(),
                 has_pid_namespace: false,
+                has_user_namespace: false,
+                has_mount_namespace: false,
+                rootfs: None,
+                _pty_master: None,
                 work_dir: String::new(),
                 uid: req.uid,
                 gid: req.gid,
@@ -1518,198 +1537,55 @@ impl SlurmAgent for AgentService {
         Ok(Response::new(ReceiverStream::new(rx)))
     }
 
-    async fn attach_job(
+    async fn interactive_session(
         &self,
-        request: Request<tonic::Streaming<AttachJobInput>>,
-    ) -> Result<Response<Self::AttachJobStream>, Status> {
-        let mut in_stream = request.into_inner();
+        request: Request<tonic::Streaming<InteractiveInput>>,
+    ) -> Result<Response<Self::InteractiveSessionStream>, Status> {
+        use crate::pty::WindowSize as PtyWinSize;
 
-        // Read the first message to get the job_id
-        let first_msg = in_stream
+        let mut inbound = request.into_inner();
+
+        let first = inbound
             .message()
             .await
-            .map_err(|e| Status::internal(format!("failed to read first message: {}", e)))?
-            .ok_or_else(|| {
-                Status::invalid_argument("empty stream — expected job_id in first message")
-            })?;
+            .map_err(|e| Status::internal(format!("stream recv error: {e}")))?
+            .ok_or_else(|| Status::invalid_argument("empty stream: expected InitSession"))?;
 
-        let job_id = first_msg.job_id;
-
-        // Check the job is running and get its PID for namespace entry
-        let (pid, env_vars) = {
-            let jobs = self.running.lock().await;
-            match jobs.get(&job_id) {
-                Some(tracked) => {
-                    let pid = tracked.job.pid().ok_or_else(|| {
-                        Status::failed_precondition(format!("job {} has no PID", job_id))
-                    })?;
-                    // Read a few env vars from /proc to replicate the job's environment
-                    let env = Self::read_proc_env(pid);
-                    (pid, env)
-                }
-                None => {
-                    return Err(Status::not_found(format!(
-                        "job {} not running on this node",
-                        job_id
-                    )));
-                }
+        let init = match first.msg {
+            Some(interactive_input::Msg::Init(init)) => init,
+            _ => {
+                return Err(Status::invalid_argument(
+                    "first message must be InitSession",
+                ));
             }
         };
 
-        // Issue #54: Use a larger buffer to prevent deadlock when stdout+stderr
-        // produce high-volume output concurrently.
-        let (tx, rx) = tokio::sync::mpsc::channel::<Result<AttachJobOutput, Status>>(256);
+        let entry = self.job_entry(init.job_id).await?;
 
-        tokio::spawn(async move {
-            // Spawn an interactive shell inside the job's cgroup/namespace
-            use std::process::Stdio;
-            use tokio::io::{AsyncReadExt, AsyncWriteExt};
-            use tokio::process::Command;
-
-            // Use nsenter to enter the job process's namespaces if possible,
-            // otherwise just spawn a shell with the same environment.
-            let mut cmd = Command::new("/bin/sh");
-            cmd.arg("-i")
-                .stdin(Stdio::piped())
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped());
-
-            // Set the job's environment variables
-            for (k, v) in &env_vars {
-                cmd.env(k, v);
-            }
-            cmd.env("SPUR_JOB_ID", job_id.to_string());
-            cmd.env("SLURM_JOB_ID", job_id.to_string());
-
-            // Try nsenter for namespace isolation (if running as root)
-            let mut child = if nix::unistd::geteuid().is_root() {
-                let mut ns_cmd = Command::new("nsenter");
-                ns_cmd
-                    .args(["-t", &pid.to_string(), "--mount", "--pid", "--"])
-                    .args(["/bin/sh", "-i"])
-                    .stdin(Stdio::piped())
-                    .stdout(Stdio::piped())
-                    .stderr(Stdio::piped());
-                for (k, v) in &env_vars {
-                    ns_cmd.env(k, v);
-                }
-                ns_cmd.env("SPUR_JOB_ID", job_id.to_string());
-                ns_cmd.env("SLURM_JOB_ID", job_id.to_string());
-                match ns_cmd.spawn() {
-                    Ok(c) => c,
-                    Err(_) => match cmd.spawn() {
-                        Ok(c) => c,
-                        Err(e) => {
-                            let _ = tx
-                                .send(Err(Status::internal(format!(
-                                    "failed to spawn shell: {}",
-                                    e
-                                ))))
-                                .await;
-                            return;
-                        }
-                    },
-                }
-            } else {
-                match cmd.spawn() {
-                    Ok(c) => c,
-                    Err(e) => {
-                        let _ = tx
-                            .send(Err(Status::internal(format!(
-                                "failed to spawn shell: {}",
-                                e
-                            ))))
-                            .await;
-                        return;
-                    }
-                }
-            };
-
-            let mut child_stdin = child.stdin.take().unwrap();
-            let mut child_stdout = child.stdout.take().unwrap();
-            let mut child_stderr = child.stderr.take().unwrap();
-
-            // Forward initial data from first message (if any)
-            if !first_msg.data.is_empty() {
-                let _ = child_stdin.write_all(&first_msg.data).await;
-            }
-
-            let tx_clone = tx.clone();
-
-            // Task: read from client stream → child stdin
-            let stdin_task = tokio::spawn(async move {
-                while let Ok(Some(msg)) = in_stream.message().await {
-                    if !msg.data.is_empty() && child_stdin.write_all(&msg.data).await.is_err() {
-                        break;
-                    }
-                }
-                drop(child_stdin); // EOF to child
-            });
-
-            // Task: read child stderr → merge into output
-            let tx_stderr = tx.clone();
-            let stderr_task = tokio::spawn(async move {
-                let mut buf = vec![0u8; 4096];
-                loop {
-                    match child_stderr.read(&mut buf).await {
-                        Ok(0) => break,
-                        Ok(n) => {
-                            if tx_stderr
-                                .send(Ok(AttachJobOutput {
-                                    data: buf[..n].to_vec(),
-                                    eof: false,
-                                }))
-                                .await
-                                .is_err()
-                            {
-                                break;
-                            }
-                        }
-                        Err(_) => break,
-                    }
-                }
-            });
-
-            // Main: read child stdout → output stream
-            let mut buf = vec![0u8; 4096];
-            loop {
-                match child_stdout.read(&mut buf).await {
-                    Ok(0) => break,
-                    Ok(n) => {
-                        if tx_clone
-                            .send(Ok(AttachJobOutput {
-                                data: buf[..n].to_vec(),
-                                eof: false,
-                            }))
-                            .await
-                            .is_err()
-                        {
-                            break;
-                        }
-                    }
-                    Err(_) => break,
-                }
-            }
-
-            // Wait for child to exit, then let I/O tasks drain gracefully
-            // before sending EOF. Aborting immediately loses buffered data
-            // (issue #54).
-            let _ = child.wait().await;
-            // Give tasks a moment to flush remaining data
-            let _ = tokio::time::timeout(std::time::Duration::from_secs(2), async {
-                let _ = stderr_task.await;
-            })
-            .await;
-            stdin_task.abort();
-
-            // Send EOF
-            let _ = tx_clone
-                .send(Ok(AttachJobOutput {
-                    data: Vec::new(),
-                    eof: true,
-                }))
-                .await;
+        let winsize = init.winsize.as_ref().map(|ws| PtyWinSize {
+            rows: ws.rows as u16,
+            cols: ws.cols as u16,
+            xpixel: ws.xpixel as u16,
+            ypixel: ws.ypixel as u16,
         });
+
+        let argv: Vec<String> = init.argv.clone();
+
+        let (master_fd, child, child_pid) =
+            Self::spawn_pty_in_job(&entry, &argv, init.job_id, winsize.as_ref())?;
+
+        info!(
+            job_id = init.job_id,
+            child_pid,
+            overlap = init.overlap,
+            "interactive session started"
+        );
+
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<InteractiveOutput, Status>>(64);
+
+        tokio::spawn(Self::run_pty_bridge(
+            master_fd, child, child_pid, inbound, tx,
+        ));
 
         Ok(Response::new(ReceiverStream::new(rx)))
     }
@@ -2044,8 +1920,287 @@ impl AgentService {
         });
     }
 
+    /// Extract a `JobEntry` from a tracked running job for namespace entry.
+    async fn job_entry(&self, job_id: u32) -> Result<crate::job_entry::JobEntry, Status> {
+        let jobs = self.running.lock().await;
+        let tracked = jobs
+            .get(&job_id)
+            .ok_or_else(|| Status::not_found(format!("job {} not running on this node", job_id)))?;
+        let pid = tracked.job.pid().ok_or_else(|| {
+            Status::failed_precondition(format!("job {} has no tracked PID", job_id))
+        })?;
+        Ok(crate::job_entry::JobEntry {
+            pid: pid as i32,
+            has_pid_namespace: tracked.has_pid_namespace,
+            has_user_namespace: tracked.has_user_namespace,
+            has_mount_namespace: tracked.has_mount_namespace,
+            _rootfs: tracked.rootfs.clone(),
+            uid: tracked.uid,
+            gid: tracked.gid,
+            work_dir: tracked.work_dir.clone(),
+        })
+    }
+
+    /// Bidirectional PTY bridge: reads master fd, forwards inbound messages
+    /// (stdin, resize, signal), and drains remaining output after child exit.
+    async fn run_pty_bridge<S>(
+        master: std::os::fd::OwnedFd,
+        mut child: tokio::process::Child,
+        child_pid: i32,
+        mut inbound: S,
+        tx: tokio::sync::mpsc::Sender<Result<InteractiveOutput, Status>>,
+    ) where
+        S: tokio_stream::Stream<Item = Result<InteractiveInput, Status>> + Unpin + Send,
+    {
+        use crate::pty::WindowSize as PtyWinSize;
+        use std::os::fd::AsRawFd;
+        use tokio::io::unix::AsyncFd;
+        use tokio_stream::StreamExt;
+
+        let master_raw = master.as_raw_fd();
+        let async_fd = match AsyncFd::new(master) {
+            Ok(fd) => fd,
+            Err(e) => {
+                let _ = tx
+                    .send(Err(Status::internal(format!("AsyncFd setup: {e}"))))
+                    .await;
+                return;
+            }
+        };
+
+        let mut read_buf = vec![0u8; 4096];
+        let mut child_exited = false;
+        let mut exit_code: i32 = 128;
+
+        loop {
+            tokio::select! {
+                readable = async_fd.readable() => {
+                    match readable {
+                        Ok(mut guard) => {
+                            match Self::try_read_pty(&mut guard, &mut read_buf) {
+                                Ok(None) => break,
+                                Ok(Some(0)) => continue,
+                                Ok(Some(n)) => {
+                                    let msg = InteractiveOutput {
+                                        msg: Some(interactive_output::Msg::Data(
+                                            read_buf[..n].to_vec(),
+                                        )),
+                                    };
+                                    if tx.send(Ok(msg)).await.is_err() {
+                                        break;
+                                    }
+                                }
+                                Err(e) => {
+                                    warn!(error = %e, "PTY read error");
+                                    break;
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            warn!(error = %e, "AsyncFd readable error");
+                            break;
+                        }
+                    }
+                }
+
+                item = inbound.next(), if !child_exited => {
+                    match item {
+                        Some(Ok(input)) => {
+                            match input.msg {
+                                Some(interactive_input::Msg::Stdin(data)) => {
+                                    if Self::async_write_pty(&async_fd, &data).await.is_err() {
+                                        break;
+                                    }
+                                }
+                                Some(interactive_input::Msg::Resize(ws)) => {
+                                    let _ = crate::pty::resize(master_raw, &PtyWinSize {
+                                        rows: ws.rows as u16,
+                                        cols: ws.cols as u16,
+                                        xpixel: ws.xpixel as u16,
+                                        ypixel: ws.ypixel as u16,
+                                    });
+                                }
+                                Some(interactive_input::Msg::Signal(sig)) => {
+                                    let _ = crate::pty::signal_foreground(
+                                        master_raw, child_pid, sig,
+                                    );
+                                }
+                                Some(interactive_input::Msg::Init(_)) | None => {}
+                            }
+                        }
+                        Some(Err(_)) | None => {
+                            unsafe { libc::kill(child_pid, libc::SIGHUP); }
+                            break;
+                        }
+                    }
+                }
+
+                status = child.wait(), if !child_exited => {
+                    exit_code = match status {
+                        Ok(s) => s.code().unwrap_or(128),
+                        Err(_) => 128,
+                    };
+                    child_exited = true;
+                }
+            }
+        }
+
+        if !child_exited {
+            exit_code = match child.wait().await {
+                Ok(s) => s.code().unwrap_or(128),
+                Err(_) => 128,
+            };
+        }
+
+        let _ = tx
+            .send(Ok(InteractiveOutput {
+                msg: Some(interactive_output::Msg::ExitStatus(exit_code)),
+            }))
+            .await;
+    }
+
+    /// Non-blocking read from a PTY master via an AsyncFd ready guard.
+    /// Returns `Ok(Some(n))` on data, `Ok(None)` on EOF/EIO, `Err` on
+    /// fatal error. `Some(0)` means WouldBlock (caller should continue).
+    fn try_read_pty(
+        guard: &mut tokio::io::unix::AsyncFdReadyGuard<'_, std::os::fd::OwnedFd>,
+        buf: &mut [u8],
+    ) -> Result<Option<usize>, std::io::Error> {
+        use std::os::fd::AsRawFd;
+        match guard.try_io(|fd| {
+            let n = unsafe { libc::read(fd.as_raw_fd(), buf.as_mut_ptr() as *mut _, buf.len()) };
+            if n < 0 {
+                Err(std::io::Error::last_os_error())
+            } else {
+                Ok(n as usize)
+            }
+        }) {
+            Ok(Ok(0)) => Ok(None),
+            Ok(Ok(n)) => Ok(Some(n)),
+            Ok(Err(e)) if e.raw_os_error() == Some(libc::EIO) => Ok(None),
+            Ok(Err(e)) => Err(e),
+            Err(_would_block) => Ok(Some(0)),
+        }
+    }
+
+    /// Non-blocking write to a PTY master via AsyncFd.
+    async fn async_write_pty(
+        async_fd: &tokio::io::unix::AsyncFd<std::os::fd::OwnedFd>,
+        data: &[u8],
+    ) -> Result<(), std::io::Error> {
+        use std::os::fd::AsRawFd;
+        let mut written = 0;
+        while written < data.len() {
+            let mut guard = async_fd.writable().await?;
+            match guard.try_io(|fd| {
+                let n = unsafe {
+                    libc::write(
+                        fd.as_raw_fd(),
+                        data[written..].as_ptr() as *const _,
+                        data.len() - written,
+                    )
+                };
+                if n < 0 {
+                    Err(std::io::Error::last_os_error())
+                } else {
+                    Ok(n as usize)
+                }
+            }) {
+                Ok(Ok(n)) => written += n,
+                Ok(Err(e)) => return Err(e),
+                Err(_would_block) => continue,
+            }
+        }
+        Ok(())
+    }
+
+    fn spawn_pty_in_job(
+        entry: &crate::job_entry::JobEntry,
+        argv: &[String],
+        job_id: u32,
+        winsize: Option<&crate::pty::WindowSize>,
+    ) -> Result<(std::os::fd::OwnedFd, tokio::process::Child, i32), Status> {
+        use std::os::fd::AsRawFd;
+        use std::process::Stdio;
+
+        let (master, slave) = crate::pty::openpty_with_winsize(winsize)
+            .map_err(|e| Status::internal(format!("openpty: {e}")))?;
+
+        let shell = if argv.is_empty() {
+            vec!["/bin/bash".to_string()]
+        } else {
+            argv.to_vec()
+        };
+
+        let drop_priv = entry.uid > 0 && nix::unistd::geteuid().is_root();
+
+        let (launch_cmd, launch_args) = if entry.has_namespaces() {
+            let mut args = entry.nsenter_args();
+            // nsenter needs root to open /proc/<pid>/ns/*; drop privileges
+            // inside the namespace via --setuid/--setgid instead of
+            // Command::uid()/gid() which would drop before exec.
+            if drop_priv {
+                args.push(format!("--setuid={}", entry.uid));
+                args.push(format!("--setgid={}", entry.gid));
+            }
+            args.push("--".into());
+            args.extend(shell);
+            ("nsenter".to_string(), args)
+        } else {
+            (shell[0].clone(), shell[1..].to_vec())
+        };
+
+        let mut cmd = tokio::process::Command::new(&launch_cmd);
+        cmd.args(&launch_args)
+            .current_dir(&entry.work_dir)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+
+        for (k, v) in Self::read_proc_environ(entry.pid as u32) {
+            cmd.env(k, v);
+        }
+        for (k, v) in entry.env_vars(job_id) {
+            cmd.env(k, v);
+        }
+
+        let raw = crate::executor::JobIoRaw::Pty {
+            master: master.as_raw_fd(),
+            slave: slave.as_raw_fd(),
+        };
+        unsafe {
+            cmd.pre_exec(move || raw.wire());
+        }
+
+        // For non-nsenter case, drop privs via Command::uid()/gid().
+        // nsenter case already handled above via --setuid/--setgid.
+        if drop_priv && !entry.has_namespaces() {
+            cmd.gid(entry.gid);
+            cmd.uid(entry.uid);
+        }
+
+        let child = cmd
+            .spawn()
+            .map_err(|e| Status::internal(format!("spawn PTY shell: {e}")))?;
+        let child_pid = child
+            .id()
+            .ok_or_else(|| Status::internal("spawned PTY child exited before pid could be read"))?
+            as i32;
+
+        drop(slave);
+
+        // Set non-blocking so AsyncFd reads/writes are correct.
+        nix::fcntl::fcntl(
+            &master,
+            nix::fcntl::FcntlArg::F_SETFL(nix::fcntl::OFlag::O_NONBLOCK),
+        )
+        .map_err(|e| Status::internal(format!("fcntl O_NONBLOCK: {e}")))?;
+
+        Ok((master, child, child_pid))
+    }
+
     /// Read environment variables from a running process via /proc.
-    fn read_proc_env(pid: u32) -> Vec<(String, String)> {
+    fn read_proc_environ(pid: u32) -> Vec<(String, String)> {
         let path = format!("/proc/{}/environ", pid);
         match std::fs::read(&path) {
             Ok(data) => data
@@ -2080,6 +2235,10 @@ impl TrackedJob {
             stdout_path: "/dev/null".into(),
             stderr_path: "/dev/null".into(),
             has_pid_namespace: false,
+            has_user_namespace: false,
+            has_mount_namespace: false,
+            rootfs: None,
+            _pty_master: None,
             work_dir: "/tmp".into(),
             uid: 0,
             gid: 0,
@@ -2661,6 +2820,10 @@ mod tests {
             stdout_path: "/dev/null".into(),
             stderr_path: "/dev/null".into(),
             has_pid_namespace: false,
+            has_user_namespace: false,
+            has_mount_namespace: false,
+            rootfs: None,
+            _pty_master: None,
             work_dir: "/tmp".into(),
             uid: 0,
             gid: 0,
@@ -2872,5 +3035,113 @@ mod tests {
             wait_job_reaped(&svc, job_id, 5_000).await,
             "monitor should reap SIGKILL'd job within 5s"
         );
+    }
+
+    #[tokio::test]
+    async fn job_entry_from_tracked_job() {
+        let (svc, job_id) = run_command_test_setup().await;
+
+        let entry = svc
+            .job_entry(job_id)
+            .await
+            .expect("job_entry should succeed");
+        assert!(entry.pid > 0);
+        assert_eq!(entry.uid, 0);
+        assert_eq!(entry.gid, 0);
+        assert!(!entry.has_namespaces());
+    }
+
+    #[tokio::test]
+    async fn job_entry_not_found() {
+        let (svc, _) = run_command_test_setup().await;
+
+        let err = svc.job_entry(9999).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::NotFound);
+    }
+
+    #[tokio::test]
+    async fn run_pty_bridge_echo_and_exit() {
+        use spur_proto::proto::{interactive_input, interactive_output, InteractiveInput};
+
+        let (master, slave) = crate::pty::openpty_with_winsize(None).expect("openpty");
+
+        nix::fcntl::fcntl(
+            &master,
+            nix::fcntl::FcntlArg::F_SETFL(nix::fcntl::OFlag::O_NONBLOCK),
+        )
+        .expect("O_NONBLOCK");
+
+        let raw = crate::executor::JobIoRaw::Pty {
+            master: std::os::fd::AsRawFd::as_raw_fd(&master),
+            slave: std::os::fd::AsRawFd::as_raw_fd(&slave),
+        };
+        let mut cmd = tokio::process::Command::new("cat");
+        cmd.stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null());
+        unsafe {
+            cmd.pre_exec(move || raw.wire());
+        }
+        let child = cmd.spawn().expect("spawn cat");
+        let child_pid = child.id().expect("child pid") as i32;
+        drop(slave);
+
+        let (in_tx, in_rx) =
+            tokio::sync::mpsc::channel::<Result<InteractiveInput, tonic::Status>>(64);
+        let (out_tx, mut out_rx) = tokio::sync::mpsc::channel::<
+            Result<spur_proto::proto::InteractiveOutput, tonic::Status>,
+        >(64);
+
+        let inbound = tokio_stream::wrappers::ReceiverStream::new(in_rx);
+        tokio::spawn(AgentService::run_pty_bridge(
+            master, child, child_pid, inbound, out_tx,
+        ));
+
+        in_tx
+            .send(Ok(InteractiveInput {
+                msg: Some(interactive_input::Msg::Stdin(b"hello\n".to_vec())),
+            }))
+            .await
+            .unwrap();
+
+        let mut collected = Vec::new();
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let remaining = deadline.duration_since(tokio::time::Instant::now());
+            match tokio::time::timeout(remaining, out_rx.recv()).await {
+                Ok(Some(Ok(msg))) => match msg.msg {
+                    Some(interactive_output::Msg::Data(d)) => {
+                        collected.extend_from_slice(&d);
+                        if collected.windows(5).any(|w| w == b"hello") {
+                            break;
+                        }
+                    }
+                    Some(interactive_output::Msg::ExitStatus(_)) => break,
+                    None => {}
+                },
+                _ => break,
+            }
+        }
+        let text = String::from_utf8_lossy(&collected);
+        assert!(
+            text.contains("hello"),
+            "expected echoed 'hello', got: {text}"
+        );
+
+        drop(in_tx);
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let remaining = deadline.duration_since(tokio::time::Instant::now());
+            match tokio::time::timeout(remaining, out_rx.recv()).await {
+                Ok(Some(Ok(msg))) => {
+                    if let Some(interactive_output::Msg::ExitStatus(_code)) = msg.msg {
+                        return;
+                    }
+                }
+                _ => break,
+            }
+        }
+        panic!("did not receive exit status from bridge");
     }
 }

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -1303,25 +1303,30 @@ async fn launch_container_job(
                 .collect();
             let c_env_refs: Vec<&std::ffi::CStr> = c_env.iter().map(|s| s.as_c_str()).collect();
 
-            // Build exec args: with or without entrypoint
-            let c_bash = CString::new("/bin/bash").unwrap();
+            // Pick a shell that exists in the container
+            let shell = if Path::new("/bin/bash").exists() {
+                "/bin/bash"
+            } else {
+                "/bin/sh"
+            };
+            let c_shell = CString::new(shell).unwrap();
             let exec_args: Vec<CString> = if let Some(ref ep) = entrypoint {
-                let cmd = format!("{} && /bin/bash /tmp/spur_job_{}.sh", ep, job_id);
+                let cmd = format!("{} && {} /tmp/spur_job_{}.sh", ep, shell, job_id);
                 vec![
-                    c_bash.clone(),
+                    c_shell.clone(),
                     CString::new("-c").unwrap(),
                     CString::new(cmd).unwrap(),
                 ]
             } else {
                 vec![
-                    c_bash.clone(),
+                    c_shell.clone(),
                     CString::new(format!("/tmp/spur_job_{}.sh", job_id)).unwrap(),
                 ]
             };
             let exec_arg_refs: Vec<&std::ffi::CStr> =
                 exec_args.iter().map(|s| s.as_c_str()).collect();
 
-            let _ = nix::unistd::execve(&c_bash, &exec_arg_refs, &c_env_refs);
+            let _ = nix::unistd::execve(&c_shell, &exec_arg_refs, &c_env_refs);
             eprintln!("spur: execve failed: {}", std::io::Error::last_os_error());
             std::process::exit(1);
         }

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -446,7 +446,7 @@ async fn spawn_job_process(
 
     // Build resolved output paths (empty for PTY mode since output goes to the terminal).
     let (stdout_resolved, stderr_resolved) = if cfg.io_mode == LaunchIo::Pty {
-        (String::new(), String::new())
+        ("/dev/null".to_string(), "/dev/null".to_string())
     } else {
         (
             resolve_output_path(stdout_path, job_id, work_dir),
@@ -1259,11 +1259,12 @@ async fn launch_container_job(
                 libc::signal(libc::SIGPIPE, libc::SIG_DFL);
             }
 
-            // wire() must run before close_inherited_fds: it dup2's the
-            // job's fds onto 0/1/2, then close_inherited_fds reaps
-            // everything else > 2 (except ready_w).
             unsafe {
-                let _ = raw_io.wire();
+                if let Err(e) = raw_io.wire() {
+                    let msg = format!("E:stdio wire failed: {:#}", e);
+                    let _ = libc::write(ready_w, msg.as_ptr() as *const _, msg.len());
+                    libc::_exit(1);
+                }
             }
 
             crate::container::close_inherited_fds(ready_w);

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -58,6 +58,17 @@ pub struct ContainerLaunchConfig {
 ///
 /// Groups the resolved execution parameters that come from multiple sources
 /// (JobSpec, scheduler allocation, agent config) into a single value.
+/// How the job's I/O is connected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LaunchIo {
+    /// Traditional file-based stdout/stderr capture.
+    #[default]
+    File,
+    /// PTY-backed: stdout/stderr/stdin all go through a pseudo-terminal.
+    /// The master fd is returned in `LaunchResult::pty_master`.
+    Pty,
+}
+
 pub struct JobLaunchConfig {
     pub job_id: JobId,
     pub script: String,
@@ -81,12 +92,111 @@ pub struct JobLaunchConfig {
     pub host_device_plan: Option<spur_devices::inject::HostInjectionPlan>,
     /// RLIMIT_MEMLOCK to apply before exec (while still privileged).
     pub memlock: MemlockLimit,
+    /// I/O mode for the job.
+    pub io_mode: LaunchIo,
 }
 
 pub struct LaunchResult {
     pub job: RunningJob,
     pub stdout_path: String,
     pub stderr_path: String,
+    /// Master fd of the PTY (only set when `io_mode == LaunchIo::Pty`).
+    pub pty_master: Option<OwnedFd>,
+}
+
+/// Owns the resolved fds for a job's stdio, built once and consumed by both
+/// the container (raw fork) and non-container (tokio::Command) spawn paths.
+enum JobIo {
+    File {
+        stdin: Option<OwnedFd>,
+        stdout: OwnedFd,
+        stderr: OwnedFd,
+    },
+    Pty {
+        master: OwnedFd,
+        slave: OwnedFd,
+    },
+}
+
+/// `Copy` snapshot of raw fds from a `JobIo`, safe to move into a `pre_exec`
+/// closure or use in a raw-fork child. The parent retains ownership of the
+/// underlying `OwnedFd`s so they stay valid through the fork boundary.
+#[derive(Clone, Copy)]
+pub(crate) enum JobIoRaw {
+    File {
+        stdin: Option<RawFd>,
+        stdout: RawFd,
+        stderr: RawFd,
+    },
+    Pty {
+        master: RawFd,
+        slave: RawFd,
+    },
+}
+
+impl JobIo {
+    fn raw(&self) -> JobIoRaw {
+        match self {
+            JobIo::File {
+                stdin,
+                stdout,
+                stderr,
+            } => JobIoRaw::File {
+                stdin: stdin.as_ref().map(|fd| fd.as_raw_fd()),
+                stdout: stdout.as_raw_fd(),
+                stderr: stderr.as_raw_fd(),
+            },
+            JobIo::Pty { master, slave } => JobIoRaw::Pty {
+                master: master.as_raw_fd(),
+                slave: slave.as_raw_fd(),
+            },
+        }
+    }
+
+    /// Parent-side: extract the PTY master fd, dropping everything else.
+    fn into_master(self) -> Option<OwnedFd> {
+        match self {
+            JobIo::Pty { master, .. } => Some(master),
+            JobIo::File { .. } => None,
+        }
+    }
+}
+
+impl JobIoRaw {
+    /// Wire this job's stdio into the current process.
+    ///
+    /// For File mode: dup2 stdin/stdout/stderr from the opened files.
+    /// For PTY mode: setsid + TIOCSCTTY + dup2 slave + close master.
+    ///
+    /// # Safety
+    /// Must only be called in a child process (post-fork or inside pre_exec).
+    /// All operations are async-signal-safe.
+    pub(crate) unsafe fn wire(self) -> std::io::Result<()> {
+        match self {
+            JobIoRaw::File {
+                stdin,
+                stdout,
+                stderr,
+            } => {
+                if let Some(fd) = stdin {
+                    crate::pty::checked_dup2(fd, libc::STDIN_FILENO)?;
+                    if fd > 2 {
+                        libc::close(fd);
+                    }
+                }
+                crate::pty::checked_dup2(stdout, libc::STDOUT_FILENO)?;
+                if stdout > 2 {
+                    libc::close(stdout);
+                }
+                crate::pty::checked_dup2(stderr, libc::STDERR_FILENO)?;
+                if stderr > 2 && stderr != stdout {
+                    libc::close(stderr);
+                }
+                Ok(())
+            }
+            JobIoRaw::Pty { master, slave } => crate::pty::pty_pre_exec(slave, master),
+        }
+    }
 }
 
 /// A running job process — either a tokio-managed child or a raw-forked container.
@@ -334,30 +444,73 @@ async fn spawn_job_process(
     let script_path = spool_dir.join("spur_job.sh");
     write_job_scratch(&script_path, script, uid, gid).context("failed to write job script")?;
 
-    // Resolve stdout/stderr paths
-    let stdout_resolved = resolve_output_path(stdout_path, job_id, work_dir);
-    let stderr_resolved = resolve_output_path(stderr_path, job_id, work_dir);
+    // Build resolved output paths (empty for PTY mode since output goes to the terminal).
+    let (stdout_resolved, stderr_resolved) = if cfg.io_mode == LaunchIo::Pty {
+        (String::new(), String::new())
+    } else {
+        (
+            resolve_output_path(stdout_path, job_id, work_dir),
+            resolve_output_path(stderr_path, job_id, work_dir),
+        )
+    };
 
-    // Guard: stdin must not overlap stdout/stderr (truncation would destroy input)
-    if !stdin_path.is_empty() {
-        let stdin_resolved = resolve_output_path(stdin_path, job_id, work_dir);
-        if stdin_resolved == stdout_resolved || stdin_resolved == stderr_resolved {
-            anyhow::bail!(
-                "stdin path {} overlaps with an output path; this would truncate the input",
-                stdin_resolved
-            );
+    // Build JobIo: a single object owning the fds for either file or PTY mode.
+    let job_io = match cfg.io_mode {
+        LaunchIo::Pty => {
+            let (master, slave) = crate::pty::openpty_with_winsize(None).context("PTY openpty")?;
+            JobIo::Pty { master, slave }
         }
-    }
+        LaunchIo::File => {
+            let stdin_resolved = if stdin_path.is_empty() {
+                None
+            } else {
+                let r = resolve_output_path(stdin_path, job_id, work_dir);
+                if r == stdout_resolved || r == stderr_resolved {
+                    anyhow::bail!(
+                        "stdin path {} overlaps with an output path; this would truncate the input",
+                        r
+                    );
+                }
+                Some(r)
+            };
 
-    let use_append = open_mode
-        .as_deref()
-        .map(|m| m.eq_ignore_ascii_case("append"))
-        .unwrap_or(false);
+            let use_append = open_mode
+                .as_deref()
+                .map(|m| m.eq_ignore_ascii_case("append"))
+                .unwrap_or(false);
 
-    // Opened as the submitting user, not root — see open_job_output.
-    let (stdout_file, stderr_file) =
-        open_job_output(uid, gid, use_append, &stdout_resolved, &stderr_resolved)
-            .context("failed to open job output files")?;
+            let (out, err) =
+                open_job_output(uid, gid, use_append, &stdout_resolved, &stderr_resolved)
+                    .context("failed to open job output files")?;
+
+            let stdin_fd = match stdin_resolved {
+                None => None,
+                Some(ref resolved) => {
+                    if uid > 0 {
+                        use std::os::unix::fs::MetadataExt;
+                        let meta = std::fs::metadata(resolved)
+                            .with_context(|| format!("stdin file not found: {}", resolved))?;
+                        let (fuid, fgid, mode) = (meta.uid(), meta.gid(), meta.mode());
+                        let readable = (fuid == uid && mode & 0o400 != 0)
+                            || (fgid == gid && mode & 0o040 != 0)
+                            || (mode & 0o004 != 0);
+                        if !readable {
+                            anyhow::bail!("stdin file {} is not readable by uid {}", resolved, uid);
+                        }
+                    }
+                    let f = std::fs::File::open(resolved)
+                        .with_context(|| format!("failed to open stdin file: {}", resolved))?;
+                    Some(OwnedFd::from(f))
+                }
+            };
+
+            JobIo::File {
+                stdin: stdin_fd,
+                stdout: OwnedFd::from(out),
+                stderr: OwnedFd::from(err),
+            }
+        }
+    };
 
     let mut env = environment.clone();
 
@@ -397,17 +550,18 @@ async fn spawn_job_process(
 
     // Container jobs: use explicit fork() + container_init() instead of bash wrapper.
     if let Some(ctn) = container {
-        if !stdin_path.is_empty() {
+        if !stdin_path.is_empty() && matches!(job_io, JobIo::File { .. }) {
             warn!(
                 job_id,
                 "stdin redirection is not supported for container jobs, ignoring"
             );
         }
-        let job = launch_container_job(cfg, ctn, &env, stdout_file, stderr_file).await?;
+        let (job, pty_master) = launch_container_job(cfg, ctn, &env, job_io).await?;
         return Ok(LaunchResult {
             job,
             stdout_path: stdout_resolved,
             stderr_path: stderr_resolved,
+            pty_master,
         });
     }
 
@@ -444,38 +598,13 @@ async fn spawn_job_process(
 
     // Launch the process
     let mut cmd = Command::new(&launch_cmd);
-    let stdin_stdio: Stdio = if stdin_path.is_empty() {
-        Stdio::null()
-    } else {
-        let resolved = resolve_output_path(stdin_path, job_id, work_dir);
-        // spurd runs as root; check owner/group/other read bits against
-        // the job's uid/gid so users cannot exfiltrate root-readable files.
-        // Supplementary groups and ACLs are not checked.
-        if uid > 0 {
-            use std::os::unix::fs::MetadataExt;
-            let meta = std::fs::metadata(&resolved)
-                .with_context(|| format!("stdin file not found: {}", resolved))?;
-            let (fuid, fgid, mode) = (meta.uid(), meta.gid(), meta.mode());
-            let readable = (fuid == uid && mode & 0o400 != 0)
-                || (fgid == gid && mode & 0o040 != 0)
-                || (mode & 0o004 != 0);
-            if !readable {
-                anyhow::bail!("stdin file {} is not readable by uid {}", resolved, uid);
-            }
-        }
-        let f = std::fs::File::open(&resolved)
-            .with_context(|| format!("failed to open stdin file: {}", resolved))?;
-        Stdio::from(f)
-    };
     cmd.args(&launch_args)
         .current_dir(work_dir)
         .envs(&env)
-        .stdout(stdout_file)
-        .stderr(stderr_file)
-        .stdin(stdin_stdio)
-        // Run the batch process in its own process group (pgid == its pid) so
-        // signals can target the whole job tree without touching spurd's group.
-        .process_group(0);
+        .process_group(0)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
 
     // Reset signal dispositions to default before exec. spurd is launched in the
     // background (SIGINT/SIGQUIT/SIGHUP set to SIG_IGN), and a child inherits that
@@ -573,7 +702,16 @@ async fn spawn_job_process(
         }
     }
 
+    // Wire job I/O (file dup2 or PTY setsid+TIOCSCTTY+dup2) in the child.
+    let raw_io = job_io.raw();
+    unsafe {
+        cmd.pre_exec(move || raw_io.wire());
+    }
+
     let child = cmd.spawn().context("failed to spawn job process")?;
+
+    // Drop the slave fd immediately so the master gets EOF when the child exits.
+    let pty_master = job_io.into_master();
 
     // Move process into cgroup
     if let Some(ref cgroup) = cgroup_path {
@@ -593,6 +731,7 @@ async fn spawn_job_process(
         job: RunningJob::Managed { child, cgroup_path },
         stdout_path: stdout_resolved,
         stderr_path: stderr_resolved,
+        pty_master,
     })
 }
 
@@ -1074,15 +1213,10 @@ async fn launch_container_job(
     cfg: &JobLaunchConfig,
     ctn: &ContainerLaunchConfig,
     env: &HashMap<String, String>,
-    stdout_fd: std::fs::File,
-    stderr_fd: std::fs::File,
-) -> anyhow::Result<RunningJob> {
+    job_io: JobIo,
+) -> anyhow::Result<(RunningJob, Option<OwnedFd>)> {
     let job_id = cfg.job_id;
     let cgroup_path = setup_cgroup(job_id, cfg.cpus, cfg.memory_mb, &cfg.cpu_ids)?;
-
-    // stdout_fd/stderr_fd are already opened as the submitting user by the
-    // caller (open_job_output). The child dup2's these inherited fds directly,
-    // preserving the append/truncate mode set at open time.
 
     // Sync pipe: child writes status, parent reads.
     // Convert OwnedFd to raw fds for manual lifecycle management across fork.
@@ -1098,6 +1232,11 @@ async fn launch_container_job(
     // Keep OwnedFd alive so the fds aren't closed prematurely
     let _pipe_r_owner = pipe_r;
     let _pipe_w_owner = pipe_w;
+
+    // Snapshot raw I/O fds before fork — the Copy JobIoRaw can be used
+    // in the child without owning the fds (parent's OwnedFds keep them alive
+    // across the fork boundary).
+    let raw_io = job_io.raw();
 
     // Snapshot everything the child needs (must not reference async state after fork)
     let config = &ctn.config;
@@ -1120,14 +1259,13 @@ async fn launch_container_job(
                 libc::signal(libc::SIGPIPE, libc::SIG_DFL);
             }
 
-            // Redirect stdout/stderr to the user-opened output files (inherited
-            // fds), then let close_inherited_fds reap the now-redundant originals.
+            // wire() must run before close_inherited_fds: it dup2's the
+            // job's fds onto 0/1/2, then close_inherited_fds reaps
+            // everything else > 2 (except ready_w).
             unsafe {
-                libc::dup2(stdout_fd.as_raw_fd(), libc::STDOUT_FILENO);
-                libc::dup2(stderr_fd.as_raw_fd(), libc::STDERR_FILENO);
+                let _ = raw_io.wire();
             }
 
-            // Close inherited fds (gRPC sockets, other jobs' files)
             crate::container::close_inherited_fds(ready_w);
 
             // RLIMIT_MEMLOCK: raise while still root, before container_init drops privileges.
@@ -1193,6 +1331,9 @@ async fn launch_container_job(
                 libc::close(ready_w);
             }
 
+            // Drop the slave fd immediately so the master gets EOF when the child exits.
+            let pty_master = job_io.into_master();
+
             let child_pid = child.as_raw();
 
             if let Some(ref cgroup) = cgroup_path {
@@ -1224,12 +1365,15 @@ async fn launch_container_job(
                 "containerized job launched (fork + pivot_root)"
             );
 
-            Ok(RunningJob::Forked {
-                pid: child_pid,
-                _pidfd: pidfd,
-                cgroup_path,
-                reaped: false,
-            })
+            Ok((
+                RunningJob::Forked {
+                    pid: child_pid,
+                    _pidfd: pidfd,
+                    cgroup_path,
+                    reaped: false,
+                },
+                pty_master,
+            ))
         }
     }
 }
@@ -1749,5 +1893,157 @@ mod tests {
 
         assert!(wrapper.contains("renderD128"));
         assert!(!wrapper.contains("nvidia"));
+    }
+
+    #[tokio::test]
+    async fn jobio_wire_pty() {
+        let (master, slave) = crate::pty::openpty_with_winsize(Some(&crate::pty::WindowSize {
+            rows: 24,
+            cols: 80,
+            xpixel: 0,
+            ypixel: 0,
+        }))
+        .expect("openpty");
+
+        let job_io = JobIo::Pty { master, slave };
+        let raw = job_io.raw();
+
+        let mut cmd = Command::new("/bin/echo");
+        cmd.arg("pty_test_output")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+
+        unsafe {
+            cmd.pre_exec(move || raw.wire());
+        }
+
+        let mut child = cmd.spawn().expect("spawn");
+        let master_fd = job_io.into_master().expect("PTY must have master");
+
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        let mut buf = [0u8; 256];
+        let n = unsafe { libc::read(master_fd.as_raw_fd(), buf.as_mut_ptr() as *mut _, buf.len()) };
+        assert!(n > 0, "expected output from PTY master");
+        let output = String::from_utf8_lossy(&buf[..n as usize]);
+        assert!(
+            output.contains("pty_test_output"),
+            "expected 'pty_test_output' in output, got: {output}"
+        );
+
+        let status = child.wait().await.expect("wait");
+        assert!(status.success());
+    }
+
+    #[tokio::test]
+    async fn jobio_wire_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let out_path = dir.path().join("stdout");
+        let err_path = dir.path().join("stderr");
+
+        let out_file = std::fs::File::create(&out_path).unwrap();
+        let err_file = std::fs::File::create(&err_path).unwrap();
+
+        let job_io = JobIo::File {
+            stdin: None,
+            stdout: OwnedFd::from(out_file),
+            stderr: OwnedFd::from(err_file),
+        };
+        let raw = job_io.raw();
+
+        let mut cmd = Command::new("/bin/sh");
+        cmd.arg("-c")
+            .arg("echo file_stdout; echo file_stderr >&2")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+
+        unsafe {
+            cmd.pre_exec(move || raw.wire());
+        }
+
+        let mut child = cmd.spawn().expect("spawn");
+        assert!(job_io.into_master().is_none(), "File mode has no master");
+
+        let status = child.wait().await.expect("wait");
+        assert!(status.success());
+
+        let stdout = std::fs::read_to_string(&out_path).unwrap();
+        let stderr = std::fs::read_to_string(&err_path).unwrap();
+        assert!(
+            stdout.contains("file_stdout"),
+            "expected 'file_stdout' in stdout, got: {stdout}"
+        );
+        assert!(
+            stderr.contains("file_stderr"),
+            "expected 'file_stderr' in stderr, got: {stderr}"
+        );
+    }
+
+    #[test]
+    fn wire_file_closes_originals_gt_2() {
+        // After wire(), originals > 2 should be closed. Verify by checking that
+        // a write to the original fd fails with EBADF.
+        use std::os::fd::AsRawFd;
+        let dir = tempfile::tempdir().unwrap();
+        let out_path = dir.path().join("out");
+        let err_path = dir.path().join("err");
+
+        let out_file = std::fs::File::create(&out_path).unwrap();
+        let err_file = std::fs::File::create(&err_path).unwrap();
+        let out_fd = out_file.as_raw_fd();
+        let err_fd = err_file.as_raw_fd();
+
+        // Both fds should be > 2 since 0/1/2 are taken.
+        assert!(out_fd > 2);
+        assert!(err_fd > 2);
+
+        // Fork so we don't corrupt our own stdio.
+        let pid = unsafe { libc::fork() };
+        assert!(pid >= 0, "fork failed");
+
+        if pid == 0 {
+            let raw = JobIoRaw::File {
+                stdin: None,
+                stdout: out_fd,
+                stderr: err_fd,
+            };
+            let result = unsafe { raw.wire() };
+            // Exit with code 0 on success, 1 on failure.
+            std::process::exit(if result.is_ok() { 0 } else { 1 });
+        }
+
+        // Parent: wait for child.
+        let mut status = 0i32;
+        unsafe { libc::waitpid(pid, &mut status, 0) };
+        assert!(
+            libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0,
+            "child exited with non-zero status"
+        );
+    }
+
+    #[test]
+    fn wire_file_bad_fd_returns_error() {
+        let raw = JobIoRaw::File {
+            stdin: None,
+            stdout: -1,
+            stderr: -1,
+        };
+        // Fork to avoid clobbering test process stdio.
+        let pid = unsafe { libc::fork() };
+        assert!(pid >= 0, "fork failed");
+
+        if pid == 0 {
+            let result = unsafe { raw.wire() };
+            std::process::exit(if result.is_err() { 0 } else { 1 });
+        }
+
+        let mut status = 0i32;
+        unsafe { libc::waitpid(pid, &mut status, 0) };
+        assert!(
+            libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0,
+            "wire() should have returned an error for bad fd"
+        );
     }
 }

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -638,37 +638,27 @@ async fn spawn_job_process(
     }
 
     // Issue #99, #107: Run job as the submitting user (not root).
-    // Must set supplementary groups (video, render) via initgroups()
-    // so the process can access GPU device nodes.
+    // Must set supplementary groups (video, render) so the process can
+    // access GPU device nodes.
     //
     // Issue #128: when use_namespaces is true, the wrapper handles the priv
     // drop *after* unshare runs (via setpriv). Dropping priv here would cause
     // unshare(2) to fail with EPERM since the unprivileged user lacks
     // CAP_SYS_ADMIN.
-    if uid > 0 && nix::unistd::geteuid().is_root() && !use_namespaces {
-        let target_uid = uid;
-        let target_gid = gid;
-        unsafe {
-            cmd.pre_exec(move || {
-                // Set supplementary groups from /etc/group for this user.
-                // This is critical for GPU access — /dev/dri and /dev/kfd
-                // are typically owned by root:video or root:render.
-                let username = nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(target_uid))
-                    .ok()
-                    .flatten()
-                    .map(|u| u.name)
-                    .unwrap_or_else(|| format!("{}", target_uid));
-                let c_name = std::ffi::CString::new(username).unwrap_or_default();
-                libc::initgroups(c_name.as_ptr(), target_gid);
-                Ok(())
-            });
+    if !use_namespaces {
+        if let Some(pd) = crate::privdrop::PrivDrop::resolve_if_needed(uid, gid) {
+            unsafe {
+                cmd.pre_exec(move || {
+                    pd.apply()
+                        .map_err(|e| std::io::Error::from_raw_os_error(e as i32))?;
+                    Ok(())
+                });
+            }
+            debug!(
+                job_id,
+                uid, gid, "job will run as non-root user with supplementary groups"
+            );
         }
-        cmd.uid(uid);
-        cmd.gid(gid);
-        debug!(
-            job_id,
-            uid, gid, "job will run as non-root user with supplementary groups"
-        );
     }
 
     // Issue #99: Apply seccomp-BPF syscall filter (opt-in via SPUR_SECCOMP=1).
@@ -894,40 +884,10 @@ fn should_run_as_user(uid: u32) -> bool {
     uid > 0 && nix::unistd::geteuid().is_root()
 }
 
-/// A user's credentials with the supplementary group list already resolved.
-struct UserCreds {
-    uid: nix::unistd::Uid,
-    gid: nix::unistd::Gid,
-    groups: Vec<nix::unistd::Gid>,
-}
-
-/// Resolve the user's supplementary groups in the parent, before any fork:
-/// `getpwuid_r`/`getgrouplist` allocate and lock, so they're unsafe between fork
-/// and exec in a multithreaded process. Leaves the child only async-signal-safe
-/// syscalls (`apply_user_creds`). Falls back to the primary gid if unresolved.
-fn resolve_user_creds(uid: u32, gid: u32) -> UserCreds {
-    let gid = nix::unistd::Gid::from_raw(gid);
-    let groups = nix::unistd::User::from_uid(nix::unistd::Uid::from_raw(uid))
-        .ok()
-        .flatten()
-        .and_then(|u| std::ffi::CString::new(u.name).ok())
-        .and_then(|name| nix::unistd::getgrouplist(&name, gid).ok())
-        .unwrap_or_else(|| vec![gid]);
-    UserCreds {
-        uid: nix::unistd::Uid::from_raw(uid),
-        gid,
-        groups,
-    }
-}
-
-/// Drop to the submitting user in a forked child using pre-resolved credentials.
-/// Groups before gid before uid, since each drop removes the privilege the prior
-/// step needs. Only setgroups/setgid/setuid run here — all async-signal-safe.
-fn apply_user_creds(creds: &UserCreds) -> nix::Result<()> {
-    nix::unistd::setgroups(&creds.groups)?;
-    nix::unistd::setgid(creds.gid)?;
-    nix::unistd::setuid(creds.uid)?;
-    Ok(())
+/// Resolve and apply user credentials for container fork children.
+/// Delegates to the centralized `PrivDrop` implementation.
+fn resolve_user_creds(uid: u32, gid: u32) -> Option<crate::privdrop::PrivDrop> {
+    crate::privdrop::PrivDrop::resolve_if_needed(uid, gid)
 }
 
 /// Open a single output file, creating parent directories. Runs in whatever
@@ -1027,8 +987,10 @@ fn open_job_output(
             // Exit codes distinguish failure stages.
             drop(parent_sock);
             let code = 'open: {
-                if apply_user_creds(&creds).is_err() {
-                    break 'open 1;
+                if let Some(ref pd) = creds {
+                    if pd.apply().is_err() {
+                        break 'open 1;
+                    }
                 }
                 let Ok(out) = open_output_file(stdout_path, use_append) else {
                     break 'open 2;
@@ -1083,12 +1045,13 @@ fn create_dir_as_user(dir: &Path, uid: u32, gid: u32) -> bool {
     if !should_run_as_user(uid) {
         return std::fs::create_dir_all(dir).is_ok();
     }
-    // Resolve credentials before the fork; see resolve_user_creds.
+    // Resolve credentials before the fork.
     let creds = resolve_user_creds(uid, gid);
     match unsafe { nix::unistd::fork() } {
         Ok(nix::unistd::ForkResult::Child) => {
             // _exit skips atexit/stdio flushing, unsafe in a post-fork child.
-            let ok = apply_user_creds(&creds).is_ok() && std::fs::create_dir_all(dir).is_ok();
+            let ok = creds.as_ref().map(|c| c.apply().is_ok()).unwrap_or(true)
+                && std::fs::create_dir_all(dir).is_ok();
             unsafe { libc::_exit(if ok { 0 } else { 1 }) };
         }
         Ok(nix::unistd::ForkResult::Parent { child }) => {

--- a/crates/spurd/src/job_entry.rs
+++ b/crates/spurd/src/job_entry.rs
@@ -1,8 +1,6 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::PathBuf;
-
 /// Namespace and isolation metadata for a tracked job, used to build the
 /// correct `nsenter` arguments for entering the job's execution context.
 #[derive(Debug, Clone)]
@@ -11,7 +9,6 @@ pub struct JobEntry {
     pub has_pid_namespace: bool,
     pub has_user_namespace: bool,
     pub has_mount_namespace: bool,
-    pub _rootfs: Option<PathBuf>,
     pub uid: u32,
     pub gid: u32,
     pub work_dir: String,
@@ -63,7 +60,6 @@ mod tests {
             has_pid_namespace: true,
             has_user_namespace: false,
             has_mount_namespace: true,
-            _rootfs: None,
             uid: 1000,
             gid: 1000,
             work_dir: "/home/user".into(),
@@ -79,7 +75,6 @@ mod tests {
             has_pid_namespace: true,
             has_user_namespace: true,
             has_mount_namespace: true,
-            _rootfs: Some(PathBuf::from("/var/spool/spur/containers/abc")),
             uid: 0,
             gid: 0,
             work_dir: "/".into(),
@@ -95,7 +90,6 @@ mod tests {
             has_pid_namespace: false,
             has_user_namespace: false,
             has_mount_namespace: false,
-            _rootfs: None,
             uid: 1000,
             gid: 1000,
             work_dir: "/tmp".into(),
@@ -112,7 +106,6 @@ mod tests {
             has_pid_namespace: true,
             has_user_namespace: true,
             has_mount_namespace: true,
-            _rootfs: Some(PathBuf::from("/var/spool/spur/containers/xyz")),
             uid: 1000,
             gid: 1000,
             work_dir: "/".into(),

--- a/crates/spurd/src/job_entry.rs
+++ b/crates/spurd/src/job_entry.rs
@@ -47,6 +47,34 @@ impl JobEntry {
             ("SLURM_JOB_ID".into(), job_id.to_string()),
         ]
     }
+
+    /// Configure privilege drop on a Command for the non-namespace path.
+    ///
+    /// When spurd runs as root and the job belongs to a non-root user, the
+    /// spawned process must not inherit root. For namespace paths, nsenter
+    /// handles this via --setuid/--setgid. For the direct-spawn path (no
+    /// namespaces), we set uid/gid on the Command itself.
+    pub fn apply_privilege_drop(&self, cmd: &mut tokio::process::Command) {
+        let is_root_spurd = nix::unistd::geteuid().is_root();
+        if is_root_spurd && self.uid > 0 && !self.has_namespaces() {
+            cmd.uid(self.uid);
+            cmd.gid(self.gid);
+        }
+    }
+
+    /// Build nsenter arguments with privilege drop included.
+    ///
+    /// When spurd runs as root and the job belongs to a non-root user,
+    /// appends --setuid/--setgid to drop privileges inside the namespace.
+    pub fn nsenter_args_with_priv_drop(&self) -> Vec<String> {
+        let mut args = self.nsenter_args();
+        let is_root_spurd = nix::unistd::geteuid().is_root();
+        if is_root_spurd && self.uid > 0 {
+            args.push(format!("--setuid={}", self.uid));
+            args.push(format!("--setgid={}", self.gid));
+        }
+        args
+    }
 }
 
 #[cfg(test)]

--- a/crates/spurd/src/job_entry.rs
+++ b/crates/spurd/src/job_entry.rs
@@ -47,34 +47,6 @@ impl JobEntry {
             ("SLURM_JOB_ID".into(), job_id.to_string()),
         ]
     }
-
-    /// Configure privilege drop on a Command for the non-namespace path.
-    ///
-    /// When spurd runs as root and the job belongs to a non-root user, the
-    /// spawned process must not inherit root. For namespace paths, nsenter
-    /// handles this via --setuid/--setgid. For the direct-spawn path (no
-    /// namespaces), we set uid/gid on the Command itself.
-    pub fn apply_privilege_drop(&self, cmd: &mut tokio::process::Command) {
-        let is_root_spurd = nix::unistd::geteuid().is_root();
-        if is_root_spurd && self.uid > 0 && !self.has_namespaces() {
-            cmd.uid(self.uid);
-            cmd.gid(self.gid);
-        }
-    }
-
-    /// Build nsenter arguments with privilege drop included.
-    ///
-    /// When spurd runs as root and the job belongs to a non-root user,
-    /// appends --setuid/--setgid to drop privileges inside the namespace.
-    pub fn nsenter_args_with_priv_drop(&self) -> Vec<String> {
-        let mut args = self.nsenter_args();
-        let is_root_spurd = nix::unistd::geteuid().is_root();
-        if is_root_spurd && self.uid > 0 {
-            args.push(format!("--setuid={}", self.uid));
-            args.push(format!("--setgid={}", self.gid));
-        }
-        args
-    }
 }
 
 #[cfg(test)]

--- a/crates/spurd/src/job_entry.rs
+++ b/crates/spurd/src/job_entry.rs
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+
+/// Namespace and isolation metadata for a tracked job, used to build the
+/// correct `nsenter` arguments for entering the job's execution context.
+#[derive(Debug, Clone)]
+pub struct JobEntry {
+    pub pid: i32,
+    pub has_pid_namespace: bool,
+    pub has_user_namespace: bool,
+    pub has_mount_namespace: bool,
+    pub _rootfs: Option<PathBuf>,
+    pub uid: u32,
+    pub gid: u32,
+    pub work_dir: String,
+}
+
+impl JobEntry {
+    /// Build `nsenter` arguments for entering this job's namespaces.
+    ///
+    /// Returns the arguments to pass between `nsenter` and `--`.
+    /// The caller prepends `nsenter` and appends `-- <command>`.
+    pub fn nsenter_args(&self) -> Vec<String> {
+        let mut args = vec!["--target".to_string(), self.pid.to_string()];
+
+        if self.has_user_namespace {
+            args.push("--user".to_string());
+        }
+        if self.has_mount_namespace {
+            args.push("--mount".to_string());
+        }
+        if self.has_pid_namespace {
+            args.push("--pid".to_string());
+        }
+
+        args
+    }
+
+    /// Whether nsenter is useful (at least one namespace to enter).
+    pub fn has_namespaces(&self) -> bool {
+        self.has_pid_namespace || self.has_user_namespace || self.has_mount_namespace
+    }
+
+    /// Build env vars that should be set in the entered context.
+    pub fn env_vars(&self, job_id: u32) -> Vec<(String, String)> {
+        vec![
+            ("SPUR_JOB_ID".into(), job_id.to_string()),
+            ("SLURM_JOB_ID".into(), job_id.to_string()),
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nsenter_args_root_non_container() {
+        let entry = JobEntry {
+            pid: 1234,
+            has_pid_namespace: true,
+            has_user_namespace: false,
+            has_mount_namespace: true,
+            _rootfs: None,
+            uid: 1000,
+            gid: 1000,
+            work_dir: "/home/user".into(),
+        };
+        let args = entry.nsenter_args();
+        assert_eq!(args, vec!["--target", "1234", "--mount", "--pid"]);
+    }
+
+    #[test]
+    fn nsenter_args_root_container() {
+        let entry = JobEntry {
+            pid: 5678,
+            has_pid_namespace: true,
+            has_user_namespace: true,
+            has_mount_namespace: true,
+            _rootfs: Some(PathBuf::from("/var/spool/spur/containers/abc")),
+            uid: 0,
+            gid: 0,
+            work_dir: "/".into(),
+        };
+        let args = entry.nsenter_args();
+        assert_eq!(args, vec!["--target", "5678", "--user", "--mount", "--pid"]);
+    }
+
+    #[test]
+    fn nsenter_args_non_root_no_namespaces() {
+        let entry = JobEntry {
+            pid: 9999,
+            has_pid_namespace: false,
+            has_user_namespace: false,
+            has_mount_namespace: false,
+            _rootfs: None,
+            uid: 1000,
+            gid: 1000,
+            work_dir: "/tmp".into(),
+        };
+        assert!(!entry.has_namespaces());
+        let args = entry.nsenter_args();
+        assert_eq!(args, vec!["--target", "9999"]);
+    }
+
+    #[test]
+    fn nsenter_args_rootless_container() {
+        let entry = JobEntry {
+            pid: 4444,
+            has_pid_namespace: true,
+            has_user_namespace: true,
+            has_mount_namespace: true,
+            _rootfs: Some(PathBuf::from("/var/spool/spur/containers/xyz")),
+            uid: 1000,
+            gid: 1000,
+            work_dir: "/".into(),
+        };
+        let args = entry.nsenter_args();
+        assert_eq!(args, vec!["--target", "4444", "--user", "--mount", "--pid"]);
+        assert!(entry.has_namespaces());
+    }
+}

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -5,8 +5,10 @@ mod agent_server;
 mod cluster;
 pub mod container;
 mod executor;
+pub(crate) mod job_entry;
 mod landlock;
 pub mod pmi;
+pub(crate) mod pty;
 mod reporter;
 mod seccomp;
 

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -8,6 +8,7 @@ mod executor;
 pub(crate) mod job_entry;
 mod landlock;
 pub mod pmi;
+pub(crate) mod privdrop;
 pub(crate) mod pty;
 mod reporter;
 mod seccomp;

--- a/crates/spurd/src/privdrop.rs
+++ b/crates/spurd/src/privdrop.rs
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use nix::unistd::{Gid, Uid};
+
+/// Pre-resolved credentials for privilege drop. Resolve in the parent
+/// (where allocation is safe), apply in the child (async-signal-safe only).
+pub(crate) struct PrivDrop {
+    uid: Uid,
+    gid: Gid,
+    groups: Vec<Gid>,
+}
+
+impl PrivDrop {
+    /// Resolve credentials if privilege drop is needed. Returns None if
+    /// spurd is not root or the job user is already root.
+    pub fn resolve_if_needed(uid: u32, gid: u32) -> Option<Self> {
+        if uid == 0 || !nix::unistd::geteuid().is_root() {
+            return None;
+        }
+        let gid_nix = Gid::from_raw(gid);
+        let groups = nix::unistd::User::from_uid(Uid::from_raw(uid))
+            .ok()
+            .flatten()
+            .and_then(|u| std::ffi::CString::new(u.name).ok())
+            .and_then(|name| nix::unistd::getgrouplist(&name, gid_nix).ok())
+            .unwrap_or_else(|| {
+                tracing::warn!(
+                    uid,
+                    gid,
+                    "user not found in /etc/passwd; falling back to primary gid only"
+                );
+                vec![gid_nix]
+            });
+
+        Some(Self {
+            uid: Uid::from_raw(uid),
+            gid: gid_nix,
+            groups,
+        })
+    }
+
+    /// Apply inside a pre_exec closure (async-signal-safe: setgroups+setgid+setuid).
+    pub fn apply(&self) -> nix::Result<()> {
+        nix::unistd::setgroups(&self.groups)?;
+        nix::unistd::setgid(self.gid)?;
+        nix::unistd::setuid(self.uid)?;
+        Ok(())
+    }
+
+    /// Return nsenter --setuid/--setgid args for the namespace path.
+    pub fn nsenter_args(&self) -> Vec<String> {
+        vec![
+            format!("--setuid={}", self.uid),
+            format!("--setgid={}", self.gid),
+        ]
+    }
+}

--- a/crates/spurd/src/pty.rs
+++ b/crates/spurd/src/pty.rs
@@ -36,8 +36,9 @@ pub fn openpty_with_winsize(ws: Option<&WindowSize>) -> Result<(OwnedFd, OwnedFd
     let pty = openpty(None, None).context("openpty")?;
 
     if let Some(ws) = ws {
-        unsafe {
-            libc::ioctl(pty.slave.as_raw_fd(), libc::TIOCSWINSZ, &ws.to_libc());
+        let ret = unsafe { libc::ioctl(pty.slave.as_raw_fd(), libc::TIOCSWINSZ, &ws.to_libc()) };
+        if ret < 0 {
+            tracing::warn!("TIOCSWINSZ failed: {}", std::io::Error::last_os_error());
         }
     }
 

--- a/crates/spurd/src/pty.rs
+++ b/crates/spurd/src/pty.rs
@@ -1,0 +1,181 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! PTY primitives for interactive job I/O. These are building blocks called
+//! by executor.rs (primary PTY launch) and the interactive_session handler
+//! (overlap/exec-into-job). This module does NOT spawn processes.
+
+use std::os::fd::{AsRawFd, OwnedFd, RawFd};
+
+use anyhow::{Context, Result};
+use nix::pty::openpty;
+use nix::sys::signal::{self, Signal};
+use nix::unistd::Pid;
+
+pub struct WindowSize {
+    pub rows: u16,
+    pub cols: u16,
+    pub xpixel: u16,
+    pub ypixel: u16,
+}
+
+impl WindowSize {
+    pub fn to_libc(&self) -> libc::winsize {
+        libc::winsize {
+            ws_row: self.rows,
+            ws_col: self.cols,
+            ws_xpixel: self.xpixel,
+            ws_ypixel: self.ypixel,
+        }
+    }
+}
+
+/// Open a PTY pair and optionally set the initial window size on the slave.
+/// Returns `(master, slave)`.
+pub fn openpty_with_winsize(ws: Option<&WindowSize>) -> Result<(OwnedFd, OwnedFd)> {
+    let pty = openpty(None, None).context("openpty")?;
+
+    if let Some(ws) = ws {
+        unsafe {
+            libc::ioctl(pty.slave.as_raw_fd(), libc::TIOCSWINSZ, &ws.to_libc());
+        }
+    }
+
+    Ok((pty.master, pty.slave))
+}
+
+/// Pre-exec hook that makes the PTY slave the child's controlling terminal.
+///
+/// Must be called inside an `unsafe { cmd.pre_exec(...) }` closure, after fork
+/// but before exec.
+///
+/// # Safety
+/// Caller must ensure `slave_fd` and `master_fd` are valid open file
+/// descriptors in the child process. Only async-signal-safe operations are used.
+pub unsafe fn pty_pre_exec(slave_fd: RawFd, master_fd: RawFd) -> std::io::Result<()> {
+    if libc::setsid() < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    if libc::ioctl(slave_fd, libc::TIOCSCTTY, 0) < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    checked_dup2(slave_fd, libc::STDIN_FILENO)?;
+    checked_dup2(slave_fd, libc::STDOUT_FILENO)?;
+    checked_dup2(slave_fd, libc::STDERR_FILENO)?;
+
+    if slave_fd > 2 {
+        libc::close(slave_fd);
+    }
+
+    libc::close(master_fd);
+
+    Ok(())
+}
+
+/// Async-signal-safe dup2 wrapper that returns an error on failure.
+pub(crate) unsafe fn checked_dup2(oldfd: RawFd, newfd: RawFd) -> std::io::Result<()> {
+    if libc::dup2(oldfd, newfd) < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Resize a PTY (TIOCSWINSZ on the master fd).
+pub fn resize(master: RawFd, ws: &WindowSize) -> Result<()> {
+    let ret = unsafe { libc::ioctl(master, libc::TIOCSWINSZ, &ws.to_libc()) };
+    if ret < 0 {
+        anyhow::bail!("TIOCSWINSZ failed: {}", std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Send a signal to the foreground process group of the PTY, falling back
+/// to signaling the child directly if `tcgetpgrp` fails.
+pub fn signal_foreground(master: RawFd, child_pid: i32, sig: i32) -> Result<()> {
+    let pgrp = unsafe { libc::tcgetpgrp(master) };
+    if pgrp <= 0 {
+        signal::kill(Pid::from_raw(child_pid), Signal::try_from(sig)?)?;
+    } else {
+        signal::killpg(Pid::from_raw(pgrp), Signal::try_from(sig)?)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn openpty_creates_valid_fds() {
+        let (master, slave) = openpty_with_winsize(None).expect("openpty failed");
+        assert!(master.as_raw_fd() >= 0);
+        assert!(slave.as_raw_fd() >= 0);
+    }
+
+    #[test]
+    fn openpty_sets_winsize() {
+        let ws = WindowSize {
+            rows: 40,
+            cols: 120,
+            xpixel: 0,
+            ypixel: 0,
+        };
+        let (master, _slave) = openpty_with_winsize(Some(&ws)).expect("openpty failed");
+
+        let mut got: libc::winsize = unsafe { std::mem::zeroed() };
+        let ret = unsafe { libc::ioctl(master.as_raw_fd(), libc::TIOCGWINSZ, &mut got) };
+        assert_eq!(ret, 0);
+        assert_eq!(got.ws_row, 40);
+        assert_eq!(got.ws_col, 120);
+    }
+
+    #[test]
+    fn pty_pre_exec_bad_slave_returns_error() {
+        // setsid() will succeed, but dup2 with an invalid fd should fail.
+        let pid = unsafe { libc::fork() };
+        assert!(pid >= 0, "fork failed");
+
+        if pid == 0 {
+            let result = unsafe { pty_pre_exec(-1, -1) };
+            // setsid succeeds, TIOCSCTTY on -1 fails.
+            std::process::exit(if result.is_err() { 0 } else { 1 });
+        }
+
+        let mut status = 0i32;
+        unsafe { libc::waitpid(pid, &mut status, 0) };
+        assert!(
+            libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0,
+            "pty_pre_exec should fail with invalid slave fd"
+        );
+    }
+
+    #[test]
+    fn resize_updates_winsize() {
+        let (master, _slave) = openpty_with_winsize(Some(&WindowSize {
+            rows: 24,
+            cols: 80,
+            xpixel: 0,
+            ypixel: 0,
+        }))
+        .expect("openpty failed");
+
+        resize(
+            master.as_raw_fd(),
+            &WindowSize {
+                rows: 50,
+                cols: 200,
+                xpixel: 0,
+                ypixel: 0,
+            },
+        )
+        .expect("resize failed");
+
+        let mut got: libc::winsize = unsafe { std::mem::zeroed() };
+        let ret = unsafe { libc::ioctl(master.as_raw_fd(), libc::TIOCGWINSZ, &mut got) };
+        assert_eq!(ret, 0);
+        assert_eq!(got.ws_row, 50);
+        assert_eq!(got.ws_col, 200);
+    }
+}

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -859,6 +859,7 @@ message RegisterJobAllocationRequest {
   repeated string gpu_devices = 8;
   ResourceAllocations allocated = 9;
   string mpi = 10;
+  string work_dir = 11;
 }
 
 message RegisterJobAllocationResponse {}

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -164,6 +164,10 @@ message JobSpec {
   // Standalone srun: reserve an allocation without launching a batch script;
   // the user command runs as a job step after nodes are registered.
   bool srun_job = 82;
+
+  // Interactive PTY session (srun --pty)
+  bool pty = 83;
+  WindowSize initial_winsize = 84;
 }
 
 message JobInfo {
@@ -361,8 +365,8 @@ service SlurmAgent {
   // Record an allocation on this node without launching a batch process.
   rpc RegisterJobAllocation(RegisterJobAllocationRequest) returns (RegisterJobAllocationResponse);
   rpc StreamJobOutput(StreamJobOutputRequest) returns (stream StreamJobOutputChunk);
-  // Interactive attach: bidirectional streaming for stdin/stdout forwarding
-  rpc AttachJob(stream AttachJobInput) returns (stream AttachJobOutput);
+  // PTY-backed interactive session (srun --pty, sattach, srun --overlap --pty)
+  rpc InteractiveSession(stream InteractiveInput) returns (stream InteractiveOutput);
 
   // -- Native cluster component control: the controller drives each node's
   //    spurd-owned k0s systemd unit through these. --
@@ -875,14 +879,39 @@ message StreamJobOutputChunk {
   bool eof = 2;
 }
 
-message AttachJobInput {
-  uint32 job_id = 1;   // set on first message; ignored after
-  bytes data = 2;       // stdin data to forward to the job
+// -- Interactive PTY session (srun --pty, sattach, srun --overlap --pty) --
+
+message WindowSize {
+  uint32 rows = 1;
+  uint32 cols = 2;
+  uint32 xpixel = 3;
+  uint32 ypixel = 4;
 }
 
-message AttachJobOutput {
-  bytes data = 1;       // stdout+stderr from the job
-  bool eof = 2;
+message InitSession {
+  uint32 job_id = 1;
+  uint32 step_id = 2;        // 0 = primary job session
+  bool overlap = 3;          // Enter running job's namespaces (--overlap)
+  bool pty = 4;              // Always true for now
+  WindowSize winsize = 5;    // Initial terminal dimensions
+  repeated string argv = 6;  // Command to run (empty = default shell)
+  map<string, string> env = 7;
+}
+
+message InteractiveInput {
+  oneof msg {
+    InitSession init = 1;    // First message: session setup
+    bytes stdin = 2;         // Raw stdin bytes
+    WindowSize resize = 3;   // Terminal resize (SIGWINCH)
+    int32 signal = 4;        // Out-of-band signal to foreground pgrp
+  }
+}
+
+message InteractiveOutput {
+  oneof msg {
+    bytes data = 1;          // PTY master output (stdout+stderr merged)
+    int32 exit_status = 2;   // Final exit code; terminates the stream
+  }
 }
 
 // -- Accounting --
@@ -1116,10 +1145,14 @@ message CreateJobStepRequest {
   repeated string command = 2;
   uint32 num_tasks = 3;
   uint32 cpus_per_task = 4;
+  bool overlap = 5;           // Share resources with existing step (--overlap)
+  bool pty = 6;               // Allocate a PTY for the step
+  WindowSize winsize = 7;     // Initial terminal dimensions
 }
 
 message CreateJobStepResponse {
   uint32 step_id = 1;
+  string node_addr = 2;        // Address of the first allocated node (host:port for agent)
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary

- Add `srun --pty` support: submits a `sleep infinity` holder job for resource allocation, then creates an interactive PTY step for the user's command via the `InteractiveSession` RPC. The holder is cancelled on session exit and the PTY exit code is propagated.
- Add retry loop (up to 5 attempts, 500ms backoff) around `CreateJobStep` + `InteractiveSession` to handle the race between the controller reporting a job as Running and the agent finishing setup.
- Split `interactive.rs` into `open_interactive_session` / `drive_interactive_session` so retry logic can match on `tonic::Status` codes instead of error message text.
- Deduplicate agent connection logic into a shared `connect_agent` helper (used by both `srun` and `sattach`).
- Fall back to `/bin/sh` when `/bin/bash` is missing in container rootfs (fixes container job failures on BusyBox/Alpine).
- Remove unused `rootfs` field from `TrackedJob`/`JobEntry`, replace unreachable priv-drop branch with `debug_assert`, and bound `read_proc_environ` to 1 MiB.

## Test plan

- [x] `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` (clean)
- [x] `cargo test --locked` (all pass)
- [x] Full 25-test bare-metal smoke suite across all 4 nodes:
  - Batch: non-container, container (BusyBox, Alpine), node selection
  - srun non-interactive: non-container, container
  - srun --pty: short commands, interactive shells, container (BusyBox, Alpine), all 4 nodes, exit code propagation, SIGINT cleanup, stderr passthrough, env vars, command-not-found, 5x rapid-fire stress test