### PR TITLE
fix(spur-cli): display node features in sinfo

### DIFF
--- a/crates/spur-cli/src/sinfo.rs
+++ b/crates/spur-cli/src/sinfo.rs
@@ -215,6 +215,13 @@ fn resolve_node_field(
         }
         'O' => node.cpu_load.to_string(),
         'e' => node.free_memory_mb.to_string(),
+        'f' => {
+            if node.features.is_empty() {
+                "(null)".into()
+            } else {
+                node.features.join(",")
+            }
+        }
         'l' => "UNLIMITED".into(), // Would need partition context
         _ => "?".into(),
     }
@@ -458,6 +465,29 @@ mod tests {
         assert!(lines[0].contains("idle"));
         assert!(lines[1].contains("n2"));
         assert!(lines[1].contains("down"));
+    }
+
+    #[test]
+    fn node_oriented_output_displays_available_features() {
+        let fields = format_engine::parse_format("%n|%f", &format_engine::sinfo_header);
+        let partitions = vec![make_partition("gpu", true)];
+        let mut node = make_node("gpu-node1", NodeState::NodeIdle, "gpu");
+        node.features = vec!["mi350x".into(), "atl".into()];
+
+        let lines = render_sinfo_output(&fields, &partitions, &[node], true);
+
+        assert_eq!(lines, ["gpu-node1|mi350x,atl"]);
+    }
+
+    #[test]
+    fn node_oriented_output_displays_null_when_features_are_empty() {
+        let fields = format_engine::parse_format("%n|%f", &format_engine::sinfo_header);
+        let partitions = vec![make_partition("cpu", true)];
+        let node = make_node("cpu-node1", NodeState::NodeIdle, "cpu");
+
+        let lines = render_sinfo_output(&fields, &partitions, &[node], true);
+
+        assert_eq!(lines, ["cpu-node1|(null)"]);
     }
 
     // --- effective_state_str tests ---

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -2131,6 +2131,7 @@ fn node_to_proto(node: &spur_core::node::Node) -> NodeInfo {
         active_reservation: String::new(),
         labels: node.labels.clone(),
         reservation_maint: false,
+        features: node.features.clone(),
     }
 }
 
@@ -2407,6 +2408,16 @@ mod tests {
             spur_core::node::Node::new(name.into(), spur_core::resource::ResourceSet::default());
         n.partitions = vec![partition.into()];
         n
+    }
+
+    #[test]
+    fn node_info_includes_available_features() {
+        let mut node = core_node("gpu-node1", "gpu");
+        node.features = vec!["mi350x".into(), "atl".into()];
+
+        let info = node_to_proto(&node);
+
+        assert_eq!(info.features, ["mi350x", "atl"]);
     }
 
     fn names(pattern: &str) -> Option<HashSet<String>> {

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -239,6 +239,7 @@ message NodeInfo {
   string active_reservation = 50;
   map<string, string> labels = 51;
   bool reservation_maint = 52;
+  repeated string features = 53;
 }
 
 message PartitionInfo {


### PR DESCRIPTION
## Summary

- expose each node's resolved features through `NodeInfo`
- render `%f` in node-oriented `sinfo`, using a comma-separated list or `(null)` when empty
- cover both the controller conversion and populated/empty CLI output

## Design

Dynamic registration already maps node labels through `NodeConfig` into the controller's `Node.features`. this adds the missing transport and rendering path w/o changing feature resolution

Partition-oriented `%f` is out of scope b/c those rows are currently grouped only by node state; reporting heterogeneous feature sets correctly there requires feature-aware grouping.

## Testing

- `cargo fmt --all -- --check`
- `PROTOC=/opt/homebrew/bin/protoc cargo test -p spur-cli --locked`
- `PROTOC=/opt/homebrew/bin/protoc cargo test -p spurctld --locked`
- `PROTOC=/opt/homebrew/bin/protoc cargo clippy -p spur-cli -p spurctld --all-targets --locked -- -D warnings`
- local release-build smoke test using a real `spurctld`, synthetic `RegisterAgent` calls, and `sinfo -N`:

  ```text
  gpu-node1|mi350x,atl
  gpu-node2|(null)
  ```

Attempted the full workspace test and Clippy commands, but the untouched  `spurd` crate does not compile on macOS because it uses Linux mount namespace, Landlock, and seccomp APIs.
Both changed crates pass their complete test suites and Clippy checks.

Closes #355
