### PR TITLE
feat(spurctld): report node-resolved job output path in scontrol

### DIFF
--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -664,8 +664,9 @@ pub struct Job {
     pub bb_stage_state: BbStageState,
 
     /// Absolute path the primary agent resolved at launch (incl. `/tmp` fallback).
-    /// Best-effort, not Raft-replicated: `None` before launch and after a failover/
-    /// restart that missed it, when queries use `resolved_stdout`/`resolved_stderr`.
+    /// Best-effort advisory: set post-launch, not via WAL replay (may ride along in a
+    /// snapshot). `None` before launch or after a failover that missed it, when
+    /// queries fall back to `resolved_stdout`/`resolved_stderr`.
     #[serde(default)]
     pub actual_stdout_path: Option<String>,
     #[serde(default)]
@@ -846,34 +847,66 @@ pub const DEFAULT_WORK_DIR: &str = "/tmp";
 /// `work_dir` (or `DEFAULT_WORK_DIR` when empty) so it is absolute, matching
 /// Slurm. An empty pattern defaults to `spur-<id>.out`.
 pub fn resolve_output_pattern(pattern: &str, ctx: &OutputPathContext) -> String {
-    let mut result = if pattern.is_empty() {
-        format!("spur-{}.out", ctx.job_id)
+    let default;
+    let template: &str = if pattern.is_empty() {
+        default = format!("spur-{}.out", ctx.job_id);
+        &default
     } else {
-        pattern.to_string()
+        pattern
     };
-    result = result.replace("%j", &ctx.job_id.to_string());
-    result = result.replace("%J", &ctx.job_id.to_string());
-    result = result.replace("%x", ctx.name);
-    if let Some(tid) = ctx.array_task_id {
-        result = result.replace("%a", &tid.to_string());
-        result = result.replace("%A", &ctx.array_job_id.unwrap_or(ctx.job_id).to_string());
+
+    // Decide anchoring from the raw pattern, not the expanded result: a crafted
+    // job name (`%x`) could otherwise inject a leading `/` and escape work_dir.
+    let anchor = std::path::Path::new(template).is_relative();
+    let expanded = expand_pattern_codes(template, ctx);
+    if !anchor {
+        return expanded;
     }
-    if let Some(node) = ctx.node {
-        result = result.replace("%N", node);
+
+    let base = if ctx.work_dir.is_empty() {
+        DEFAULT_WORK_DIR
+    } else {
+        ctx.work_dir
+    };
+    // Join by hand (not `Path::join`, which a substituted leading `/` would
+    // short-circuit) so an injected absolute value still lands under `base`.
+    format!(
+        "{}/{}",
+        base.trim_end_matches('/'),
+        expanded.trim_start_matches('/')
+    )
+}
+
+/// Single-pass `%`-code expansion. Unlike a chain of `str::replace`, a value
+/// spliced in for one code is never rescanned for a later code. Unknown or
+/// inapplicable codes (`%a`/`%A`/`%N` off an array/node) are left verbatim.
+fn expand_pattern_codes(template: &str, ctx: &OutputPathContext) -> String {
+    let mut out = String::with_capacity(template.len());
+    let mut chars = template.chars();
+    while let Some(c) = chars.next() {
+        if c != '%' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('j') | Some('J') => out.push_str(&ctx.job_id.to_string()),
+            Some('x') => out.push_str(ctx.name),
+            Some('u') => out.push_str(ctx.user),
+            Some('a') if ctx.array_task_id.is_some() => {
+                out.push_str(&ctx.array_task_id.unwrap_or_default().to_string());
+            }
+            Some('A') if ctx.array_task_id.is_some() => {
+                out.push_str(&ctx.array_job_id.unwrap_or(ctx.job_id).to_string());
+            }
+            Some('N') if ctx.node.is_some() => out.push_str(ctx.node.unwrap_or_default()),
+            Some(other) => {
+                out.push('%');
+                out.push(other);
+            }
+            None => out.push('%'),
+        }
     }
-    result = result.replace("%u", ctx.user);
-    if std::path::Path::new(&result).is_relative() {
-        let base = if ctx.work_dir.is_empty() {
-            DEFAULT_WORK_DIR
-        } else {
-            ctx.work_dir
-        };
-        result = std::path::Path::new(base)
-            .join(&result)
-            .to_string_lossy()
-            .into_owned();
-    }
-    result
+    out
 }
 
 /// State transitions.
@@ -1083,6 +1116,53 @@ mod tests {
             },
         );
         assert_eq!(job.resolved_stdout(), "/shared/job-9.out");
+    }
+
+    // A crafted job name must not turn a relative pattern absolute and escape
+    // work_dir: relativity is judged on the pattern, not the substituted value.
+    #[test]
+    fn resolved_stdout_injected_absolute_name_stays_under_work_dir() {
+        let job = Job::new(
+            5,
+            JobSpec {
+                name: "/abs/evil".into(),
+                work_dir: "/work".into(),
+                stdout_path: Some("%x.out".into()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(job.resolved_stdout(), "/work/abs/evil.out");
+    }
+
+    // A `%` code appearing inside a substituted value is not re-expanded.
+    #[test]
+    fn resolved_stdout_substituted_value_not_re_expanded() {
+        let job = Job::new(
+            7,
+            JobSpec {
+                name: "%u".into(),
+                user: "bob".into(),
+                work_dir: "/work".into(),
+                stdout_path: Some("%x.out".into()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(job.resolved_stdout(), "/work/%u.out");
+    }
+
+    // Absoluteness is guaranteed at submission (CLI cwd, agent /tmp fallback),
+    // not fabricated here: a relative work_dir yields a relative path.
+    #[test]
+    fn resolved_stdout_relative_work_dir_anchored_as_is() {
+        let job = Job::new(
+            3,
+            JobSpec {
+                work_dir: "relwork".into(),
+                stdout_path: Some("out.log".into()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(job.resolved_stdout(), "relwork/out.log");
     }
 
     #[test]

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -662,6 +662,14 @@ pub struct Job {
     /// once it completes. A BB job is held off dispatch until `Ready`.
     #[serde(default)]
     pub bb_stage_state: BbStageState,
+
+    /// Absolute output path the primary node's agent actually resolved at launch
+    /// (including the `/tmp` fallback). `None` until launch; queries fall back to
+    /// the computed `resolved_stdout`/`resolved_stderr` while unset.
+    #[serde(default)]
+    pub actual_stdout_path: Option<String>,
+    #[serde(default)]
+    pub actual_stderr_path: Option<String>,
 }
 
 impl Job {
@@ -706,6 +714,8 @@ impl Job {
             suspended_secs: 0,
             bb_stage_state: BbStageState::None,
             srun_step_dispatch: false,
+            actual_stdout_path: None,
+            actual_stderr_path: None,
         }
     }
 
@@ -813,6 +823,14 @@ impl Job {
             result = result.replace("%N", node);
         }
         result = result.replace("%u", &self.spec.user);
+        // Anchor relative patterns to the job's work_dir so the reported path is
+        // absolute (matching Slurm), mirroring how the agent joins its work_dir.
+        if std::path::Path::new(&result).is_relative() && !self.spec.work_dir.is_empty() {
+            result = std::path::Path::new(&self.spec.work_dir)
+                .join(&result)
+                .to_string_lossy()
+                .into_owned();
+        }
         result
     }
 }
@@ -969,6 +987,45 @@ mod tests {
     fn effective_memory_mb_defaults_to_zero_when_unset() {
         let spec = JobSpec::default();
         assert_eq!(effective_memory_mb(&spec, 1), 0);
+    }
+
+    #[test]
+    fn resolved_stdout_default_is_absolute_under_work_dir() {
+        let job = Job::new(
+            7,
+            JobSpec {
+                work_dir: "/home/alice".into(),
+                ..Default::default()
+            },
+        );
+        assert_eq!(job.resolved_stdout(), "/home/alice/spur-7.out");
+        assert_eq!(job.resolved_stderr(), "/home/alice/spur-7.out");
+    }
+
+    #[test]
+    fn resolved_stdout_relative_pattern_joined_and_substituted() {
+        let job = Job::new(
+            42,
+            JobSpec {
+                work_dir: "/work".into(),
+                stdout_path: Some("out-%j.log".into()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(job.resolved_stdout(), "/work/out-42.log");
+    }
+
+    #[test]
+    fn resolved_stdout_absolute_pattern_passes_through() {
+        let job = Job::new(
+            9,
+            JobSpec {
+                work_dir: "/work".into(),
+                stdout_path: Some("/shared/job-%j.out".into()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(job.resolved_stdout(), "/shared/job-9.out");
     }
 
     #[test]
@@ -1535,9 +1592,16 @@ mod tests {
         job.job_id = 42;
         job.spec.name = "train".into();
         job.spec.user = "bob".into();
+        job.spec.work_dir = "/work".into();
 
-        assert_eq!(job.resolve_path("spur-%j.out"), "spur-42.out");
-        assert_eq!(job.resolve_path("output-%x-%u.log"), "output-train-bob.log");
+        // Relative patterns are anchored to work_dir (absolute), matching Slurm.
+        assert_eq!(job.resolve_path("spur-%j.out"), "/work/spur-42.out");
+        assert_eq!(
+            job.resolve_path("output-%x-%u.log"),
+            "/work/output-train-bob.log"
+        );
+        // Absolute patterns pass through unchanged.
+        assert_eq!(job.resolve_path("/abs/out-%j.log"), "/abs/out-42.log");
     }
 
     #[test]
@@ -1612,10 +1676,12 @@ mod tests {
     fn resolved_stdin_expands_pattern() {
         let spec = JobSpec {
             stdin_path: Some("input-%j.txt".into()),
+            work_dir: "/work".into(),
             ..Default::default()
         };
         let job = Job::new(42, spec);
-        assert_eq!(job.resolved_stdin(), Some("input-42.txt".into()));
+        // Relative stdin is anchored to work_dir, mirroring stdout/stderr.
+        assert_eq!(job.resolved_stdin(), Some("/work/input-42.txt".into()));
     }
 
     #[test]

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -663,9 +663,9 @@ pub struct Job {
     #[serde(default)]
     pub bb_stage_state: BbStageState,
 
-    /// Absolute output path the primary node's agent actually resolved at launch
-    /// (including the `/tmp` fallback). `None` until launch; queries fall back to
-    /// the computed `resolved_stdout`/`resolved_stderr` while unset.
+    /// Absolute path the primary agent resolved at launch (incl. `/tmp` fallback).
+    /// Best-effort, not Raft-replicated: `None` before launch and after a failover/
+    /// restart that missed it, when queries use `resolved_stdout`/`resolved_stderr`.
     #[serde(default)]
     pub actual_stdout_path: Option<String>,
     #[serde(default)]
@@ -799,7 +799,8 @@ impl Job {
         self.resolve_path(self.spec.stderr_path.as_deref().unwrap_or("spur-%j.out"))
     }
 
-    /// Resolve stdin path, if set.
+    /// Resolve stdin path, if set. Absolute (anchored like stdout/stderr) and
+    /// controller-display-only; the agent resolves stdin itself at launch.
     pub fn resolved_stdin(&self) -> Option<String> {
         self.spec
             .stdin_path
@@ -808,31 +809,71 @@ impl Job {
     }
 
     fn resolve_path(&self, pattern: &str) -> String {
-        let mut result = pattern.to_string();
-        result = result.replace("%j", &self.job_id.to_string());
-        result = result.replace("%J", &self.job_id.to_string());
-        result = result.replace("%x", &self.spec.name);
-        if let Some(tid) = self.spec.array_task_id {
-            result = result.replace("%a", &tid.to_string());
-            result = result.replace(
-                "%A",
-                &self.spec.array_job_id.unwrap_or(self.job_id).to_string(),
-            );
-        }
-        if let Some(node) = self.allocated_nodes.first() {
-            result = result.replace("%N", node);
-        }
-        result = result.replace("%u", &self.spec.user);
-        // Anchor relative patterns to the job's work_dir so the reported path is
-        // absolute (matching Slurm), mirroring how the agent joins its work_dir.
-        if std::path::Path::new(&result).is_relative() && !self.spec.work_dir.is_empty() {
-            result = std::path::Path::new(&self.spec.work_dir)
-                .join(&result)
-                .to_string_lossy()
-                .into_owned();
-        }
-        result
+        resolve_output_pattern(
+            pattern,
+            &OutputPathContext {
+                job_id: self.job_id,
+                name: &self.spec.name,
+                user: &self.spec.user,
+                work_dir: &self.spec.work_dir,
+                node: self.allocated_nodes.first().map(String::as_str),
+                array_job_id: self.spec.array_job_id,
+                array_task_id: self.spec.array_task_id,
+            },
+        )
     }
+}
+
+/// Inputs for expanding Slurm-style output path patterns. Shared by controller
+/// (fallback) and agent (actual) so both resolve the same location — else
+/// `scontrol` shows a path differing from the real output.
+pub struct OutputPathContext<'a> {
+    pub job_id: JobId,
+    pub name: &'a str,
+    pub user: &'a str,
+    pub work_dir: &'a str,
+    /// `%N`: controller passes the primary node, agent its own target (same for primary).
+    pub node: Option<&'a str>,
+    pub array_job_id: Option<JobId>,
+    pub array_task_id: Option<u32>,
+}
+
+/// Fallback work_dir when a job specifies none; the agent launches here, so
+/// path resolution anchors here too.
+pub const DEFAULT_WORK_DIR: &str = "/tmp";
+
+/// Expand `%j`/`%J`/`%x`/`%u`/`%N`/`%a`/`%A` and anchor a relative result to
+/// `work_dir` (or `DEFAULT_WORK_DIR` when empty) so it is absolute, matching
+/// Slurm. An empty pattern defaults to `spur-<id>.out`.
+pub fn resolve_output_pattern(pattern: &str, ctx: &OutputPathContext) -> String {
+    let mut result = if pattern.is_empty() {
+        format!("spur-{}.out", ctx.job_id)
+    } else {
+        pattern.to_string()
+    };
+    result = result.replace("%j", &ctx.job_id.to_string());
+    result = result.replace("%J", &ctx.job_id.to_string());
+    result = result.replace("%x", ctx.name);
+    if let Some(tid) = ctx.array_task_id {
+        result = result.replace("%a", &tid.to_string());
+        result = result.replace("%A", &ctx.array_job_id.unwrap_or(ctx.job_id).to_string());
+    }
+    if let Some(node) = ctx.node {
+        result = result.replace("%N", node);
+    }
+    result = result.replace("%u", ctx.user);
+    if std::path::Path::new(&result).is_relative() {
+        let base = if ctx.work_dir.is_empty() {
+            DEFAULT_WORK_DIR
+        } else {
+            ctx.work_dir
+        };
+        result = std::path::Path::new(base)
+            .join(&result)
+            .to_string_lossy()
+            .into_owned();
+    }
+    result
 }
 
 /// State transitions.
@@ -1000,6 +1041,22 @@ mod tests {
         );
         assert_eq!(job.resolved_stdout(), "/home/alice/spur-7.out");
         assert_eq!(job.resolved_stderr(), "/home/alice/spur-7.out");
+    }
+
+    #[test]
+    fn resolved_stdout_empty_work_dir_anchors_to_default() {
+        let job = Job::new(
+            7,
+            JobSpec {
+                work_dir: String::new(),
+                ..Default::default()
+            },
+        );
+        // Matches where the agent launches the job, so reported/computed paths agree.
+        assert_eq!(
+            job.resolved_stdout(),
+            format!("{}/spur-7.out", DEFAULT_WORK_DIR)
+        );
     }
 
     #[test]

--- a/crates/spur-k8s/src/agent.rs
+++ b/crates/spur-k8s/src/agent.rs
@@ -441,6 +441,7 @@ impl SlurmAgent for VirtualAgent {
                 Ok(Response::new(LaunchJobResponse {
                     success: true,
                     error: String::new(),
+                    ..Default::default()
                 }))
             }
             Err(kube::Error::Api(e)) if e.code == 409 => {
@@ -448,6 +449,7 @@ impl SlurmAgent for VirtualAgent {
                 Ok(Response::new(LaunchJobResponse {
                     success: true,
                     error: String::new(),
+                    ..Default::default()
                 }))
             }
             Err(e) => {
@@ -455,6 +457,7 @@ impl SlurmAgent for VirtualAgent {
                 Ok(Response::new(LaunchJobResponse {
                     success: false,
                     error: e.to_string(),
+                    ..Default::default()
                 }))
             }
         }

--- a/crates/spur-tests/src/t28_arrays.rs
+++ b/crates/spur-tests/src/t28_arrays.rs
@@ -55,7 +55,8 @@ mod tests {
         job.spec.array_job_id = Some(100);
         job.spec.array_task_id = Some(5);
 
-        assert_eq!(job.resolved_stdout(), "output_100_5.log");
+        // Relative patterns are anchored to work_dir (default /tmp), matching Slurm.
+        assert_eq!(job.resolved_stdout(), "/tmp/output_100_5.log");
     }
 
     #[test]
@@ -69,8 +70,8 @@ mod tests {
                 ..Default::default()
             },
         );
-        // %A and %a should not be substituted for non-array jobs
-        assert_eq!(job.resolved_stdout(), "output_%A_%a.log");
+        // %A/%a stay intact for non-array jobs; relative path anchored to /tmp.
+        assert_eq!(job.resolved_stdout(), "/tmp/output_%A_%a.log");
     }
 
     // ── T28.5: Array job IDs ─────────────────────────────────────

--- a/crates/spur-tests/src/t50_core.rs
+++ b/crates/spur-tests/src/t50_core.rs
@@ -112,7 +112,8 @@ mod tests {
     fn t50_15_path_resolve_job_id() {
         let mut job = make_job("train");
         job.job_id = 42;
-        assert_eq!(job.resolved_stdout(), "spur-42.out");
+        // Relative default is anchored to work_dir (/tmp), matching Slurm.
+        assert_eq!(job.resolved_stdout(), "/tmp/spur-42.out");
     }
 
     #[test]
@@ -121,7 +122,7 @@ mod tests {
         job.job_id = 42;
         job.spec.user = "bob".into();
         job.spec.stdout_path = Some("output-%x-%u-%j.log".into());
-        assert_eq!(job.resolved_stdout(), "output-train-bob-42.log");
+        assert_eq!(job.resolved_stdout(), "/tmp/output-train-bob-42.log");
     }
 
     #[test]
@@ -130,7 +131,7 @@ mod tests {
         job.job_id = 10;
         job.allocated_nodes = vec!["gpu001".into()];
         job.spec.stdout_path = Some("out-%N-%j.log".into());
-        assert_eq!(job.resolved_stdout(), "out-gpu001-10.log");
+        assert_eq!(job.resolved_stdout(), "/tmp/out-gpu001-10.log");
     }
 
     // ── T50.18: Job run time ──────────────────────────────────────

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1569,15 +1569,15 @@ impl ClusterManager {
         Ok(())
     }
 
-    /// Record the absolute output paths resolved by the primary node's agent at
-    /// launch, so queries can report where output actually landed (including the
-    /// `/tmp` fallback). Advisory metadata: updated directly rather than through
-    /// the WAL, mirroring the non-WAL-tracked fields in `update_job`.
+    /// Record the primary agent's resolved output paths for `scontrol`. Display-only
+    /// advisory metadata written straight to the in-memory job, not via Raft/WAL, so
+    /// after failover/restart a leader that missed the launch shows the computed path.
+    /// Empty paths stay `None` (a mixed-version agent decodes the fields as "").
     pub fn set_job_output_paths(&self, job_id: JobId, stdout_path: String, stderr_path: String) {
         let mut jobs = self.jobs.write();
         if let Some(job) = jobs.get_mut(&job_id) {
-            job.actual_stdout_path = Some(stdout_path);
-            job.actual_stderr_path = Some(stderr_path);
+            job.actual_stdout_path = (!stdout_path.is_empty()).then_some(stdout_path);
+            job.actual_stderr_path = (!stderr_path.is_empty()).then_some(stderr_path);
         }
     }
 
@@ -3121,6 +3121,9 @@ impl ClusterManager {
         job.allocated_resources = None;
         job.per_node_alloc.clear();
         job.pending_reason = PendingReason::None;
+        // Stale after requeue (points at nodes the job left); next dispatch resets it.
+        job.actual_stdout_path = None;
+        job.actual_stderr_path = None;
     }
 
     /// Requeue after a dispatch failure or Timeout/NodeFail: counts against
@@ -10273,6 +10276,10 @@ mod tests {
         .unwrap();
         settle(&cm, id, JobState::Running);
 
+        // A reported path must not survive requeue (points at a node the job leaves).
+        cm.set_job_output_paths(id, "/tmp/spur.out".into(), "/tmp/spur.out".into());
+        assert!(cm.get_job(id).unwrap().actual_stdout_path.is_some());
+
         cm.apply_operation(&WalOperation::JobComplete {
             job_id: id,
             exit_code: -1,
@@ -10305,6 +10312,24 @@ mod tests {
             "allocated_resources should be cleared"
         );
         assert_eq!(job.pending_reason, PendingReason::None);
+        assert!(
+            job.actual_stdout_path.is_none() && job.actual_stderr_path.is_none(),
+            "stale reported output path should be cleared on requeue"
+        );
+    }
+
+    // Empty ("" from a mixed-version agent) must not shadow the computed fallback.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn set_job_output_paths_ignores_empty() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 4, 8000);
+        let id = submit_and_wait(&cm, basic_spec("empty-paths"));
+
+        cm.set_job_output_paths(id, String::new(), String::new());
+        let job = cm.get_job(id).unwrap();
+        assert!(job.actual_stdout_path.is_none());
+        assert!(job.actual_stderr_path.is_none());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1569,6 +1569,18 @@ impl ClusterManager {
         Ok(())
     }
 
+    /// Record the absolute output paths resolved by the primary node's agent at
+    /// launch, so queries can report where output actually landed (including the
+    /// `/tmp` fallback). Advisory metadata: updated directly rather than through
+    /// the WAL, mirroring the non-WAL-tracked fields in `update_job`.
+    pub fn set_job_output_paths(&self, job_id: JobId, stdout_path: String, stderr_path: String) {
+        let mut jobs = self.jobs.write();
+        if let Some(job) = jobs.get_mut(&job_id) {
+            job.actual_stdout_path = Some(stdout_path);
+            job.actual_stderr_path = Some(stderr_path);
+        }
+    }
+
     /// Update node state (admin: drain, resume, etc.)
     ///
     /// When draining a node that still has running jobs, the state is set to

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1570,8 +1570,9 @@ impl ClusterManager {
     }
 
     /// Record the primary agent's resolved output paths for `scontrol`. Display-only
-    /// advisory metadata written straight to the in-memory job, not via Raft/WAL, so
-    /// after failover/restart a leader that missed the launch shows the computed path.
+    /// advisory metadata written straight to the in-memory job — not applied via a WAL
+    /// op (though it may ride along in a periodic snapshot), so a failover before the
+    /// next snapshot falls back to the computed path.
     /// Empty paths stay `None` (a mixed-version agent decodes the fields as "").
     pub fn set_job_output_paths(&self, job_id: JobId, stdout_path: String, stderr_path: String) {
         let mut jobs = self.jobs.write();
@@ -6357,6 +6358,34 @@ mod tests {
 
         let job = cm.get_job(job_id).unwrap();
         assert_eq!(job.state, JobState::Cancelled);
+    }
+
+    // A cancelled job keeps its reported path (unlike requeue): the file was
+    // created there, so scontrol should still point at it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cancel_preserves_output_path() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 4, 8000);
+        let id = submit_and_wait(&cm, basic_spec("cancel-me"));
+
+        let alloc = scalar_alloc(2, 4000);
+        cm.start_job(
+            id,
+            vec!["n1".into()],
+            alloc.clone(),
+            per_node_for(&["n1"], alloc),
+        )
+        .unwrap();
+        settle(&cm, id, JobState::Running);
+
+        cm.set_job_output_paths(id, "/tmp/spur.out".into(), "/tmp/spur.out".into());
+        cm.cancel_job(id, "testuser").unwrap();
+        settle(&cm, id, JobState::Cancelled);
+
+        let job = cm.get_job(id).unwrap();
+        assert_eq!(job.actual_stdout_path.as_deref(), Some("/tmp/spur.out"));
+        assert_eq!(job.actual_stderr_path.as_deref(), Some("/tmp/spur.out"));
     }
 
     /// Drive a fresh job all the way to RUNNING on `node`, returning its id.

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -2430,13 +2430,14 @@ mod tests {
                 .iter()
                 .map(|n| (n.clone(), ResourceAllocations::with_scalar(1, 0)))
                 .collect();
-            cm.start_job(
-                job_id,
-                nodes.clone(),
-                ResourceAllocations::with_scalar(2, 0),
-                per_node_allocs.clone(),
-            )
-            .unwrap();
+            let run_attempt = cm
+                .start_job(
+                    job_id,
+                    nodes.clone(),
+                    ResourceAllocations::with_scalar(2, 0),
+                    per_node_allocs.clone(),
+                )
+                .unwrap();
             settle(&cm, job_id, JobState::Running);
 
             dispatch_job_to_nodes(
@@ -2448,6 +2449,7 @@ mod tests {
                 per_node_allocs,
                 "n1,n2".into(),
                 1,
+                run_attempt,
             )
             .await;
 
@@ -2496,13 +2498,14 @@ mod tests {
                 .iter()
                 .map(|n| (n.clone(), ResourceAllocations::with_scalar(1, 0)))
                 .collect();
-            cm.start_job(
-                job_id,
-                nodes.clone(),
-                ResourceAllocations::with_scalar(2, 0),
-                per_node_allocs.clone(),
-            )
-            .unwrap();
+            let run_attempt = cm
+                .start_job(
+                    job_id,
+                    nodes.clone(),
+                    ResourceAllocations::with_scalar(2, 0),
+                    per_node_allocs.clone(),
+                )
+                .unwrap();
             settle(&cm, job_id, JobState::Running);
 
             dispatch_job_to_nodes(
@@ -2514,6 +2517,7 @@ mod tests {
                 per_node_allocs,
                 "n1,n2".into(),
                 1,
+                run_attempt,
             )
             .await;
 
@@ -2557,13 +2561,14 @@ mod tests {
                 .iter()
                 .map(|n| (n.clone(), ResourceAllocations::with_scalar(1, 0)))
                 .collect();
-            cm.start_job(
-                job_id,
-                nodes.clone(),
-                ResourceAllocations::with_scalar(2, 0),
-                per_node_allocs.clone(),
-            )
-            .unwrap();
+            let run_attempt = cm
+                .start_job(
+                    job_id,
+                    nodes.clone(),
+                    ResourceAllocations::with_scalar(2, 0),
+                    per_node_allocs.clone(),
+                )
+                .unwrap();
             settle(&cm, job_id, JobState::Running);
 
             dispatch_job_to_nodes(
@@ -2575,6 +2580,7 @@ mod tests {
                 per_node_allocs,
                 "n1,n2".into(),
                 1,
+                run_attempt,
             )
             .await;
 

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -762,11 +762,17 @@ struct AgentDispatchParams<'a> {
     run_attempt: u32,
 }
 
+/// Resolved output paths reported by an agent after a successful launch.
+struct LaunchOutcome {
+    stdout_path: String,
+    stderr_path: String,
+}
+
 /// Send a LaunchJob RPC to a node agent.
 async fn dispatch_to_agent(
     agent_addr: &str,
     params: &AgentDispatchParams<'_>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<LaunchOutcome> {
     let mut client = SlurmAgentClient::connect(agent_addr.to_string())
         .await?
         .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
@@ -876,7 +882,10 @@ async fn dispatch_to_agent(
         anyhow::bail!("agent rejected job: {}", inner.error);
     }
 
-    Ok(())
+    Ok(LaunchOutcome {
+        stdout_path: inner.stdout_path,
+        stderr_path: inner.stderr_path,
+    })
 }
 
 /// Outcome of parallel RegisterJobAllocation RPCs for a standalone srun job.
@@ -1052,6 +1061,11 @@ async fn dispatch_job_to_nodes(
     let mut succeeded_nodes: Vec<String> = Vec::new();
     let total = dispatch_nodes.len() as u32;
 
+    // Batch stdout/stderr live on the primary node (task_offset == 0). Capture
+    // only its resolved paths; the JoinSet completes out of order, so select by
+    // this flag rather than arrival order.
+    let mut primary_outcome: Option<LaunchOutcome> = None;
+
     let mut set = tokio::task::JoinSet::new();
     for (node_idx, node_name) in dispatch_nodes.iter().enumerate() {
         let node_info = cluster.get_node(node_name);
@@ -1072,6 +1086,7 @@ async fn dispatch_job_to_nodes(
         let spec = spec.clone();
         let peer_addrs = peer_addrs.clone();
         let task_offset = node_idx as u32 * tasks_per_node;
+        let is_primary = task_offset == 0;
         let target_node = node_name.clone();
         let result_node = node_name.clone();
         let allocated = per_node_allocs.get(node_name).cloned().unwrap_or_default();
@@ -1091,17 +1106,20 @@ async fn dispatch_job_to_nodes(
                 },
             )
             .await;
-            (result_node, result)
+            (result_node, is_primary, result)
         });
     }
 
     while let Some(result) = set.join_next().await {
         match result {
-            Ok((node_name, Ok(()))) => {
+            Ok((node_name, is_primary, Ok(outcome))) => {
                 successes += 1;
                 succeeded_nodes.push(node_name);
+                if is_primary {
+                    primary_outcome = Some(outcome);
+                }
             }
-            Ok((node_name, Err(e))) => {
+            Ok((node_name, _, Err(e))) => {
                 error!(job_id, node = %node_name, error = %e, "dispatch to agent failed");
                 failures += 1;
             }
@@ -1109,6 +1127,15 @@ async fn dispatch_job_to_nodes(
                 error!(job_id, error = %e, "dispatch task panicked");
                 failures += 1;
             }
+        }
+    }
+
+    // Only surface the primary's paths on a clean launch; a partial/total
+    // failure requeues or evicts the job, leaving it to fall back to the
+    // computed path on the next attempt.
+    if failures == 0 {
+        if let Some(outcome) = primary_outcome {
+            cluster.set_job_output_paths(job_id, outcome.stdout_path, outcome.stderr_path);
         }
     }
 
@@ -1947,12 +1974,18 @@ mod tests {
 
             async fn launch_job(
                 &self,
-                _request: tonic::Request<spur_proto::proto::LaunchJobRequest>,
+                request: tonic::Request<spur_proto::proto::LaunchJobRequest>,
             ) -> Result<tonic::Response<spur_proto::proto::LaunchJobResponse>, tonic::Status>
             {
+                // Echo a path keyed by task_offset so tests can assert the
+                // controller keeps the primary node's (task_offset == 0) path.
+                let req = request.into_inner();
+                let path = format!("/spool/off{}/spur.out", req.task_offset);
                 Ok(tonic::Response::new(spur_proto::proto::LaunchJobResponse {
                     success: true,
                     error: String::new(),
+                    stdout_path: path.clone(),
+                    stderr_path: path,
                 }))
             }
 
@@ -2364,6 +2397,132 @@ mod tests {
             let job = cm.get_job(job_id).unwrap();
             assert_eq!(job.state, JobState::Pending);
             assert!(job.allocated_nodes.is_empty());
+        }
+
+        // Mock agents echo an offset-keyed path; the stored path must be the
+        // primary's (task_offset == 0) regardless of which response arrives first.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn clean_dispatch_stores_primary_node_output_path() {
+            use spur_core::job::JobState;
+
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+
+            let (addr1, _) = spawn_mock_agent().await;
+            let (addr2, _) = spawn_mock_agent().await;
+            register_node_at(&cm, "n1", addr1);
+            register_node_at(&cm, "n2", addr2);
+
+            let spec = JobSpec {
+                name: "multi-out".into(),
+                user: "testuser".into(),
+                num_nodes: 2,
+                num_tasks: 2,
+                cpus_per_task: 1,
+                work_dir: "/tmp".into(),
+                ..Default::default()
+            };
+            let job_id = submit_and_wait(&cm, spec.clone());
+            let spec = cm.get_job(job_id).unwrap().spec;
+
+            let nodes = vec!["n1".to_string(), "n2".to_string()];
+            let per_node_allocs: HashMap<String, ResourceAllocations> = nodes
+                .iter()
+                .map(|n| (n.clone(), ResourceAllocations::with_scalar(1, 0)))
+                .collect();
+            cm.start_job(
+                job_id,
+                nodes.clone(),
+                ResourceAllocations::with_scalar(2, 0),
+                per_node_allocs.clone(),
+            )
+            .unwrap();
+            settle(&cm, job_id, JobState::Running);
+
+            dispatch_job_to_nodes(
+                cm.clone(),
+                job_id,
+                nodes,
+                spec,
+                Vec::new(),
+                per_node_allocs,
+                "n1,n2".into(),
+                1,
+            )
+            .await;
+
+            let job = cm.get_job(job_id).unwrap();
+            assert_eq!(
+                job.actual_stdout_path.as_deref(),
+                Some("/spool/off0/spur.out"),
+                "must store the primary (task_offset==0) node's path"
+            );
+            assert_eq!(
+                job.actual_stderr_path.as_deref(),
+                Some("/spool/off0/spur.out")
+            );
+        }
+
+        // If the primary node fails to launch, the dispatch requeues/evicts the
+        // job and no output path is recorded, so queries fall back to the
+        // computed path.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn failed_primary_leaves_output_path_unset() {
+            use spur_core::job::JobState;
+
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+
+            // Primary (n1) is unreachable; secondary (n2) accepts.
+            let bad_addr = unreachable_addr().await;
+            let (good_addr, _) = spawn_mock_agent().await;
+            register_node_at(&cm, "n1", bad_addr);
+            register_node_at(&cm, "n2", good_addr);
+
+            let spec = JobSpec {
+                name: "primary-fail".into(),
+                user: "testuser".into(),
+                num_nodes: 2,
+                num_tasks: 2,
+                cpus_per_task: 1,
+                work_dir: "/tmp".into(),
+                ..Default::default()
+            };
+            let job_id = submit_and_wait(&cm, spec.clone());
+            let spec = cm.get_job(job_id).unwrap().spec;
+
+            let nodes = vec!["n1".to_string(), "n2".to_string()];
+            let per_node_allocs: HashMap<String, ResourceAllocations> = nodes
+                .iter()
+                .map(|n| (n.clone(), ResourceAllocations::with_scalar(1, 0)))
+                .collect();
+            cm.start_job(
+                job_id,
+                nodes.clone(),
+                ResourceAllocations::with_scalar(2, 0),
+                per_node_allocs.clone(),
+            )
+            .unwrap();
+            settle(&cm, job_id, JobState::Running);
+
+            dispatch_job_to_nodes(
+                cm.clone(),
+                job_id,
+                nodes,
+                spec,
+                Vec::new(),
+                per_node_allocs,
+                "n1,n2".into(),
+                1,
+            )
+            .await;
+
+            let job = cm.get_job(job_id).unwrap();
+            assert!(
+                job.actual_stdout_path.is_none(),
+                "a failed dispatch must not record an output path"
+            );
+            assert!(job.actual_stderr_path.is_none());
         }
     }
 

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -2524,6 +2524,67 @@ mod tests {
             );
             assert!(job.actual_stderr_path.is_none());
         }
+
+        // A secondary-node failure (primary succeeds) still evicts/requeues the
+        // job, so the `failures == 0` gate must skip storing the primary's path.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn secondary_failure_leaves_output_path_unset() {
+            use spur_core::job::JobState;
+
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+
+            // Primary (n1) accepts; secondary (n2) is unreachable.
+            let (good_addr, _) = spawn_mock_agent().await;
+            let bad_addr = unreachable_addr().await;
+            register_node_at(&cm, "n1", good_addr);
+            register_node_at(&cm, "n2", bad_addr);
+
+            let spec = JobSpec {
+                name: "secondary-fail".into(),
+                user: "testuser".into(),
+                num_nodes: 2,
+                num_tasks: 2,
+                cpus_per_task: 1,
+                work_dir: "/tmp".into(),
+                ..Default::default()
+            };
+            let job_id = submit_and_wait(&cm, spec.clone());
+            let spec = cm.get_job(job_id).unwrap().spec;
+
+            let nodes = vec!["n1".to_string(), "n2".to_string()];
+            let per_node_allocs: HashMap<String, ResourceAllocations> = nodes
+                .iter()
+                .map(|n| (n.clone(), ResourceAllocations::with_scalar(1, 0)))
+                .collect();
+            cm.start_job(
+                job_id,
+                nodes.clone(),
+                ResourceAllocations::with_scalar(2, 0),
+                per_node_allocs.clone(),
+            )
+            .unwrap();
+            settle(&cm, job_id, JobState::Running);
+
+            dispatch_job_to_nodes(
+                cm.clone(),
+                job_id,
+                nodes,
+                spec,
+                Vec::new(),
+                per_node_allocs,
+                "n1,n2".into(),
+                1,
+            )
+            .await;
+
+            let job = cm.get_job(job_id).unwrap();
+            assert!(
+                job.actual_stdout_path.is_none(),
+                "a partial dispatch failure must not record an output path"
+            );
+            assert!(job.actual_stderr_path.is_none());
+        }
     }
 
     #[test]

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -2394,6 +2394,31 @@ mod tests {
         assert_eq!(status.code(), Code::Internal);
     }
 
+    #[test]
+    fn job_to_proto_output_path_prefers_actual_else_absolute_computed() {
+        use spur_core::job::{Job, JobSpec};
+
+        let mut job = Job::new(
+            42,
+            JobSpec {
+                work_dir: "/home/alice".into(),
+                ..Default::default()
+            },
+        );
+
+        // Unset: absolute computed fallback.
+        let info = job_to_proto(&job);
+        assert_eq!(info.stdout_path, "/home/alice/spur-42.out");
+        assert_eq!(info.stderr_path, "/home/alice/spur-42.out");
+
+        // Set: reported path wins.
+        job.actual_stdout_path = Some("/tmp/spur-42.out".into());
+        job.actual_stderr_path = Some("/tmp/spur-42.out".into());
+        let info = job_to_proto(&job);
+        assert_eq!(info.stdout_path, "/tmp/spur-42.out");
+        assert_eq!(info.stderr_path, "/tmp/spur-42.out");
+    }
+
     fn make_node_info(name: &str) -> NodeInfo {
         NodeInfo {
             name: name.into(),

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -2109,8 +2109,14 @@ fn job_to_proto(job: &spur_core::job::Job) -> JobInfo {
         exit_code: job.exit_code.unwrap_or(0),
         exit_signal: job.exit_signal,
         derived_exit_code: job.derived_exit_code,
-        stdout_path: job.resolved_stdout(),
-        stderr_path: job.resolved_stderr(),
+        stdout_path: job
+            .actual_stdout_path
+            .clone()
+            .unwrap_or_else(|| job.resolved_stdout()),
+        stderr_path: job
+            .actual_stderr_path
+            .clone()
+            .unwrap_or_else(|| job.resolved_stderr()),
         stdin_path: job.resolved_stdin().unwrap_or_default(),
         resources: job.allocated_resources.as_ref().map(allocations_to_proto),
         priority: job.priority,

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -930,6 +930,10 @@ impl SlurmAgent for AgentService {
                 info!(job_id, gpus = ?launch_cfg.gpu_devices, "job launched successfully");
                 let is_root = nix::unistd::geteuid().is_root();
                 let is_container = launch_cfg.container.is_some();
+                // Report the real resolved paths back so the controller can
+                // surface where output actually landed (e.g. the /tmp fallback).
+                let stdout_path = result.stdout_path.clone();
+                let stderr_path = result.stderr_path.clone();
                 let displaced = jobs.insert(
                     job_id,
                     TrackedJob {
@@ -967,6 +971,8 @@ impl SlurmAgent for AgentService {
                 Ok(Response::new(LaunchJobResponse {
                     success: true,
                     error: String::new(),
+                    stdout_path,
+                    stderr_path,
                 }))
             }
             Err(e) => {
@@ -1000,6 +1006,8 @@ impl SlurmAgent for AgentService {
                 Ok(Response::new(LaunchJobResponse {
                     success: false,
                     error: err_msg,
+                    stdout_path: String::new(),
+                    stderr_path: String::new(),
                 }))
             }
         }
@@ -2711,6 +2719,45 @@ mod tests {
             1,
             "GPU allocation must be released after a post-record launch failure"
         );
+    }
+
+    // A successful launch must report the real resolved output path back so the
+    // controller can surface where output landed. With an empty stdout_path the
+    // agent defaults to spur-<id>.out anchored to the job's work_dir.
+    #[tokio::test]
+    async fn launch_reports_resolved_output_paths() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        let work_dir = tempfile::tempdir().unwrap();
+        let work_dir_str = work_dir.path().to_string_lossy().to_string();
+
+        let req = Request::new(LaunchJobRequest {
+            job_id: 77,
+            spec: Some(JobSpec {
+                script: "#!/bin/sh\ntrue\n".into(),
+                cpus_per_task: 1,
+                work_dir: work_dir_str.clone(),
+                ..Default::default()
+            }),
+            allocated: Some(ResourceAllocations {
+                cpus: 1,
+                memory_mb: 0,
+                devices: std::collections::HashMap::new(),
+            }),
+            ..Default::default()
+        });
+
+        let resp = svc.launch_job(req).await.expect("launch should succeed");
+        let inner = resp.into_inner();
+        assert!(inner.success, "launch failed: {}", inner.error);
+        let expected = format!("{}/spur-77.out", work_dir_str);
+        assert_eq!(inner.stdout_path, expected);
+        assert_eq!(inner.stderr_path, expected);
     }
 
     // The monitor loop's reconcile step must reclaim an

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -582,7 +582,7 @@ impl SlurmAgent for AgentService {
         );
 
         let work_dir = if spec.work_dir.is_empty() {
-            "/tmp".to_string()
+            spur_core::job::DEFAULT_WORK_DIR.to_string()
         } else {
             spec.work_dir.clone()
         };
@@ -891,6 +891,11 @@ impl SlurmAgent for AgentService {
             job_id,
             script: launch_script,
             work_dir: work_dir.clone(),
+            name: spec.name.clone(),
+            user: spec.user.clone(),
+            node: req.target_node.clone(),
+            array_job_id: (array_job_id != 0).then_some(array_job_id),
+            array_task_id: (array_job_id != 0).then_some(array_task_id),
             environment: env,
             stdout_path: spec.stdout_path.clone(),
             stderr_path: spec.stderr_path.clone(),

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -73,6 +73,12 @@ pub struct JobLaunchConfig {
     pub job_id: JobId,
     pub script: String,
     pub work_dir: String,
+    /// Needed to expand `%x`/`%u`/`%N`/`%a`/`%A` in output paths as the controller does.
+    pub name: String,
+    pub user: String,
+    pub node: String,
+    pub array_job_id: Option<JobId>,
+    pub array_task_id: Option<u32>,
     pub environment: HashMap<String, String>,
     pub stdout_path: String,
     pub stderr_path: String,
@@ -449,8 +455,8 @@ async fn spawn_job_process(
         ("/dev/null".to_string(), "/dev/null".to_string())
     } else {
         (
-            resolve_output_path(stdout_path, job_id, work_dir),
-            resolve_output_path(stderr_path, job_id, work_dir),
+            resolve_output_path(cfg, work_dir, stdout_path),
+            resolve_output_path(cfg, work_dir, stderr_path),
         )
     };
 
@@ -464,7 +470,7 @@ async fn spawn_job_process(
             let stdin_resolved = if stdin_path.is_empty() {
                 None
             } else {
-                let r = resolve_output_path(stdin_path, job_id, work_dir);
+                let r = resolve_output_path(cfg, work_dir, stdin_path);
                 if r == stdout_resolved || r == stderr_resolved {
                     anyhow::bail!(
                         "stdin path {} overlaps with an output path; this would truncate the input",
@@ -1145,23 +1151,21 @@ pub fn cleanup_job_spool(job_id: JobId) {
 }
 
 /// Resolve output path patterns (%j → job_id, etc.)
-fn resolve_output_path(pattern: &str, job_id: JobId, work_dir: &str) -> String {
-    let resolved = if pattern.is_empty() {
-        format!("spur-{}.out", job_id)
-    } else {
-        pattern
-            .replace("%j", &job_id.to_string())
-            .replace("%J", &job_id.to_string())
-    };
-
-    if Path::new(&resolved).is_absolute() {
-        resolved
-    } else {
-        PathBuf::from(work_dir)
-            .join(resolved)
-            .to_string_lossy()
-            .into()
-    }
+/// Resolve a pattern against the *effective* work_dir (may be the `/tmp`
+/// fallback) via the shared resolver, so agent and controller paths match.
+fn resolve_output_path(cfg: &JobLaunchConfig, work_dir: &str, pattern: &str) -> String {
+    spur_core::job::resolve_output_pattern(
+        pattern,
+        &spur_core::job::OutputPathContext {
+            job_id: cfg.job_id,
+            name: &cfg.name,
+            user: &cfg.user,
+            work_dir,
+            node: (!cfg.node.is_empty()).then_some(cfg.node.as_str()),
+            array_job_id: cfg.array_job_id,
+            array_task_id: cfg.array_task_id,
+        },
+    )
 }
 
 /// Launch a containerized job via explicit fork() + container_init().
@@ -1692,17 +1696,54 @@ mod tests {
         assert!(received.is_empty());
     }
 
+    fn launch_cfg_for_paths(job_id: JobId, name: &str, user: &str, node: &str) -> JobLaunchConfig {
+        JobLaunchConfig {
+            job_id,
+            script: String::new(),
+            work_dir: String::new(),
+            name: name.to_string(),
+            user: user.to_string(),
+            node: node.to_string(),
+            array_job_id: None,
+            array_task_id: None,
+            environment: HashMap::new(),
+            stdout_path: String::new(),
+            stderr_path: String::new(),
+            stdin_path: String::new(),
+            cpus: 1,
+            memory_mb: 0,
+            gpu_devices: Vec::new(),
+            cpu_ids: Vec::new(),
+            open_mode: None,
+            uid: 0,
+            gid: 0,
+            container: None,
+            prolog_script: None,
+            partition: String::new(),
+            nodelist: String::new(),
+            host_device_plan: None,
+            memlock: MemlockLimit::Unlimited,
+            io_mode: LaunchIo::File,
+        }
+    }
+
     #[test]
     fn test_resolve_output_path() {
+        let cfg = launch_cfg_for_paths(42, "train", "alice", "node7");
         assert_eq!(
-            resolve_output_path("spur-%j.out", 42, "/home/user"),
+            resolve_output_path(&cfg, "/home/user", "spur-%j.out"),
             "/home/user/spur-42.out"
         );
         assert_eq!(
-            resolve_output_path("/var/log/job-%j.log", 42, "/home/user"),
+            resolve_output_path(&cfg, "/home/user", "/var/log/job-%j.log"),
             "/var/log/job-42.log"
         );
-        assert_eq!(resolve_output_path("", 42, "/tmp"), "/tmp/spur-42.out");
+        assert_eq!(resolve_output_path(&cfg, "/tmp", ""), "/tmp/spur-42.out");
+        // Same codes as the controller (%x/%u/%N), so reported/computed never diverge.
+        assert_eq!(
+            resolve_output_path(&cfg, "/tmp", "out-%x-%u-%N.log"),
+            "/tmp/out-train-alice-node7.log"
+        );
     }
 
     #[test]

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -670,6 +670,8 @@ message LaunchJobRequest {
 message LaunchJobResponse {
   bool success = 1;
   string error = 2;
+  string stdout_path = 3;  // absolute resolved output path on the launching node
+  string stderr_path = 4;
 }
 
 message AgentCancelJobRequest {

--- a/tests/native_host/e2e/test_single_node.py
+++ b/tests/native_host/e2e/test_single_node.py
@@ -88,6 +88,26 @@ class TestJobBasics:
         content = cluster.read_output_on_any_node(path)
         assert "J_OK" in content
 
+    def test_scontrol_reports_absolute_output_path(self, cluster):
+        # A relative -o pattern is resolved to an absolute path on the compute
+        # node and reported back, so `scontrol show job` tells the user exactly
+        # where output landed (anchored to the job's work_dir).
+        script = cluster.write_file("test-abspath.sh", "#!/bin/bash\necho ABSPATH_OK\n")
+        sb = cluster.sbatch(
+            ["-J", "test-abspath", "-N", "1", "-D", cluster.remote_dir,
+             "-o", "rel-%j.out", script]
+        )
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+        wait_job(cluster, job_id, timeout=60)
+
+        show = cluster.scontrol("show", "job", str(job_id))
+        expected = f"StdOut={cluster.remote_dir}/rel-{job_id}.out"
+        assert expected in show, f"expected '{expected}' in:\n{show}"
+
+        content = cluster.read_output_on_any_node(f"{cluster.remote_dir}/rel-{job_id}.out")
+        assert "ABSPATH_OK" in content, f"output:\n{content}"
+
 
 class TestJobLifecycle:
     def test_job_cancel(self, cluster):


### PR DESCRIPTION
## Summary

`scontrol show job` previously showed the controller's *computed* `StdOut`/`StdErr`, which could be relative and — when a node couldn't use the job's `work_dir` and fell back to `/tmp` — pointed at the wrong place entirely. The agent already resolves the real absolute path at launch, but the controller never learned it.

This PR reports the real path back and makes controller/agent resolution provably consistent:

- **Report the resolved path.** `LaunchJobResponse` carries the agent's resolved `stdout_path`/`stderr_path`. The controller stores the primary node's (`task_offset == 0`) paths, selected by node identity since the dispatch `JoinSet` completes out of order. `scontrol` prefers the reported path and falls back to the computed one when unset (pending jobs, mixed-version agents). No file contents are copied — only the location.
- **Single shared resolver.** The agent previously expanded only `%j`/`%J`, so a job using `%x`/`%u`/`%N` in `-o`/`-e` wrote (and would report) an unexpanded filename that diverged from the controller. Both sides now use one resolver in `spur-core` (`resolve_output_pattern` / `OutputPathContext`), so reported and computed paths always agree.
- **Absolute paths, matching Slurm.** Relative patterns anchor to `work_dir`, or to `DEFAULT_WORK_DIR` (`/tmp`) when unset — mirroring where the agent actually launches the job.
- **No stale paths.** The reported path is cleared on requeue/evict so `scontrol` never shows a location on a node the job has left; the next dispatch records the new primary's path.

## Design notes / trade-offs

- The reported path is **best-effort, leader-local advisory metadata** — written to the in-memory job, not replicated via Raft/WAL. After a failover or restart-from-WAL, a leader that never observed the launch falls back to the computed (now absolute) path. This is acceptable because the field is display-only.
- Out of scope: copying back file contents, streaming/`--wait`. The batch script still fans out to all allocated nodes (pre-existing behavior); only the primary node's path is reported.

## Test plan

- [x] `spur-core`: resolver produces absolute paths for relative/`%j`/`%x`/`%u`/`%N` patterns and anchors empty `work_dir` to `/tmp`.
- [x] `spurd`: agent expands the same codes as the controller; a successful launch reports absolute paths.
- [x] `spurctld`: primary-node path stored regardless of `JoinSet` completion order; failed primary leaves paths unset; `job_to_proto` prefers the reported path else the absolute computed one; requeue clears the stale path.
- [x] Updated `t28`/`t50` path assertions to the new absolute form.
- [x] Native e2e: submit with a relative `-o` and assert `scontrol show job` reports the absolute path.
- [x] `cargo fmt --check` + SPDX header pre-commit hook pass.