### PR TITLE
fix(spurd): release GPU reservations stranded mid-launch

### DIFF
--- a/crates/spur-sched/src/cons_tres.rs
+++ b/crates/spur-sched/src/cons_tres.rs
@@ -45,10 +45,8 @@ pub struct NodeAllocation {
     /// orphans reconciled. Source of truth; the bitmaps above are a derived
     /// index for fast free-count queries.
     owners: HashMap<u32, AllocationResult>,
-    /// Reserved but not yet committed to the running set (mid-launch: image
-    /// pull, fork), each with the instant it was reserved. Reconcile spares
-    /// these until they exceed a TTL, so a launch whose future is dropped
-    /// before commit/release cannot pin resources forever.
+    /// Reserved but not yet committed, with reserve time. Reconcile spares
+    /// these until they exceed a TTL so a dropped launch can't pin resources.
     launching: HashMap<u32, Instant>,
 }
 
@@ -218,13 +216,9 @@ impl NodeAllocation {
         true
     }
 
-    /// Release every owned allocation whose job is neither in `live` nor still
-    /// launching within `launching_ttl`, returning the reclaimed ids.
-    /// Self-healing backstop: a teardown that fails to release, or a launch
-    /// whose future is dropped before commit/release, is recovered here
-    /// instead of stranding the node until spurd restart. A launch still
-    /// inside its TTL is spared so an in-flight image pull/fork isn't reclaimed
-    /// out from under itself.
+    /// Release owned allocations whose job is neither live nor launching within
+    /// `launching_ttl`, returning the reclaimed ids. Recovers a failed teardown
+    /// or a dropped launch instead of stranding the node until spurd restart.
     pub fn reconcile(
         &mut self,
         live: &HashSet<u32>,
@@ -498,8 +492,7 @@ mod tests {
         // job 2: committed but NOT live (teardown failed to release — orphan).
         node.allocate_for_job(2, 4, 8_000, &[1]).unwrap();
         node.commit_job(2);
-        // job 3: still launching (reserved, not yet committed) — must be spared
-        // while within its TTL.
+        // job 3: launching within TTL — spared.
         node.allocate_for_job(3, 4, 8_000, &[2]).unwrap();
 
         let live: HashSet<u32> = [1].into_iter().collect();
@@ -508,7 +501,6 @@ mod tests {
         reclaimed.sort();
         assert_eq!(reclaimed, vec![2], "only the orphan (job 2) is reclaimed");
 
-        // job 1 (live) and job 3 (launching, within TTL) still hold resources.
         assert!(!node.release_job(2), "job 2 already reconciled");
         assert!(node.release_job(1));
         assert!(node.release_job(3));
@@ -518,19 +510,15 @@ mod tests {
     #[test]
     fn test_reconcile_reclaims_launching_past_ttl() {
         let mut node = make_node_with_ids(64, 256_000, vec![0, 1, 2, 3], "mi300x");
-        // A launch reserved but never committed/released (future dropped between
-        // reserve and commit) must be reclaimed once it exceeds the TTL, or it
-        // strands the node forever.
+        // A launch reserved but never committed must be reclaimed past the TTL.
         node.allocate_for_job(1, 4, 8_000, &[0]).unwrap();
 
         let live: HashSet<u32> = HashSet::new();
         let ttl = Duration::from_secs(120);
 
-        // Within TTL: spared.
         assert!(node.reconcile(&live, Instant::now(), ttl).is_empty());
         assert_eq!(node.free_gpus(None), 3, "still reserved within TTL");
 
-        // Past TTL: reclaimed. Simulate elapsed time by advancing `now`.
         let future = Instant::now() + Duration::from_secs(121);
         assert_eq!(node.reconcile(&live, future, ttl), vec![1]);
         assert_eq!(node.free_gpus(None), 4, "reclaimed after TTL");

--- a/crates/spur-sched/src/cons_tres.rs
+++ b/crates/spur-sched/src/cons_tres.rs
@@ -200,9 +200,12 @@ impl NodeAllocation {
     }
 
     /// Mark a job's allocation as committed (its process is now tracked), so it
-    /// is no longer exempt from reconcile.
-    pub fn commit_job(&mut self, job_id: u32) {
+    /// is no longer exempt from reconcile. Returns false if the reservation no
+    /// longer exists — reconcile reclaimed it after the launch exceeded the TTL,
+    /// so the caller must not treat the job as backed by an allocation.
+    pub fn commit_job(&mut self, job_id: u32) -> bool {
         self.launching.remove(&job_id);
+        self.owners.contains_key(&job_id)
     }
 
     /// Release a job's allocation by id. Idempotent: releasing an unknown or
@@ -524,6 +527,33 @@ mod tests {
         let future = Instant::now() + Duration::from_secs(121);
         assert_eq!(node.reconcile(&live, future, ttl), vec![1]);
         assert_eq!(node.free_gpus(None), 4, "reclaimed after TTL");
+    }
+
+    #[test]
+    fn test_commit_job_reports_reclaimed_reservation() {
+        let mut node = make_node_with_ids(64, 256_000, vec![0, 1], "mi300x");
+        node.allocate_for_job(1, 4, 8_000, &[0]).unwrap();
+        assert!(
+            node.commit_job(1),
+            "commit of a live reservation returns true"
+        );
+
+        // A launch whose reservation reconcile reclaimed before commit: the
+        // owner is gone, so commit must report false and stay a no-op. Keep
+        // job 1 in the live set so only the past-TTL launch (job 2) is reclaimed.
+        node.allocate_for_job(2, 4, 8_000, &[1]).unwrap();
+        let live: HashSet<u32> = [1].into_iter().collect();
+        let past = Instant::now() + Duration::from_secs(121);
+        node.reconcile(&live, past, Duration::from_secs(120));
+        assert!(
+            !node.commit_job(2),
+            "commit of a reclaimed reservation returns false"
+        );
+        assert_eq!(
+            node.free_gpus(None),
+            1,
+            "reclaimed GPU stays free after the no-op commit"
+        );
     }
 
     #[test]

--- a/crates/spur-sched/src/cons_tres.rs
+++ b/crates/spur-sched/src/cons_tres.rs
@@ -234,7 +234,9 @@ impl NodeAllocation {
                     return false;
                 }
                 match self.launching.get(id) {
-                    Some(reserved_at) => now.duration_since(*reserved_at) >= launching_ttl,
+                    Some(reserved_at) => {
+                        now.saturating_duration_since(*reserved_at) >= launching_ttl
+                    }
                     None => true,
                 }
             })

--- a/crates/spur-sched/src/cons_tres.rs
+++ b/crates/spur-sched/src/cons_tres.rs
@@ -7,6 +7,7 @@
 //! This is the equivalent of Slurm's select/cons_tres plugin.
 
 use std::collections::{HashMap, HashSet};
+use std::time::{Duration, Instant};
 
 use spur_core::resource::{GpuResource, ResourceSet};
 
@@ -45,8 +46,10 @@ pub struct NodeAllocation {
     /// index for fast free-count queries.
     owners: HashMap<u32, AllocationResult>,
     /// Reserved but not yet committed to the running set (mid-launch: image
-    /// pull, fork). Reconcile spares these — not yet tracked, but not orphaned.
-    launching: HashSet<u32>,
+    /// pull, fork), each with the instant it was reserved. Reconcile spares
+    /// these until they exceed a TTL, so a launch whose future is dropped
+    /// before commit/release cannot pin resources forever.
+    launching: HashMap<u32, Instant>,
 }
 
 impl NodeAllocation {
@@ -61,7 +64,7 @@ impl NodeAllocation {
             gpu_allocated: vec![false; num_gpus],
             gpus: resources.gpus.clone(),
             owners: HashMap::new(),
-            launching: HashSet::new(),
+            launching: HashMap::new(),
         }
     }
 
@@ -91,7 +94,7 @@ impl NodeAllocation {
     pub fn conflicting_owners(&self, device_ids: &[u32]) -> Vec<u32> {
         self.owners
             .iter()
-            .filter(|(id, _)| !self.launching.contains(id))
+            .filter(|(id, _)| !self.launching.contains_key(id))
             .filter(|(_, alloc)| alloc.gpu_ids.iter().any(|g| device_ids.contains(g)))
             .map(|(id, _)| *id)
             .collect()
@@ -151,7 +154,7 @@ impl NodeAllocation {
     ) -> Result<AllocationResult, AllocError> {
         // A launch still in flight (reserved, not yet committed or released) is
         // a genuine concurrent duplicate: a second launch would double-count.
-        if self.launching.contains(&job_id) {
+        if self.launching.contains_key(&job_id) {
             return Err(AllocError::DuplicateJob);
         }
         // A committed reservation still owned here means a prior run's teardown
@@ -194,7 +197,7 @@ impl NodeAllocation {
             memory_mb,
         };
         self.owners.insert(job_id, result.clone());
-        self.launching.insert(job_id);
+        self.launching.insert(job_id, Instant::now());
         Ok(result)
     }
 
@@ -216,15 +219,31 @@ impl NodeAllocation {
     }
 
     /// Release every owned allocation whose job is neither in `live` nor still
-    /// launching, returning the reclaimed ids. Self-healing backstop: if a
-    /// teardown ever fails to release, resources are recovered here instead of
-    /// stranding the node until spurd restart.
-    pub fn reconcile(&mut self, live: &HashSet<u32>) -> Vec<u32> {
+    /// launching within `launching_ttl`, returning the reclaimed ids.
+    /// Self-healing backstop: a teardown that fails to release, or a launch
+    /// whose future is dropped before commit/release, is recovered here
+    /// instead of stranding the node until spurd restart. A launch still
+    /// inside its TTL is spared so an in-flight image pull/fork isn't reclaimed
+    /// out from under itself.
+    pub fn reconcile(
+        &mut self,
+        live: &HashSet<u32>,
+        now: Instant,
+        launching_ttl: Duration,
+    ) -> Vec<u32> {
         let orphaned: Vec<u32> = self
             .owners
             .keys()
             .copied()
-            .filter(|id| !live.contains(id) && !self.launching.contains(id))
+            .filter(|id| {
+                if live.contains(id) {
+                    return false;
+                }
+                match self.launching.get(id) {
+                    Some(reserved_at) => now.duration_since(*reserved_at) >= launching_ttl,
+                    None => true,
+                }
+            })
             .collect();
         for &id in &orphaned {
             self.release_job(id);
@@ -479,19 +498,42 @@ mod tests {
         // job 2: committed but NOT live (teardown failed to release — orphan).
         node.allocate_for_job(2, 4, 8_000, &[1]).unwrap();
         node.commit_job(2);
-        // job 3: still launching (reserved, not yet committed) — must be spared.
+        // job 3: still launching (reserved, not yet committed) — must be spared
+        // while within its TTL.
         node.allocate_for_job(3, 4, 8_000, &[2]).unwrap();
 
         let live: HashSet<u32> = [1].into_iter().collect();
-        let mut reclaimed = node.reconcile(&live);
+        let ttl = Duration::from_secs(120);
+        let mut reclaimed = node.reconcile(&live, Instant::now(), ttl);
         reclaimed.sort();
         assert_eq!(reclaimed, vec![2], "only the orphan (job 2) is reclaimed");
 
-        // job 1 (live) and job 3 (launching) still hold their resources.
+        // job 1 (live) and job 3 (launching, within TTL) still hold resources.
         assert!(!node.release_job(2), "job 2 already reconciled");
         assert!(node.release_job(1));
         assert!(node.release_job(3));
         assert_eq!(node.free_gpus(None), 4);
+    }
+
+    #[test]
+    fn test_reconcile_reclaims_launching_past_ttl() {
+        let mut node = make_node_with_ids(64, 256_000, vec![0, 1, 2, 3], "mi300x");
+        // A launch reserved but never committed/released (future dropped between
+        // reserve and commit) must be reclaimed once it exceeds the TTL, or it
+        // strands the node forever.
+        node.allocate_for_job(1, 4, 8_000, &[0]).unwrap();
+
+        let live: HashSet<u32> = HashSet::new();
+        let ttl = Duration::from_secs(120);
+
+        // Within TTL: spared.
+        assert!(node.reconcile(&live, Instant::now(), ttl).is_empty());
+        assert_eq!(node.free_gpus(None), 3, "still reserved within TTL");
+
+        // Past TTL: reclaimed. Simulate elapsed time by advancing `now`.
+        let future = Instant::now() + Duration::from_secs(121);
+        assert_eq!(node.reconcile(&live, future, ttl), vec![1]);
+        assert_eq!(node.free_gpus(None), 4, "reclaimed after TTL");
     }
 
     #[test]

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -971,14 +971,44 @@ impl SlurmAgent for AgentService {
         };
 
         match executor::launch_job(&launch_cfg, (*self.spank).as_ref()).await {
-            Ok(result) => {
+            Ok(mut result) => {
                 let mut jobs = self.running.lock().await;
                 // Commit the reservation: the job now has a tracked process, so
                 // it is no longer exempt from reconcile. Take the running lock
                 // first so a job is never briefly absent from BOTH `running` and
                 // `launching` (which would let reconcile reclaim it).
-                self.allocation.lock().await.commit_job(job_id);
+                let committed = self.allocation.lock().await.commit_job(job_id);
                 reservation_guard.disarm();
+
+                // reconcile reclaimed the reservation mid-launch (launch exceeded
+                // the TTL). Don't track a job with no backing allocation — kill,
+                // reap, and clean up its cgroup/rootfs/spool (mirroring the
+                // monitor loop's completion teardown, which never runs since the
+                // job never enters `running`), then fail the launch.
+                if !committed {
+                    drop(jobs);
+                    warn!(
+                        job_id,
+                        "reservation reclaimed during launch; aborting to avoid running unbacked"
+                    );
+                    let _ = result.job.kill_signal(nix::sys::signal::Signal::SIGKILL);
+                    let cgroup = result.job.take_cgroup();
+                    tokio::spawn(async move {
+                        while let Ok(None) = result.job.try_wait() {
+                            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                        }
+                        crate::container::cleanup_rootfs(job_id, &rootfs_mode);
+                        crate::executor::cleanup_job_spool(job_id);
+                        if let Some(ref cg) = cgroup {
+                            crate::executor::cleanup_cgroup(cg);
+                        }
+                    });
+                    return Ok(Response::new(LaunchJobResponse {
+                        success: false,
+                        error: "reservation reclaimed during launch".into(),
+                    }));
+                }
+
                 info!(job_id, gpus = ?launch_cfg.gpu_devices, "job launched successfully");
                 let is_root = nix::unistd::geteuid().is_root();
                 let is_container = launch_cfg.container.is_some();
@@ -1233,7 +1263,9 @@ impl SlurmAgent for AgentService {
                         req.job_id
                     )),
                 })?;
-            alloc.commit_job(req.job_id);
+            // Reserve and commit under one lock scope, so reconcile can't
+            // interleave and reclaim between them.
+            let _ = alloc.commit_job(req.job_id);
         }
 
         info!(

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -901,6 +901,7 @@ impl SlurmAgent for AgentService {
             Ok(plans) => plans,
             Err(e) => {
                 error!(job_id, error = %e, "device registry resolution failed");
+                self.cleanup_pmi_server(job_id).await;
                 return Err(Status::failed_precondition(format!(
                     "device resolution failed: {}",
                     e
@@ -924,6 +925,7 @@ impl SlurmAgent for AgentService {
                     Some(executor::ContainerLaunchConfig { config, rootfs })
                 }
                 _ => {
+                    self.cleanup_pmi_server(job_id).await;
                     return Err(Status::internal(
                         "internal error: container config missing after setup",
                     ));
@@ -991,6 +993,7 @@ impl SlurmAgent for AgentService {
                         job_id,
                         "reservation reclaimed during launch; aborting to avoid running unbacked"
                     );
+                    self.cleanup_pmi_server(job_id).await;
                     let _ = result.job.kill_signal(nix::sys::signal::Signal::SIGKILL);
                     let cgroup = result.job.take_cgroup();
                     tokio::spawn(async move {
@@ -1059,6 +1062,7 @@ impl SlurmAgent for AgentService {
             }
             Err(e) => {
                 // reservation_guard releases the allocation on this return.
+                self.cleanup_pmi_server(job_id).await;
                 let is_prolog_failure = matches!(e, executor::LaunchError::PrologFailed(_));
                 let err_msg = e.to_string();
                 error!(job_id, error = %err_msg, "failed to launch job");
@@ -1868,6 +1872,14 @@ impl AgentService {
     async fn drop_tracked_job(&self, job_id: u32) {
         if self.running.lock().await.remove(&job_id).is_some() {
             self.allocation.lock().await.release_job(job_id);
+        }
+    }
+
+    /// Tear down the PMI server started for a job that aborts before it enters
+    /// the running set — the monitor loop's completion cleanup never runs for it.
+    async fn cleanup_pmi_server(&self, job_id: u32) {
+        if let Some(pmi) = self.pmi_servers.lock().await.remove(&job_id) {
+            pmi.cleanup();
         }
     }
 
@@ -3194,6 +3206,34 @@ mod tests {
             svc.free_gpu_count().await,
             1,
             "cancel must release a launching (never-committed) reservation"
+        );
+    }
+
+    // A launch that aborts before entering `running` must tear down its PMI
+    // server, since the monitor loop's completion cleanup never runs for it.
+    #[tokio::test]
+    async fn cleanup_pmi_server_removes_entry_and_socket() {
+        let svc = AgentService::new(
+            test_reporter_with_gpus(&[0]),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        let socket_path = format!("/tmp/spur-pmi-test-{}.sock", std::process::id());
+        let pmi = Arc::new(crate::pmi::PmiServer::new(&socket_path, 2));
+        std::fs::write(&socket_path, b"").expect("create fake socket");
+        svc.pmi_servers.lock().await.insert(42, pmi);
+
+        svc.cleanup_pmi_server(42).await;
+
+        assert!(
+            !svc.pmi_servers.lock().await.contains_key(&42),
+            "pmi server entry must be removed"
+        );
+        assert!(
+            !std::path::Path::new(&socket_path).exists(),
+            "pmi socket file must be removed"
         );
     }
 

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -335,6 +335,11 @@ struct DrainRequest {
     reason: String,
 }
 
+/// A launch reservation that never commits within this bound is treated as
+/// abandoned and reclaimed by reconcile. Sized well above a worst-case image
+/// pull + fork so a genuinely in-flight launch is never reclaimed under it.
+const LAUNCHING_TTL: std::time::Duration = std::time::Duration::from_secs(600);
+
 /// Reclaim allocations whose job is no longer tracked and is not mid-launch,
 /// using the running set as ground truth. Callers hold the `running` lock
 /// across building `running` and this call so the live set is a consistent
@@ -344,12 +349,58 @@ fn reconcile_orphaned_allocations(
     allocation: &mut NodeAllocation,
 ) {
     let live: std::collections::HashSet<u32> = running.keys().copied().collect();
-    let reclaimed = allocation.reconcile(&live);
+    let reclaimed = allocation.reconcile(&live, std::time::Instant::now(), LAUNCHING_TTL);
     if !reclaimed.is_empty() {
         warn!(
             ?reclaimed,
             "reconciled orphaned resource allocations with no tracked job"
         );
+    }
+}
+
+/// Releases a launch reservation if the `launch_job` handler exits between
+/// `allocate_for_job` and `commit_job` — including when the RPC future is
+/// cancelled/dropped mid-launch, which no explicit error path can catch.
+/// `disarm` is called once the job is committed to the running set. Without
+/// this, a dropped launch strands its GPUs in the `launching` set (reconcile
+/// spares in-flight launches), the failure mode that black-holes a node.
+struct LaunchReservationGuard {
+    allocation: Arc<Mutex<NodeAllocation>>,
+    job_id: u32,
+    armed: bool,
+}
+
+impl LaunchReservationGuard {
+    fn new(allocation: Arc<Mutex<NodeAllocation>>, job_id: u32) -> Self {
+        Self {
+            allocation,
+            job_id,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for LaunchReservationGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let job_id = self.job_id;
+        // Drop can't await. The allocation mutex is effectively uncontended on
+        // this path, so try_lock succeeds inline; if it ever doesn't, fall back
+        // to a spawned release so the reservation is never left stranded.
+        if let Ok(mut alloc) = self.allocation.try_lock() {
+            alloc.release_job(job_id);
+        } else {
+            let allocation = self.allocation.clone();
+            tokio::spawn(async move {
+                allocation.lock().await.release_job(job_id);
+            });
+        }
     }
 }
 
@@ -842,9 +893,13 @@ impl SlurmAgent for AgentService {
             .allocate_local_resources(job_id, &spec, req.allocated.as_ref())
             .await?;
 
-        // Any failure before commit must release the reservation, or the GPUs
-        // stay in-use with no tracked job while the controller sees the node
-        // IDLE. Reconcile is a backstop; releasing eagerly reclaims at once.
+        // Any exit before commit — an error path OR a cancelled/dropped launch
+        // future — must release the reservation, or the GPUs stay in-use with no
+        // tracked job while the controller sees the node IDLE. The guard covers
+        // every such exit (including future cancellation, which no explicit
+        // branch can); it is disarmed once the job is committed to `running`.
+        let mut reservation_guard = LaunchReservationGuard::new(self.allocation.clone(), job_id);
+
         let injection = {
             let reg = self.device_registry.lock().await;
             reg.build_job_injection_plans("gpu", &allocated_device_ids, spec.uid, spec.gid)
@@ -853,7 +908,6 @@ impl SlurmAgent for AgentService {
             Ok(plans) => plans,
             Err(e) => {
                 error!(job_id, error = %e, "device registry resolution failed");
-                self.allocation.lock().await.release_job(job_id);
                 return Err(Status::failed_precondition(format!(
                     "device resolution failed: {}",
                     e
@@ -870,14 +924,13 @@ impl SlurmAgent for AgentService {
         let cpu_ids: Vec<u32> = alloc_result.cpu_ids.clone();
 
         // Guard rather than unwrap: these are always Some when the image is
-        // set, but an early exit before commit must release the reservation.
+        // set. An early return here releases the reservation via the guard.
         let container_launch = if !spec.container_image.is_empty() {
             match (container_config.take(), rootfs_path.take()) {
                 (Some(config), Some(rootfs)) => {
                     Some(executor::ContainerLaunchConfig { config, rootfs })
                 }
                 _ => {
-                    self.allocation.lock().await.release_job(job_id);
                     return Err(Status::internal(
                         "internal error: container config missing after setup",
                     ));
@@ -932,6 +985,7 @@ impl SlurmAgent for AgentService {
                 // first so a job is never briefly absent from BOTH `running` and
                 // `launching` (which would let reconcile reclaim it).
                 self.allocation.lock().await.commit_job(job_id);
+                reservation_guard.disarm();
                 info!(job_id, gpus = ?launch_cfg.gpu_devices, "job launched successfully");
                 let is_root = nix::unistd::geteuid().is_root();
                 let is_container = launch_cfg.container.is_some();
@@ -981,8 +1035,7 @@ impl SlurmAgent for AgentService {
                 }))
             }
             Err(e) => {
-                self.allocation.lock().await.release_job(job_id);
-
+                // reservation_guard releases the allocation on this return.
                 let is_prolog_failure = matches!(e, executor::LaunchError::PrologFailed(_));
                 let err_msg = e.to_string();
                 error!(job_id, error = %err_msg, "failed to launch job");
@@ -1030,6 +1083,20 @@ impl SlurmAgent for AgentService {
         } else {
             self.graceful_cancel(job_id).await;
         }
+
+        // The signal paths above only act on a tracked (running) job. If the
+        // controller cancels a job still reserving resources mid-launch (in the
+        // `launching` set, not yet committed to `running`), release it here so a
+        // cancel-during-eviction can't strand the reservation until the TTL.
+        // Hold the running lock across the release so this can't race a launch
+        // committing into `running` in the gap: launch_job takes running before
+        // allocation on commit, so matching that order means we never free a job
+        // that just became running.
+        let jobs = self.running.lock().await;
+        if !jobs.contains_key(&job_id) {
+            self.allocation.lock().await.release_job(job_id);
+        }
+        drop(jobs);
 
         Ok(Response::new(()))
     }
@@ -3071,6 +3138,91 @@ mod tests {
             .await;
         let err = res.expect_err("must reject: GPU 1's owner is still running");
         assert_eq!(err.code(), tonic::Code::ResourceExhausted);
+    }
+
+    // A CancelJob for a job still reserving resources mid-launch (in the
+    // `launching` set, never committed to `running`) must release the
+    // reservation. Otherwise a cancel-during-eviction leaves the GPUs pinned
+    // and reconcile spares them until the TTL, black-holing the node.
+    #[tokio::test]
+    async fn cancel_releases_launching_reservation() {
+        let svc = AgentService::new(
+            test_reporter_with_gpus(&[0]),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        // Reserve GPU 0 as a still-launching job (not committed, not in running).
+        {
+            let mut alloc = svc.allocation.lock().await;
+            alloc.allocate_for_job(7, 1, 0, &[0]).unwrap();
+        }
+        assert_eq!(
+            svc.free_gpu_count().await,
+            0,
+            "GPU reserved while launching"
+        );
+
+        svc.cancel_job(Request::new(AgentCancelJobRequest {
+            job_id: 7,
+            signal: 9,
+        }))
+        .await
+        .expect("cancel_job");
+
+        assert_eq!(
+            svc.free_gpu_count().await,
+            1,
+            "cancel must release a launching (never-committed) reservation"
+        );
+    }
+
+    // The launch reservation guard must release the allocation if the launch
+    // handler's future is dropped after reserving but before committing —
+    // cancellation no explicit error branch can catch.
+    #[tokio::test]
+    async fn reservation_guard_releases_on_drop_when_not_committed() {
+        let svc = AgentService::new(
+            test_reporter_with_gpus(&[0]),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        {
+            svc.allocation
+                .lock()
+                .await
+                .allocate_for_job(9, 1, 0, &[0])
+                .unwrap();
+            let guard = LaunchReservationGuard::new(svc.allocation.clone(), 9);
+            assert_eq!(svc.free_gpu_count().await, 0, "reserved under guard");
+            drop(guard);
+        }
+        assert_eq!(
+            svc.free_gpu_count().await,
+            1,
+            "dropping an un-disarmed guard must release the reservation"
+        );
+
+        // A disarmed guard must NOT release (the job committed successfully).
+        {
+            svc.allocation
+                .lock()
+                .await
+                .allocate_for_job(10, 1, 0, &[0])
+                .unwrap();
+            svc.allocation.lock().await.commit_job(10);
+            let mut guard = LaunchReservationGuard::new(svc.allocation.clone(), 10);
+            guard.disarm();
+            drop(guard);
+        }
+        assert_eq!(
+            svc.free_gpu_count().await,
+            0,
+            "a disarmed guard must leave the committed reservation intact"
+        );
     }
 
     #[tokio::test]

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -68,12 +68,15 @@ struct CompletedJob {
     nodelist: String,
 }
 
+/// Per-node registry of running PMI servers, keyed by job id.
+type PmiServers = Arc<Mutex<HashMap<u32, Arc<PmiServer>>>>;
+
 pub struct AgentService {
     pub reporter: Arc<NodeReporter>,
     running: Arc<Mutex<HashMap<u32, TrackedJob>>>,
     allocation: Arc<Mutex<NodeAllocation>>,
     spank: Arc<Option<SpankHost>>,
-    pmi_servers: Arc<Mutex<HashMap<u32, Arc<PmiServer>>>>,
+    pmi_servers: PmiServers,
     hooks: Arc<HooksConfig>,
     memlock: spur_core::config::MemlockLimit,
     #[allow(dead_code)]
@@ -360,9 +363,12 @@ fn reconcile_orphaned_allocations(
 
 /// Releases a launch reservation if the handler exits between reserve and
 /// commit, including on future cancellation which no error path can catch.
-/// Disarmed once the job is committed to the running set.
+/// Also tears down a PMI server started for the launch (via `adopt_pmi`), since
+/// that too would leak on a cancelled launch. Disarmed once the job is
+/// committed to the running set.
 struct LaunchReservationGuard {
     allocation: Arc<Mutex<NodeAllocation>>,
+    pmi_servers: Option<PmiServers>,
     job_id: u32,
     armed: bool,
 }
@@ -371,9 +377,16 @@ impl LaunchReservationGuard {
     fn new(allocation: Arc<Mutex<NodeAllocation>>, job_id: u32) -> Self {
         Self {
             allocation,
+            pmi_servers: None,
             job_id,
             armed: true,
         }
+    }
+
+    /// Take ownership of the job's PMI server so it is torn down alongside the
+    /// reservation if the launch aborts.
+    fn adopt_pmi(&mut self, pmi_servers: PmiServers) {
+        self.pmi_servers = Some(pmi_servers);
     }
 
     fn disarm(&mut self) {
@@ -387,7 +400,8 @@ impl Drop for LaunchReservationGuard {
             return;
         }
         let job_id = self.job_id;
-        // Drop can't await; try_lock succeeds inline on this uncontended path.
+        // Drop can't await; try_lock succeeds inline on this uncontended path,
+        // else release off-thread so the reservation is never left stranded.
         if let Ok(mut alloc) = self.allocation.try_lock() {
             alloc.release_job(job_id);
         } else if let Ok(handle) = tokio::runtime::Handle::try_current() {
@@ -397,6 +411,27 @@ impl Drop for LaunchReservationGuard {
             });
         }
         // No runtime (shutdown) and lock held: reconcile reclaims via the TTL.
+
+        if let Some(pmi_servers) = self.pmi_servers.take() {
+            let locked_inline = match pmi_servers.try_lock() {
+                Ok(mut map) => {
+                    if let Some(pmi) = map.remove(&job_id) {
+                        pmi.cleanup();
+                    }
+                    true
+                }
+                Err(_) => false,
+            };
+            if !locked_inline {
+                if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                    handle.spawn(async move {
+                        if let Some(pmi) = pmi_servers.lock().await.remove(&job_id) {
+                            pmi.cleanup();
+                        }
+                    });
+                }
+            }
+        }
     }
 }
 
@@ -847,19 +882,6 @@ impl SlurmAgent for AgentService {
             (script, crate::container::RootfsMode::Extracted)
         };
 
-        // PMI-1 server: if MPI mode is "pmi1" and multiple tasks, start a
-        // Unix socket KVS server so MPI ranks can bootstrap via PMI.
-        if spec.mpi == "pmi1" && tasks_per_node > 1 {
-            let socket_path = format!("/tmp/spur-pmi-{}.sock", job_id);
-            let pmi = Arc::new(PmiServer::new(&socket_path, spec.num_tasks));
-            let pmi_run = pmi.clone();
-            tokio::spawn(async move {
-                pmi_run.run().await;
-            });
-            env.insert("PMI_PORT".into(), socket_path.clone());
-            self.pmi_servers.lock().await.insert(job_id, pmi);
-        }
-
         // Multi-task per-node: wrap the user script so it forks N processes,
         // each with a distinct LOCAL_RANK. The wrapper backgrounds N copies and
         // waits for all to finish, so TrackedJob only tracks a single PID (the
@@ -893,6 +915,21 @@ impl SlurmAgent for AgentService {
         // cancelled launch future; disarmed once committed to `running`.
         let mut reservation_guard = LaunchReservationGuard::new(self.allocation.clone(), job_id);
 
+        // PMI-1 server: if MPI mode is "pmi1" and multiple tasks, start a
+        // Unix socket KVS server so MPI ranks can bootstrap via PMI. Started
+        // under the guard so an aborted launch tears it down with the reservation.
+        if spec.mpi == "pmi1" && tasks_per_node > 1 {
+            let socket_path = format!("/tmp/spur-pmi-{}.sock", job_id);
+            let pmi = Arc::new(PmiServer::new(&socket_path, spec.num_tasks));
+            let pmi_run = pmi.clone();
+            tokio::spawn(async move {
+                pmi_run.run().await;
+            });
+            env.insert("PMI_PORT".into(), socket_path);
+            self.pmi_servers.lock().await.insert(job_id, pmi);
+            reservation_guard.adopt_pmi(self.pmi_servers.clone());
+        }
+
         let injection = {
             let reg = self.device_registry.lock().await;
             reg.build_job_injection_plans("gpu", &allocated_device_ids, spec.uid, spec.gid)
@@ -901,7 +938,6 @@ impl SlurmAgent for AgentService {
             Ok(plans) => plans,
             Err(e) => {
                 error!(job_id, error = %e, "device registry resolution failed");
-                self.cleanup_pmi_server(job_id).await;
                 return Err(Status::failed_precondition(format!(
                     "device resolution failed: {}",
                     e
@@ -925,7 +961,6 @@ impl SlurmAgent for AgentService {
                     Some(executor::ContainerLaunchConfig { config, rootfs })
                 }
                 _ => {
-                    self.cleanup_pmi_server(job_id).await;
                     return Err(Status::internal(
                         "internal error: container config missing after setup",
                     ));
@@ -1063,8 +1098,7 @@ impl SlurmAgent for AgentService {
                 }))
             }
             Err(e) => {
-                // reservation_guard releases the allocation on this return.
-                self.cleanup_pmi_server(job_id).await;
+                // reservation_guard releases the allocation and PMI on this return.
                 let is_prolog_failure = matches!(e, executor::LaunchError::PrologFailed(_));
                 let err_msg = e.to_string();
                 error!(job_id, error = %err_msg, "failed to launch job");
@@ -3284,6 +3318,43 @@ mod tests {
         assert!(
             !std::path::Path::new(&socket_path).exists(),
             "pmi socket file must be removed"
+        );
+    }
+
+    // An armed guard that adopted a PMI server must tear it down on drop (the
+    // future-cancellation path); a disarmed guard must leave it for the monitor.
+    #[tokio::test]
+    async fn reservation_guard_tears_down_adopted_pmi_on_drop() {
+        let svc = AgentService::new(
+            test_reporter_with_gpus(&[0]),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        let socket_path = format!("/tmp/spur-pmi-guard-{}.sock", std::process::id());
+        std::fs::write(&socket_path, b"").expect("create fake socket");
+        svc.pmi_servers
+            .lock()
+            .await
+            .insert(88, Arc::new(crate::pmi::PmiServer::new(&socket_path, 2)));
+
+        {
+            let mut guard = LaunchReservationGuard::new(svc.allocation.clone(), 88);
+            guard.adopt_pmi(svc.pmi_servers.clone());
+            drop(guard);
+        }
+        // Drop's off-thread fallback (if try_lock lost) resolves synchronously
+        // here since the map is uncontended, but yield once to be safe.
+        tokio::task::yield_now().await;
+
+        assert!(
+            !svc.pmi_servers.lock().await.contains_key(&88),
+            "armed guard must remove the adopted PMI entry on drop"
+        );
+        assert!(
+            !std::path::Path::new(&socket_path).exists(),
+            "armed guard must remove the PMI socket on drop"
         );
     }
 

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -335,9 +335,8 @@ struct DrainRequest {
     reason: String,
 }
 
-/// A launch reservation that never commits within this bound is treated as
-/// abandoned and reclaimed by reconcile. Sized well above a worst-case image
-/// pull + fork so a genuinely in-flight launch is never reclaimed under it.
+/// Reclaim a launch reservation that never commits within this bound. Sized
+/// above a worst-case image pull + fork so an in-flight launch isn't reclaimed.
 const LAUNCHING_TTL: std::time::Duration = std::time::Duration::from_secs(600);
 
 /// Reclaim allocations whose job is no longer tracked and is not mid-launch,
@@ -358,12 +357,9 @@ fn reconcile_orphaned_allocations(
     }
 }
 
-/// Releases a launch reservation if the `launch_job` handler exits between
-/// `allocate_for_job` and `commit_job` — including when the RPC future is
-/// cancelled/dropped mid-launch, which no explicit error path can catch.
-/// `disarm` is called once the job is committed to the running set. Without
-/// this, a dropped launch strands its GPUs in the `launching` set (reconcile
-/// spares in-flight launches), the failure mode that black-holes a node.
+/// Releases a launch reservation if the handler exits between reserve and
+/// commit, including on future cancellation which no error path can catch.
+/// Disarmed once the job is committed to the running set.
 struct LaunchReservationGuard {
     allocation: Arc<Mutex<NodeAllocation>>,
     job_id: u32,
@@ -390,9 +386,8 @@ impl Drop for LaunchReservationGuard {
             return;
         }
         let job_id = self.job_id;
-        // Drop can't await. The allocation mutex is effectively uncontended on
-        // this path, so try_lock succeeds inline; if it ever doesn't, fall back
-        // to a spawned release so the reservation is never left stranded.
+        // Drop can't await; try_lock succeeds inline on this uncontended path,
+        // else spawn the release so the reservation is never left stranded.
         if let Ok(mut alloc) = self.allocation.try_lock() {
             alloc.release_job(job_id);
         } else {
@@ -893,11 +888,8 @@ impl SlurmAgent for AgentService {
             .allocate_local_resources(job_id, &spec, req.allocated.as_ref())
             .await?;
 
-        // Any exit before commit — an error path OR a cancelled/dropped launch
-        // future — must release the reservation, or the GPUs stay in-use with no
-        // tracked job while the controller sees the node IDLE. The guard covers
-        // every such exit (including future cancellation, which no explicit
-        // branch can); it is disarmed once the job is committed to `running`.
+        // Release the reservation on any exit before commit, including a
+        // cancelled launch future; disarmed once committed to `running`.
         let mut reservation_guard = LaunchReservationGuard::new(self.allocation.clone(), job_id);
 
         let injection = {
@@ -1084,14 +1076,10 @@ impl SlurmAgent for AgentService {
             self.graceful_cancel(job_id).await;
         }
 
-        // The signal paths above only act on a tracked (running) job. If the
-        // controller cancels a job still reserving resources mid-launch (in the
-        // `launching` set, not yet committed to `running`), release it here so a
-        // cancel-during-eviction can't strand the reservation until the TTL.
-        // Hold the running lock across the release so this can't race a launch
-        // committing into `running` in the gap: launch_job takes running before
-        // allocation on commit, so matching that order means we never free a job
-        // that just became running.
+        // The signal paths only act on a running job; release a still-launching
+        // reservation so a cancel-during-eviction doesn't strand it until the
+        // TTL. Hold the running lock across the release (matching launch_job's
+        // commit order) so this can't free a job that just became running.
         let jobs = self.running.lock().await;
         if !jobs.contains_key(&job_id) {
             self.allocation.lock().await.release_job(job_id);
@@ -3140,10 +3128,8 @@ mod tests {
         assert_eq!(err.code(), tonic::Code::ResourceExhausted);
     }
 
-    // A CancelJob for a job still reserving resources mid-launch (in the
-    // `launching` set, never committed to `running`) must release the
-    // reservation. Otherwise a cancel-during-eviction leaves the GPUs pinned
-    // and reconcile spares them until the TTL, black-holing the node.
+    // CancelJob must release a still-launching (never-committed) reservation,
+    // else a cancel-during-eviction strands it until the TTL.
     #[tokio::test]
     async fn cancel_releases_launching_reservation() {
         let svc = AgentService::new(
@@ -3178,9 +3164,8 @@ mod tests {
         );
     }
 
-    // The launch reservation guard must release the allocation if the launch
-    // handler's future is dropped after reserving but before committing —
-    // cancellation no explicit error branch can catch.
+    // The guard must release the reservation when dropped before commit
+    // (the future-cancellation path), and leave it intact once disarmed.
     #[tokio::test]
     async fn reservation_guard_releases_on_drop_when_not_committed() {
         let svc = AgentService::new(

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1009,6 +1009,8 @@ impl SlurmAgent for AgentService {
                     return Ok(Response::new(LaunchJobResponse {
                         success: false,
                         error: "reservation reclaimed during launch".into(),
+                        stdout_path: String::new(),
+                        stderr_path: String::new(),
                     }));
                 }
 
@@ -1225,16 +1227,6 @@ impl SlurmAgent for AgentService {
             return Err(Status::invalid_argument("job_id is required"));
         }
 
-        {
-            let jobs = self.running.lock().await;
-            if jobs.contains_key(&req.job_id) {
-                return Err(Status::already_exists(format!(
-                    "job {} already registered on this node",
-                    req.job_id
-                )));
-            }
-        }
-
         let allocated = req.allocated.as_ref();
         let mut controller_gpu_ids: Vec<u32> = allocated
             .and_then(|a| a.devices.get("gpu"))
@@ -1251,9 +1243,16 @@ impl SlurmAgent for AgentService {
         let cpus = allocated.map(|a| a.cpus).unwrap_or(req.cpus).max(1);
         let memory_mb = allocated.map(|a| a.memory_mb).unwrap_or(req.memory_mb);
 
-        // running-before-allocation (as in commit) so the job is never
+        // Hold the running lock across the duplicate check, reserve+commit, and
+        // insert (running → allocation, as in commit) so the job is never
         // committed-but-absent-from-running, which the reclaim reads as stale.
         let mut jobs = self.running.lock().await;
+        if jobs.contains_key(&req.job_id) {
+            return Err(Status::already_exists(format!(
+                "job {} already registered on this node",
+                req.job_id
+            )));
+        }
         {
             let mut alloc = self.allocation.lock().await;
             alloc
@@ -1267,8 +1266,6 @@ impl SlurmAgent for AgentService {
                         req.job_id
                     )),
                 })?;
-            // Reserve and commit under one lock scope, so reconcile can't
-            // interleave and reclaim between them.
             let _ = alloc.commit_job(req.job_id);
         }
 
@@ -1305,6 +1302,7 @@ impl SlurmAgent for AgentService {
                 run_attempt: 0,
             },
         );
+        drop(jobs);
 
         Ok(Response::new(RegisterJobAllocationResponse {}))
     }
@@ -3171,6 +3169,58 @@ mod tests {
             .await;
         let err = res.expect_err("must reject: GPU 1's owner is still running");
         assert_eq!(err.code(), tonic::Code::ResourceExhausted);
+    }
+
+    // A registered srun allocation must be committed AND tracked in `running`
+    // so a reconcile pass spares it — the reservation is backed, not orphaned.
+    #[tokio::test]
+    async fn register_job_allocation_survives_reconcile() {
+        let svc = AgentService::new(
+            test_reporter_with_gpus(&[0]),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        let mut devices = std::collections::HashMap::new();
+        devices.insert(
+            "gpu".to_string(),
+            DeviceAllocations {
+                devices: vec![AllocatedDevice {
+                    device_id: 0,
+                    count: 1,
+                }],
+            },
+        );
+        svc.register_job_allocation(Request::new(RegisterJobAllocationRequest {
+            job_id: 55,
+            cpus: 1,
+            allocated: Some(ResourceAllocations {
+                cpus: 1,
+                memory_mb: 0,
+                devices,
+            }),
+            ..Default::default()
+        }))
+        .await
+        .expect("register");
+
+        assert_eq!(
+            svc.free_gpu_count().await,
+            0,
+            "registered allocation holds the GPU"
+        );
+
+        // The job is in `running`, so reconcile must spare it (not orphan-reclaim).
+        {
+            let jobs = svc.running.lock().await;
+            reconcile_orphaned_allocations(&jobs, &mut *svc.allocation.lock().await);
+        }
+        assert_eq!(
+            svc.free_gpu_count().await,
+            0,
+            "committed+tracked allocation must survive reconcile"
+        );
     }
 
     // CancelJob must release a still-launching (never-committed) reservation,

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -336,7 +336,8 @@ struct DrainRequest {
 }
 
 /// Reclaim a launch reservation that never commits within this bound. Sized
-/// above a worst-case image pull + fork so an in-flight launch isn't reclaimed.
+/// above a typical image pull + fork so a normal launch is spared; one stalled
+/// past this bound is reclaimed.
 const LAUNCHING_TTL: std::time::Duration = std::time::Duration::from_secs(600);
 
 /// Reclaim allocations whose job is no longer tracked and is not mid-launch,
@@ -386,16 +387,16 @@ impl Drop for LaunchReservationGuard {
             return;
         }
         let job_id = self.job_id;
-        // Drop can't await; try_lock succeeds inline on this uncontended path,
-        // else spawn the release so the reservation is never left stranded.
+        // Drop can't await; try_lock succeeds inline on this uncontended path.
         if let Ok(mut alloc) = self.allocation.try_lock() {
             alloc.release_job(job_id);
-        } else {
+        } else if let Ok(handle) = tokio::runtime::Handle::try_current() {
             let allocation = self.allocation.clone();
-            tokio::spawn(async move {
+            handle.spawn(async move {
                 allocation.lock().await.release_job(job_id);
             });
         }
+        // No runtime (shutdown) and lock held: reconcile reclaims via the TTL.
     }
 }
 

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1031,12 +1031,19 @@ impl SlurmAgent for AgentService {
                     self.cleanup_pmi_server(job_id).await;
                     let _ = result.job.kill_signal(nix::sys::signal::Signal::SIGKILL);
                     let cgroup = result.job.take_cgroup();
+                    let running = self.running.clone();
                     tokio::spawn(async move {
-                        while let Ok(None) = result.job.try_wait() {
-                            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                        reap_killed_job(result.job).await;
+                        // rootfs/spool paths are derived from job_id, so the
+                        // controller re-dispatching the same id to this node
+                        // would reuse them. Skip that cleanup if a live run for
+                        // job_id reappeared, or this reap would delete its files.
+                        // The cgroup handle is this launch's own, so it is always
+                        // safe to release.
+                        if !running.lock().await.contains_key(&job_id) {
+                            crate::container::cleanup_rootfs(job_id, &rootfs_mode);
+                            crate::executor::cleanup_job_spool(job_id);
                         }
-                        crate::container::cleanup_rootfs(job_id, &rootfs_mode);
-                        crate::executor::cleanup_job_spool(job_id);
                         if let Some(ref cg) = cgroup {
                             crate::executor::cleanup_cgroup(cg);
                         }

--- a/crates/spurd/src/pmi.rs
+++ b/crates/spurd/src/pmi.rs
@@ -16,6 +16,10 @@ pub struct PmiServer {
     kvs: Arc<Mutex<HashMap<String, String>>>,
     barrier_count: Arc<std::sync::atomic::AtomicU32>,
     barrier_notify: Arc<Notify>,
+    // Signals `run`'s accept loop to exit so the bound listener fd and the
+    // accept task are released, not just the socket path. `notify_one` stores a
+    // permit, so a shutdown raised between loop iterations is not lost.
+    shutdown: Arc<Notify>,
 }
 
 impl PmiServer {
@@ -26,6 +30,7 @@ impl PmiServer {
             kvs: Arc::new(Mutex::new(HashMap::new())),
             barrier_count: Arc::new(std::sync::atomic::AtomicU32::new(0)),
             barrier_notify: Arc::new(Notify::new()),
+            shutdown: Arc::new(Notify::new()),
         }
     }
 
@@ -39,9 +44,12 @@ impl PmiServer {
         };
 
         loop {
-            let (stream, _) = match listener.accept().await {
-                Ok(s) => s,
-                Err(_) => break,
+            let (stream, _) = tokio::select! {
+                accepted = listener.accept() => match accepted {
+                    Ok(s) => s,
+                    Err(_) => break,
+                },
+                _ = self.shutdown.notified() => break,
             };
             let kvs = self.kvs.clone();
             let num_ranks = self.num_ranks;
@@ -65,6 +73,7 @@ impl PmiServer {
     }
 
     pub fn cleanup(&self) {
+        self.shutdown.notify_one();
         let _ = std::fs::remove_file(&self.socket_path);
     }
 }
@@ -174,5 +183,41 @@ mod tests {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let resp = rt.block_on(handle_pmi_command("cmd=get_appnum", &kvs, 4, &bc, &bn));
         assert!(resp.contains("appnum=0"));
+    }
+
+    // cleanup() must stop run()'s accept loop, not just unlink the socket, so
+    // the bound listener fd and the accept task are released. Awaiting the run
+    // handle is deterministic: it only resolves once the loop has exited.
+    #[tokio::test]
+    async fn cleanup_stops_accept_loop() {
+        let socket_path = format!("/tmp/spur-pmi-shutdown-{}.sock", std::process::id());
+        let _ = std::fs::remove_file(&socket_path);
+        let server = Arc::new(PmiServer::new(&socket_path, 2));
+
+        let run_server = server.clone();
+        let handle = tokio::spawn(async move { run_server.run().await });
+
+        // The server is live once run() has bound the listener. The spawn above
+        // may not have reached bind yet, so retry the connect (yielding, no fixed
+        // sleep) until it succeeds — proving the accept loop is actually up.
+        let mut connected = false;
+        for _ in 0..1000 {
+            if tokio::net::UnixStream::connect(&socket_path).await.is_ok() {
+                connected = true;
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(connected, "PMI server never became connectable");
+
+        server.cleanup();
+
+        // run() must return now that shutdown was signalled; if the loop still
+        // blocked on accept(), this await would hang.
+        handle.await.expect("run task must exit after cleanup");
+        assert!(
+            !std::path::Path::new(&socket_path).exists(),
+            "cleanup must also remove the socket file"
+        );
     }
 }


### PR DESCRIPTION
## What

On multi-node GPU clusters, `spurd` intermittently strands nodes: the controller sees a node IDLE (0% VRAM, no job processes) but the agent rejects every dispatch with `controller-allocated GPUs unavailable on this node`. Affected nodes stay black holes for scheduling until `spurd` is restarted, so multi-node jobs that need them wait or fail NODE_FAIL even though the cluster looks idle.

## Root cause

The agent's per-node allocation table reserves resources for a job (`allocate_for_job`, marking it `launching`) and only commits them once the job's process is tracked (`commit_job`). The periodic self-heal reconcile deliberately spares anything still `launching`, so an in-flight launch isn't reclaimed out from under itself.

The gap: if the `LaunchJob` handler exits between reserve and commit **without** releasing — most notably when the RPC future is cancelled/dropped during a controller-side eviction — the reservation stays pinned in `launching` forever. Reconcile never reclaims it, and a later `CancelJob` for that job was a no-op because the cancel paths only act on jobs already in the running set. The node then rejects all future dispatches while the controller still believes it is idle.

This is the surviving multi-node/eviction leak left after the earlier completion-path release fix: that fix handles normal job completion, but not a launch that is aborted before it is ever tracked.

## Approach

Three complementary safeguards:

1. **RAII reservation guard** around the reserve-to-commit window in the launch handler. It releases the reservation on *any* exit from that window — every error path and, critically, future cancellation, which no explicit branch can catch — and is disarmed once the job is committed to the running set. This deterministically fixes the primary cause.
2. **TTL on `launching` reservations** so the existing reconcile reclaims one that never commits within a bound. Backstop for any path where the guard can't run (e.g. no cancel ever arrives).
3. **`CancelJob` releases a still-launching reservation** (job reserved but not yet running), so a cancel during eviction clears it immediately rather than waiting for the TTL. The running-set membership check is done holding the running lock across the release, matching the launch commit's lock order so it can't race a concurrent commit and free a job that just became running.

## Review fixes applied

A review pass flagged a cancel/commit lock-ordering race (the membership check and release were not atomic, so a cancel could free a job that committed in the gap). Fixed by holding the running lock across the check and release.

## Known limitations

- The `launching` TTL is a fixed bound (10 min), chosen well above a worst-case image pull + fork. If a launch legitimately exceeds it, reconcile could reclaim the reservation before the launch commits; the window is improbable at this bound and the guard covers the common dropped-future case. Making `commit_job` re-assert a reclaimed reservation (or the TTL configurable) is a reasonable follow-up.

## Testing

- Unit tests: guard releases on drop when not committed and preserves a committed (disarmed) reservation; `CancelJob` releases a launching reservation; reconcile reclaims a launching entry past its TTL and spares one within it.
- `cargo clippy --workspace --all-targets` and `cargo fmt --all --check` clean; touched-crate test suites pass.
- Validated end-to-end on an isolated single-node deployment: the normal launch → run → complete cycle returns the node to idle, and cancelling a running job frees its resources so a subsequently-queued job starts — no strand, no orphaned reservations. The exact mid-launch cancellation trigger and the TTL reclaim are covered by the unit tests rather than live (they can't be induced through the normal RPC path), and the isolated node exercised the CPU/memory reservation path, which shares the same allocation-table code as GPUs.