### PR TITLE
fix(spur-cli): target the -w node when attaching an interactive PTY

### DIFF
--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -912,7 +912,7 @@ fn first_node(nodelist: &str) -> String {
     nodelist
         .split(',')
         .next()
-        .unwrap_or(nodelist)
+        .unwrap_or_default()
         .trim()
         .to_string()
 }
@@ -922,7 +922,7 @@ async fn try_stream_output(
     nodelist: &str,
     job_id: u32,
 ) -> bool {
-    let first_node = nodelist.split(',').next().unwrap_or(nodelist).trim();
+    let first_node = nodelist.split(',').next().unwrap_or_default().trim();
     if first_node.is_empty() {
         return false;
     }

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -212,7 +212,9 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         if !args.overlap {
             anyhow::bail!("--jobid requires --overlap");
         }
-        let exit_code = run_interactive_pty(&args.controller, job_id, args.command.clone()).await?;
+        let node = args.nodelist.clone().unwrap_or_default();
+        let exit_code =
+            run_interactive_pty(&args.controller, job_id, args.command.clone(), node).await?;
         std::process::exit(exit_code);
     }
 
@@ -673,6 +675,7 @@ async fn dispatch_step(
             overlap: false,
             pty: false,
             winsize: None,
+            node: String::new(),
         })
         .await
         .context("failed to create job step")?
@@ -801,7 +804,13 @@ async fn run_standalone_srun(args: &SrunArgs, hooks: &HooksConfig, work_dir: &st
     if args.pty {
         ctrl_c_handle.abort();
         eprintln!("srun: opening interactive session on {}", nodelist);
-        let result = run_interactive_pty(&args.controller, job_id, args.command.clone()).await;
+        let result = run_interactive_pty(
+            &args.controller,
+            job_id,
+            args.command.clone(),
+            String::new(),
+        )
+        .await;
         let _ = client
             .cancel_job(CancelJobRequest {
                 job_id,
@@ -1104,7 +1113,12 @@ fn warn_unsupported_cpu_bind(environment: &HashMap<String, String>) {
 ///
 /// Retries transient failures (job not yet visible on agent after controller
 /// reports it as Running) up to a few seconds before giving up.
-async fn run_interactive_pty(controller: &str, job_id: u32, command: Vec<String>) -> Result<i32> {
+async fn run_interactive_pty(
+    controller: &str,
+    job_id: u32,
+    command: Vec<String>,
+    node: String,
+) -> Result<i32> {
     let channel = spur_client::connect_channel(controller)
         .await
         .context("cannot connect to controller")?;
@@ -1132,6 +1146,7 @@ async fn run_interactive_pty(controller: &str, job_id: u32, command: Vec<String>
                     overlap: true,
                     pty: true,
                     winsize: Some(winsize),
+                    node: node.clone(),
                 })
                 .await
             {

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -212,7 +212,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         if !args.overlap {
             anyhow::bail!("--jobid requires --overlap");
         }
-        let node = args.nodelist.clone().unwrap_or_default();
+        let node = first_node(args.nodelist.as_deref().unwrap_or_default());
         let exit_code =
             run_interactive_pty(&args.controller, job_id, args.command.clone(), node).await?;
         std::process::exit(exit_code);
@@ -904,6 +904,19 @@ fn build_command_script(command: &[String]) -> Result<String> {
     Ok(format!("#!/bin/bash\n{cmd_line}\n"))
 }
 
+/// First node of a `-w` value. Interactive `--pty` attaches to a single node,
+/// so a comma list reduces to its head; an empty value stays empty (controller
+/// then defaults to the first allocated node). Hostlist brackets are not
+/// expanded here — the controller rejects an unmatched name with a clear error.
+fn first_node(nodelist: &str) -> String {
+    nodelist
+        .split(',')
+        .next()
+        .unwrap_or(nodelist)
+        .trim()
+        .to_string()
+}
+
 async fn try_stream_output(
     controller: &mut SlurmControllerClient<tonic::transport::Channel>,
     nodelist: &str,
@@ -1292,6 +1305,26 @@ fn srun_hook_context(script_context: &str, work_dir: &str) -> spur_core::hooks::
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn first_node_reduces_comma_list_to_head() {
+        assert_eq!(first_node("node001,node002"), "node001");
+    }
+
+    #[test]
+    fn first_node_bare_name_passes_through() {
+        assert_eq!(first_node("node007"), "node007");
+    }
+
+    #[test]
+    fn first_node_trims_whitespace() {
+        assert_eq!(first_node(" node003 , node004"), "node003");
+    }
+
+    #[test]
+    fn first_node_empty_stays_empty() {
+        assert_eq!(first_node(""), "");
+    }
 
     #[test]
     fn parses_nodelist_and_exclude_short() {

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1222,6 +1222,9 @@ impl SlurmController for ControllerService {
             )));
         }
 
+        let target_node =
+            select_step_node(&job.allocated_nodes, &req.node).map_err(Status::invalid_argument)?;
+
         let existing_steps = self.cluster.get_steps(job_id);
         let step_id = existing_steps
             .iter()
@@ -1247,10 +1250,9 @@ impl SlurmController for ControllerService {
             .create_step(step)
             .map_err(|e| Status::internal(format!("failed to create job step: {e}")))?;
 
-        let node_addr = job
-            .allocated_nodes
-            .first()
-            .and_then(|name| self.cluster.get_node(name))
+        let node_addr = self
+            .cluster
+            .get_node(target_node)
             .map(|n| {
                 let host = n.address.as_deref().unwrap_or(&n.name);
                 format!("{}:{}", host, n.port)
@@ -1825,6 +1827,23 @@ pub async fn serve(
     router.serve(addr).await?;
 
     Ok(())
+}
+
+/// Resolve the node an interactive step attaches to. Empty request = the first
+/// allocated node (legacy default); a named node must be one the job actually
+/// holds, otherwise the step would attach outside the allocation.
+fn select_step_node<'a>(allocated: &'a [String], requested: &str) -> Result<&'a str, String> {
+    if requested.is_empty() {
+        return allocated
+            .first()
+            .map(String::as_str)
+            .ok_or_else(|| "job has no allocated nodes".to_string());
+    }
+    allocated
+        .iter()
+        .find(|n| n.as_str() == requested)
+        .map(String::as_str)
+        .ok_or_else(|| format!("node {requested} is not allocated to this job"))
 }
 
 // ---- Proto conversion helpers ----
@@ -2438,6 +2457,32 @@ mod tests {
 
         let status = submit_rpc_status(SubmitError::internal("raft propose failed"));
         assert_eq!(status.code(), Code::Internal);
+    }
+
+    #[test]
+    fn select_step_node_empty_request_uses_first_allocated() {
+        let allocated = vec!["node001".to_string(), "node002".to_string()];
+        assert_eq!(select_step_node(&allocated, ""), Ok("node001"));
+    }
+
+    #[test]
+    fn select_step_node_named_request_targets_that_node() {
+        let allocated = vec!["node001".to_string(), "node002".to_string()];
+        assert_eq!(select_step_node(&allocated, "node002"), Ok("node002"));
+    }
+
+    #[test]
+    fn select_step_node_rejects_node_outside_allocation() {
+        let allocated = vec!["node001".to_string(), "node002".to_string()];
+        let err = select_step_node(&allocated, "node999").unwrap_err();
+        assert!(err.contains("node999"));
+        assert!(err.contains("not allocated"));
+    }
+
+    #[test]
+    fn select_step_node_empty_request_no_nodes_errors() {
+        let allocated: Vec<String> = Vec::new();
+        assert!(select_step_node(&allocated, "").is_err());
     }
 
     #[test]

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1225,6 +1225,15 @@ impl SlurmController for ControllerService {
         let target_node =
             select_step_node(&job.allocated_nodes, &req.node).map_err(Status::invalid_argument)?;
 
+        // Resolve the target agent address BEFORE creating the step: an unregistered node returns a
+        // retryable Unavailable and the client retries the whole call, so resolving first keeps a
+        // failed attempt from leaking a step per retry.
+        let node = self.cluster.get_node(target_node).ok_or_else(|| {
+            Status::unavailable(format!("node {target_node} is not currently registered"))
+        })?;
+        let host = node.address.as_deref().unwrap_or(&node.name);
+        let node_addr = format!("{}:{}", host, node.port);
+
         let existing_steps = self.cluster.get_steps(job_id);
         let step_id = existing_steps
             .iter()
@@ -1249,12 +1258,6 @@ impl SlurmController for ControllerService {
         self.cluster
             .create_step(step)
             .map_err(|e| Status::internal(format!("failed to create job step: {e}")))?;
-
-        let node = self.cluster.get_node(target_node).ok_or_else(|| {
-            Status::unavailable(format!("node {target_node} is not currently registered"))
-        })?;
-        let host = node.address.as_deref().unwrap_or(&node.name);
-        let node_addr = format!("{}:{}", host, node.port);
 
         Ok(Response::new(CreateJobStepResponse { step_id, node_addr }))
     }
@@ -2453,6 +2456,127 @@ mod tests {
 
         let status = submit_rpc_status(SubmitError::internal("raft propose failed"));
         assert_eq!(status.code(), Code::Internal);
+    }
+
+    fn step_test_config() -> spur_core::config::SlurmConfig {
+        spur_core::config::SlurmConfig::load_from_str(
+            "cluster_name = \"test\"\n\
+             [controller]\nfirst_job_id = 1\n\
+             [[partitions]]\nname = \"default\"\ndefault = true\nnodes = \"ALL\"\n",
+        )
+        .unwrap()
+    }
+
+    async fn test_service(dir: &tempfile::TempDir) -> ControllerService {
+        use crate::cluster::ClusterManager;
+        let cluster =
+            std::sync::Arc::new(ClusterManager::new(step_test_config(), dir.path()).unwrap());
+        let handle = crate::raft::start_raft(1, &["[::1]:0".into()], dir.path(), cluster.clone())
+            .await
+            .unwrap();
+        handle
+            .raft
+            .wait(Some(std::time::Duration::from_secs(5)))
+            .metrics(|m| m.current_leader == Some(1), "leader elected")
+            .await
+            .unwrap();
+        cluster.set_raft(handle.raft.clone());
+        let raft = std::sync::Arc::new(handle);
+        ControllerService {
+            cluster,
+            raft: raft.clone(),
+            leader_proxy: LeaderProxy::new(raft, BTreeMap::new()),
+            client_addrs: BTreeMap::new(),
+            rpc_stats: std::sync::Arc::new(RpcStatsCollector::new()),
+            sched_stats: std::sync::Arc::new(SchedStatsCollector::new("backfill")),
+        }
+    }
+
+    // A step must NOT be created when the target node is allocated but unregistered: address
+    // resolution runs first and returns a retryable Unavailable, so the client's retries can't
+    // each leak a step.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn create_job_step_unregistered_target_creates_no_step() {
+        use spur_core::resource::{ResourceAllocations, ResourceSet};
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+
+        svc.cluster
+            .register_node(
+                "n1".into(),
+                ResourceSet {
+                    cpus: 8,
+                    memory_mb: 16000,
+                    ..Default::default()
+                },
+                "127.0.0.1".into(),
+                6818,
+                String::new(),
+                String::new(),
+                spur_core::node::NodeSource::NativeHost,
+                std::collections::HashMap::new(),
+            )
+            .unwrap();
+        for _ in 0..200 {
+            if svc.cluster.get_node("n1").is_some() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+
+        let mut spec = spur_core::job::JobSpec {
+            name: "leak".into(),
+            user: "u".into(),
+            num_nodes: 1,
+            num_tasks: 1,
+            cpus_per_task: 1,
+            work_dir: "/tmp".into(),
+            ..Default::default()
+        };
+        spec.srun_job = true;
+        let job_id = svc.cluster.submit_job(spec).unwrap();
+        // Allocate to a real node plus a ghost node that is never registered.
+        let res = ResourceAllocations::with_scalar(2, 4000);
+        let per_node: std::collections::HashMap<_, _> = [
+            ("n1".to_string(), res.clone()),
+            ("ghost".to_string(), res.clone()),
+        ]
+        .into_iter()
+        .collect();
+        svc.cluster
+            .start_job(job_id, vec!["n1".into(), "ghost".into()], res, per_node)
+            .unwrap();
+        for _ in 0..200 {
+            if svc.cluster.get_job(job_id).map(|j| j.state) == Some(JobState::Running) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+
+        let steps_before = svc.cluster.get_steps(job_id).len();
+        // Simulate the client's retry loop: each attempt returns retryable Unavailable and must
+        // leave the step count unchanged (the pre-fix bug created one step per attempt).
+        for _ in 0..5 {
+            let err = svc
+                .create_job_step(Request::new(CreateJobStepRequest {
+                    job_id,
+                    command: vec!["hostname".into()],
+                    num_tasks: 1,
+                    cpus_per_task: 1,
+                    overlap: true,
+                    pty: true,
+                    winsize: None,
+                    node: "ghost".into(),
+                }))
+                .await
+                .expect_err("unregistered target must fail");
+            assert_eq!(err.code(), Code::Unavailable);
+        }
+        assert_eq!(
+            svc.cluster.get_steps(job_id).len(),
+            steps_before,
+            "no step should be created when the target node is unregistered"
+        );
     }
 
     #[test]

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -2486,6 +2486,12 @@ mod tests {
     }
 
     #[test]
+    fn select_step_node_rejects_comma_joined_request() {
+        let allocated = vec!["node001".to_string(), "node002".to_string()];
+        assert!(select_step_node(&allocated, "node001,node002").is_err());
+    }
+
+    #[test]
     fn job_to_proto_output_path_prefers_actual_else_absolute_computed() {
         use spur_core::job::{Job, JobSpec};
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1250,14 +1250,11 @@ impl SlurmController for ControllerService {
             .create_step(step)
             .map_err(|e| Status::internal(format!("failed to create job step: {e}")))?;
 
-        let node_addr = self
-            .cluster
-            .get_node(target_node)
-            .map(|n| {
-                let host = n.address.as_deref().unwrap_or(&n.name);
-                format!("{}:{}", host, n.port)
-            })
-            .unwrap_or_default();
+        let node = self.cluster.get_node(target_node).ok_or_else(|| {
+            Status::unavailable(format!("node {target_node} is not currently registered"))
+        })?;
+        let host = node.address.as_deref().unwrap_or(&node.name);
+        let node_addr = format!("{}:{}", host, node.port);
 
         Ok(Response::new(CreateJobStepResponse { step_id, node_addr }))
     }
@@ -1829,9 +1826,8 @@ pub async fn serve(
     Ok(())
 }
 
-/// Resolve the node an interactive step attaches to. Empty request = the first
-/// allocated node (legacy default); a named node must be one the job actually
-/// holds, otherwise the step would attach outside the allocation.
+/// Resolve the target node for a job step. Empty = first allocated (legacy
+/// default); a named node must be one the job holds, else it targets outside it.
 fn select_step_node<'a>(allocated: &'a [String], requested: &str) -> Result<&'a str, String> {
     if requested.is_empty() {
         return allocated

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -1178,6 +1178,7 @@ message CreateJobStepRequest {
   bool overlap = 5;           // Share resources with existing step (--overlap)
   bool pty = 6;               // Allocate a PTY for the step
   WindowSize winsize = 7;     // Initial terminal dimensions
+  string node = 8;            // Target node (-w); empty = first allocated node
 }
 
 message CreateJobStepResponse {

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -1183,7 +1183,7 @@ message CreateJobStepRequest {
 
 message CreateJobStepResponse {
   uint32 step_id = 1;
-  string node_addr = 2;        // Address of the first allocated node (host:port for agent)
+  string node_addr = 2;        // Address of the selected node (-w target, else first allocated); host:port for agent
 }
 
 // ============================================================


### PR DESCRIPTION
## What this fixes

`srun --jobid=N --overlap --pty -w <node>` ignored `-w` entirely: attaching an interactive shell to a multi-node job always landed on the same node no matter which one you asked for.

## Root cause

Two independent drops of the requested node:

1. The CLI's `--jobid` attach branch called `run_interactive_pty` with only the controller/job/command — `args.nodelist` (`-w`) was never forwarded.
2. `CreateJobStepRequest` had no node field, and the controller's `create_job_step` always resolved the step's agent address from `allocated_nodes.first()`.

So every attach resolved to `allocated_nodes[0]`.

## Approach

- Add an optional `node` field to `CreateJobStepRequest` (additive, field 8).
- On the attach path the CLI forwards the `-w` node. Since an interactive PTY attaches to exactly one node, a comma list is reduced to its first entry client-side.
- The controller validates the requested node is one the job actually holds (`select_step_node`) and resolves the agent address from it. A node outside the allocation is rejected with `InvalidArgument`; an empty request keeps the previous first-node default, so non-attach callers are unchanged.

## Known limitations

- Hostlist bracket syntax (e.g. `node[001-002]`) is not expanded on the attach path; pass a single node name. An unmatched name is rejected with a clear error.
- The non-interactive in-allocation step path (`dispatch_step`) still defaults to the first node; its placement is driven separately and it does not consume the returned address, so it is left unchanged here.

## Testing

- Unit tests for node selection (empty/named/not-allocated/empty-list/comma-joined) and the client-side `-w` reduction.
- `cargo clippy` + `cargo test` on the touched crates — clean.
- Validated end-to-end on an isolated 2-node deployment: attaching with `-w nodeA` vs `-w nodeB` opens the shell on the corresponding host; no `-w` falls back to the first allocated node; a non-allocated `-w` is rejected; a comma list reduces to its first node.