### PR TITLE
fix(spur): reclaim node resources when completion and eviction desync

### DIFF
--- a/crates/spur-sched/src/cons_tres.rs
+++ b/crates/spur-sched/src/cons_tres.rs
@@ -86,6 +86,20 @@ impl NodeAllocation {
             .collect()
     }
 
+    /// Job ids that own any of `device_ids` and are NOT mid-launch. A launching
+    /// job is deliberately excluded: a launch in flight for overlapping GPUs is a
+    /// genuine concurrent duplicate, never a reclaimable stale owner. Used by the
+    /// agent to reclaim a stale committed reservation on dispatch when the owning
+    /// job is no longer running locally.
+    pub fn conflicting_owners(&self, device_ids: &[u32]) -> Vec<u32> {
+        self.owners
+            .iter()
+            .filter(|(id, _)| !self.launching.contains(id))
+            .filter(|(_, alloc)| alloc.gpu_ids.iter().any(|g| device_ids.contains(g)))
+            .map(|(id, _)| *id)
+            .collect()
+    }
+
     /// Available GPU count (optionally filtered by type).
     pub fn free_gpus(&self, gpu_type: Option<&str>) -> u32 {
         self.gpu_allocated
@@ -437,6 +451,28 @@ mod tests {
         assert_eq!(node.free_gpus(None), 1);
         // The failed job left no owner entry.
         assert!(!node.release_job(2));
+    }
+
+    #[test]
+    fn test_conflicting_owners_reports_committed_but_not_launching() {
+        let mut node = make_node_with_ids(64, 256_000, vec![0, 1, 2, 3], "mi300x");
+        // job 1: committed, owns GPUs 0 and 1.
+        node.allocate_for_job(1, 4, 8_000, &[0, 1]).unwrap();
+        node.commit_job(1);
+        // job 2: still launching (reserved, not committed), owns GPU 2.
+        node.allocate_for_job(2, 4, 8_000, &[2]).unwrap();
+
+        // A new dispatch onto GPU 1 conflicts with committed job 1.
+        assert_eq!(node.conflicting_owners(&[1]), vec![1]);
+        // A dispatch onto GPU 3 (free) conflicts with nobody.
+        assert!(node.conflicting_owners(&[3]).is_empty());
+        // A dispatch onto GPU 2 conflicts with a still-launching job, which must
+        // NOT be reported — a launch in flight is a real concurrent duplicate,
+        // never a reclaimable stale owner.
+        assert!(node.conflicting_owners(&[2]).is_empty());
+        // A dispatch spanning a committed and a launching device reports only the
+        // committed owner.
+        assert_eq!(node.conflicting_owners(&[1, 2]), vec![1]);
     }
 
     #[test]

--- a/crates/spur-sched/src/cons_tres.rs
+++ b/crates/spur-sched/src/cons_tres.rs
@@ -86,11 +86,8 @@ impl NodeAllocation {
             .collect()
     }
 
-    /// Job ids that own any of `device_ids` and are NOT mid-launch. A launching
-    /// job is deliberately excluded: a launch in flight for overlapping GPUs is a
-    /// genuine concurrent duplicate, never a reclaimable stale owner. Used by the
-    /// agent to reclaim a stale committed reservation on dispatch when the owning
-    /// job is no longer running locally.
+    /// Job ids owning any of `device_ids`, excluding mid-launch owners (a launch
+    /// in flight is a real duplicate, not a reclaimable stale owner).
     pub fn conflicting_owners(&self, device_ids: &[u32]) -> Vec<u32> {
         self.owners
             .iter()
@@ -466,9 +463,7 @@ mod tests {
         assert_eq!(node.conflicting_owners(&[1]), vec![1]);
         // A dispatch onto GPU 3 (free) conflicts with nobody.
         assert!(node.conflicting_owners(&[3]).is_empty());
-        // A dispatch onto GPU 2 conflicts with a still-launching job, which must
-        // NOT be reported — a launch in flight is a real concurrent duplicate,
-        // never a reclaimable stale owner.
+        // GPU 2's owner is still launching — a real duplicate, never reported.
         assert!(node.conflicting_owners(&[2]).is_empty());
         // A dispatch spanning a committed and a launching device reports only the
         // committed owner.

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -1333,14 +1333,10 @@ async fn enforce_completing_timeout(cluster: Arc<ClusterManager>, raft: Arc<Raft
 
 /// Force-finish a job the controller has waited on past `complete_wait_secs`.
 ///
-/// The nodes that never reported are about to have their resources freed in the
-/// controller's accounting. Their agents may still hold the local allocation
-/// (their completion report was lost or the process never exited), so cancel the
-/// job on exactly those nodes first — otherwise the controller re-advertises a
-/// node the agent still owns, the next dispatch is rejected with
-/// "controller-allocated GPUs unavailable", and the victim job requeues to
-/// JobHoldMaxRequeue. The cancel is bounded and best-effort; the agent-side
-/// stale-owner reclaim covers the case where it does not arrive in time.
+/// The unreported nodes are about to have their resources freed here, but their
+/// agents may still hold the allocation, so cancel the job on those nodes first
+/// or the next dispatch is rejected and the victim requeues to JobHoldMaxRequeue.
+/// Best-effort; the agent-side reclaim covers a cancel that arrives too late.
 async fn force_finish_completing_job(cluster: &Arc<ClusterManager>, job: &spur_core::job::Job) {
     let missing: Vec<_> = job
         .allocated_nodes

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -1331,12 +1331,9 @@ async fn enforce_completing_timeout(cluster: Arc<ClusterManager>, raft: Arc<Raft
     }
 }
 
-/// Force-finish a job the controller has waited on past `complete_wait_secs`.
-///
-/// The unreported nodes are about to have their resources freed here, but their
-/// agents may still hold the allocation, so cancel the job on those nodes first
-/// or the next dispatch is rejected and the victim requeues to JobHoldMaxRequeue.
-/// Best-effort; the agent-side reclaim covers a cancel that arrives too late.
+/// Force-finish a job stuck in Completing past `complete_wait_secs`, cancelling
+/// it on the unreported nodes first so their agents release the allocation
+/// before the controller frees those nodes. Best-effort; the agent reclaim backs it.
 async fn force_finish_completing_job(cluster: &Arc<ClusterManager>, job: &spur_core::job::Job) {
     let missing: Vec<_> = job
         .allocated_nodes
@@ -2413,10 +2410,8 @@ mod tests {
             assert!(job.allocated_nodes.is_empty());
         }
 
-        // On a completing-timeout force-finish, the controller frees the
-        // still-unreported node in its accounting. It must first cancel the job
-        // on exactly that node — otherwise its agent keeps the stale local
-        // allocation and rejects the next dispatch, stranding the node.
+        // Force-finish must cancel the job on the unreported node before freeing
+        // it, or the agent keeps the stale allocation and rejects the next dispatch.
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
         async fn completing_timeout_cancels_only_the_unreported_node() {
             use spur_core::job::JobState;

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -2478,6 +2478,57 @@ mod tests {
             );
         }
 
+        // When no node reported (e.g. a suspended job's tasks died out-of-band),
+        // every allocated node is unreported and must be cancelled on force-finish.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn completing_timeout_cancels_all_nodes_when_none_reported() {
+            use spur_core::job::JobState;
+
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+
+            let (addr1, cancel1) = spawn_mock_agent().await;
+            let (addr2, cancel2) = spawn_mock_agent().await;
+            register_node_at(&cm, "n1", addr1);
+            register_node_at(&cm, "n2", addr2);
+
+            let spec = JobSpec {
+                name: "completing-none".into(),
+                user: "testuser".into(),
+                num_nodes: 2,
+                num_tasks: 2,
+                cpus_per_task: 1,
+                work_dir: "/tmp".into(),
+                ..Default::default()
+            };
+            let job_id = submit_and_wait(&cm, spec);
+
+            let nodes = vec!["n1".to_string(), "n2".to_string()];
+            let per_node_allocs: HashMap<String, ResourceAllocations> = nodes
+                .iter()
+                .map(|n| (n.clone(), ResourceAllocations::with_scalar(1, 0)))
+                .collect();
+            cm.start_job(
+                job_id,
+                nodes,
+                ResourceAllocations::with_scalar(2, 0),
+                per_node_allocs,
+            )
+            .unwrap();
+            settle(&cm, job_id, JobState::Running);
+
+            // Suspend routes through Completing; no node reports completion.
+            cm.suspend_job(job_id, "").unwrap();
+            settle(&cm, job_id, JobState::Suspended);
+            let mut job = cm.get_job(job_id).unwrap();
+            job.transition(JobState::Completing).unwrap();
+
+            force_finish_completing_job(&cm, &job).await;
+
+            assert_eq!(cancel1.load(Ordering::SeqCst), 1, "n1 must be cancelled");
+            assert_eq!(cancel2.load(Ordering::SeqCst), 1, "n2 must be cancelled");
+        }
+
         // Mock agents echo an offset-keyed path; the stored path must be the
         // primary's (task_offset == 0) regardless of which response arrives first.
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -1326,49 +1326,67 @@ async fn enforce_completing_timeout(cluster: Arc<ClusterManager>, raft: Arc<Raft
                 continue;
             }
 
-            let missing: Vec<_> = job
-                .allocated_nodes
-                .iter()
-                .filter(|n| !job.node_completions.contains_key(*n))
-                .cloned()
-                .collect();
-
-            // Empty when no nodes allocated; derived_completion falls back to worst completion.
-            let primary = job.allocated_nodes.first().cloned().unwrap_or_default();
-            let (mut state, mut exit_code, _signal) =
-                spur_core::job::Job::derived_completion(&job.node_completions, &primary);
-            if job.node_completions.is_empty() {
-                state = spur_core::job::JobState::Failed;
-                exit_code = -1;
-            } else if !missing.is_empty() {
-                warn!(
-                    job_id = job.job_id,
-                    missing = ?missing,
-                    reported = job.node_completions.len(),
-                    expected = job.allocated_nodes.len(),
-                    "completing timeout — not all nodes reported"
-                );
-                state = spur_core::job::JobState::Failed;
-                if exit_code == 0 {
-                    exit_code = 1;
-                }
-            }
-
-            info!(
-                job_id = job.job_id,
-                state = ?state,
-                exit_code,
-                "completing timeout expired — force-finishing job"
-            );
-
-            if let Err(e) = cluster.complete_job(job.job_id, exit_code, state) {
-                warn!(
-                    job_id = job.job_id,
-                    error = %e,
-                    "failed to force-finish job after completing timeout"
-                );
-            }
+            force_finish_completing_job(&cluster, &job).await;
         }
+    }
+}
+
+/// Force-finish a job the controller has waited on past `complete_wait_secs`.
+///
+/// The nodes that never reported are about to have their resources freed in the
+/// controller's accounting. Their agents may still hold the local allocation
+/// (their completion report was lost or the process never exited), so cancel the
+/// job on exactly those nodes first — otherwise the controller re-advertises a
+/// node the agent still owns, the next dispatch is rejected with
+/// "controller-allocated GPUs unavailable", and the victim job requeues to
+/// JobHoldMaxRequeue. The cancel is bounded and best-effort; the agent-side
+/// stale-owner reclaim covers the case where it does not arrive in time.
+async fn force_finish_completing_job(cluster: &Arc<ClusterManager>, job: &spur_core::job::Job) {
+    let missing: Vec<_> = job
+        .allocated_nodes
+        .iter()
+        .filter(|n| !job.node_completions.contains_key(*n))
+        .cloned()
+        .collect();
+
+    // Empty when no nodes allocated; derived_completion falls back to worst completion.
+    let primary = job.allocated_nodes.first().cloned().unwrap_or_default();
+    let (mut state, mut exit_code, _signal) =
+        spur_core::job::Job::derived_completion(&job.node_completions, &primary);
+    if job.node_completions.is_empty() {
+        state = spur_core::job::JobState::Failed;
+        exit_code = -1;
+    } else if !missing.is_empty() {
+        warn!(
+            job_id = job.job_id,
+            missing = ?missing,
+            reported = job.node_completions.len(),
+            expected = job.allocated_nodes.len(),
+            "completing timeout — not all nodes reported"
+        );
+        state = spur_core::job::JobState::Failed;
+        if exit_code == 0 {
+            exit_code = 1;
+        }
+    }
+
+    if !missing.is_empty() {
+        cancel_job_on_nodes(cluster, job.job_id, &missing, 9).await;
+    }
+
+    info!(
+        job_id = job.job_id,
+        state = ?state,
+        exit_code,
+        "completing timeout expired — force-finishing job"
+    );
+
+    if let Err(e) = cluster.complete_job(job.job_id, exit_code, state) {
+        warn!(
+            job_id = job.job_id,
+            error = %e,
+            "failed to force-finish job after completing timeout"
+        );
     }
 }
 
@@ -2397,6 +2415,67 @@ mod tests {
             let job = cm.get_job(job_id).unwrap();
             assert_eq!(job.state, JobState::Pending);
             assert!(job.allocated_nodes.is_empty());
+        }
+
+        // On a completing-timeout force-finish, the controller frees the
+        // still-unreported node in its accounting. It must first cancel the job
+        // on exactly that node — otherwise its agent keeps the stale local
+        // allocation and rejects the next dispatch, stranding the node.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn completing_timeout_cancels_only_the_unreported_node() {
+            use spur_core::job::JobState;
+
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+
+            let (addr1, cancel1) = spawn_mock_agent().await;
+            let (addr2, cancel2) = spawn_mock_agent().await;
+            register_node_at(&cm, "n1", addr1);
+            register_node_at(&cm, "n2", addr2);
+
+            let spec = JobSpec {
+                name: "completing-timeout".into(),
+                user: "testuser".into(),
+                num_nodes: 2,
+                num_tasks: 2,
+                cpus_per_task: 1,
+                work_dir: "/tmp".into(),
+                ..Default::default()
+            };
+            let job_id = submit_and_wait(&cm, spec);
+
+            let nodes = vec!["n1".to_string(), "n2".to_string()];
+            let per_node_allocs: HashMap<String, ResourceAllocations> = nodes
+                .iter()
+                .map(|n| (n.clone(), ResourceAllocations::with_scalar(1, 0)))
+                .collect();
+            let run_attempt = cm
+                .start_job(
+                    job_id,
+                    nodes,
+                    ResourceAllocations::with_scalar(2, 0),
+                    per_node_allocs,
+                )
+                .unwrap();
+            settle(&cm, job_id, JobState::Running);
+
+            // n1 reports completion; n2 never does, so the job stays Completing.
+            cm.node_complete(job_id, "n1", 0, 0, run_attempt).unwrap();
+            settle(&cm, job_id, JobState::Completing);
+
+            let job = cm.get_job(job_id).unwrap();
+            force_finish_completing_job(&cm, &job).await;
+
+            assert_eq!(
+                cancel2.load(Ordering::SeqCst),
+                1,
+                "the unreported node n2 must be cancelled before its resources are freed"
+            );
+            assert_eq!(
+                cancel1.load(Ordering::SeqCst),
+                0,
+                "the node that already reported must not be cancelled"
+            );
         }
 
         // Mock agents echo an offset-keyed path; the stored path must be the

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -2989,6 +2989,90 @@ mod tests {
         );
     }
 
+    fn gpu_alloc_request(device_ids: &[u32]) -> ResourceAllocations {
+        let devices = device_ids
+            .iter()
+            .map(|id| AllocatedDevice {
+                device_id: *id,
+                count: 1,
+            })
+            .collect();
+        let mut map = std::collections::HashMap::new();
+        map.insert("gpu".to_string(), DeviceAllocations { devices });
+        ResourceAllocations {
+            cpus: 1,
+            memory_mb: 0,
+            devices: map,
+        }
+    }
+
+    // A dispatch spanning two GPUs each held by a distinct stale owner must
+    // reclaim both and succeed.
+    #[tokio::test]
+    async fn dispatch_reclaims_multiple_stale_owners() {
+        let svc = AgentService::new(
+            test_reporter_with_gpus(&[0, 1]),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        {
+            let mut alloc = svc.allocation.lock().await;
+            alloc.allocate_for_job(98, 1, 0, &[0]).unwrap();
+            alloc.commit_job(98);
+            alloc.allocate_for_job(99, 1, 0, &[1]).unwrap();
+            alloc.commit_job(99);
+        }
+        assert_eq!(svc.free_gpu_count().await, 0);
+
+        let spec = JobSpec {
+            cpus_per_task: 1,
+            gres: vec!["gpu:2".into()],
+            ..Default::default()
+        };
+        let res = svc
+            .allocate_local_resources(100, &spec, Some(&gpu_alloc_request(&[0, 1])))
+            .await;
+        assert!(
+            res.is_ok(),
+            "both stale owners must be reclaimed, got {res:?}"
+        );
+    }
+
+    // A dispatch spanning a stale GPU and a still-running GPU must reject: the
+    // running owner cannot be reclaimed, so the retry still fails.
+    #[tokio::test]
+    async fn dispatch_rejects_partial_overlap_with_running_owner() {
+        let svc = AgentService::new(
+            test_reporter_with_gpus(&[0, 1]),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        // Job 98 (GPU 0) is stale; job 99 (GPU 1) is actively running.
+        svc.insert_test_job(99, TrackedJob::dummy(0)).await;
+        {
+            let mut alloc = svc.allocation.lock().await;
+            alloc.allocate_for_job(98, 1, 0, &[0]).unwrap();
+            alloc.commit_job(98);
+            alloc.allocate_for_job(99, 1, 0, &[1]).unwrap();
+            alloc.commit_job(99);
+        }
+
+        let spec = JobSpec {
+            cpus_per_task: 1,
+            gres: vec!["gpu:2".into()],
+            ..Default::default()
+        };
+        let res = svc
+            .allocate_local_resources(100, &spec, Some(&gpu_alloc_request(&[0, 1])))
+            .await;
+        let err = res.expect_err("must reject: GPU 1's owner is still running");
+        assert_eq!(err.code(), tonic::Code::ResourceExhausted);
+    }
+
     #[tokio::test]
     async fn run_command_injects_gpu_env_from_tracked_job() {
         let svc = AgentService::new(

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1802,11 +1802,10 @@ impl AgentService {
             )));
         }
 
-        // Snapshot the live set BEFORE taking the allocation lock, matching the
-        // launch commit's lock order (running then allocation) so the reclaim
-        // below cannot deadlock or race a concurrent commit.
-        let live: std::collections::HashSet<u32> =
-            self.running.lock().await.keys().copied().collect();
+        // Hold running across the reclaim (running-then-allocation, as in commit)
+        // so a concurrent commit can't make a live owner look stale.
+        let running = self.running.lock().await;
+        let live: std::collections::HashSet<u32> = running.keys().copied().collect();
 
         let mut alloc = self.allocation.lock().await;
 
@@ -2943,6 +2942,59 @@ mod tests {
             .await;
         let err = res.expect_err("must reject: the conflicting GPU owner is still running");
         assert_eq!(err.code(), tonic::Code::ResourceExhausted);
+    }
+
+    // A conflicting owner still mid-launch (reserved, not yet committed) is a
+    // real concurrent duplicate, not a strand: the reclaim must spare it, so the
+    // retry still fails and the dispatch is rejected.
+    #[tokio::test]
+    async fn dispatch_rejects_when_conflicting_owner_still_launching() {
+        let svc = AgentService::new(
+            test_reporter_with_gpus(&[0]),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        // Prior job 99 owns GPU 0 and is still launching (never committed).
+        {
+            let mut alloc = svc.allocation.lock().await;
+            alloc.allocate_for_job(99, 1, 0, &[0]).unwrap();
+        }
+
+        let mut devices = std::collections::HashMap::new();
+        devices.insert(
+            "gpu".to_string(),
+            DeviceAllocations {
+                devices: vec![AllocatedDevice {
+                    device_id: 0,
+                    count: 1,
+                }],
+            },
+        );
+        let spec = JobSpec {
+            cpus_per_task: 1,
+            gres: vec!["gpu:1".into()],
+            ..Default::default()
+        };
+        let allocated = ResourceAllocations {
+            cpus: 1,
+            memory_mb: 0,
+            devices,
+        };
+
+        let res = svc
+            .allocate_local_resources(100, &spec, Some(&allocated))
+            .await;
+        let err = res.expect_err("must reject: the conflicting GPU owner is still launching");
+        assert_eq!(err.code(), tonic::Code::ResourceExhausted);
+
+        // The launching owner must NOT have been reclaimed.
+        assert_eq!(
+            svc.free_gpu_count().await,
+            0,
+            "launching owner must be spared"
+        );
     }
 
     #[tokio::test]

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1825,10 +1825,8 @@ impl AgentService {
         ) {
             Ok(result) => result,
             Err(AllocError::GpusUnavailable) => {
-                // The controller only re-launches after freeing the prior job,
-                // so a conflicting owner absent from the live set is stale (a
-                // lost release); reclaim it and retry. Launching owners are
-                // spared by conflicting_owners — a real duplicate, not a strand.
+                // A conflicting owner absent from the live set is stale (the
+                // controller only re-launches after freeing it); reclaim and retry.
                 let stale: Vec<u32> = alloc
                     .conflicting_owners(&controller_gpu_ids)
                     .into_iter()
@@ -2842,11 +2840,8 @@ mod tests {
         );
     }
 
-    // A dispatch whose controller-allocated GPUs are still owned locally by a
-    // prior job that is NO LONGER running must reclaim those stale GPUs and
-    // succeed, instead of rejecting and stranding the node. The controller only
-    // re-issues a launch after freeing the prior job, so an owner absent from
-    // `running` is definitionally stale.
+    // A conflicting owner no longer in `running` is stale and must be reclaimed
+    // so the dispatch succeeds instead of stranding the node.
     #[tokio::test]
     async fn dispatch_reclaims_stale_gpu_owner_not_running() {
         let svc = AgentService::new(
@@ -2895,9 +2890,8 @@ mod tests {
         );
     }
 
-    // The reclaim must NOT free a GPU still held by a job that is actually
-    // running: that would double-allocate the device. A conflicting owner that
-    // IS in `running` keeps the dispatch rejected.
+    // A conflicting owner still in `running` must never be reclaimed (that would
+    // double-allocate the GPU); the dispatch stays rejected.
     #[tokio::test]
     async fn dispatch_rejects_when_conflicting_owner_still_running() {
         let svc = AgentService::new(
@@ -2943,9 +2937,8 @@ mod tests {
         assert_eq!(err.code(), tonic::Code::ResourceExhausted);
     }
 
-    // A conflicting owner still mid-launch (reserved, not yet committed) is a
-    // real concurrent duplicate, not a strand: the reclaim must spare it, so the
-    // retry still fails and the dispatch is rejected.
+    // A still-launching conflicting owner is a real duplicate: the reclaim must
+    // spare it, so the retry fails and the dispatch stays rejected.
     #[tokio::test]
     async fn dispatch_rejects_when_conflicting_owner_still_launching() {
         let svc = AgentService::new(

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1802,6 +1802,12 @@ impl AgentService {
             )));
         }
 
+        // Snapshot the live set BEFORE taking the allocation lock, matching the
+        // launch commit's lock order (running then allocation) so the reclaim
+        // below cannot deadlock or race a concurrent commit.
+        let live: std::collections::HashSet<u32> =
+            self.running.lock().await.keys().copied().collect();
+
         let mut alloc = self.allocation.lock().await;
 
         let cpus = if spec.cpus_per_task > 0 {
@@ -1817,16 +1823,50 @@ impl AgentService {
         ) {
             Ok(result) => result,
             Err(AllocError::GpusUnavailable) => {
-                warn!(
+                // The conflicting GPUs may be held by a prior job that already
+                // ended locally but whose release never ran (e.g. the controller
+                // force-finished it after a lost completion report). The
+                // controller only re-issues a launch after freeing the prior job,
+                // so any conflicting owner absent from the live running set is
+                // stale: reclaim it and retry once. A still-launching owner is
+                // spared by conflicting_owners — that is a real concurrent
+                // duplicate, not a strand.
+                let stale: Vec<u32> = alloc
+                    .conflicting_owners(&controller_gpu_ids)
+                    .into_iter()
+                    .filter(|owner| !live.contains(owner))
+                    .collect();
+                if !stale.is_empty() {
+                    warn!(
+                        job_id,
+                        reclaimed = ?stale,
+                        requested = ?controller_gpu_ids,
+                        "reclaiming stale GPU owners no longer running, then retrying dispatch"
+                    );
+                    for owner in &stale {
+                        alloc.release_job(*owner);
+                    }
+                }
+                match alloc.allocate_for_job(
                     job_id,
-                    requested = ?controller_gpu_ids,
-                    already_allocated = ?alloc.allocated_gpu_ids(),
-                    "rejecting dispatch: controller-allocated GPUs already in use in the local \
-                     allocation table (stale allocation from a prior job would strand this node)"
-                );
-                return Err(Status::resource_exhausted(
-                    "controller-allocated GPUs unavailable on this node",
-                ));
+                    cpus,
+                    spec.memory_per_node_mb,
+                    &controller_gpu_ids,
+                ) {
+                    Ok(result) => result,
+                    Err(_) => {
+                        warn!(
+                            job_id,
+                            requested = ?controller_gpu_ids,
+                            already_allocated = ?alloc.allocated_gpu_ids(),
+                            "rejecting dispatch: controller-allocated GPUs already in use in the \
+                             local allocation table by a still-running or launching job"
+                        );
+                        return Err(Status::resource_exhausted(
+                            "controller-allocated GPUs unavailable on this node",
+                        ));
+                    }
+                }
             }
             Err(AllocError::DuplicateJob) => {
                 // A launch is already in flight for this job id (reserved, not
@@ -2802,6 +2842,107 @@ mod tests {
             1,
             "exactly the orphan's GPU must be reclaimed; the tracked job's is spared"
         );
+    }
+
+    // A dispatch whose controller-allocated GPUs are still owned locally by a
+    // prior job that is NO LONGER running must reclaim those stale GPUs and
+    // succeed, instead of rejecting and stranding the node. The controller only
+    // re-issues a launch after freeing the prior job, so an owner absent from
+    // `running` is definitionally stale.
+    #[tokio::test]
+    async fn dispatch_reclaims_stale_gpu_owner_not_running() {
+        let svc = AgentService::new(
+            test_reporter_with_gpus(&[0]),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        // Prior job 99 owns GPU 0 (committed) but never entered `running`
+        // (its completion report was force-finished by the controller).
+        {
+            let mut alloc = svc.allocation.lock().await;
+            alloc.allocate_for_job(99, 1, 0, &[0]).unwrap();
+            alloc.commit_job(99);
+        }
+        assert_eq!(svc.free_gpu_count().await, 0);
+
+        let mut devices = std::collections::HashMap::new();
+        devices.insert(
+            "gpu".to_string(),
+            DeviceAllocations {
+                devices: vec![AllocatedDevice {
+                    device_id: 0,
+                    count: 1,
+                }],
+            },
+        );
+        let spec = JobSpec {
+            cpus_per_task: 1,
+            gres: vec!["gpu:1".into()],
+            ..Default::default()
+        };
+        let allocated = ResourceAllocations {
+            cpus: 1,
+            memory_mb: 0,
+            devices,
+        };
+
+        let res = svc
+            .allocate_local_resources(100, &spec, Some(&allocated))
+            .await;
+        assert!(
+            res.is_ok(),
+            "dispatch must reclaim the stale owner's GPU and succeed, got {res:?}"
+        );
+    }
+
+    // The reclaim must NOT free a GPU still held by a job that is actually
+    // running: that would double-allocate the device. A conflicting owner that
+    // IS in `running` keeps the dispatch rejected.
+    #[tokio::test]
+    async fn dispatch_rejects_when_conflicting_owner_still_running() {
+        let svc = AgentService::new(
+            test_reporter_with_gpus(&[0]),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        // Prior job 99 owns GPU 0 AND is actively tracked in `running`.
+        svc.insert_test_job(99, TrackedJob::dummy(0)).await;
+        {
+            let mut alloc = svc.allocation.lock().await;
+            alloc.allocate_for_job(99, 1, 0, &[0]).unwrap();
+            alloc.commit_job(99);
+        }
+
+        let mut devices = std::collections::HashMap::new();
+        devices.insert(
+            "gpu".to_string(),
+            DeviceAllocations {
+                devices: vec![AllocatedDevice {
+                    device_id: 0,
+                    count: 1,
+                }],
+            },
+        );
+        let spec = JobSpec {
+            cpus_per_task: 1,
+            gres: vec!["gpu:1".into()],
+            ..Default::default()
+        };
+        let allocated = ResourceAllocations {
+            cpus: 1,
+            memory_mb: 0,
+            devices,
+        };
+
+        let res = svc
+            .allocate_local_resources(100, &spec, Some(&allocated))
+            .await;
+        let err = res.expect_err("must reject: the conflicting GPU owner is still running");
+        assert_eq!(err.code(), tonic::Code::ResourceExhausted);
     }
 
     #[tokio::test]

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1161,6 +1161,9 @@ impl SlurmAgent for AgentService {
         let cpus = allocated.map(|a| a.cpus).unwrap_or(req.cpus).max(1);
         let memory_mb = allocated.map(|a| a.memory_mb).unwrap_or(req.memory_mb);
 
+        // running-before-allocation (as in commit) so the job is never
+        // committed-but-absent-from-running, which the reclaim reads as stale.
+        let mut jobs = self.running.lock().await;
         {
             let mut alloc = self.allocation.lock().await;
             alloc
@@ -1185,7 +1188,7 @@ impl SlurmAgent for AgentService {
             "registered srun allocation"
         );
 
-        self.running.lock().await.insert(
+        jobs.insert(
             req.job_id,
             TrackedJob {
                 job: executor::RunningJob::AllocationOnly,
@@ -1822,14 +1825,10 @@ impl AgentService {
         ) {
             Ok(result) => result,
             Err(AllocError::GpusUnavailable) => {
-                // The conflicting GPUs may be held by a prior job that already
-                // ended locally but whose release never ran (e.g. the controller
-                // force-finished it after a lost completion report). The
-                // controller only re-issues a launch after freeing the prior job,
-                // so any conflicting owner absent from the live running set is
-                // stale: reclaim it and retry once. A still-launching owner is
-                // spared by conflicting_owners — that is a real concurrent
-                // duplicate, not a strand.
+                // The controller only re-launches after freeing the prior job,
+                // so a conflicting owner absent from the live set is stale (a
+                // lost release); reclaim it and retry. Launching owners are
+                // spared by conflicting_owners — a real duplicate, not a strand.
                 let stale: Vec<u32> = alloc
                     .conflicting_owners(&controller_gpu_ids)
                     .into_iter()

--- a/tests/native_host/e2e/test_completing_timeout.py
+++ b/tests/native_host/e2e/test_completing_timeout.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E test for the completing-timeout node-cancel fix.
+
+When a multi-node job stalls in COMPLETING because one node never reports
+(a lost completion report, or a task that outlives the run), the controller
+force-finishes it after ``complete_wait_secs`` and frees that node's resources
+in its own accounting. If it does not also tell the node's agent to stop the
+job, the agent keeps the stale local allocation and rejects the next dispatch
+("controller-allocated GPUs unavailable"), stranding the node until the job
+requeues to JobHoldMaxRequeue.
+
+This reproduces the stall deterministically without GPUs: rank 0 exits (and
+reports), rank 1 sleeps on a unique marker and never reports, so the job sits
+in COMPLETING until the shortened timeout force-finishes it. The fix must
+deliver a cancel to rank 1's node, killing the orphaned marker process.
+
+Requires at least 2 nodes in SPUR_TEST_NODES.
+"""
+
+import time
+
+import pytest
+
+from cluster import parse_job_id, wait_job
+
+
+class TestCompletingTimeoutCancel:
+    # Well above the 10s force-finish tick, low enough to keep the test fast.
+    COMPLETE_WAIT = 15
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return {"scheduler": {"complete_wait_secs": self.COMPLETE_WAIT}}
+
+    def test_completing_timeout_cancels_stuck_node(self, multi_node_cluster):
+        cluster = multi_node_cluster
+
+        # Unique duration so pgrep -f matches only this test's process.
+        marker = "8675309"
+        script = cluster.write_file(
+            "completing-stuck.sh",
+            "#!/bin/bash\n"
+            # Rank 0 exits immediately -> reports -> job enters COMPLETING.
+            'if [ "${SPUR_NODE_RANK}" = "0" ]; then exit 0; fi\n'
+            # Rank 1 outlives the run and never reports.
+            f"sleep {marker}\n",
+        )
+        sb = cluster.sbatch(["-J", "completing-stuck", "-N", "2", script])
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+
+        # Force-finish sets a job with an unreported node to Failed; reaching a
+        # terminal state confirms the completing-timeout path ran.
+        state = wait_job(cluster, job_id, timeout=self.COMPLETE_WAIT + 60)
+        assert state in ("F", "GONE"), (
+            f"expected force-finish to a terminal state, got {state}"
+        )
+
+        # The orphaned marker on rank 1's node must be gone: the fix's cancel
+        # killed the process and freed the local allocation. Poll briefly to let
+        # the cancel RPC and the agent's reap land.
+        deadline = time.time() + 30
+        still_running = True
+        while time.time() < deadline:
+            if not self._marker_running(cluster, marker):
+                still_running = False
+                break
+            time.sleep(2)
+
+        assert not still_running, (
+            f"marker process 'sleep {marker}' survived force-finish — the "
+            "completing-timeout cancel never reached the stuck node, so its "
+            "agent still holds the stale allocation"
+        )
+
+    @staticmethod
+    def _marker_running(cluster, marker: str) -> bool:
+        # Bracket the first char so the pgrep pattern cannot match its own
+        # `bash -c "pgrep -f ..."` command line (a classic self-match footgun).
+        for node in cluster.nodes:
+            out = node.exec_allow_fail(f"pgrep -f '[s]leep {marker}' || true")
+            if out.strip():
+                return True
+        return False


### PR DESCRIPTION
## What

Fixes a class of node-stranding where the controller believes a node is idle but its agent still holds the prior job's local allocation, so every new dispatch to that node is rejected with `controller-allocated GPUs unavailable on this node` and the victim job requeues until it lands in `JobHoldMaxRequeue`. Reported live (SPUR-100), with SPUR-103 as a likely downstream symptom (empty-NodeList holds).

## Root cause

The normal completion path is race-free: the agent releases its local allocation **before** it reports completion to the controller. The divergence comes from a path where the controller frees a node **without** a matching agent release — most notably the `Completing` force-finish timer.

When a multi-node job stalls in `Completing` because one node's completion report is lost or never sent, the controller force-finishes it after `complete_wait_secs` (default 300s) and deallocates the still-unreported nodes in its own accounting. It never told those nodes' agents, so an agent keeps the job's GPUs marked in-use, rejects the next dispatch, and the node is stranded until the job requeues to `JobHoldMaxRequeue`. The `complete_wait_secs` default lines up with the reported 2–5 minute window.

## Approach

Two complementary fixes:

- **Controller** (`enforce_completing_timeout`): cancel the job on exactly the unreported nodes before force-freeing them, mirroring what the timeout-kill and heartbeat-eviction paths already do. The per-job body is extracted into `force_finish_completing_job` so it is unit-testable.
- **Agent** (dispatch path): on a `GpusUnavailable` rejection, reclaim conflicting GPU owners that are no longer running locally (and not mid-launch), then retry the allocation once. The controller only re-issues a launch after freeing the prior job, so an owner absent from the running set is definitionally stale. A still-running or still-launching owner is never reclaimed, so a live GPU can't be double-allocated. This makes the agent self-heal even when the cancel above can't arrive (e.g. the agent was unreachable at force-finish time).

The two layers are defense-in-depth: the controller stops creating the divergence, and the agent recovers deterministically if it ever occurs.

## Testing

- **Unit:** `conflicting_owners` semantics (excludes launching); agent reclaim-success and reject-when-still-running; controller cancels only the unreported node. Each was RED/GREEN verified (temporarily disabled the fix and watched the right test fail, guard test stay green).
- **e2e** (`tests/native_host/e2e/test_completing_timeout.py`, new): reproduces the controller path without GPUs — rank 0 exits, rank 1 stalls and never reports, so the job sits in `Completing` until a shortened `complete_wait_secs` force-finishes it; asserts the orphaned process is killed. Verified as a genuine regression guard: it **fails** against a controller built without the cancel and **passes** with it.
- Validated live on an isolated 2-node lab cluster (no GPUs on the nodes, so the agent-side reclaim is unit-covered only).
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` and `cargo fmt --all --check` clean; full workspace test suite passes.

## Notes

This is a distinct bug from #489 (which fixes the *launch-path* leak, where a reservation is stuck in `launching`). Here the stale owner is a *committed* allocation whose process wasn't reaped when the controller force-freed the node.