### PR TITLE
fix(oci): key container images by canonical reference

### DIFF
--- a/crates/spur-cli/src/image.rs
+++ b/crates/spur-cli/src/image.rs
@@ -311,7 +311,7 @@ fn cmd_list() -> Result<()> {
 
     println!("{:<50} {:>10}", "IMAGE", "SIZE");
     for (name, size) in &images {
-        let display_name = name.replace('+', "/");
+        let display_name = spur_net::oci::display_name(name);
         let size_str = if *size > 1_073_741_824 {
             format!("{:.1} GB", *size as f64 / 1_073_741_824.0)
         } else {

--- a/crates/spur-cli/src/image.rs
+++ b/crates/spur-cli/src/image.rs
@@ -102,7 +102,7 @@ async fn cmd_import_dockerd(image: &str) -> Result<()> {
     eprintln!("Importing from Docker daemon: {}", image);
 
     let image_dir = resolve_image_dir();
-    let name = spur_net::oci::sanitize_name(image);
+    let name = spur_net::oci::image_file_stem(image);
     let output_path = image_dir.join(format!("{}.sqsh", name));
     if output_path.exists() {
         eprintln!("Image already imported: {}", output_path.display());
@@ -155,7 +155,7 @@ async fn cmd_import_podman(image: &str) -> Result<()> {
     eprintln!("Importing from Podman: {}", image);
 
     let image_dir = resolve_image_dir();
-    let name = spur_net::oci::sanitize_name(image);
+    let name = spur_net::oci::image_file_stem(image);
     let output_path = image_dir.join(format!("{}.sqsh", name));
     if output_path.exists() {
         eprintln!("Image already imported: {}", output_path.display());
@@ -324,7 +324,7 @@ fn cmd_list() -> Result<()> {
 }
 
 fn cmd_remove(name: &str) -> Result<()> {
-    let sanitized = spur_net::oci::sanitize_name(name);
+    let sanitized = spur_net::oci::image_file_stem(name);
     let image_dir = resolve_image_dir();
     let path = image_dir.join(format!("{}.sqsh", sanitized));
 

--- a/crates/spur-cli/src/sbatch.rs
+++ b/crates/spur-cli/src/sbatch.rs
@@ -618,7 +618,7 @@ fn resolve_container_image(image: Option<&str>) -> String {
     }
 
     // Try to find the .sqsh file in the image directory
-    let sanitized = spur_net::oci::sanitize_name(image);
+    let sanitized = spur_net::oci::image_file_stem(image);
 
     // Check $SPUR_IMAGE_DIR first, then system default, then user fallback
     let candidates = {
@@ -1301,6 +1301,34 @@ echo "hello world"
         assert_eq!(
             wrap_command_body("#SBATCH --nodes=9"),
             "#!/bin/sh\n# This script was created by sbatch --wrap.\n\n#SBATCH --nodes=9\n"
+        );
+    }
+
+    #[test]
+    fn test_resolve_container_image_cross_form() {
+        use std::sync::Mutex;
+        static ENV_LOCK: Mutex<()> = Mutex::new(());
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let dir = tempfile::tempdir().unwrap();
+        let stem = spur_net::oci::image_file_stem("docker://busybox:latest");
+        let image_path = dir.path().join(format!("{}.sqsh", stem));
+        std::fs::write(&image_path, b"fake").unwrap();
+
+        let prev = std::env::var_os("SPUR_IMAGE_DIR");
+        std::env::set_var("SPUR_IMAGE_DIR", dir.path());
+
+        let resolved = resolve_container_image(Some("busybox"));
+
+        match prev {
+            Some(v) => std::env::set_var("SPUR_IMAGE_DIR", v),
+            None => std::env::remove_var("SPUR_IMAGE_DIR"),
+        }
+
+        assert_eq!(
+            resolved,
+            image_path.to_string_lossy(),
+            "bare 'busybox' must resolve to the image imported as 'docker://busybox:latest'"
         );
     }
 }

--- a/crates/spur-net/src/oci.rs
+++ b/crates/spur-net/src/oci.rs
@@ -116,6 +116,18 @@ pub fn image_file_stem(image: &str) -> String {
     sanitize_name(&parse_image_ref(image).canonical())
 }
 
+/// Render a stored filename stem back to a canonical image reference for display.
+///
+/// The last `+` is always the tag separator (canonical form guarantees a tag),
+/// and remaining `+` map back to `/`. Port-bearing registries lose the port
+/// colon (shown as `/`) since `sanitize_name` maps both `:` and `/` to `+`.
+pub fn display_name(stem: &str) -> String {
+    match stem.rsplit_once('+') {
+        Some((path, tag)) => format!("{}:{}", path.replace('+', "/"), tag),
+        None => stem.to_string(),
+    }
+}
+
 /// Pull an image from a registry and create a squashfs file.
 ///
 /// Returns the path to the squashfs file.
@@ -128,7 +140,7 @@ pub async fn pull_image(image: &str, output_dir: &Path) -> anyhow::Result<PathBu
         "pulling image"
     );
 
-    let sanitized = image_file_stem(image);
+    let sanitized = sanitize_name(&image_ref.canonical());
     let sqsh_path = output_dir.join(format!("{}.sqsh", sanitized));
 
     if sqsh_path.exists() {
@@ -800,6 +812,29 @@ mod tests {
             image_file_stem("nvcr.io/nvidia/pytorch:24.01"),
             "nvcr.io+nvidia+pytorch+24.01"
         );
+    }
+
+    #[test]
+    fn test_canonical_port_bearing_registry() {
+        let r = parse_image_ref("localhost:5000/myimage:dev");
+        assert_eq!(r.canonical(), "localhost:5000/myimage:dev");
+        assert_eq!(
+            image_file_stem("localhost:5000/myimage:dev"),
+            "localhost+5000+myimage+dev"
+        );
+    }
+
+    #[test]
+    fn test_display_name() {
+        assert_eq!(
+            display_name("docker.io+library+busybox+latest"),
+            "docker.io/library/busybox:latest"
+        );
+        assert_eq!(
+            display_name("nvcr.io+nvidia+pytorch+24.01"),
+            "nvcr.io/nvidia/pytorch:24.01"
+        );
+        assert_eq!(display_name("alpine"), "alpine");
     }
 
     #[test]

--- a/crates/spur-net/src/oci.rs
+++ b/crates/spur-net/src/oci.rs
@@ -98,6 +98,24 @@ pub fn parse_image_ref(image: &str) -> ImageRef {
     }
 }
 
+impl ImageRef {
+    /// Canonical `registry/repository:tag` form.
+    ///
+    /// Equivalent references (`busybox`, `busybox:latest`, `docker://busybox`,
+    /// `docker.io/library/busybox:latest`) all normalize to the same string.
+    pub fn canonical(&self) -> String {
+        format!("{}/{}:{}", self.registry, self.repository, self.tag)
+    }
+}
+
+/// Canonical filename stem for an image reference.
+///
+/// Derives the on-disk name from the normalized `ImageRef` rather than the raw
+/// input string, so all equivalent references map to a single stored image.
+pub fn image_file_stem(image: &str) -> String {
+    sanitize_name(&parse_image_ref(image).canonical())
+}
+
 /// Pull an image from a registry and create a squashfs file.
 ///
 /// Returns the path to the squashfs file.
@@ -110,7 +128,7 @@ pub async fn pull_image(image: &str, output_dir: &Path) -> anyhow::Result<PathBu
         "pulling image"
     );
 
-    let sanitized = sanitize_name(image);
+    let sanitized = image_file_stem(image);
     let sqsh_path = output_dir.join(format!("{}.sqsh", sanitized));
 
     if sqsh_path.exists() {
@@ -748,6 +766,40 @@ mod tests {
         );
         assert_eq!(registry_base_url("ghcr.io"), "https://ghcr.io");
         assert_eq!(registry_base_url("localhost:5000"), "http://localhost:5000");
+    }
+
+    #[test]
+    fn test_canonical_equivalent_refs_collapse() {
+        // All of these reference the same Docker Hub official image and must
+        // resolve to a single canonical name / filename stem.
+        let expected = "docker.io/library/busybox:latest";
+        for r in [
+            "busybox",
+            "busybox:latest",
+            "docker://busybox",
+            "docker://busybox:latest",
+            "docker.io/library/busybox:latest",
+        ] {
+            assert_eq!(parse_image_ref(r).canonical(), expected, "ref: {}", r);
+            assert_eq!(
+                image_file_stem(r),
+                "docker.io+library+busybox+latest",
+                "ref: {}",
+                r
+            );
+        }
+    }
+
+    #[test]
+    fn test_canonical_custom_registry() {
+        assert_eq!(
+            parse_image_ref("nvcr.io/nvidia/pytorch:24.01").canonical(),
+            "nvcr.io/nvidia/pytorch:24.01"
+        );
+        assert_eq!(
+            image_file_stem("nvcr.io/nvidia/pytorch:24.01"),
+            "nvcr.io+nvidia+pytorch+24.01"
+        );
     }
 
     #[test]

--- a/crates/spurd/src/container.rs
+++ b/crates/spurd/src/container.rs
@@ -1496,6 +1496,34 @@ mod tests {
         assert_eq!(resolved, image_path);
     }
 
+    #[test]
+    fn test_resolve_image_cross_form_reference() {
+        let images_dir = tempfile::tempdir().unwrap();
+        // Import under one form...
+        let image_path = images_dir.path().join(format!(
+            "{}.sqsh",
+            spur_net::oci::image_file_stem("docker://busybox:latest")
+        ));
+        std::fs::write(&image_path, b"fake squashfs").unwrap();
+
+        let _guard = env_lock();
+        let prev = std::env::var_os("SPUR_IMAGE_DIR");
+        std::env::set_var("SPUR_IMAGE_DIR", images_dir.path());
+
+        // ...resolve under a different equivalent form.
+        let result = resolve_image("busybox", None, None);
+
+        match prev {
+            Some(v) => std::env::set_var("SPUR_IMAGE_DIR", v),
+            None => std::env::remove_var("SPUR_IMAGE_DIR"),
+        }
+
+        let resolved = result.expect(
+            "resolve_image('busybox') must find image imported as 'docker://busybox:latest'",
+        );
+        assert_eq!(resolved, image_path);
+    }
+
     // --- create_mount_target: source-type detection ---
 
     #[test]

--- a/crates/spurd/src/container.rs
+++ b/crates/spurd/src/container.rs
@@ -191,7 +191,7 @@ pub fn resolve_image(
     }
 
     let dirs = image_dirs_for_job(job_user, job_uid);
-    let sanitized = sanitize_name(image);
+    let sanitized = spur_net::oci::image_file_stem(image);
 
     for dir in &dirs {
         // Try with .sqsh extension
@@ -1139,7 +1139,7 @@ pub fn list_images() -> Vec<(String, u64)> {
 
 /// Remove an imported image.
 pub fn remove_image(name: &str) -> anyhow::Result<()> {
-    let path = image_dir().join(format!("{}.sqsh", sanitize_name(name)));
+    let path = image_dir().join(format!("{}.sqsh", spur_net::oci::image_file_stem(name)));
     if !path.exists() {
         bail!("image '{}' not found", name);
     }
@@ -1469,7 +1469,12 @@ mod tests {
         // test_resolve_job_user_home_for_current_uid +
         // test_compose_image_dirs_includes_existing_user_home_dir.)
         let images_dir = tempfile::tempdir().unwrap();
-        let image_path = images_dir.path().join("myimage.sqsh");
+        // Stored under the canonical stem, matching how `spur image import`
+        // names files (registry+repository+tag).
+        let image_path = images_dir.path().join(format!(
+            "{}.sqsh",
+            spur_net::oci::image_file_stem("myimage")
+        ));
         std::fs::write(&image_path, b"fake squashfs").unwrap();
 
         // Use SPUR_IMAGE_DIR to inject a known dir into the search path.


### PR DESCRIPTION
## What

`spur image import` and the agent-side image resolution (used by `srun --container-image`) keyed stored squashfs files off the raw reference string via `sanitize_name`. Equivalent references for the same image therefore mapped to different files:

| Reference | Stored file (before) |
|---|---|
| `busybox` | `busybox.sqsh` |
| `busybox:latest` | `busybox+latest.sqsh` |
| `docker://busybox:latest` | `busybox+latest.sqsh` |
| `docker.io/library/busybox:latest` | `docker.io+library+busybox+latest.sqsh` |

Import one form and reference another (e.g. import `busybox`, run `srun --container-image busybox:latest`) and the job failed with a spurious "not found, import it first", even though `parse_image_ref` already knew all four forms are the same image.

## Approach

Add `ImageRef::canonical()` (→ `registry/repository:tag`) and `image_file_stem()` in `spur-net`, and derive filenames from the normalized reference instead of the raw string. Applied consistently in:

- the native OCI puller (`pull_image`)
- the `dockerd://` / `podman://` importers
- `spur image remove`
- the agent's `resolve_image` / `remove_image`

All equivalent references now collapse to a single stored image (`docker.io+library+busybox+latest.sqsh`). The local `sanitize_name` in `spurd` is retained only for `--container-name`, a separate namespace.

## Compatibility

Not backward compatible: images stored under the old raw-string names no longer resolve and must be re-imported. Acceptable pre-release.

## Testing

- New unit tests in `spur-net` verifying equivalent refs collapse to one canonical name/stem, plus a custom-registry case.
- Updated the `spurd` user-home resolution test to use the canonical stem.
- Verified end-to-end: all four import forms produce one file, and `spur image remove busybox` deletes an image imported as `busybox:latest`.
- `cargo test -p spur-net -p spurd` and `cargo clippy -p spur-net -p spurd -p spur-cli --all-targets` pass clean.

## Note

`spur image list` renders `+` as `/`, so canonical stems display as `docker.io/library/busybox/latest` (tag separator shown as `/`). Pre-existing display quirk, left untouched to keep this focused.