### PR TITLE
fix(spurctld): update upsert_account test call for grp_tres arity

### DIFF
--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -1387,7 +1387,7 @@ mod job_history_tests {
             .execute(&pool)
             .await?;
 
-        upsert_account(&pool, &account, "d", "o", None, 1, None).await?;
+        upsert_account(&pool, &account, "d", "o", None, 1, None, None).await?;
         add_user(
             &pool,
             &matching_user,


### PR DESCRIPTION
## What

`main` currently fails to compile the `spurctld` test target:

```
error[E0061]: this function takes 8 arguments but 7 arguments were supplied
  --> crates/spurctld/src/accounting/db.rs:1390:9
```

## Cause

This is a cross-commit / semantic-merge conflict, not a mistake in either PR on its own:

- #477 added a `grp_tres: Option<&str>` parameter to `db::upsert_account` and updated every call site it could see.
- #447 concurrently added a new `upsert_account(...)` call inside the accounting DB tests, written against the old 7-argument signature.

Each PR's CI was green against the `main` it branched from, so neither run saw the other's change. When both landed, the new call site from #447 was left calling the new 8-argument signature from #477 with only 7 arguments — a conflict textual merge can't catch, so `main` broke on merge.

## Fix

Pass `None` for `grp_tres` at the one stale call site, matching every other `upsert_account` test call. Test-only, one line.

## Testing

`cargo clippy -p spurctld --all-targets` and `cargo fmt --all --check` are clean. The affected call is in an `#[ignore]` Postgres-backed test that CI runs against its database.