### PR TITLE
fix(spur-core): run hooks from /tmp when work_dir can't be entered to avoid draining nodes

### DIFF
--- a/crates/spur-core/src/hooks.rs
+++ b/crates/spur-core/src/hooks.rs
@@ -66,17 +66,13 @@ pub async fn run_hook(script_path: &str, ctx: &HookContext) -> anyhow::Result<()
     for (k, v) in env.into_map() {
         cmd.env(k, v);
     }
-    let child = cmd
-        .current_dir(&ctx.work_dir)
-        .stdout(Stdio::null())
-        .stderr(Stdio::piped())
-        .spawn()
-        .with_context(|| {
-            format!(
-                "{} script failed to execute: {}",
-                ctx.script_context, script_path
-            )
-        })?;
+    cmd.stdout(Stdio::null()).stderr(Stdio::piped());
+    let child = spawn_hook_in_work_dir(&mut cmd, &ctx.work_dir).with_context(|| {
+        format!(
+            "{} script failed to execute: {}",
+            ctx.script_context, script_path
+        )
+    })?;
 
     let output = child
         .wait_with_output()
@@ -104,6 +100,25 @@ pub async fn run_hook(script_path: &str, ctx: &HookContext) -> anyhow::Result<()
     }
 
     Ok(())
+}
+
+/// Spawn a hook in `work_dir`, retrying from `/tmp` if the spawn fails there.
+/// A missing/untraversable `work_dir` must not fail the hook (spurd drains the
+/// node on hook failure); only a failure that also persists from `/tmp` is real.
+fn spawn_hook_in_work_dir(
+    cmd: &mut Command,
+    work_dir: &str,
+) -> std::io::Result<tokio::process::Child> {
+    if work_dir.is_empty() || work_dir == "/tmp" {
+        return cmd.current_dir("/tmp").spawn();
+    }
+    let first_err = match cmd.current_dir(work_dir).spawn() {
+        Ok(child) => return Ok(child),
+        Err(e) => e,
+    };
+    let child = cmd.current_dir("/tmp").spawn()?;
+    warn!(work_dir, error = %first_err, "hook could not start in work_dir, ran from /tmp instead");
+    Ok(child)
 }
 
 fn resolve_username(uid: u32) -> String {
@@ -227,5 +242,79 @@ mod tests {
         let ctx = test_ctx();
         let result = run_hook(script.to_str().unwrap(), &ctx).await;
         assert!(result.is_ok());
+    }
+
+    // A missing work_dir must not fail the hook (spurd would drain the node).
+    #[tokio::test]
+    #[serial(run_hooks)]
+    async fn hook_with_missing_work_dir_still_runs() {
+        let script = make_script("exit 0");
+        let mut ctx = test_ctx();
+        ctx.work_dir = "/nonexistent/path/that/does/not/exist".into();
+        let result = run_hook(script.to_str().unwrap(), &ctx).await;
+        assert!(result.is_ok());
+    }
+
+    // An existing-but-untraversable work_dir (NFS root_squash) also fails to
+    // spawn, which a stat-based precheck would miss. Root bypasses perm checks.
+    #[tokio::test]
+    #[serial(run_hooks)]
+    async fn hook_with_untraversable_work_dir_still_runs() {
+        if nix::unistd::geteuid().is_root() {
+            return;
+        }
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o000)).unwrap();
+        let script = make_script("exit 0");
+        let mut ctx = test_ctx();
+        ctx.work_dir = dir.path().to_string_lossy().into_owned();
+        let result = run_hook(script.to_str().unwrap(), &ctx).await;
+        std::fs::set_permissions(dir.path(), std::fs::Permissions::from_mode(0o755)).unwrap();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    #[serial(run_hooks)]
+    async fn hook_runs_in_work_dir_when_present() {
+        let dir = tempfile::tempdir().unwrap();
+        let canonical = std::fs::canonicalize(dir.path()).unwrap();
+        let marker = NamedTempFile::new().unwrap();
+        let marker_path = marker.path().to_str().unwrap().to_string();
+        let body = format!("pwd -P > {}", marker_path);
+        let script = make_script(&body);
+        let mut ctx = test_ctx();
+        ctx.work_dir = canonical.to_string_lossy().into_owned();
+        run_hook(script.to_str().unwrap(), &ctx).await.unwrap();
+        let content = std::fs::read_to_string(&marker_path).unwrap();
+        assert_eq!(content.trim(), canonical.to_string_lossy());
+    }
+
+    // SPUR_JOB_WORK_DIR still reports the submitted path when the CWD falls back.
+    #[tokio::test]
+    #[serial(run_hooks)]
+    async fn hook_reports_submitted_work_dir_when_cwd_falls_back() {
+        let marker = NamedTempFile::new().unwrap();
+        let marker_path = marker.path().to_str().unwrap().to_string();
+        let body = format!("echo \"$SPUR_JOB_WORK_DIR|$(pwd)\" > {}", marker_path);
+        let script = make_script(&body);
+        let mut ctx = test_ctx();
+        ctx.work_dir = "/nonexistent/submitted/dir".into();
+        run_hook(script.to_str().unwrap(), &ctx).await.unwrap();
+
+        let content = std::fs::read_to_string(&marker_path).unwrap();
+        let parts: Vec<&str> = content.trim().split('|').collect();
+        assert_eq!(parts[0], "/nonexistent/submitted/dir");
+        assert_eq!(parts[1], "/tmp");
+    }
+
+    // A genuinely broken script still errors — the /tmp retry doesn't mask it.
+    #[tokio::test]
+    #[serial(run_hooks)]
+    async fn hook_missing_script_still_errors_after_fallback() {
+        let mut ctx = test_ctx();
+        ctx.work_dir = "/nonexistent/submitted/dir".into();
+        let result = run_hook("/nonexistent/hook_script.sh", &ctx).await;
+        assert!(result.is_err());
     }
 }

--- a/crates/spur-core/src/hooks.rs
+++ b/crates/spur-core/src/hooks.rs
@@ -67,12 +67,13 @@ pub async fn run_hook(script_path: &str, ctx: &HookContext) -> anyhow::Result<()
         cmd.env(k, v);
     }
     cmd.stdout(Stdio::null()).stderr(Stdio::piped());
-    let child = spawn_hook_in_work_dir(&mut cmd, &ctx.work_dir).with_context(|| {
-        format!(
-            "{} script failed to execute: {}",
-            ctx.script_context, script_path
-        )
-    })?;
+    let child = spawn_hook_in_work_dir(&mut cmd, &ctx.work_dir, ctx.job_id, &ctx.script_context)
+        .with_context(|| {
+            format!(
+                "{} script failed to execute: {}",
+                ctx.script_context, script_path
+            )
+        })?;
 
     let output = child
         .wait_with_output()
@@ -108,8 +109,10 @@ pub async fn run_hook(script_path: &str, ctx: &HookContext) -> anyhow::Result<()
 fn spawn_hook_in_work_dir(
     cmd: &mut Command,
     work_dir: &str,
+    job_id: JobId,
+    script_context: &str,
 ) -> std::io::Result<tokio::process::Child> {
-    if work_dir.is_empty() || work_dir == "/tmp" {
+    if work_dir.is_empty() {
         return cmd.current_dir("/tmp").spawn();
     }
     let first_err = match cmd.current_dir(work_dir).spawn() {
@@ -117,7 +120,13 @@ fn spawn_hook_in_work_dir(
         Err(e) => e,
     };
     let child = cmd.current_dir("/tmp").spawn()?;
-    warn!(work_dir, error = %first_err, "hook could not start in work_dir, ran from /tmp instead");
+    warn!(
+        job_id,
+        hook = %script_context,
+        work_dir,
+        error = %first_err,
+        "hook could not start in work_dir, ran from /tmp instead"
+    );
     Ok(child)
 }
 

--- a/tests/native_host/e2e/test_prolog_epilog.py
+++ b/tests/native_host/e2e/test_prolog_epilog.py
@@ -427,6 +427,42 @@ class TestHookFailure:
 
         cluster.scancel(str(job_id))
 
+    def test_missing_work_dir_does_not_drain_node(self, unstarted_cluster):
+        """A job whose WorkDir is absent on the node must run, not drain it."""
+        cluster = unstarted_cluster
+        cluster.start(_setup_hooks(cluster, prolog=LOGGING_PROLOG))
+
+        # Unique per run so a leftover dir can't let the prolog chdir succeed.
+        missing = f"{cluster.remote_dir}/nonexistent-wd/deep/missing"
+        out_path = f"{cluster.remote_dir}/missing-wd.out"
+        script = cluster.write_file("test.sh", "#!/bin/bash\necho WD_OK\n")
+        sb = cluster.sbatch(
+            ["-J", "missing-wd", "-N", "1", "-D", missing, "-o", out_path, script]
+        )
+        job_id = parse_job_id(sb)
+        assert job_id is not None
+
+        state = wait_job(cluster, job_id, timeout=60)
+        assert state in ("CD", "GONE"), (
+            f"job with a missing WorkDir should complete, got {state}"
+        )
+
+        info = cluster.sinfo()
+        assert "drain" not in info.lower(), (
+            f"a missing WorkDir must not drain the node:\n{info}"
+        )
+
+        content = cluster.read_output_on_any_node(out_path)
+        assert "WD_OK" in content, f"job output missing:\n{content}"
+
+        # Prolog ran from the fallback CWD but still reports the submitted dir.
+        prolog = _read_hook_log(cluster, job_id, "prolog")
+        assert prolog["SPUR_JOB_ID"] == str(job_id)
+        assert prolog["SPUR_JOB_WORK_DIR"] == missing, (
+            f"prolog should still report the submitted WorkDir, got "
+            f"{prolog.get('SPUR_JOB_WORK_DIR')!r}"
+        )
+
     def test_epilog_slurmctld_failure_is_nonfatal(self, unstarted_cluster):
         """EpilogSlurmctld failure is logged but does not affect job or node state."""
         cluster = unstarted_cluster


### PR DESCRIPTION
## What this fixes

A job whose `WorkDir` does not exist on the assigned compute node could drain the node — and, because the job then requeues onto other nodes, drain node after node across the partition until it hit `JobHoldMaxRequeue`. A single user's bad `WorkDir` could take a large fraction of a partition offline.

## Root cause

`run_hook` set the prolog/epilog child process's working directory to the job's submitted `work_dir`. That path may only exist on the *submitting* node. When it is absent — or present but not traversable — on the compute node, `Command::spawn()` fails at `chdir()` before the hook script ever runs. spurd classifies this spawn failure as a hook execution failure and drains the node, even though the node and the hook are perfectly healthy.

The failure signature is a fast (~1ms) "script failed to execute" with nothing written by the script body, and a node draining with `Reason=prolog failed: ... script failed to execute`.

## Approach

Fix it at the shared root in `run_hook`: attempt to spawn the hook in `work_dir`, and retry from `/tmp` on any spawn failure. This mirrors `slurmstepd`, which does the same for the job process itself (`chdir(cwd)` falling back to `/tmp`). Attempting the spawn and falling back — rather than pre-checking the path with a `stat` — is deliberate: it also covers a directory that exists but isn't traversable (permissions, NFS `root_squash`) and avoids a TOCTOU window a pre-check would leave open. A spawn failure that still persists from `/tmp` (a missing or non-executable script) surfaces as a real error, so genuine hook problems are not masked. `SPUR_JOB_WORK_DIR` continues to report the submitted path, so a hook that needs the intended location can still act on it — only the process CWD falls back.

Because the fix lives in the shared hook runner, it covers every hook type in one place — prolog/epilog on the node, and `prolog_slurmctld`/`epilog_slurmctld` on the controller, where a compute-node `WorkDir` may never exist locally.

Genuine hook failures (script present, valid CWD, non-zero exit) still surface as failures and still drain, unchanged.

## Why run from /tmp rather than fail the job

The issue title frames this as "drains node instead of failing job," but the fix intentionally does neither: it runs the job (and the hook) from `/tmp` and keeps the node up. This is deliberate, for parity with Slurm, which spur targets for CLI/API compatibility:

- When a job's working directory is missing on the compute node, Slurm's `slurmstepd` chdir's into it and, on failure, falls back to `/tmp` and continues — the job runs, it is not failed, and the node is not drained.
- Slurm never runs the node prolog in the job's `WorkDir` at all: the directory is passed only as the `SLURM_JOB_WORK_DIR` environment variable, and drain-on-prolog-failure is keyed on the script's exit code, not on a chdir at spawn.

So a missing/bad `WorkDir` is a user-side path error that, in Slurm, never takes a node offline. The real defect here is that spurd let user-supplied input (the `WorkDir`) determine whether a hook could even spawn, and then treated that spawn failure as a node-health fault. Matching Slurm's actual behavior — run from `/tmp`, never drain for a user path error — is the correct outcome; failing the job instead would diverge further from Slurm, not less.

## Tests

- A hook run against a nonexistent `work_dir` now succeeds instead of failing to spawn.
- A hook run against an existing-but-non-traversable `work_dir` (mode `000`, as with `root_squash`) also succeeds via the `/tmp` retry — a case a `stat`-based check would miss.
- A hook whose CWD falls back to `/tmp` still exposes the submitted path via `SPUR_JOB_WORK_DIR`.
- A hook that runs in an accessible `work_dir` uses it as-is.
- A genuinely missing/non-executable script still errors after the `/tmp` retry, so real failures aren't masked.

Validated end-to-end on an isolated 2-node deployment: with this change, a job submitted with a nonexistent `WorkDir` runs to completion and the node stays `IDLE`; without it, the same job drains the node with the reported signature. The non-traversable case likewise keeps the node up.