### PR TITLE
fix(spur-core): default JobSpec.pty so pre-0.6 Raft logs replay

### DIFF
--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -1098,8 +1098,7 @@ mod tests {
         assert_eq!(effective_memory_mb(&spec, 1), 0);
     }
 
-    // A JobSpec serialized before the `pty` field existed (v0.5.1 Raft log
-    // entries) must still deserialize, or spurctld crashes on upgrade replay.
+    // Pre-`pty` JobSpec must still deserialize, or spurctld crashes on replay.
     #[test]
     fn job_spec_deserializes_without_pty_field() {
         let mut value = serde_json::to_value(JobSpec::default()).unwrap();

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -486,6 +486,7 @@ pub struct JobSpec {
     pub open_mode: Option<String>,
 
     // Interactive PTY
+    #[serde(default)]
     pub pty: bool,
 }
 
@@ -1095,6 +1096,16 @@ mod tests {
     fn effective_memory_mb_defaults_to_zero_when_unset() {
         let spec = JobSpec::default();
         assert_eq!(effective_memory_mb(&spec, 1), 0);
+    }
+
+    // A JobSpec serialized before the `pty` field existed (v0.5.1 Raft log
+    // entries) must still deserialize, or spurctld crashes on upgrade replay.
+    #[test]
+    fn job_spec_deserializes_without_pty_field() {
+        let mut value = serde_json::to_value(JobSpec::default()).unwrap();
+        value.as_object_mut().unwrap().remove("pty");
+        let spec: JobSpec = serde_json::from_value(value).unwrap();
+        assert!(!spec.pty);
     }
 
     #[test]

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -344,20 +344,13 @@ mod reservation_wal_tests {
 mod tests {
     use super::*;
 
-    // Frozen v0.5.1 JobSubmit payload, captured before `gpus*`, `pty`, and
-    // `srun_job` were added to JobSpec. spurctld persists Raft log entries as
-    // JSON and replays them on startup under strict recovery, so a new JobSpec
-    // field without `#[serde(default)]` makes this exact blob fail to
-    // deserialize and crashes the controller on upgrade. This literal must NOT
-    // be regenerated when fields are added — its whole purpose is to stay
-    // frozen at the old shape. If it fails to deserialize, the newly added
-    // field needs `#[serde(default)]` (or to be `Option`), not a fixture edit.
-    const JOB_SUBMIT_V0_5_1: &str = r#"{"JobSubmit":{"job_id":7,"spec":{"name":"fixture","partition":null,"account":null,"user":"alice","uid":1000,"gid":1000,"num_nodes":1,"num_tasks":1,"tasks_per_node":null,"cpus_per_task":1,"memory_per_node_mb":null,"memory_per_cpu_mb":null,"gres":[],"script":null,"argv":[],"script_args":[],"work_dir":"/home/alice","stdout_path":null,"stderr_path":null,"stdin_path":null,"environment":{},"time_limit":null,"time_min":null,"qos":null,"priority":null,"reservation":null,"dependency":[],"nodelist":null,"exclude":null,"constraint":null,"mpi":null,"distribution":null,"het_group":null,"array_spec":null,"array_job_id":null,"array_task_id":null,"array_max_concurrent":null,"requeue":false,"exclusive":false,"hold":false,"interactive":false,"mail_type":[],"mail_user":null,"comment":null,"wckey":null,"container_image":null,"container_mounts":[],"container_workdir":null,"container_name":null,"container_readonly":false,"container_mount_home":false,"container_env":{},"container_entrypoint":null,"container_remap_root":false,"burst_buffer":null,"begin_time":null,"deadline":null,"spread_job":false,"topology":null,"host_network":false,"privileged":false,"host_ipc":false,"shm_size":null,"extra_resources":{},"open_mode":null}}}"#;
-
-    // A JobSubmit entry written by v0.5.1 must still deserialize on current code,
-    // or spurctld crashes replaying its Raft log across the upgrade.
+    // Frozen pre-`pty` v0.5.1 Raft entry; must still deserialize or spurctld
+    // crashes on upgrade replay. Never regenerate — a failure here means a new
+    // field needs `#[serde(default)]`, not a fixture edit.
     #[test]
     fn job_submit_v0_5_1_payload_still_deserializes() {
+        const JOB_SUBMIT_V0_5_1: &str = r#"{"JobSubmit":{"job_id":7,"spec":{"name":"fixture","partition":null,"account":null,"user":"alice","uid":1000,"gid":1000,"num_nodes":1,"num_tasks":1,"tasks_per_node":null,"cpus_per_task":1,"memory_per_node_mb":null,"memory_per_cpu_mb":null,"gres":[],"script":null,"argv":[],"script_args":[],"work_dir":"/home/alice","stdout_path":null,"stderr_path":null,"stdin_path":null,"environment":{},"time_limit":null,"time_min":null,"qos":null,"priority":null,"reservation":null,"dependency":[],"nodelist":null,"exclude":null,"constraint":null,"mpi":null,"distribution":null,"het_group":null,"array_spec":null,"array_job_id":null,"array_task_id":null,"array_max_concurrent":null,"requeue":false,"exclusive":false,"hold":false,"interactive":false,"mail_type":[],"mail_user":null,"comment":null,"wckey":null,"container_image":null,"container_mounts":[],"container_workdir":null,"container_name":null,"container_readonly":false,"container_mount_home":false,"container_env":{},"container_entrypoint":null,"container_remap_root":false,"burst_buffer":null,"begin_time":null,"deadline":null,"spread_job":false,"topology":null,"host_network":false,"privileged":false,"host_ipc":false,"shm_size":null,"extra_resources":{},"open_mode":null}}}"#;
+
         let op: WalOperation = serde_json::from_str(JOB_SUBMIT_V0_5_1).expect(
             "v0.5.1 JobSubmit must deserialize; a new JobSpec field needs #[serde(default)]",
         );
@@ -366,7 +359,6 @@ mod tests {
                 assert_eq!(job_id, 7);
                 assert_eq!(spec.name, "fixture");
                 assert_eq!(spec.work_dir, "/home/alice");
-                // Fields added after v0.5.1 fall back to their defaults.
                 assert!(!spec.pty);
                 assert!(!spec.srun_job);
                 assert!(spec.gpus.is_none());

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -344,6 +344,37 @@ mod reservation_wal_tests {
 mod tests {
     use super::*;
 
+    // Frozen v0.5.1 JobSubmit payload, captured before `gpus*`, `pty`, and
+    // `srun_job` were added to JobSpec. spurctld persists Raft log entries as
+    // JSON and replays them on startup under strict recovery, so a new JobSpec
+    // field without `#[serde(default)]` makes this exact blob fail to
+    // deserialize and crashes the controller on upgrade. This literal must NOT
+    // be regenerated when fields are added — its whole purpose is to stay
+    // frozen at the old shape. If it fails to deserialize, the newly added
+    // field needs `#[serde(default)]` (or to be `Option`), not a fixture edit.
+    const JOB_SUBMIT_V0_5_1: &str = r#"{"JobSubmit":{"job_id":7,"spec":{"name":"fixture","partition":null,"account":null,"user":"alice","uid":1000,"gid":1000,"num_nodes":1,"num_tasks":1,"tasks_per_node":null,"cpus_per_task":1,"memory_per_node_mb":null,"memory_per_cpu_mb":null,"gres":[],"script":null,"argv":[],"script_args":[],"work_dir":"/home/alice","stdout_path":null,"stderr_path":null,"stdin_path":null,"environment":{},"time_limit":null,"time_min":null,"qos":null,"priority":null,"reservation":null,"dependency":[],"nodelist":null,"exclude":null,"constraint":null,"mpi":null,"distribution":null,"het_group":null,"array_spec":null,"array_job_id":null,"array_task_id":null,"array_max_concurrent":null,"requeue":false,"exclusive":false,"hold":false,"interactive":false,"mail_type":[],"mail_user":null,"comment":null,"wckey":null,"container_image":null,"container_mounts":[],"container_workdir":null,"container_name":null,"container_readonly":false,"container_mount_home":false,"container_env":{},"container_entrypoint":null,"container_remap_root":false,"burst_buffer":null,"begin_time":null,"deadline":null,"spread_job":false,"topology":null,"host_network":false,"privileged":false,"host_ipc":false,"shm_size":null,"extra_resources":{},"open_mode":null}}}"#;
+
+    // A JobSubmit entry written by v0.5.1 must still deserialize on current code,
+    // or spurctld crashes replaying its Raft log across the upgrade.
+    #[test]
+    fn job_submit_v0_5_1_payload_still_deserializes() {
+        let op: WalOperation = serde_json::from_str(JOB_SUBMIT_V0_5_1).expect(
+            "v0.5.1 JobSubmit must deserialize; a new JobSpec field needs #[serde(default)]",
+        );
+        match op {
+            WalOperation::JobSubmit { job_id, spec } => {
+                assert_eq!(job_id, 7);
+                assert_eq!(spec.name, "fixture");
+                assert_eq!(spec.work_dir, "/home/alice");
+                // Fields added after v0.5.1 fall back to their defaults.
+                assert!(!spec.pty);
+                assert!(!spec.srun_job);
+                assert!(spec.gpus.is_none());
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
     #[test]
     fn job_node_complete_signal_round_trips() {
         let op = WalOperation::JobNodeComplete {


### PR DESCRIPTION
## What this fixes

Upgrading a controller from v0.5.1 to v0.6.0 crashes on startup with a Raft log deserialization error (*missing field `pty`*).

## Root cause

`spurctld` persists Raft log entries as JSON (`serde_json`, `raft.rs`). `WalOperation::JobSubmit` embeds `Box<JobSpec>`. The PTY-session work (#482) added `pub pty: bool` to `JobSpec` **without** `#[serde(default)]`. On upgrade, the controller replays `JobSubmit` entries (and snapshots) whose serialized `JobSpec` predates the field, so serde fails with *missing field `pty`*. Because strict WAL recovery is the startup default, spurctld refuses to start rather than degrading — a hard crash loop until the operator intervenes.

`pty` is the only field added to any WAL-embedded type since v0.5.1 that lacks a serde default; every sibling (`srun_job`, `run_attempt`, reservation `owner`, node `k0s_*`, …) already has one.

## Approach

- Annotate `JobSpec.pty` with `#[serde(default)]`, consistent with how every other post-v0.5.1 field was handled.
- Add a **frozen-fixture regression test** (`wal.rs`): a real v0.5.1 `JobSubmit` JSON payload — captured before the `gpus*`, `pty`, and `srun_job` fields existed — that current code must still deserialize. The existing `wal.rs` serde tests all round-trip through *today's* schema, so a missing `#[serde(default)]` is invisible to them (the field is present on both sides); that is exactly how this shipped. The frozen literal is intentionally immovable — any future non-defaulted `JobSpec` field breaks it, pointing the author at the fix before release rather than at a controller crash on upgrade.

## Testing

- `cargo test -p spur-core --locked` — 375 passed. Both new tests fail without the `pty` annotation and pass with it.
- `cargo clippy -p spur-core --all-targets --locked` — clean.