### PR TITLE
fix(spurctld): distinguish missing vs unavailable QOS in validation errors

### DIFF
--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1523,7 +1523,12 @@ impl ClusterManager {
                     anyhow::bail!("cannot clear a job's QOS");
                 }
                 if self.qos_cache.get(&q).is_none() {
-                    anyhow::bail!("QOS '{q}' does not exist");
+                    let hint = if self.qos_cache.is_loaded() {
+                        ""
+                    } else {
+                        " (hint: accounting may not be enabled on this controller — check controller logs)"
+                    };
+                    anyhow::bail!("QOS '{q}' does not exist{hint}");
                 }
                 // Treat account="" as unset so we authorize against the
                 // job's existing account, rather than erroring on a blank
@@ -4741,7 +4746,14 @@ fn apply_default_qos(
 
     if let Some(name) = spec.qos.as_deref().filter(|n| !n.is_empty()) {
         if qos_cache.get(name).is_none() {
-            return Err(SubmitError::invalid(format!("QOS '{name}' does not exist")));
+            let hint = if qos_cache.is_loaded() {
+                String::new()
+            } else {
+                " (hint: accounting may not be enabled on this controller — check controller logs)".into()
+            };
+            return Err(SubmitError::invalid(format!(
+                "QOS '{name}' does not exist{hint}"
+            )));
         }
         if !qos_permitted(&allowed_qos, default_qos_for_auth.as_deref(), name) {
             return Err(SubmitError::invalid(format!(
@@ -4774,8 +4786,13 @@ fn apply_default_qos(
     let fallback = accounting.default_qos.trim();
     if !fallback.is_empty() {
         if qos_cache.get(fallback).is_none() {
+            let hint = if qos_cache.is_loaded() {
+                String::new()
+            } else {
+                " (hint: accounting may not be enabled on this controller — check controller logs)".into()
+            };
             return Err(SubmitError::invalid(format!(
-                "configured default QOS '{fallback}' does not exist"
+                "configured default QOS '{fallback}' does not exist{hint}"
             )));
         }
         if qos_permitted(&allowed_qos, default_qos_for_auth.as_deref(), fallback) {

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -4749,7 +4749,8 @@ fn apply_default_qos(
             let hint = if qos_cache.is_loaded() {
                 String::new()
             } else {
-                " (hint: accounting may not be enabled on this controller — check controller logs)".into()
+                " (hint: accounting may not be enabled on this controller — check controller logs)"
+                    .into()
             };
             return Err(SubmitError::invalid(format!(
                 "QOS '{name}' does not exist{hint}"
@@ -4789,7 +4790,8 @@ fn apply_default_qos(
             let hint = if qos_cache.is_loaded() {
                 String::new()
             } else {
-                " (hint: accounting may not be enabled on this controller — check controller logs)".into()
+                " (hint: accounting may not be enabled on this controller — check controller logs)"
+                    .into()
             };
             return Err(SubmitError::invalid(format!(
                 "configured default QOS '{fallback}' does not exist{hint}"
@@ -10272,6 +10274,21 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn update_job_qos_hints_when_cache_unloaded() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        let id = submit_and_wait(&cm, basic_spec("q"));
+        assert_eq!(cm.get_job(id).unwrap().spec.qos, None);
+
+        let err = cm
+            .update_job(id, None, None, None, None, None, Some("any-qos".into()))
+            .unwrap_err();
+        assert!(err.to_string().contains("QOS 'any-qos' does not exist"));
+        assert!(err.to_string().contains("accounting may not be enabled"));
+        assert_eq!(cm.get_job(id).unwrap().spec.qos, None);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn update_job_qos_rejects_unauthorized_association_qos() {
         // `scontrol update job qos=` must enforce the same per-association
         // authorization as submission (SPUR-101).
@@ -11170,6 +11187,18 @@ mod tests {
     }
 
     #[test]
+    fn apply_default_qos_explicit_invalid_hints_when_cache_unloaded() {
+        let assoc = AssociationCache::new();
+        let qos = QosCache::new();
+        let mut spec = basic_spec("j");
+        spec.qos = Some("any-qos".into());
+
+        let err = super::apply_default_qos(&mut spec, &assoc, &qos, &acct_cfg()).unwrap_err();
+        assert!(err.to_string().contains("QOS 'any-qos' does not exist"));
+        assert!(err.to_string().contains("accounting may not be enabled"));
+    }
+
+    #[test]
     fn apply_default_qos_inherits_association_default_with_explicit_account() {
         let assoc = AssociationCache::new();
         assoc.insert_default_qos("testuser", "research", "highprio");
@@ -11365,6 +11394,25 @@ mod tests {
             err,
             SubmitError::invalid("configured default QOS 'ghost' does not exist")
         );
+    }
+
+    #[test]
+    fn apply_default_qos_cluster_default_hints_when_cache_unloaded() {
+        let assoc = AssociationCache::new();
+        let qos = QosCache::new();
+        let mut spec = basic_spec("j");
+
+        let err = super::apply_default_qos(
+            &mut spec,
+            &assoc,
+            &qos,
+            &acct_cfg_with("fallback-qos", false),
+        )
+        .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("configured default QOS 'fallback-qos' does not exist"));
+        assert!(err.to_string().contains("accounting may not be enabled"));
     }
 
     #[test]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1526,7 +1526,7 @@ impl ClusterManager {
                     let hint = if self.qos_cache.is_loaded() {
                         ""
                     } else {
-                        " (hint: accounting may not be enabled on this controller — check controller logs)"
+                        QOS_ACCOUNTING_HINT
                     };
                     anyhow::bail!("QOS '{q}' does not exist{hint}");
                 }
@@ -4718,6 +4718,9 @@ fn validate_user_account(
     }
 }
 
+const QOS_ACCOUNTING_HINT: &str =
+    " (hint: accounting may not be enabled on this controller -- check controller logs)";
+
 /// Resolve a job's QOS at submit, in Slurm's order: explicit `--qos` (must
 /// exist and be permitted for the association) → association default →
 /// cluster fallback (`accounting.default_qos`, also gated by the
@@ -4749,8 +4752,7 @@ fn apply_default_qos(
             let hint = if qos_cache.is_loaded() {
                 String::new()
             } else {
-                " (hint: accounting may not be enabled on this controller — check controller logs)"
-                    .into()
+                QOS_ACCOUNTING_HINT.into()
             };
             return Err(SubmitError::invalid(format!(
                 "QOS '{name}' does not exist{hint}"
@@ -4790,8 +4792,7 @@ fn apply_default_qos(
             let hint = if qos_cache.is_loaded() {
                 String::new()
             } else {
-                " (hint: accounting may not be enabled on this controller — check controller logs)"
-                    .into()
+                QOS_ACCOUNTING_HINT.into()
             };
             return Err(SubmitError::invalid(format!(
                 "configured default QOS '{fallback}' does not exist{hint}"
@@ -10255,6 +10256,7 @@ mod tests {
             .update_job(id, None, None, None, None, None, Some("ghost".into()))
             .unwrap_err();
         assert!(err.to_string().contains("QOS 'ghost' does not exist"));
+        assert!(!err.to_string().contains("accounting may not be enabled"));
         assert_eq!(cm.get_job(id).unwrap().spec.qos, None);
 
         // Empty QOS (clear-to-limitless) rejected.
@@ -11184,6 +11186,7 @@ mod tests {
             err,
             SubmitError::invalid("QOS 'doesnotexist' does not exist")
         );
+        assert!(!err.to_string().contains("accounting may not be enabled"));
     }
 
     #[test]
@@ -11394,6 +11397,7 @@ mod tests {
             err,
             SubmitError::invalid("configured default QOS 'ghost' does not exist")
         );
+        assert!(!err.to_string().contains("accounting may not be enabled"));
     }
 
     #[test]

--- a/crates/spurctld/src/limits_cache.rs
+++ b/crates/spurctld/src/limits_cache.rs
@@ -8,6 +8,7 @@
 //! this cache so the dormant `QOS*` pending-reasons fire against real limits.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -19,12 +20,14 @@ use spur_core::accounting::{Qos, QosLimits, QosPreemptMode, TresRecord};
 
 pub struct QosCache {
     qos: RwLock<HashMap<String, Qos>>,
+    loaded: AtomicBool,
 }
 
 impl QosCache {
     pub fn new() -> Self {
         Self {
             qos: RwLock::new(HashMap::new()),
+            loaded: AtomicBool::new(false),
         }
     }
 
@@ -32,14 +35,21 @@ impl QosCache {
         self.qos.read().get(name).cloned()
     }
 
+    /// True after at least one successful fetch from the accounting database.
+    pub fn is_loaded(&self) -> bool {
+        self.loaded.load(Ordering::Acquire)
+    }
+
     fn replace(&self, new_qos: HashMap<String, Qos>) {
         *self.qos.write() = new_qos;
+        self.loaded.store(true, Ordering::Release);
     }
 
     /// Test-only seam: populates the cache without a database.
     #[cfg(test)]
     pub(crate) fn insert(&self, qos: Qos) {
         self.qos.write().insert(qos.name.clone(), qos);
+        self.loaded.store(true, Ordering::Release);
     }
 
     pub fn spawn_refresh_loop(self: &Arc<Self>, pool: PgPool, refresh_interval_secs: u64) {

--- a/crates/spurctld/src/limits_cache.rs
+++ b/crates/spurctld/src/limits_cache.rs
@@ -8,7 +8,6 @@
 //! this cache so the dormant `QOS*` pending-reasons fire against real limits.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -18,38 +17,46 @@ use tracing::{info, warn};
 
 use spur_core::accounting::{Qos, QosLimits, QosPreemptMode, TresRecord};
 
+struct Snapshot {
+    qos: HashMap<String, Qos>,
+    loaded: bool,
+}
+
 pub struct QosCache {
-    qos: RwLock<HashMap<String, Qos>>,
-    loaded: AtomicBool,
+    snapshot: RwLock<Snapshot>,
 }
 
 impl QosCache {
     pub fn new() -> Self {
         Self {
-            qos: RwLock::new(HashMap::new()),
-            loaded: AtomicBool::new(false),
+            snapshot: RwLock::new(Snapshot {
+                qos: HashMap::new(),
+                loaded: false,
+            }),
         }
     }
 
     pub fn get(&self, name: &str) -> Option<Qos> {
-        self.qos.read().get(name).cloned()
+        self.snapshot.read().qos.get(name).cloned()
     }
 
     /// True after at least one successful fetch from the accounting database.
     pub fn is_loaded(&self) -> bool {
-        self.loaded.load(Ordering::Acquire)
+        self.snapshot.read().loaded
     }
 
     fn replace(&self, new_qos: HashMap<String, Qos>) {
-        *self.qos.write() = new_qos;
-        self.loaded.store(true, Ordering::Release);
+        let mut snap = self.snapshot.write();
+        snap.qos = new_qos;
+        snap.loaded = true;
     }
 
     /// Test-only seam: populates the cache without a database.
     #[cfg(test)]
     pub(crate) fn insert(&self, qos: Qos) {
-        self.qos.write().insert(qos.name.clone(), qos);
-        self.loaded.store(true, Ordering::Release);
+        let mut snap = self.snapshot.write();
+        snap.qos.insert(qos.name.clone(), qos);
+        snap.loaded = true;
     }
 
     pub fn spawn_refresh_loop(self: &Arc<Self>, pool: PgPool, refresh_interval_secs: u64) {


### PR DESCRIPTION
Fixes #419 

This PR adds an `is_loaded()` flag to `QosCache`, following the same pattern as `AssociationCache`, and appends a hint to the error when the cache hasn't been populated yet. I believe this makes the failure mode clearer for users without changing existing behavior.