### PR TITLE
docs(examples): document rlimits memlock in spur.conf

### DIFF
--- a/examples/spur.conf
+++ b/examples/spur.conf
@@ -87,6 +87,13 @@ agent_port = 6818
 level = "info"
 format = "text"
 
+# POSIX resource limits (RLIMIT_*) spurd applies to job steps at launch.
+[rlimits]
+# RLIMIT_MEMLOCK for job processes. "unlimited" (default) makes RDMA/NCCL work
+# out of the box; "inherit" keeps whatever spurd inherited; a plain number caps
+# it to that many bytes (e.g. "1073741824" for 1 GiB).
+memlock = "unlimited"
+
 # Native cluster (k0s) that SPUR provisions and owns: `spur k8s up/down`, spurd-owned k0s
 # systemd units, GPU CDI on join. Disabled by default. This is the INVERSE of [kubernetes]
 # (which lets SPUR run inside an existing k8s and accept SpurJob CRDs).


### PR DESCRIPTION
## What

Add the `[rlimits]` section to `examples/spur.conf` so the sample config documents the `memlock` knob that spurd already supports.

## Why

`spurd` applies `RLIMIT_MEMLOCK` to job steps (see `spur-core/src/config.rs` and `docs/deployment/native-host.rst`), but the example config didn't mention it. Users had no in-config reference for the accepted values.

## Details

Documents the three accepted values:
- `"unlimited"` (default): RDMA/NCCL work out of the box
- `"inherit"`: keep whatever spurd inherited
- a byte count (e.g. `"1073741824"`): fixed cap

## Testing

Docs/config example only, no code change.