### PR TITLE
fix(spurctld): reject job QOS not authorized for the submitting association

### DIFF
--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -127,6 +127,25 @@ const QOS_KEYS: &[&str] = &[
     "grpwall",
 ];
 
+/// Input keys the `add`/`modify user` handlers read (names + aliases). Gates
+/// mistyped fields the same way `QOS_KEYS`/`ACCOUNT_KEYS` do.
+const USER_KEYS: &[&str] = &[
+    "name",
+    "user",
+    "account",
+    "defaultaccount",
+    "adminlevel",
+    "defaultqos",
+    "qos",
+    "maxrunningjobs",
+    "maxjobs",
+    "maxsubmitjobs",
+    "maxtresperjob",
+    "grptres",
+    "maxwall",
+    "maxwallduration",
+];
+
 /// Input keys the `add`/`modify account` handlers read (names + aliases). Gates
 /// mistyped fields the same way `QOS_KEYS` does, so an unsupported field errors
 /// loudly instead of being silently dropped.
@@ -187,6 +206,7 @@ struct UserUpsertFields {
     account: String,
     admin: String,
     default_qos: String,
+    allowed_qos: String,
     max_running_jobs: u32,
     max_submit_jobs: u32,
     max_tres_per_job: String,
@@ -201,6 +221,7 @@ struct UserUpsertFields {
 fn build_add_user_request(
     p: &std::collections::HashMap<String, String>,
 ) -> Result<UserUpsertFields> {
+    reject_unknown_keys(p, USER_KEYS)?;
     let name = p
         .get("name")
         .or_else(|| p.get("user"))
@@ -216,6 +237,16 @@ fn build_add_user_request(
         .cloned()
         .unwrap_or_else(|| "none".into());
     let default_qos = p.get("defaultqos").cloned().unwrap_or_default();
+    let allowed_qos = p.get("qos").cloned().unwrap_or_default();
+    if !default_qos.is_empty()
+        && !allowed_qos.is_empty()
+        && !allowed_qos
+            .split(',')
+            .map(str::trim)
+            .any(|q| q == default_qos)
+    {
+        bail!("defaultqos={default_qos} must be included in qos={allowed_qos}");
+    }
     let max_running_jobs: u32 = p
         .get("maxrunningjobs")
         .or_else(|| p.get("maxjobs"))
@@ -241,6 +272,7 @@ fn build_add_user_request(
         account,
         admin,
         default_qos,
+        allowed_qos,
         max_running_jobs,
         max_submit_jobs,
         max_tres_per_job,
@@ -323,6 +355,7 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
                         .map(|da| da == &fields.account)
                         .unwrap_or(true),
                     default_qos: fields.default_qos.clone(),
+                    allowed_qos: fields.allowed_qos.clone(),
                     max_running_jobs: fields.max_running_jobs,
                     max_submit_jobs: fields.max_submit_jobs,
                     max_tres_per_job: fields.max_tres_per_job.clone(),
@@ -336,6 +369,9 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
                 " Adding User(s)\n  Name       = {}\n  Account    = {}\n  Admin      = {}",
                 fields.name, fields.account, fields.admin
             );
+            if !fields.allowed_qos.is_empty() {
+                println!("  QOS        = {}", fields.allowed_qos);
+            }
             if !fields.default_qos.is_empty() {
                 println!("  DefQOS     = {}", fields.default_qos);
             }
@@ -598,6 +634,7 @@ async fn modify(entity: &str, params: &[String], addr: &str) -> Result<()> {
                         .map(|da| da == &fields.account)
                         .unwrap_or(true),
                     default_qos: fields.default_qos.clone(),
+                    allowed_qos: fields.allowed_qos.clone(),
                     max_running_jobs: fields.max_running_jobs,
                     max_submit_jobs: fields.max_submit_jobs,
                     max_tres_per_job: fields.max_tres_per_job.clone(),
@@ -608,6 +645,9 @@ async fn modify(entity: &str, params: &[String], addr: &str) -> Result<()> {
                 .context("AddUser (modify) RPC failed")?;
 
             println!(" Modified user '{}'.", fields.name);
+            if !fields.allowed_qos.is_empty() {
+                println!("  QOS        = {}", fields.allowed_qos);
+            }
             if !fields.default_qos.is_empty() {
                 println!("  DefQOS     = {}", fields.default_qos);
             }
@@ -691,15 +731,20 @@ async fn show(entity: &str, params: &[String], addr: &str) -> Result<()> {
             let users = resp.into_inner().users;
 
             println!(
-                "{:<15} {:<20} {:<10} {:<20} {:<15}",
-                "User", "Account", "Admin", "Default Acct", "Def QOS"
+                "{:<15} {:<20} {:<10} {:<20} {:<20} {:<15}",
+                "User", "Account", "Admin", "Default Acct", "QOS", "Def QOS"
             );
-            println!("{}", "-".repeat(80));
+            println!("{}", "-".repeat(95));
 
             for u in &users {
                 println!(
-                    "{:<15} {:<20} {:<10} {:<20} {:<15}",
-                    u.name, u.account, u.admin_level, u.default_account, u.default_qos,
+                    "{:<15} {:<20} {:<10} {:<20} {:<20} {:<15}",
+                    u.name,
+                    u.account,
+                    u.admin_level,
+                    u.default_account,
+                    u.allowed_qos,
+                    u.default_qos,
                 );
             }
             Ok(())
@@ -924,6 +969,50 @@ mod tests {
     }
 
     #[test]
+    fn build_add_user_request_parses_qos_allow_list() {
+        let p = parse_params(&[
+            "name=testuser".into(),
+            "account=testacct".into(),
+            "qos=highprio,lowprio".into(),
+            "defaultqos=highprio".into(),
+        ]);
+        let fields = build_add_user_request(&p).unwrap();
+        assert_eq!(fields.allowed_qos, "highprio,lowprio");
+        assert_eq!(fields.default_qos, "highprio");
+    }
+
+    #[test]
+    fn build_add_user_request_allowed_qos_absent_is_empty() {
+        let p = parse_params(&["name=testuser".into(), "account=testacct".into()]);
+        let fields = build_add_user_request(&p).unwrap();
+        assert_eq!(fields.allowed_qos, "");
+    }
+
+    #[test]
+    fn build_add_user_request_rejects_default_qos_outside_allow_list() {
+        let p = parse_params(&[
+            "name=testuser".into(),
+            "account=testacct".into(),
+            "qos=highprio,lowprio".into(),
+            "defaultqos=other-teams-qos".into(),
+        ]);
+        let err = build_add_user_request(&p).unwrap_err();
+        assert!(err.to_string().contains("must be included in qos="));
+    }
+
+    #[test]
+    fn build_add_user_request_allows_defaultqos_alone_without_a_list() {
+        // Pinning only a default (no qos= list) is still valid — it's
+        // PR #490's single-QOS scoping, not a validation error.
+        let p = parse_params(&[
+            "name=testuser".into(),
+            "account=testacct".into(),
+            "defaultqos=highprio".into(),
+        ]);
+        assert!(build_add_user_request(&p).is_ok());
+    }
+
+    #[test]
     fn reject_unknown_keys_flags_dropped_field() {
         // A field the command doesn't read must error, not be silently dropped
         // (a dropped limit reads as "set" but never enforces).
@@ -958,6 +1047,44 @@ mod tests {
                 "QOS field '{field}' is read by the handler but missing from QOS_KEYS"
             );
         }
+    }
+
+    #[test]
+    fn reject_unknown_keys_accepts_every_parsed_user_field() {
+        let parsed_fields = [
+            "name",
+            "user",
+            "account",
+            "defaultaccount",
+            "adminlevel",
+            "defaultqos",
+            "qos",
+            "maxrunningjobs",
+            "maxjobs",
+            "maxsubmitjobs",
+            "maxtresperjob",
+            "grptres",
+            "maxwall",
+            "maxwallduration",
+        ];
+        for field in parsed_fields {
+            let p = parse_params(&["name=testuser".into(), format!("{field}=1")]);
+            assert!(
+                reject_unknown_keys(&p, USER_KEYS).is_ok(),
+                "user field '{field}' is read by the handler but missing from USER_KEYS"
+            );
+        }
+    }
+
+    #[test]
+    fn build_add_user_request_rejects_unknown_field() {
+        let p = parse_params(&[
+            "name=testuser".into(),
+            "account=testacct".into(),
+            "qoz=highprio".into(),
+        ]);
+        let err = build_add_user_request(&p).unwrap_err();
+        assert!(err.to_string().contains("unknown field 'qoz'"));
     }
 
     #[test]

--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -532,7 +532,7 @@ async fn delete(entity: &str, params: &[String], addr: &str) -> Result<()> {
 }
 
 async fn modify(entity: &str, params: &[String], addr: &str) -> Result<()> {
-    let p = parse_params(params);
+    let mut p = parse_params(params);
 
     // Modify is an upsert — same RPCs as add, just re-sends the record
     match entity.to_lowercase().as_str() {
@@ -621,9 +621,39 @@ async fn modify(entity: &str, params: &[String], addr: &str) -> Result<()> {
             Ok(())
         }
         "user" => {
-            let fields = build_add_user_request(&p)?;
-
             let mut client = connect(addr).await?;
+
+            // `modify user` resends the whole association record (it shares
+            // AddUserRequest with `add user`), so a QOS field left out of
+            // this command must keep its stored value, not silently reset
+            // to unrestricted — unlike a resource limit, an omitted QOS
+            // field would otherwise widen the association's access.
+            if !p.contains_key("qos") || !p.contains_key("defaultqos") {
+                let name = p
+                    .get("name")
+                    .or_else(|| p.get("user"))
+                    .cloned()
+                    .unwrap_or_default();
+                let account = p.get("account").cloned().unwrap_or_default();
+                let existing = client
+                    .list_users(ListUsersRequest {
+                        account: account.clone(),
+                        user: name.clone(),
+                    })
+                    .await
+                    .context("ListUsers (modify lookup) RPC failed")?
+                    .into_inner()
+                    .users
+                    .into_iter()
+                    .find(|u| u.name == name && u.account == account);
+                if let Some(existing) = existing {
+                    p.entry("qos".to_string()).or_insert(existing.allowed_qos);
+                    p.entry("defaultqos".to_string())
+                        .or_insert(existing.default_qos);
+                }
+            }
+
+            let fields = build_add_user_request(&p)?;
             client
                 .add_user(AddUserRequest {
                     user: fields.name.clone(),

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -125,6 +125,8 @@ ALTER TABLE jobs ADD COLUMN IF NOT EXISTS reservation TEXT NOT NULL DEFAULT '';
 -- No FK to qos(name): a stale reference (QOS deleted after being set as a
 -- default) must degrade gracefully at read time, not be blocked here.
 ALTER TABLE associations ADD COLUMN IF NOT EXISTS default_qos TEXT;
+-- Comma-separated QOS names, same degrade-gracefully rationale as default_qos.
+ALTER TABLE associations ADD COLUMN IF NOT EXISTS allowed_qos TEXT;
 ALTER TABLE qos ADD COLUMN IF NOT EXISTS grp_wall_min INTEGER;
 ALTER TABLE accounts ADD COLUMN IF NOT EXISTS grp_tres TEXT;
 "#;
@@ -566,6 +568,7 @@ pub async fn add_user(
     admin_level: &str,
     is_default: bool,
     default_qos: &str,
+    allowed_qos: &str,
     max_running_jobs: Option<i32>,
     max_submit_jobs: Option<i32>,
     max_tres_per_job: Option<&str>,
@@ -599,8 +602,9 @@ pub async fn add_user(
     let updated = sqlx::query(
         r#"
         UPDATE associations SET is_default = $3, default_qos = NULLIF($4, ''),
-            max_running_jobs = $5, max_submit_jobs = $6, max_tres_per_job = $7,
-            grp_tres = $8, max_wall_min = $9
+            allowed_qos = NULLIF($5, ''),
+            max_running_jobs = $6, max_submit_jobs = $7, max_tres_per_job = $8,
+            grp_tres = $9, max_wall_min = $10
         WHERE user_name = $1 AND account = $2
           AND (partition_name IS NULL OR partition_name = '')
         "#,
@@ -609,6 +613,7 @@ pub async fn add_user(
     .bind(account)
     .bind(is_default)
     .bind(default_qos)
+    .bind(allowed_qos)
     .bind(max_running_jobs)
     .bind(max_submit_jobs)
     .bind(max_tres_per_job)
@@ -621,14 +626,16 @@ pub async fn add_user(
         sqlx::query(
             r#"
             INSERT INTO associations (user_name, account, is_default, default_qos,
-                max_running_jobs, max_submit_jobs, max_tres_per_job, grp_tres, max_wall_min)
-            VALUES ($1, $2, $3, NULLIF($4, ''), $5, $6, $7, $8, $9)
+                allowed_qos, max_running_jobs, max_submit_jobs, max_tres_per_job,
+                grp_tres, max_wall_min)
+            VALUES ($1, $2, $3, NULLIF($4, ''), NULLIF($5, ''), $6, $7, $8, $9, $10)
             "#,
         )
         .bind(user)
         .bind(account)
         .bind(is_default)
         .bind(default_qos)
+        .bind(allowed_qos)
         .bind(max_running_jobs)
         .bind(max_submit_jobs)
         .bind(max_tres_per_job)
@@ -657,9 +664,10 @@ pub async fn remove_user(pool: &PgPool, user: &str, account: &str) -> anyhow::Re
     Ok(())
 }
 
-/// List users, joining each one's own association row for `default_qos`.
-/// `DISTINCT ON ... a.id DESC` picks the newest row if legacy duplicates
-/// exist (pre-dating the add_user upsert fix); it never touches the others.
+/// List users, joining each one's own association row for `default_qos`/
+/// `allowed_qos`. `DISTINCT ON ... a.id DESC` picks the newest row if legacy
+/// duplicates exist (pre-dating the add_user upsert fix); it never touches
+/// the others.
 pub async fn list_users(
     pool: &PgPool,
     account: Option<&str>,
@@ -668,7 +676,8 @@ pub async fn list_users(
     let rows = sqlx::query(
         r#"
         SELECT DISTINCT ON (u.name, u.account)
-            u.name, u.account, u.admin_level, u.default_account, a.default_qos
+            u.name, u.account, u.admin_level, u.default_account,
+            a.default_qos, a.allowed_qos
         FROM users u
         LEFT JOIN associations a
             ON a.user_name = u.name AND a.account = u.account
@@ -691,6 +700,7 @@ pub async fn list_users(
             admin_level: r.get("admin_level"),
             default_account: r.get("default_account"),
             default_qos: r.get("default_qos"),
+            allowed_qos: r.get("allowed_qos"),
         })
         .collect())
 }
@@ -702,6 +712,7 @@ pub struct UserRecord {
     pub admin_level: String,
     pub default_account: Option<String>,
     pub default_qos: Option<String>,
+    pub allowed_qos: Option<String>,
 }
 
 /// List every user-account association's resource limits, one row per
@@ -1213,7 +1224,7 @@ mod job_history_tests {
         .await?;
 
         add_user(
-            &pool, &user, &account, "none", true, &qos_name, None, None, None, None, None,
+            &pool, &user, &account, "none", true, &qos_name, "", None, None, None, None, None,
         )
         .await?;
         let got = list_users(&pool, Some(&account), None)
@@ -1226,7 +1237,7 @@ mod job_history_tests {
         // Upsert again with an empty default_qos: clears it (full resend,
         // not a partial patch — matches modify account/qos semantics).
         add_user(
-            &pool, &user, &account, "none", true, "", None, None, None, None, None,
+            &pool, &user, &account, "none", true, "", "", None, None, None, None, None,
         )
         .await?;
         let got = list_users(&pool, Some(&account), None)
@@ -1285,6 +1296,7 @@ mod job_history_tests {
             "none",
             true,
             "",
+            "",
             Some(2),
             Some(4),
             Some("cpu=8"),
@@ -1313,6 +1325,7 @@ mod job_history_tests {
             "none",
             true,
             "",
+            "",
             Some(10),
             Some(20),
             Some("cpu=16"),
@@ -1334,7 +1347,7 @@ mod job_history_tests {
         // Upsert again with no limits: clears them (full resend, not a
         // partial patch — matches every other field on this association).
         add_user(
-            &pool, &user, &account, "none", true, "", None, None, None, None, None,
+            &pool, &user, &account, "none", true, "", "", None, None, None, None, None,
         )
         .await?;
         let got = list_associations(&pool)
@@ -1395,6 +1408,7 @@ mod job_history_tests {
             "none",
             true,
             "",
+            "",
             None,
             None,
             None,
@@ -1408,6 +1422,7 @@ mod job_history_tests {
             &account,
             "none",
             true,
+            "",
             "",
             None,
             None,
@@ -1471,11 +1486,11 @@ mod job_history_tests {
         upsert_account(&pool, &account, "d", "o", None, 1, None, None).await?;
 
         add_user(
-            &pool, &user, &account, "none", true, "", None, None, None, None, None,
+            &pool, &user, &account, "none", true, "", "", None, None, None, None, None,
         )
         .await?;
         add_user(
-            &pool, &user, &account, "none", true, "", None, None, None, None, None,
+            &pool, &user, &account, "none", true, "", "", None, None, None, None, None,
         )
         .await?;
         add_user(
@@ -1485,6 +1500,7 @@ mod job_history_tests {
             "none",
             true,
             "highprio-does-not-need-to-exist",
+            "",
             None,
             None,
             None,

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -373,6 +373,29 @@ impl SlurmAccounting for AccountingService {
                 )));
             }
         }
+        let allowed_qos: Vec<&str> = req
+            .allowed_qos
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .collect();
+        for name in &allowed_qos {
+            let exists = db::qos_exists(&self.pool, name)
+                .await
+                .map_err(|e| Status::internal(e.to_string()))?;
+            if !exists {
+                return Err(Status::not_found(format!("QOS '{name}' does not exist")));
+            }
+        }
+        if !req.default_qos.is_empty()
+            && !allowed_qos.is_empty()
+            && !allowed_qos.contains(&req.default_qos.as_str())
+        {
+            return Err(Status::invalid_argument(format!(
+                "default QOS '{}' must be included in qos={}",
+                req.default_qos, req.allowed_qos
+            )));
+        }
         let max_running_jobs = if req.max_running_jobs == 0 {
             None
         } else {
@@ -416,6 +439,7 @@ impl SlurmAccounting for AccountingService {
             &req.admin_level,
             req.is_default,
             &req.default_qos,
+            &req.allowed_qos,
             max_running_jobs,
             max_submit_jobs,
             max_tres_per_job,
@@ -465,6 +489,7 @@ impl SlurmAccounting for AccountingService {
                 admin_level: r.admin_level,
                 default_account: r.default_account.unwrap_or_default(),
                 default_qos: r.default_qos.unwrap_or_default(),
+                allowed_qos: r.allowed_qos.unwrap_or_default(),
             })
             .collect();
 

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -432,6 +432,10 @@ impl SlurmAccounting for AccountingService {
                     .map_err(|_| Status::invalid_argument("max_wall_minutes exceeds i32::MAX"))?,
             )
         };
+        // Store the trimmed/filtered form, not the raw request string, so
+        // `sacctmgr show user` echoes back what was actually validated
+        // above rather than stray whitespace or empty entries.
+        let allowed_qos_normalized = allowed_qos.join(",");
         db::add_user(
             &self.pool,
             &req.user,
@@ -439,7 +443,7 @@ impl SlurmAccounting for AccountingService {
             &req.admin_level,
             req.is_default,
             &req.default_qos,
-            &req.allowed_qos,
+            &allowed_qos_normalized,
             max_running_jobs,
             max_submit_jobs,
             max_tres_per_job,

--- a/crates/spurctld/src/accounting/mod.rs
+++ b/crates/spurctld/src/accounting/mod.rs
@@ -58,19 +58,33 @@ pub async fn association_maps(
     HashMap<String, String>,
     HashSet<(String, String)>,
     HashMap<(String, String), AccountLimits>,
+    HashMap<(String, String), HashSet<String>>,
 )> {
     let users = db::list_users(pool, None, None).await?;
 
     let mut default_qos = HashMap::new();
     let mut default_account = HashMap::new();
     let mut memberships = HashSet::new();
+    let mut allowed_qos = HashMap::new();
     for u in users {
-        memberships.insert((u.name.clone(), u.account.clone()));
+        let key = (u.name.clone(), u.account.clone());
+        memberships.insert(key.clone());
         if let Some(qos) = u.default_qos {
-            default_qos.insert((u.name.clone(), u.account), qos);
+            default_qos.insert(key.clone(), qos);
         }
         if let Some(acct) = u.default_account {
             default_account.insert(u.name, acct);
+        }
+        if let Some(list) = u.allowed_qos {
+            let set: HashSet<String> = list
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_owned)
+                .collect();
+            if !set.is_empty() {
+                allowed_qos.insert(key, set);
+            }
         }
     }
 
@@ -83,7 +97,13 @@ pub async fn association_maps(
         })
         .collect();
 
-    Ok((default_qos, default_account, memberships, limits))
+    Ok((
+        default_qos,
+        default_account,
+        memberships,
+        limits,
+        allowed_qos,
+    ))
 }
 
 fn account_limits_from_record(r: db::AssociationRecord) -> AccountLimits {

--- a/crates/spurctld/src/association_cache.rs
+++ b/crates/spurctld/src/association_cache.rs
@@ -77,8 +77,9 @@ impl AssociationCache {
     /// the association must exist, and if it's been pinned to a QOS,
     /// `qos` must match it exactly. Membership and QOS are read under one
     /// lock so a concurrent refresh can't validate one against the other's
-    /// stale snapshot (see `resolve()`). Permissive when the cache hasn't
-    /// loaded (accounting disabled).
+    /// stale snapshot (see `resolve()`). Permissive while the cache hasn't
+    /// loaded — at startup before the first fetch completes, or while the
+    /// accounting DB stays unreachable/erroring.
     pub fn check_qos_authorized(&self, user: &str, account: &str, qos: &str) -> Result<(), String> {
         let snapshot = self.snapshot.read();
         if !snapshot.loaded {

--- a/crates/spurctld/src/association_cache.rs
+++ b/crates/spurctld/src/association_cache.rs
@@ -73,6 +73,23 @@ impl AssociationCache {
         AccountMembership::NotMember(accounts)
     }
 
+    /// Whether `qos` may be used by this (user, account) association. An
+    /// association with no default QOS on record has never been pinned to
+    /// one, so it stays unrestricted; one that has must match it exactly.
+    pub fn qos_allowed(&self, user: &str, account: &str, qos: &str) -> bool {
+        let snapshot = self.snapshot.read();
+        if !snapshot.loaded {
+            return true;
+        }
+        match snapshot
+            .default_qos
+            .get(&(user.to_owned(), account.to_owned()))
+        {
+            Some(default_qos) => default_qos == qos,
+            None => true,
+        }
+    }
+
     /// The effective account (given, or the user's default) and that
     /// association's default QOS, resolved under a single read lock so a
     /// concurrent refresh can't yield a torn old/new combination.
@@ -330,6 +347,34 @@ mod tests {
             cache.account_membership("carol", "missing"),
             AccountMembership::NotMember(Vec::new())
         );
+    }
+
+    #[test]
+    fn qos_allowed_unloaded_cache_is_permissive() {
+        let cache = AssociationCache::new();
+        assert!(cache.qos_allowed("alice", "research", "anything"));
+    }
+
+    #[test]
+    fn qos_allowed_matches_pinned_default() {
+        let cache = AssociationCache::new();
+        cache.insert_default_qos("alice", "research", "highprio");
+        assert!(cache.qos_allowed("alice", "research", "highprio"));
+        assert!(!cache.qos_allowed("alice", "research", "other-teams-qos"));
+    }
+
+    #[test]
+    fn qos_allowed_permissive_when_association_has_no_default_pinned() {
+        let cache = AssociationCache::new();
+        cache.insert_association("alice", "research");
+        assert!(cache.qos_allowed("alice", "research", "anything"));
+    }
+
+    #[test]
+    fn qos_allowed_permissive_for_unknown_association_on_loaded_cache() {
+        let cache = AssociationCache::new();
+        cache.insert_default_qos("bob", "eng", "highprio");
+        assert!(cache.qos_allowed("alice", "research", "anything"));
     }
 
     #[test]

--- a/crates/spurctld/src/association_cache.rs
+++ b/crates/spurctld/src/association_cache.rs
@@ -73,20 +73,28 @@ impl AssociationCache {
         AccountMembership::NotMember(accounts)
     }
 
-    /// Whether `qos` may be used by this (user, account) association. An
-    /// association with no default QOS on record has never been pinned to
-    /// one, so it stays unrestricted; one that has must match it exactly.
-    pub fn qos_allowed(&self, user: &str, account: &str, qos: &str) -> bool {
+    /// Check `qos` is usable by this concrete (user, account) association:
+    /// the association must exist, and if it's been pinned to a QOS,
+    /// `qos` must match it exactly. Membership and QOS are read under one
+    /// lock so a concurrent refresh can't validate one against the other's
+    /// stale snapshot (see `resolve()`). Permissive when the cache hasn't
+    /// loaded (accounting disabled).
+    pub fn check_qos_authorized(&self, user: &str, account: &str, qos: &str) -> Result<(), String> {
         let snapshot = self.snapshot.read();
         if !snapshot.loaded {
-            return true;
+            return Ok(());
         }
-        match snapshot
-            .default_qos
-            .get(&(user.to_owned(), account.to_owned()))
-        {
-            Some(default_qos) => default_qos == qos,
-            None => true,
+        let key = (user.to_owned(), account.to_owned());
+        if !snapshot.memberships.contains(&key) {
+            return Err(format!(
+                "user '{user}' is not associated with account '{account}'"
+            ));
+        }
+        match snapshot.default_qos.get(&key) {
+            Some(default_qos) if default_qos != qos => Err(format!(
+                "QOS '{qos}' is not permitted for user '{user}' under account '{account}'"
+            )),
+            _ => Ok(()),
         }
     }
 
@@ -350,31 +358,44 @@ mod tests {
     }
 
     #[test]
-    fn qos_allowed_unloaded_cache_is_permissive() {
+    fn check_qos_authorized_unloaded_cache_is_permissive() {
         let cache = AssociationCache::new();
-        assert!(cache.qos_allowed("alice", "research", "anything"));
+        assert!(cache
+            .check_qos_authorized("alice", "research", "anything")
+            .is_ok());
     }
 
     #[test]
-    fn qos_allowed_matches_pinned_default() {
+    fn check_qos_authorized_matches_pinned_default() {
         let cache = AssociationCache::new();
         cache.insert_default_qos("alice", "research", "highprio");
-        assert!(cache.qos_allowed("alice", "research", "highprio"));
-        assert!(!cache.qos_allowed("alice", "research", "other-teams-qos"));
+        assert!(cache
+            .check_qos_authorized("alice", "research", "highprio")
+            .is_ok());
+        assert!(cache
+            .check_qos_authorized("alice", "research", "other-teams-qos")
+            .is_err());
     }
 
     #[test]
-    fn qos_allowed_permissive_when_association_has_no_default_pinned() {
+    fn check_qos_authorized_permissive_when_association_has_no_default_pinned() {
         let cache = AssociationCache::new();
         cache.insert_association("alice", "research");
-        assert!(cache.qos_allowed("alice", "research", "anything"));
+        assert!(cache
+            .check_qos_authorized("alice", "research", "anything")
+            .is_ok());
     }
 
     #[test]
-    fn qos_allowed_permissive_for_unknown_association_on_loaded_cache() {
+    fn check_qos_authorized_rejects_non_member_account_on_loaded_cache() {
+        // A bogus or unaffiliated account must not be a back door: unlike a
+        // missing default QOS, a missing *association* is a hard reject.
         let cache = AssociationCache::new();
         cache.insert_default_qos("bob", "eng", "highprio");
-        assert!(cache.qos_allowed("alice", "research", "anything"));
+        let err = cache
+            .check_qos_authorized("alice", "research", "anything")
+            .unwrap_err();
+        assert!(err.contains("not associated with account 'research'"));
     }
 
     #[test]

--- a/crates/spurctld/src/association_cache.rs
+++ b/crates/spurctld/src/association_cache.rs
@@ -16,6 +16,7 @@ struct Snapshot {
     default_account: HashMap<String, String>,
     memberships: HashSet<(String, String)>,
     limits: HashMap<(String, String), AccountLimits>,
+    allowed_qos: HashMap<(String, String), HashSet<String>>,
     loaded: bool,
 }
 
@@ -33,6 +34,13 @@ pub struct AssociationCache {
     snapshot: RwLock<Snapshot>,
 }
 
+/// Whether `qos` is usable given an association's allow-list and pinned
+/// default: unrestricted if neither is set, otherwise it must be a member
+/// of the allow-list or match the default exactly.
+pub(crate) fn qos_permitted(allowed: &HashSet<String>, default: Option<&str>, qos: &str) -> bool {
+    (allowed.is_empty() && default.is_none()) || allowed.contains(qos) || default == Some(qos)
+}
+
 impl AssociationCache {
     pub fn new() -> Self {
         Self {
@@ -41,6 +49,7 @@ impl AssociationCache {
                 default_account: HashMap::new(),
                 memberships: HashSet::new(),
                 limits: HashMap::new(),
+                allowed_qos: HashMap::new(),
                 loaded: false,
             }),
         }
@@ -74,12 +83,13 @@ impl AssociationCache {
     }
 
     /// Check `qos` is usable by this concrete (user, account) association:
-    /// the association must exist, and if it's been pinned to a QOS,
-    /// `qos` must match it exactly. Membership and QOS are read under one
-    /// lock so a concurrent refresh can't validate one against the other's
-    /// stale snapshot (see `resolve()`). Permissive while the cache hasn't
-    /// loaded — at startup before the first fetch completes, or while the
-    /// accounting DB stays unreachable/erroring.
+    /// the association must exist, and if it's been scoped to an allow-list
+    /// and/or a pinned default QOS, `qos` must be one of them. Membership
+    /// and QOS are read under one lock so a concurrent refresh can't
+    /// validate one against the other's stale snapshot (see `resolve()`).
+    /// Permissive while the cache hasn't loaded — at startup before the
+    /// first fetch completes, or while the accounting DB stays
+    /// unreachable/erroring.
     pub fn check_qos_authorized(&self, user: &str, account: &str, qos: &str) -> Result<(), String> {
         let snapshot = self.snapshot.read();
         if !snapshot.loaded {
@@ -91,18 +101,27 @@ impl AssociationCache {
                 "user '{user}' is not associated with account '{account}'"
             ));
         }
-        match snapshot.default_qos.get(&key) {
-            Some(default_qos) if default_qos != qos => Err(format!(
+        let empty = HashSet::new();
+        let allowed = snapshot.allowed_qos.get(&key).unwrap_or(&empty);
+        let default = snapshot.default_qos.get(&key);
+        if qos_permitted(allowed, default.map(String::as_str), qos) {
+            Ok(())
+        } else {
+            Err(format!(
                 "QOS '{qos}' is not permitted for user '{user}' under account '{account}'"
-            )),
-            _ => Ok(()),
+            ))
         }
     }
 
-    /// The effective account (given, or the user's default) and that
-    /// association's default QOS, resolved under a single read lock so a
-    /// concurrent refresh can't yield a torn old/new combination.
-    pub fn resolve(&self, user: &str, account: Option<&str>) -> (Option<String>, Option<String>) {
+    /// The effective account (given, or the user's default), that
+    /// association's default QOS, and its allow-list (empty if unscoped),
+    /// resolved under a single read lock so a concurrent refresh can't
+    /// yield a torn old/new combination.
+    pub fn resolve(
+        &self,
+        user: &str,
+        account: Option<&str>,
+    ) -> (Option<String>, Option<String>, HashSet<String>) {
         let snapshot = self.snapshot.read();
         let effective_account = account
             .filter(|a| !a.is_empty())
@@ -120,7 +139,12 @@ impl AssociationCache {
                 .get(&(user.to_owned(), acct.clone()))
                 .cloned()
         });
-        (effective_account, default_qos)
+        let allowed_qos = effective_account
+            .as_ref()
+            .and_then(|acct| snapshot.allowed_qos.get(&(user.to_owned(), acct.clone())))
+            .cloned()
+            .unwrap_or_default();
+        (effective_account, default_qos, allowed_qos)
     }
 
     /// Resource limits for a (user, account) association; unset/unknown fields
@@ -140,12 +164,14 @@ impl AssociationCache {
         default_account: HashMap<String, String>,
         memberships: HashSet<(String, String)>,
         limits: HashMap<(String, String), AccountLimits>,
+        allowed_qos: HashMap<(String, String), HashSet<String>>,
     ) {
         *self.snapshot.write() = Snapshot {
             default_qos,
             default_account,
             memberships,
             limits,
+            allowed_qos,
             loaded: true,
         };
     }
@@ -166,6 +192,18 @@ impl AssociationCache {
             .insert((user.to_owned(), account.to_owned()));
         snap.default_qos
             .insert((user.to_owned(), account.to_owned()), qos.to_owned());
+        snap.loaded = true;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn insert_allowed_qos(&self, user: &str, account: &str, qos: &[&str]) {
+        let mut snap = self.snapshot.write();
+        snap.memberships
+            .insert((user.to_owned(), account.to_owned()));
+        snap.allowed_qos.insert(
+            (user.to_owned(), account.to_owned()),
+            qos.iter().map(|q| q.to_string()).collect(),
+        );
         snap.loaded = true;
     }
 
@@ -205,15 +243,16 @@ impl AssociationCache {
             )
             .await
             {
-                Ok(Ok((qos, accounts, memberships, limits))) => {
+                Ok(Ok((qos, accounts, memberships, limits, allowed_qos))) => {
                     info!(
                         default_qos = qos.len(),
                         default_account = accounts.len(),
                         memberships = memberships.len(),
                         limits = limits.len(),
+                        allowed_qos = allowed_qos.len(),
                         "association cache initialized"
                     );
-                    cache.replace(qos, accounts, memberships, limits);
+                    cache.replace(qos, accounts, memberships, limits, allowed_qos);
                 }
                 Ok(Err(e)) => {
                     warn!(error = %e, "initial association fetch failed, will retry in background");
@@ -232,8 +271,8 @@ impl AssociationCache {
                 )
                 .await
                 {
-                    Ok(Ok((qos, accounts, memberships, limits))) => {
-                        cache.replace(qos, accounts, memberships, limits)
+                    Ok(Ok((qos, accounts, memberships, limits, allowed_qos))) => {
+                        cache.replace(qos, accounts, memberships, limits, allowed_qos)
                     }
                     Ok(Err(e)) => {
                         warn!(error = %e, "association refresh failed, retaining stale data")
@@ -254,14 +293,14 @@ mod tests {
         let cache = AssociationCache::new();
         assert_eq!(
             cache.resolve("alice", Some("research")),
-            (Some("research".into()), None)
+            (Some("research".into()), None, HashSet::new())
         );
     }
 
     #[test]
     fn resolve_unknown_user_with_no_account_given_resolves_nothing() {
         let cache = AssociationCache::new();
-        assert_eq!(cache.resolve("alice", None), (None, None));
+        assert_eq!(cache.resolve("alice", None), (None, None, HashSet::new()));
     }
 
     #[test]
@@ -270,9 +309,25 @@ mod tests {
         cache.insert_default_qos("alice", "research", "highprio");
         assert_eq!(
             cache.resolve("alice", Some("research")),
-            (Some("research".into()), Some("highprio".into()))
+            (
+                Some("research".into()),
+                Some("highprio".into()),
+                HashSet::new()
+            )
         );
-        assert_eq!(cache.resolve("alice", Some("other")), (None, None));
+        assert_eq!(
+            cache.resolve("alice", Some("other")),
+            (None, None, HashSet::new())
+        );
+    }
+
+    #[test]
+    fn resolve_returns_allowed_qos_for_the_effective_account() {
+        let cache = AssociationCache::new();
+        cache.insert_allowed_qos("alice", "research", &["a", "b"]);
+        let (account, _, allowed) = cache.resolve("alice", Some("research"));
+        assert_eq!(account.as_deref(), Some("research"));
+        assert_eq!(allowed, HashSet::from(["a".to_string(), "b".to_string()]));
     }
 
     #[test]
@@ -284,15 +339,19 @@ mod tests {
             HashMap::from([("bob".to_string(), "eng".to_string())]),
             HashSet::from([("bob".to_string(), "eng".to_string())]),
             HashMap::new(),
+            HashMap::new(),
         );
-        assert_eq!(cache.resolve("alice", Some("research")), (None, None));
+        assert_eq!(
+            cache.resolve("alice", Some("research")),
+            (None, None, HashSet::new())
+        );
         assert_eq!(
             cache.resolve("bob", Some("eng")),
-            (Some("eng".into()), Some("new".into()))
+            (Some("eng".into()), Some("new".into()), HashSet::new())
         );
         assert_eq!(
             cache.resolve("bob", None),
-            (Some("eng".into()), Some("new".into()))
+            (Some("eng".into()), Some("new".into()), HashSet::new())
         );
     }
 
@@ -301,7 +360,7 @@ mod tests {
         let cache = AssociationCache::new();
         cache.insert_default_account("alice", "research");
         cache.insert_default_qos("alice", "other", "highprio");
-        let (account, qos) = cache.resolve("alice", Some("other"));
+        let (account, qos, _) = cache.resolve("alice", Some("other"));
         assert_eq!(account.as_deref(), Some("other"));
         assert_eq!(qos.as_deref(), Some("highprio"));
     }
@@ -311,7 +370,7 @@ mod tests {
         let cache = AssociationCache::new();
         cache.insert_default_account("alice", "research");
         cache.insert_default_qos("alice", "research", "highprio");
-        let (account, qos) = cache.resolve("alice", None);
+        let (account, qos, _) = cache.resolve("alice", None);
         assert_eq!(account.as_deref(), Some("research"));
         assert_eq!(qos.as_deref(), Some("highprio"));
     }
@@ -325,8 +384,9 @@ mod tests {
             HashMap::new(),
             HashSet::from([("bob".to_string(), "eng".to_string())]),
             HashMap::new(),
+            HashMap::new(),
         );
-        let (account, qos) = cache.resolve("alice", None);
+        let (account, qos, _) = cache.resolve("alice", None);
         assert_eq!(
             account, None,
             "old default_account must not survive the swap"
@@ -400,6 +460,31 @@ mod tests {
     }
 
     #[test]
+    fn check_qos_authorized_allows_any_member_of_the_allow_list() {
+        let cache = AssociationCache::new();
+        cache.insert_allowed_qos("alice", "research", &["a", "b", "c"]);
+        assert!(cache.check_qos_authorized("alice", "research", "a").is_ok());
+        assert!(cache.check_qos_authorized("alice", "research", "c").is_ok());
+        assert!(cache
+            .check_qos_authorized("alice", "research", "other-teams-qos")
+            .is_err());
+    }
+
+    #[test]
+    fn check_qos_authorized_default_qos_alone_still_scopes_to_one() {
+        // Pinning only a default (no explicit allow-list) keeps PR #490's
+        // original single-QOS behavior for associations never given a list.
+        let cache = AssociationCache::new();
+        cache.insert_default_qos("alice", "research", "highprio");
+        assert!(cache
+            .check_qos_authorized("alice", "research", "highprio")
+            .is_ok());
+        assert!(cache
+            .check_qos_authorized("alice", "research", "other-teams-qos")
+            .is_err());
+    }
+
+    #[test]
     fn limits_default_to_limitless_for_unknown_association() {
         let cache = AssociationCache::new();
         assert_eq!(cache.limits("alice", "research"), AccountLimits::default());
@@ -440,6 +525,7 @@ mod tests {
                     ..Default::default()
                 },
             )]),
+            HashMap::new(),
         );
         assert_eq!(
             cache.limits("alice", "research"),

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1525,13 +1525,19 @@ impl ClusterManager {
                 if self.qos_cache.get(&q).is_none() {
                     anyhow::bail!("QOS '{q}' does not exist");
                 }
-                let effective_account = account.as_deref().or(job_account.as_deref());
+                // Falling back to an unfiltered `account` would let a bogus
+                // or unaffiliated account name (or `account=""`) resolve to
+                // "no association on record", which `check_qos_authorized`
+                // treats as permissive — the exact bypass this check exists
+                // to close.
+                let effective_account = account
+                    .as_deref()
+                    .filter(|a| !a.is_empty())
+                    .or(job_account.as_deref());
                 if let Some(acct) = effective_account {
-                    if !self.association_cache.qos_allowed(&job_user, acct, &q) {
-                        anyhow::bail!(
-                            "QOS '{q}' is not permitted for user '{job_user}' under account '{acct}'"
-                        );
-                    }
+                    self.association_cache
+                        .check_qos_authorized(&job_user, acct, &q)
+                        .map_err(anyhow::Error::msg)?;
                 }
                 Some(q)
             }
@@ -4720,24 +4726,25 @@ fn apply_default_qos(
     accounting: &spur_core::config::AccountingConfig,
 ) -> Result<(), SubmitError> {
     let given_account = spec.account.as_deref().filter(|a| !a.is_empty());
+    // Resolved once and shared by both branches below: `resolve()` reads
+    // account and default QOS under a single lock, so a concurrent cache
+    // refresh can't validate one against the other's stale snapshot.
+    let (account, default_qos) = assoc_cache.resolve(&spec.user, given_account);
 
     if let Some(name) = spec.qos.as_deref().filter(|n| !n.is_empty()) {
         if qos_cache.get(name).is_none() {
             return Err(SubmitError::invalid(format!("QOS '{name}' does not exist")));
         }
-        let (account, _) = assoc_cache.resolve(&spec.user, given_account);
-        if let Some(account) = account.as_deref() {
-            if !assoc_cache.qos_allowed(&spec.user, account, name) {
-                return Err(SubmitError::invalid(format!(
-                    "QOS '{name}' is not permitted for user '{}' under account '{account}'",
-                    spec.user
-                )));
-            }
+        if default_qos.as_deref().is_some_and(|d| d != name) {
+            return Err(SubmitError::invalid(format!(
+                "QOS '{name}' is not permitted for user '{}' under account '{}'",
+                spec.user,
+                account.as_deref().unwrap_or_default()
+            )));
         }
         return Ok(());
     }
 
-    let (account, default_qos) = assoc_cache.resolve(&spec.user, given_account);
     if let Some(default_qos) = default_qos {
         if qos_cache.get(&default_qos).is_some() {
             spec.qos = Some(default_qos);
@@ -10283,6 +10290,65 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn update_job_qos_rejects_bypass_via_unaffiliated_account() {
+        // Pairing the QOS change with an account the user has no recorded
+        // association for must not fall back to "nothing to check" — that
+        // was a live bypass of the authorization this PR adds.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        cm.qos_cache().insert(Qos {
+            name: "highprio".into(),
+            ..Default::default()
+        });
+        cm.qos_cache().insert(Qos {
+            name: "other-teams-qos".into(),
+            ..Default::default()
+        });
+        cm.association_cache()
+            .insert_default_qos("testuser", "research", "highprio");
+        let id = submit_and_wait(&cm, basic_spec("q"));
+
+        let err = cm
+            .update_job(
+                id,
+                None,
+                None,
+                None,
+                None,
+                Some("made-up-account".into()),
+                Some("other-teams-qos".into()),
+            )
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("not associated with account"),
+            "expected an association error, got {err}"
+        );
+        assert_eq!(cm.get_job(id).unwrap().spec.qos, None);
+
+        // An empty account string must fall back to the job's existing
+        // account, not to "no account given" (which would skip
+        // authorization entirely).
+        let mut spec = basic_spec("q2");
+        spec.account = Some("research".into());
+        let id2 = submit_and_wait(&cm, spec);
+        let err = cm
+            .update_job(
+                id2,
+                None,
+                None,
+                None,
+                None,
+                Some(String::new()),
+                Some("other-teams-qos".into()),
+            )
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("is not permitted"),
+            "expected re-enforcement against the job's own account 'research', got {err}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn update_node_state() {
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
@@ -11250,6 +11316,28 @@ mod tests {
 
         super::apply_default_qos(&mut spec, &assoc, &qos, &acct_cfg()).unwrap();
         assert_eq!(spec.qos.as_deref(), Some("anything"));
+    }
+
+    #[test]
+    fn apply_default_qos_explicit_rejects_other_accounts_qos() {
+        // A user in two accounts, each pinned to its own QOS, must not be
+        // able to borrow one account's QOS while submitting under the
+        // other — the exact cross-account confusion reported in SPUR-101.
+        let assoc = AssociationCache::new();
+        assoc.insert_default_qos("testuser", "hyperloom", "hyperloom-qos");
+        assoc.insert_default_qos("testuser", "primus", "primus-qos");
+        let qos = qos_cache_with(&["hyperloom-qos", "primus-qos"]);
+        let mut spec = basic_spec("j");
+        spec.account = Some("hyperloom".into());
+        spec.qos = Some("primus-qos".into());
+
+        let err = super::apply_default_qos(&mut spec, &assoc, &qos, &acct_cfg()).unwrap_err();
+        assert_eq!(
+            err,
+            SubmitError::invalid(
+                "QOS 'primus-qos' is not permitted for user 'testuser' under account 'hyperloom'"
+            )
+        );
     }
 
     // ── array-parent dependency: cancel + display synthesis ──────

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -11412,6 +11412,21 @@ mod tests {
         );
     }
 
+    #[test]
+    fn apply_default_qos_no_explicit_qos_resolves_pinned_default_from_allow_list() {
+        // The common real-world config: an allow-list plus a default that's
+        // a member of it. Omitting --qos must still resolve to the default.
+        let assoc = AssociationCache::new();
+        assoc.insert_allowed_qos("testuser", "research", &["a", "b"]);
+        assoc.insert_default_qos("testuser", "research", "b");
+        let qos = qos_cache_with(&["a", "b"]);
+        let mut spec = basic_spec("j");
+        spec.account = Some("research".into());
+
+        super::apply_default_qos(&mut spec, &assoc, &qos, &acct_cfg()).unwrap();
+        assert_eq!(spec.qos.as_deref(), Some("b"));
+    }
+
     // ── array-parent dependency: cancel + display synthesis ──────
 
     /// Submit an array task job directly via the WAL (bypassing expansion) so

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1506,12 +1506,13 @@ impl ClusterManager {
         account: Option<String>,
         qos: Option<String>,
     ) -> anyhow::Result<()> {
-        {
+        let (job_user, job_account) = {
             let jobs = self.jobs.read();
-            if !jobs.contains_key(&job_id) {
-                anyhow::bail!("job {} not found", job_id);
-            }
-        }
+            let job = jobs
+                .get(&job_id)
+                .ok_or_else(|| anyhow::anyhow!("job {} not found", job_id))?;
+            (job.spec.user.clone(), job.spec.account.clone())
+        };
 
         // Reject before mutating: an unknown QOS resolves to the limitless
         // default and an empty QOS clears enforcement — both reopen the bypass.
@@ -1523,6 +1524,14 @@ impl ClusterManager {
                 }
                 if self.qos_cache.get(&q).is_none() {
                     anyhow::bail!("QOS '{q}' does not exist");
+                }
+                let effective_account = account.as_deref().or(job_account.as_deref());
+                if let Some(acct) = effective_account {
+                    if !self.association_cache.qos_allowed(&job_user, acct, &q) {
+                        anyhow::bail!(
+                            "QOS '{q}' is not permitted for user '{job_user}' under account '{acct}'"
+                        );
+                    }
                 }
                 Some(q)
             }
@@ -4701,22 +4710,33 @@ fn validate_user_account(
 }
 
 /// Resolve a job's QOS at submit, in Slurm's order: explicit `--qos` (must
-/// exist) → association default → cluster fallback (`accounting.default_qos`)
-/// → reject if `accounting.require_qos`, else accept with no QOS.
+/// exist and be permitted for the association) → association default →
+/// cluster fallback (`accounting.default_qos`) → reject if
+/// `accounting.require_qos`, else accept with no QOS.
 fn apply_default_qos(
     spec: &mut JobSpec,
     assoc_cache: &AssociationCache,
     qos_cache: &QosCache,
     accounting: &spur_core::config::AccountingConfig,
 ) -> Result<(), SubmitError> {
+    let given_account = spec.account.as_deref().filter(|a| !a.is_empty());
+
     if let Some(name) = spec.qos.as_deref().filter(|n| !n.is_empty()) {
         if qos_cache.get(name).is_none() {
             return Err(SubmitError::invalid(format!("QOS '{name}' does not exist")));
         }
+        let (account, _) = assoc_cache.resolve(&spec.user, given_account);
+        if let Some(account) = account.as_deref() {
+            if !assoc_cache.qos_allowed(&spec.user, account, name) {
+                return Err(SubmitError::invalid(format!(
+                    "QOS '{name}' is not permitted for user '{}' under account '{account}'",
+                    spec.user
+                )));
+            }
+        }
         return Ok(());
     }
 
-    let given_account = spec.account.as_deref().filter(|a| !a.is_empty());
     let (account, default_qos) = assoc_cache.resolve(&spec.user, given_account);
     if let Some(default_qos) = default_qos {
         if qos_cache.get(&default_qos).is_some() {
@@ -10209,6 +10229,60 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn update_job_qos_rejects_unauthorized_association_qos() {
+        // `scontrol update job qos=` must enforce the same per-association
+        // authorization as submission (SPUR-101).
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        cm.qos_cache().insert(Qos {
+            name: "highprio".into(),
+            ..Default::default()
+        });
+        cm.qos_cache().insert(Qos {
+            name: "other-teams-qos".into(),
+            ..Default::default()
+        });
+        cm.association_cache()
+            .insert_default_qos("testuser", "research", "highprio");
+        let mut spec = basic_spec("q");
+        spec.account = Some("research".into());
+        let id = submit_and_wait(&cm, spec);
+        // Submission already applied the association's own default QOS.
+        assert_eq!(
+            cm.get_job(id).unwrap().spec.qos.as_deref(),
+            Some("highprio")
+        );
+
+        let err = cm
+            .update_job(
+                id,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some("other-teams-qos".into()),
+            )
+            .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("QOS 'other-teams-qos' is not permitted"));
+        assert_eq!(
+            cm.get_job(id).unwrap().spec.qos.as_deref(),
+            Some("highprio"),
+            "rejected update must leave the existing QOS untouched"
+        );
+
+        // The association's own default QOS is still accepted explicitly.
+        cm.update_job(id, None, None, None, None, None, Some("highprio".into()))
+            .unwrap();
+        assert_eq!(
+            cm.get_job(id).unwrap().spec.qos.as_deref(),
+            Some("highprio")
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn update_node_state() {
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
@@ -11114,6 +11188,68 @@ mod tests {
 
         super::apply_default_qos(&mut spec, &assoc, &qos, &acct_cfg_with("", true)).unwrap();
         assert_eq!(spec.qos.as_deref(), Some("highprio"));
+    }
+
+    #[test]
+    fn apply_default_qos_explicit_unauthorized_qos_is_rejected() {
+        // An explicit QOS that exists but isn't the association's own default
+        // must be rejected, not silently accepted (SPUR-101).
+        let assoc = AssociationCache::new();
+        assoc.insert_default_qos("testuser", "research", "highprio");
+        let qos = qos_cache_with(&["highprio", "other-teams-qos"]);
+        let mut spec = basic_spec("j");
+        spec.account = Some("research".into());
+        spec.qos = Some("other-teams-qos".into());
+
+        let err = super::apply_default_qos(&mut spec, &assoc, &qos, &acct_cfg()).unwrap_err();
+        assert_eq!(
+            err,
+            SubmitError::invalid(
+                "QOS 'other-teams-qos' is not permitted for user 'testuser' under account 'research'"
+            )
+        );
+    }
+
+    #[test]
+    fn apply_default_qos_explicit_matches_association_default_is_allowed() {
+        let assoc = AssociationCache::new();
+        assoc.insert_default_qos("testuser", "research", "highprio");
+        let qos = qos_cache_with(&["highprio"]);
+        let mut spec = basic_spec("j");
+        spec.account = Some("research".into());
+        spec.qos = Some("highprio".into());
+
+        super::apply_default_qos(&mut spec, &assoc, &qos, &acct_cfg()).unwrap();
+        assert_eq!(spec.qos.as_deref(), Some("highprio"));
+    }
+
+    #[test]
+    fn apply_default_qos_explicit_allowed_when_association_has_no_default_pinned() {
+        // A loaded cache with a real membership but no default QOS on record
+        // for this association has never been pinned to one — stay permissive.
+        let assoc = AssociationCache::new();
+        assoc.insert_association("testuser", "research");
+        let qos = qos_cache_with(&["anything"]);
+        let mut spec = basic_spec("j");
+        spec.account = Some("research".into());
+        spec.qos = Some("anything".into());
+
+        super::apply_default_qos(&mut spec, &assoc, &qos, &acct_cfg()).unwrap();
+        assert_eq!(spec.qos.as_deref(), Some("anything"));
+    }
+
+    #[test]
+    fn apply_default_qos_explicit_skips_authz_when_no_account_resolves() {
+        // Cache loaded but the user has no resolvable account (e.g. no
+        // default account and none given) — nothing to authorize against.
+        let assoc = AssociationCache::new();
+        assoc.set_loaded_without_associations();
+        let qos = qos_cache_with(&["anything"]);
+        let mut spec = basic_spec("j");
+        spec.qos = Some("anything".into());
+
+        super::apply_default_qos(&mut spec, &assoc, &qos, &acct_cfg()).unwrap();
+        assert_eq!(spec.qos.as_deref(), Some("anything"));
     }
 
     // ── array-parent dependency: cancel + display synthesis ──────

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -33,7 +33,7 @@ use spur_metrics::partition::PartitionMetricsSnapshot;
 use spur_metrics::user_acct::UserAcctMetricsSnapshot;
 
 use crate::accounting::{AccountingNotifier, JobStartRecord};
-use crate::association_cache::{AccountMembership, AssociationCache};
+use crate::association_cache::{qos_permitted, AccountMembership, AssociationCache};
 use crate::fairshare_cache::FairshareCache;
 use crate::limits_cache::QosCache;
 use crate::raft::{ClientResponse, JobFinalized, SpurRaft, StateMachineApply};
@@ -4683,7 +4683,7 @@ fn apply_default_account(spec: &mut JobSpec, assoc_cache: &AssociationCache) {
     if spec.account.as_deref().is_some_and(|a| !a.is_empty()) {
         return;
     }
-    let (account, _) = assoc_cache.resolve(&spec.user, None);
+    let (account, ..) = assoc_cache.resolve(&spec.user, None);
     if let Some(acct) = account.filter(|a| !a.is_empty()) {
         spec.account = Some(acct);
     }
@@ -4725,15 +4725,16 @@ fn apply_default_qos(
 ) -> Result<(), SubmitError> {
     let given_account = spec.account.as_deref().filter(|a| !a.is_empty());
     // Resolved once and shared by both branches below: `resolve()` reads
-    // account and default QOS under a single lock, so a concurrent cache
-    // refresh can't validate one against the other's stale snapshot.
-    let (account, default_qos) = assoc_cache.resolve(&spec.user, given_account);
+    // the account, default QOS, and allow-list under a single lock, so a
+    // concurrent cache refresh can't validate one against the other's
+    // stale snapshot.
+    let (account, default_qos, allowed_qos) = assoc_cache.resolve(&spec.user, given_account);
 
     if let Some(name) = spec.qos.as_deref().filter(|n| !n.is_empty()) {
         if qos_cache.get(name).is_none() {
             return Err(SubmitError::invalid(format!("QOS '{name}' does not exist")));
         }
-        if default_qos.as_deref().is_some_and(|d| d != name) {
+        if !qos_permitted(&allowed_qos, default_qos.as_deref(), name) {
             return Err(SubmitError::invalid(format!(
                 "QOS '{name}' is not permitted for user '{}' under account '{}'",
                 spec.user,
@@ -10347,6 +10348,46 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn update_job_qos_allows_any_member_of_the_allow_list() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        cm.qos_cache().insert(Qos {
+            name: "a".into(),
+            ..Default::default()
+        });
+        cm.qos_cache().insert(Qos {
+            name: "b".into(),
+            ..Default::default()
+        });
+        cm.qos_cache().insert(Qos {
+            name: "other-teams-qos".into(),
+            ..Default::default()
+        });
+        cm.association_cache()
+            .insert_allowed_qos("testuser", "research", &["a", "b"]);
+        let mut spec = basic_spec("q");
+        spec.account = Some("research".into());
+        let id = submit_and_wait(&cm, spec);
+
+        cm.update_job(id, None, None, None, None, None, Some("b".into()))
+            .unwrap();
+        assert_eq!(cm.get_job(id).unwrap().spec.qos.as_deref(), Some("b"));
+
+        let err = cm
+            .update_job(
+                id,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some("other-teams-qos".into()),
+            )
+            .unwrap_err();
+        assert!(err.to_string().contains("is not permitted"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn update_node_state() {
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
@@ -11334,6 +11375,39 @@ mod tests {
             err,
             SubmitError::invalid(
                 "QOS 'primus-qos' is not permitted for user 'testuser' under account 'hyperloom'"
+            )
+        );
+    }
+
+    #[test]
+    fn apply_default_qos_explicit_allows_any_member_of_the_allow_list() {
+        let assoc = AssociationCache::new();
+        assoc.insert_allowed_qos("testuser", "research", &["a", "b", "c"]);
+        let qos = qos_cache_with(&["a", "b", "c"]);
+        let mut spec = basic_spec("j");
+        spec.account = Some("research".into());
+
+        for name in ["a", "b", "c"] {
+            spec.qos = Some(name.into());
+            super::apply_default_qos(&mut spec, &assoc, &qos, &acct_cfg()).unwrap();
+            assert_eq!(spec.qos.as_deref(), Some(name));
+        }
+    }
+
+    #[test]
+    fn apply_default_qos_explicit_rejects_qos_outside_the_allow_list() {
+        let assoc = AssociationCache::new();
+        assoc.insert_allowed_qos("testuser", "research", &["a", "b"]);
+        let qos = qos_cache_with(&["a", "b", "other-teams-qos"]);
+        let mut spec = basic_spec("j");
+        spec.account = Some("research".into());
+        spec.qos = Some("other-teams-qos".into());
+
+        let err = super::apply_default_qos(&mut spec, &assoc, &qos, &acct_cfg()).unwrap_err();
+        assert_eq!(
+            err,
+            SubmitError::invalid(
+                "QOS 'other-teams-qos' is not permitted for user 'testuser' under account 'research'"
             )
         );
     }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -4715,8 +4715,9 @@ fn validate_user_account(
 
 /// Resolve a job's QOS at submit, in Slurm's order: explicit `--qos` (must
 /// exist and be permitted for the association) → association default →
-/// cluster fallback (`accounting.default_qos`) → reject if
-/// `accounting.require_qos`, else accept with no QOS.
+/// cluster fallback (`accounting.default_qos`, also gated by the
+/// association's allow-list) → reject if `accounting.require_qos`, else
+/// accept with no QOS.
 fn apply_default_qos(
     spec: &mut JobSpec,
     assoc_cache: &AssociationCache,
@@ -4729,12 +4730,20 @@ fn apply_default_qos(
     // concurrent cache refresh can't validate one against the other's
     // stale snapshot.
     let (account, default_qos, allowed_qos) = assoc_cache.resolve(&spec.user, given_account);
+    // A stale pinned default (removed from qos_cache since it was set) is
+    // treated as unset for authorization, matching how the fallback chain
+    // below already ignores it rather than letting it block every explicit
+    // `--qos` a user could otherwise submit.
+    let default_qos_for_auth = default_qos
+        .as_deref()
+        .filter(|d| qos_cache.get(d).is_some())
+        .map(str::to_owned);
 
     if let Some(name) = spec.qos.as_deref().filter(|n| !n.is_empty()) {
         if qos_cache.get(name).is_none() {
             return Err(SubmitError::invalid(format!("QOS '{name}' does not exist")));
         }
-        if !qos_permitted(&allowed_qos, default_qos.as_deref(), name) {
+        if !qos_permitted(&allowed_qos, default_qos_for_auth.as_deref(), name) {
             return Err(SubmitError::invalid(format!(
                 "QOS '{name}' is not permitted for user '{}' under account '{}'",
                 spec.user,
@@ -4758,7 +4767,10 @@ fn apply_default_qos(
     }
 
     // A configured fallback naming a nonexistent QOS is a hard error — silently
-    // ignoring it would leave the job unenforced, the gap this closes.
+    // ignoring it would leave the job unenforced, the gap this closes. A fallback
+    // that exists but isn't permitted for this association degrades like a stale
+    // default instead, since it reflects the association's own restriction, not
+    // a misconfiguration.
     let fallback = accounting.default_qos.trim();
     if !fallback.is_empty() {
         if qos_cache.get(fallback).is_none() {
@@ -4766,8 +4778,16 @@ fn apply_default_qos(
                 "configured default QOS '{fallback}' does not exist"
             )));
         }
-        spec.qos = Some(fallback.to_string());
-        return Ok(());
+        if qos_permitted(&allowed_qos, default_qos_for_auth.as_deref(), fallback) {
+            spec.qos = Some(fallback.to_string());
+            return Ok(());
+        }
+        warn!(
+            user = %spec.user,
+            account = account.as_deref().unwrap_or_default(),
+            qos = %fallback,
+            "cluster default QOS not permitted for this association, ignoring"
+        );
     }
 
     if accounting.require_qos {
@@ -11221,6 +11241,82 @@ mod tests {
 
         super::apply_default_qos(&mut spec, &assoc, &qos, &acct_cfg_with("normal", false)).unwrap();
         assert_eq!(spec.qos.as_deref(), Some("normal"));
+    }
+
+    #[test]
+    fn apply_default_qos_explicit_permitted_despite_stale_association_default() {
+        // Association's pinned default was deleted from the cluster; that must
+        // not poison authorization for an unrelated, unrestricted explicit --qos.
+        let assoc = AssociationCache::new();
+        assoc.insert_default_qos("testuser", "research", "deleted-qos");
+        let qos = qos_cache_with(&["highprio"]);
+        let mut spec = basic_spec("j");
+        spec.account = Some("research".into());
+        spec.qos = Some("highprio".into());
+
+        super::apply_default_qos(&mut spec, &assoc, &qos, &acct_cfg()).unwrap();
+        assert_eq!(spec.qos.as_deref(), Some("highprio"));
+    }
+
+    #[test]
+    fn apply_default_qos_cluster_fallback_ignored_outside_allow_list() {
+        // Association is restricted to an allow-list that omits the cluster
+        // fallback; omitting --qos must not silently grant it.
+        let assoc = AssociationCache::new();
+        assoc.insert_allowed_qos("testuser", "research", &["a", "b"]);
+        let qos = qos_cache_with(&["a", "b", "cluster-default"]);
+        let mut spec = basic_spec("j");
+        spec.account = Some("research".into());
+
+        super::apply_default_qos(
+            &mut spec,
+            &assoc,
+            &qos,
+            &acct_cfg_with("cluster-default", false),
+        )
+        .unwrap();
+        assert_eq!(spec.qos, None, "unauthorized fallback must not be assigned");
+    }
+
+    #[test]
+    fn apply_default_qos_cluster_fallback_outside_allow_list_with_require_qos_errors() {
+        let assoc = AssociationCache::new();
+        assoc.insert_allowed_qos("testuser", "research", &["a", "b"]);
+        let qos = qos_cache_with(&["a", "b", "cluster-default"]);
+        let mut spec = basic_spec("j");
+        spec.account = Some("research".into());
+
+        let err = super::apply_default_qos(
+            &mut spec,
+            &assoc,
+            &qos,
+            &acct_cfg_with("cluster-default", true),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            SubmitError::invalid(
+                "no QOS specified and no default QOS is configured for this user/account"
+            )
+        );
+    }
+
+    #[test]
+    fn apply_default_qos_cluster_fallback_permitted_when_in_allow_list() {
+        let assoc = AssociationCache::new();
+        assoc.insert_allowed_qos("testuser", "research", &["cluster-default"]);
+        let qos = qos_cache_with(&["cluster-default"]);
+        let mut spec = basic_spec("j");
+        spec.account = Some("research".into());
+
+        super::apply_default_qos(
+            &mut spec,
+            &assoc,
+            &qos,
+            &acct_cfg_with("cluster-default", false),
+        )
+        .unwrap();
+        assert_eq!(spec.qos.as_deref(), Some("cluster-default"));
     }
 
     #[test]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1525,11 +1525,9 @@ impl ClusterManager {
                 if self.qos_cache.get(&q).is_none() {
                     anyhow::bail!("QOS '{q}' does not exist");
                 }
-                // Falling back to an unfiltered `account` would let a bogus
-                // or unaffiliated account name (or `account=""`) resolve to
-                // "no association on record", which `check_qos_authorized`
-                // treats as permissive — the exact bypass this check exists
-                // to close.
+                // Treat account="" as unset so we authorize against the
+                // job's existing account, rather than erroring on a blank
+                // value that check_qos_authorized would otherwise reject.
                 let effective_account = account
                     .as_deref()
                     .filter(|a| !a.is_empty())

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -1059,6 +1059,10 @@ message AddUserRequest {
   string max_tres_per_job = 8;
   string grp_tres = 9;
   uint32 max_wall_minutes = 10;
+  // Comma-separated QOS names this association may use. Same full-resend
+  // semantics: empty clears an existing allow-list back to unrestricted.
+  // default_qos must be a member when both are set.
+  string allowed_qos = 11;
 }
 
 message RemoveUserRequest {
@@ -1081,6 +1085,7 @@ message UserInfo {
   string admin_level = 3;
   string default_account = 4;
   string default_qos = 5;
+  string allowed_qos = 6;
 }
 
 message CreateQosRequest {

--- a/tests/native_host/e2e/test_accounting.py
+++ b/tests/native_host/e2e/test_accounting.py
@@ -454,6 +454,47 @@ class TestSacctmgrQosAuthorization:
         )
         assert "not permitted" in out, f"expected an authorization rejection, got {out!r}"
 
+    def test_submission_allows_any_member_of_the_qos_allow_list(self, accounting_cluster):
+        # sacctmgr add/modify user qos=a,b grants a set, not just one pinned
+        # default — mirrors Slurm's per-association QOS allow-list.
+        c = accounting_cluster
+        user = c.nodes[0].user
+
+        c.sacctmgr(["add", "qos", "name=burstqos"])
+        c.sacctmgr(["add", "qos", "name=normalqos"])
+        c.sacctmgr(["add", "qos", "name=otherqos"])
+        c.sacctmgr(["add", "account", "name=qoslist"])
+        c.sacctmgr(
+            [
+                "add",
+                "user",
+                f"name={user}",
+                "account=qoslist",
+                "qos=burstqos,normalqos",
+                "defaultqos=normalqos",
+            ]
+        )
+        time.sleep(15)
+
+        script = c.write_file("qos-list.sh", "#!/bin/bash\ntrue\n")
+
+        first_id = parse_job_id(
+            c.sbatch(["-J", "qos-list-a", "-N", "1", "-A", "qoslist", "--qos=burstqos", script])
+        )
+        assert first_id is not None
+        wait_job(c, first_id, timeout=30)
+
+        second_id = parse_job_id(
+            c.sbatch(["-J", "qos-list-b", "-N", "1", "-A", "qoslist", "--qos=normalqos", script])
+        )
+        assert second_id is not None
+        wait_job(c, second_id, timeout=30)
+
+        out = c.cli_allow_fail(
+            ["sbatch", "-J", "qos-list-bad", "-N", "1", "-A", "qoslist", "--qos=otherqos", script]
+        )
+        assert "not permitted" in out, f"expected an authorization rejection, got {out!r}"
+
 
 class TestSacctmgrInvalidInput:
     def test_add_qos_with_non_numeric_limit_fails_cleanly(self, accounting_cluster):

--- a/tests/native_host/e2e/test_accounting.py
+++ b/tests/native_host/e2e/test_accounting.py
@@ -422,6 +422,38 @@ class TestSacctmgrQosAuthorization:
         assert good_id is not None
         wait_job(c, good_id, timeout=30)
 
+    def test_submission_rejects_borrowing_qos_from_a_different_account(self, accounting_cluster):
+        # A user in two accounts, each pinned to its own QOS, must not be
+        # able to submit under one account while borrowing the other's QOS
+        # — the exact cross-account confusion reported in SPUR-101.
+        c = accounting_cluster
+        user = c.nodes[0].user
+
+        c.sacctmgr(["add", "qos", "name=hyperloomqos"])
+        c.sacctmgr(["add", "qos", "name=primusqos"])
+        c.sacctmgr(["add", "account", "name=hyperloom"])
+        c.sacctmgr(["add", "account", "name=primus"])
+        c.sacctmgr(["add", "user", f"name={user}", "account=hyperloom", "defaultqos=hyperloomqos"])
+        c.sacctmgr(["add", "user", f"name={user}", "account=primus", "defaultqos=primusqos"])
+        time.sleep(15)
+
+        script = c.write_file("qos-cross-acct.sh", "#!/bin/bash\ntrue\n")
+
+        out = c.cli_allow_fail(
+            [
+                "sbatch",
+                "-J",
+                "qos-borrow",
+                "-N",
+                "1",
+                "-A",
+                "hyperloom",
+                "--qos=primusqos",
+                script,
+            ]
+        )
+        assert "not permitted" in out, f"expected an authorization rejection, got {out!r}"
+
 
 class TestSacctmgrInvalidInput:
     def test_add_qos_with_non_numeric_limit_fails_cleanly(self, accounting_cluster):

--- a/tests/native_host/e2e/test_accounting.py
+++ b/tests/native_host/e2e/test_accounting.py
@@ -554,6 +554,136 @@ class TestSacctmgrQosAuthorization:
         assert still_allowed_id is not None, "keepqosb must still be usable after the unrelated modify"
         wait_job(c, still_allowed_id, timeout=30)
 
+    def test_modify_user_explicit_empty_qos_clears_the_allow_list(self, accounting_cluster):
+        # The other half of the preserve-semantics fix: an *explicit* empty
+        # qos= must actually clear the allow-list (unlike omitting qos=
+        # entirely, which preserves it — see the test above).
+        c = accounting_cluster
+        user = c.nodes[0].user
+
+        c.sacctmgr(["add", "qos", "name=clearqosa"])
+        c.sacctmgr(["add", "qos", "name=clearqosb"])
+        c.sacctmgr(["add", "account", "name=clearqos"])
+        c.sacctmgr(
+            [
+                "add",
+                "user",
+                f"name={user}",
+                "account=clearqos",
+                "qos=clearqosa,clearqosb",
+                "defaultqos=clearqosa",
+            ]
+        )
+
+        c.sacctmgr(["modify", "user", f"name={user}", "account=clearqos", "set", "qos="])
+
+        out = c.sacctmgr(["show", "user"])
+        row = next(line for line in out.splitlines() if "clearqos" in line and user in line)
+        assert "clearqosa,clearqosb" not in row, f"allow-list must be cleared, got {row!r}"
+        assert "clearqosa" in row, f"pinned default must survive the explicit clear, got {row!r}"
+
+        time.sleep(15)
+        script = c.write_file("qos-cleared.sh", "#!/bin/bash\ntrue\n")
+
+        out = c.cli_allow_fail(
+            ["sbatch", "-J", "qos-cleared-bad", "-N", "1", "-A", "clearqos", "--qos=clearqosb", script]
+        )
+        assert "not permitted" in out, f"cleared allow-list member must now be rejected, got {out!r}"
+
+        still_default_id = parse_job_id(
+            c.sbatch(["-J", "qos-cleared-ok", "-N", "1", "-A", "clearqos", "--qos=clearqosa", script])
+        )
+        assert still_default_id is not None, "the pinned default must still be usable"
+        wait_job(c, still_default_id, timeout=30)
+
+    def test_stale_association_default_does_not_block_unrelated_explicit_qos(self, accounting_cluster):
+        # An association's pinned default can go stale (its QOS deleted
+        # cluster-wide) without disturbing authorization for an unrelated,
+        # still-valid explicit --qos.
+        c = accounting_cluster
+        user = c.nodes[0].user
+
+        c.sacctmgr(["add", "qos", "name=stalegoal"])
+        c.sacctmgr(["add", "qos", "name=stalesurvivor"])
+        c.sacctmgr(["add", "account", "name=staleacct"])
+        c.sacctmgr(["add", "user", f"name={user}", "account=staleacct", "defaultqos=stalegoal"])
+        c.sacctmgr(["delete", "qos", "name=stalegoal"])
+        time.sleep(15)
+
+        script = c.write_file("qos-stale-default.sh", "#!/bin/bash\ntrue\n")
+        job_id = parse_job_id(
+            c.sbatch(["-J", "qos-stale", "-N", "1", "-A", "staleacct", "--qos=stalesurvivor", script])
+        )
+        assert job_id is not None, "explicit --qos must succeed despite a stale pinned default"
+        wait_job(c, job_id, timeout=30)
+
+    def test_cluster_fallback_qos_withheld_when_outside_association_allow_list(self, accounting_cluster):
+        # A restricted association omitting --qos must not silently receive
+        # the cluster-wide fallback QOS when that fallback isn't in its
+        # allow-list — closes the gap where the fallback chain bypassed
+        # per-association authorization entirely.
+        c = accounting_cluster
+        user = c.nodes[0].user
+
+        c.sacctmgr(["add", "qos", "name=fallbackqos"])
+        c.sacctmgr(["add", "qos", "name=restrictedqos"])
+        c.sacctmgr(["add", "account", "name=fallbackacct"])
+        c.sacctmgr(["add", "user", f"name={user}", "account=fallbackacct", "qos=restrictedqos"])
+
+        deep_merge(c.config_overrides, {"accounting": {"default_qos": "fallbackqos"}})
+        c._write_config()
+        c.restart_controller()
+        time.sleep(15)
+
+        script = c.write_file("qos-fallback-outside.sh", "#!/bin/bash\ntrue\n")
+        job_id = parse_job_id(
+            c.sbatch(["-J", "qos-fallback", "-N", "1", "-A", "fallbackacct", script])
+        )
+        assert job_id is not None, "job with no --qos must still be accepted"
+        wait_job(c, job_id, timeout=30)
+
+        show = c.scontrol("show", "job", str(job_id))
+        assert "QOS=fallbackqos" not in show, (
+            f"unauthorized cluster fallback must not be silently granted: {show!r}"
+        )
+
+    def test_update_job_qos_rejects_unauthorized_and_account_spoofing(self, accounting_cluster):
+        # scontrol update job qos= must enforce the same per-association
+        # authorization as submission, including when qos= and account= are
+        # changed together to an account the user has no association with
+        # (the account-spoofing bypass this PR closes).
+        c = accounting_cluster
+        user = c.nodes[0].user
+
+        c.sacctmgr(["add", "qos", "name=updateallowed"])
+        c.sacctmgr(["add", "qos", "name=updateforbidden"])
+        c.sacctmgr(["add", "account", "name=updateacct"])
+        c.sacctmgr(["add", "account", "name=updatestranger"])
+        c.sacctmgr(["add", "user", f"name={user}", "account=updateacct", "defaultqos=updateallowed"])
+        time.sleep(15)
+
+        script = c.write_file("qos-update.sh", "#!/bin/bash\nsleep 30\n")
+        job_id = parse_job_id(
+            c.sbatch(["-J", "qos-update", "-N", "1", "-t", "60", "-A", "updateacct", script])
+        )
+        assert job_id is not None
+
+        out = c.cli_allow_fail(["scontrol", "update", f"jobid={job_id}", "qos=updateforbidden"])
+        assert "not permitted" in out, f"expected an authorization rejection, got {out!r}"
+        show = c.scontrol("show", "job", str(job_id))
+        assert "QOS=updateallowed" in show, f"job QOS must be unchanged after rejected update: {show!r}"
+
+        out = c.cli_allow_fail(
+            ["scontrol", "update", f"jobid={job_id}", "qos=updateforbidden", "account=updatestranger"]
+        )
+        assert "not associated" in out, f"expected a membership rejection, got {out!r}"
+        show = c.scontrol("show", "job", str(job_id))
+        assert "QOS=updateallowed" in show and "Account=updateacct" in show, (
+            f"job must be untouched after a rejected account-spoofing update: {show!r}"
+        )
+
+        c.scancel(str(job_id))
+
 
 class TestSacctmgrInvalidInput:
     def test_add_qos_with_non_numeric_limit_fails_cleanly(self, accounting_cluster):

--- a/tests/native_host/e2e/test_accounting.py
+++ b/tests/native_host/e2e/test_accounting.py
@@ -495,6 +495,65 @@ class TestSacctmgrQosAuthorization:
         )
         assert "not permitted" in out, f"expected an authorization rejection, got {out!r}"
 
+    def test_show_user_displays_qos_and_default_qos_columns(self, accounting_cluster):
+        c = accounting_cluster
+        user = c.nodes[0].user
+
+        c.sacctmgr(["add", "qos", "name=showqosa"])
+        c.sacctmgr(["add", "qos", "name=showqosb"])
+        c.sacctmgr(["add", "account", "name=showqos"])
+        c.sacctmgr(
+            [
+                "add",
+                "user",
+                f"name={user}",
+                "account=showqos",
+                "qos=showqosa,showqosb",
+                "defaultqos=showqosb",
+            ]
+        )
+
+        out = c.sacctmgr(["show", "user"])
+        row = next(line for line in out.splitlines() if "showqos" in line and user in line)
+        assert "showqosa,showqosb" in row, f"expected the QOS list in the row, got {row!r}"
+        assert "showqosb" in row, f"expected the default QOS in the row, got {row!r}"
+
+    def test_modify_user_without_qos_preserves_existing_allow_list(self, accounting_cluster):
+        # An unrelated `modify user` must not silently widen access by
+        # dropping a previously-granted QOS allow-list/default.
+        c = accounting_cluster
+        user = c.nodes[0].user
+
+        c.sacctmgr(["add", "qos", "name=keepqosa"])
+        c.sacctmgr(["add", "qos", "name=keepqosb"])
+        c.sacctmgr(["add", "account", "name=keepqos"])
+        c.sacctmgr(
+            [
+                "add",
+                "user",
+                f"name={user}",
+                "account=keepqos",
+                "qos=keepqosa,keepqosb",
+                "defaultqos=keepqosa",
+            ]
+        )
+
+        # Unrelated modify: touches only maxjobs, never mentions qos=/defaultqos=.
+        c.sacctmgr(["modify", "user", f"name={user}", "account=keepqos", "set", "maxjobs=5"])
+
+        out = c.sacctmgr(["show", "user"])
+        row = next(line for line in out.splitlines() if "keepqos" in line and user in line)
+        assert "keepqosa,keepqosb" in row, f"allow-list must survive an unrelated modify, got {row!r}"
+        assert "keepqosa" in row, f"default QOS must survive an unrelated modify, got {row!r}"
+
+        time.sleep(15)
+        script = c.write_file("qos-preserve.sh", "#!/bin/bash\ntrue\n")
+        still_allowed_id = parse_job_id(
+            c.sbatch(["-J", "qos-preserve", "-N", "1", "-A", "keepqos", "--qos=keepqosb", script])
+        )
+        assert still_allowed_id is not None, "keepqosb must still be usable after the unrelated modify"
+        wait_job(c, still_allowed_id, timeout=30)
+
 
 class TestSacctmgrInvalidInput:
     def test_add_qos_with_non_numeric_limit_fails_cleanly(self, accounting_cluster):

--- a/tests/native_host/e2e/test_accounting.py
+++ b/tests/native_host/e2e/test_accounting.py
@@ -393,6 +393,36 @@ class TestSacctmgrUserAssociationLimits:
         assert reason == "AssocMaxJobsLimit", f"expected AssocMaxJobsLimit, got {reason!r}"
 
 
+class TestSacctmgrQosAuthorization:
+    """A user submitting an explicit --qos outside their association's
+    pinned default QOS must be rejected (SPUR-101), not silently accepted."""
+
+    def test_submission_rejects_qos_outside_association_default(self, accounting_cluster):
+        c = accounting_cluster
+        user = c.nodes[0].user
+
+        c.sacctmgr(["add", "qos", "name=authqos"])
+        c.sacctmgr(["add", "qos", "name=otherqos"])
+        c.sacctmgr(["add", "account", "name=qosauthz"])
+        c.sacctmgr(["add", "user", f"name={user}", "account=qosauthz", "defaultqos=authqos"])
+        # Wait past the association cache refresh floor (10s) before
+        # submitting, else the pinned default hasn't loaded yet.
+        time.sleep(15)
+
+        script = c.write_file("qos-authz.sh", "#!/bin/bash\ntrue\n")
+
+        out = c.cli_allow_fail(
+            ["sbatch", "-J", "qos-bad", "-N", "1", "-A", "qosauthz", "--qos=otherqos", script]
+        )
+        assert "not permitted" in out, f"expected an authorization rejection, got {out!r}"
+
+        good_id = parse_job_id(
+            c.sbatch(["-J", "qos-good", "-N", "1", "-A", "qosauthz", "--qos=authqos", script])
+        )
+        assert good_id is not None
+        wait_job(c, good_id, timeout=30)
+
+
 class TestSacctmgrInvalidInput:
     def test_add_qos_with_non_numeric_limit_fails_cleanly(self, accounting_cluster):
         c = accounting_cluster


### PR DESCRIPTION
## Summary

- Job submission and `scontrol update job qos=` only checked that a requested `--qos` existed somewhere on the cluster, never that the submitting user's (user, account) association was actually authorized to use it. A user in an account pinned to one QOS could submit `--qos=<any-other-existing-qos>` and the job would run with it.
- Adds a per-association QOS allow-list matching Slurm's real model (`assoc_table.qos` + `def_qos_id`): `sacctmgr add/modify user ... qos=<a>,<b> defaultqos=<a>` grants a *set* of usable QOS, not just one. An association with only `defaultqos=` set (no `qos=`) stays scoped to that single value; one with neither is unrestricted (preserves existing behavior for associations an operator never touched).
- A review pass on the initial single-QOS fix found `scontrol update job` could still bypass the check by pairing the QOS change with an account the user has no association for (or an empty account string). A later review pass on the allow-list addition found `sacctmgr modify user` calls touching an unrelated field (e.g. `maxjobs=`) would silently wipe an existing QOS allow-list back to unrestricted, since `modify` always resends the whole record. Both are fixed — see Approach.

Fixes SPUR-101.

## Approach

- `AssociationCache::check_qos_authorized(user, account, qos)` is the single source of truth: permissive when accounting isn't loaded, hard-reject when the association doesn't exist, otherwise a QOS is allowed if it's in the association's allow-list or matches its pinned default. Membership, default, and allow-list are all read under one lock (`resolve()`/`check_qos_authorized()`), so a concurrent cache refresh can't validate one against another's stale snapshot.
- New `associations.allowed_qos` column (comma-separated QOS names, following the existing `grp_tres`-style convention — no array/JSON columns exist elsewhere in this schema) and matching `AddUserRequest`/`UserInfo` proto fields.
- `qos=` on `add`/`modify user` is a full replace, consistent with how every other field on this RPC already works (no `+=`/`-=` incremental operators — out of scope for this change). Server-side validation confirms every listed QOS exists and that `defaultqos` is a member of the list when both are given together.
- `sacctmgr modify user` now looks up the existing record first and preserves `qos=`/`defaultqos=` when a command doesn't mention them, instead of blindly resending empty values — otherwise an unrelated `modify` would silently widen a restricted association back to unrestricted. An explicit `qos=` (even empty, to intentionally clear it) still overrides.

## Known limitations

- If a user has no default account and none is given at submission, there's no association to authorize an explicit `--qos` against, so it's accepted as long as it exists globally — a deliberate no-op (there's nothing to check, not a live bypass), documented and covered by a test.
- The modify-preserves-existing-value fix applies only to the QOS fields (`qos=`/`defaultqos=`), the ones with authorization consequences. Numeric limits (`maxrunningjobs`, `grptres`, etc.) still fully reset on a `modify user` call that omits them — pre-existing behavior for this RPC family, unchanged here.

## Upgrade note

Adds one nullable DB column (`associations.allowed_qos`) and two backward-compatible proto fields (both empty-string-default on old clients/records) — no data migration needed, safe for a rolling deploy. Behavioral impact: any (user, account) association that already has a `default_qos` pinned will, after this deploys, reject submissions/updates requesting any other QOS — which the old code silently accepted. Associations with neither `qos=` nor `defaultqos=` configured are unaffected. Already-running or already-queued jobs are not retroactively touched. Operators relying on the old permissive behavior for a pinned association should confirm that's intentional before upgrading, and can grant additional QOS via `qos=<a>,<b>` if they need more than one.

## Testing

- Unit tests in `association_cache.rs` and `cluster.rs`: authorized/unauthorized explicit QOS, cross-account confusion (a user in two accounts each pinned to a different QOS — the exact reported scenario), the account-spoofing bypass via `scontrol update`, allow-list membership (multiple QOS per association), and default-QOS resolution when both an allow-list and a default are set.
- Unit tests in `sacctmgr.rs`: `qos=` parsing, the `defaultqos`-must-be-a-member validation, and the new `USER_KEYS` allowlist (add/modify user previously had no unknown-key rejection at all).
- Added e2e coverage in `tests/native_host/e2e/test_accounting.py`: single-account rejection, cross-account rejection, multi-QOS allow-list (all members usable, non-members rejected), `show user` displaying the new QOS column, and the modify-preserves-allow-list fix (including that the job still runs after an unrelated modify).
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` and `cargo fmt --all --check` clean; `cargo test -p spurctld -p spur-cli --locked` passes (416 + 211 tests, 13 ignored Postgres-backed).
- Validated end-to-end on two isolated deployments (one per review round): reproduced the exact reported scenario, confirmed submission-time and `scontrol update`-time rejections fire with the intended error messages, confirmed the multi-QOS allow-list accepts every granted QOS and rejects others, confirmed default-QOS resolution against an allow-list, and confirmed an unrelated `modify user` no longer wipes an existing allow-list (job submission with a previously-granted QOS still succeeds afterward). Production confirmed unaffected after each round.
