### PR TITLE
test(spur-core): freeze per-variant WAL payloads to guard replay back-compat

### DIFF
--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -340,21 +340,8 @@ mod reservation_wal_tests {
     }
 }
 
-// Backward-compatibility guard for the WAL log-entry surface. spurctld persists
-// every `WalOperation` as JSON and replays it on startup under strict recovery, so
-// a field added to any embedded type without `#[serde(default)]` (or `Option`)
-// makes old entries fail to deserialize and crashes the controller on upgrade.
-//
-// Each `FIXTURES` entry is a frozen JSON blob for one variant; collections hold at
-// least one element so serde descends into the element structs (an empty Vec/Map
-// would leave them unguarded). They must NOT be regenerated: a failure here means a
-// new field needs `#[serde(default)]`, not a fixture edit. `variant_tag` is an
-// exhaustive match (no `_` arm), so a new `WalOperation` variant breaks compilation
-// until an arm — and a matching frozen fixture — is added.
-//
-// Scope/limits: this guards only the added-non-defaulted-field case (serde ignores
-// unknown fields, so renames/removals are not caught here). The separate snapshot
-// blob (`ClusterSnapshot`, full `Job`/`Node`) is a distinct surface, not covered.
+// Frozen old WAL payloads: a new field without `#[serde(default)]` breaks replay and
+// crashes spurctld on upgrade. Do not regenerate — fix the field, not the fixture.
 #[cfg(test)]
 mod backcompat_fixtures {
     use super::*;
@@ -485,7 +472,7 @@ mod backcompat_fixtures {
     fn every_frozen_fixture_still_deserializes() {
         for (tag, json) in FIXTURES {
             let op: WalOperation = serde_json::from_str(json).unwrap_or_else(|e| {
-                panic!("frozen {tag} WAL entry no longer deserializes ({e}); a new field needs #[serde(default)], or a variant/field was renamed or removed — none of which old Raft logs can survive")
+                panic!("frozen {tag} no longer deserializes ({e}); new field needs #[serde(default)], or a rename/removal broke replay")
             });
             assert_eq!(
                 variant_tag(&op),
@@ -495,9 +482,7 @@ mod backcompat_fixtures {
         }
     }
 
-    // Fails if a variant is missing from FIXTURES. Combined with the exhaustive
-    // `variant_tag` match (which breaks the build on a new variant), this makes a
-    // new WalOperation variant impossible to ship without a frozen fixture.
+    // New variant → exhaustive `variant_tag` won't compile; this catches a missing fixture.
     #[test]
     fn every_variant_has_a_fixture() {
         let covered: std::collections::HashSet<&str> =
@@ -512,8 +497,7 @@ mod backcompat_fixtures {
         }
     }
 
-    // One constructed instance per variant, used only to enumerate the variant set
-    // at runtime. Add a variant here when you add one to `WalOperation`.
+    // One instance per variant. Add here when you add a `WalOperation` variant.
     fn all_variants() -> Vec<WalOperation> {
         use crate::job::JobSpec;
         use crate::reservation::Reservation;
@@ -525,8 +509,7 @@ mod backcompat_fixtures {
         let dt = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
             .unwrap()
             .with_timezone(&chrono::Utc);
-        // Non-empty so serde actually descends into the element structs — an empty
-        // Vec/Map would leave GpuResource/AllocatedDevice untraversed and unguarded.
+        // Non-empty so serde descends into the element structs.
         let resource_set = ResourceSet {
             cpus: 0,
             memory_mb: 0,

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -340,6 +340,347 @@ mod reservation_wal_tests {
     }
 }
 
+// Backward-compatibility guard for the WAL log-entry surface. spurctld persists
+// every `WalOperation` as JSON and replays it on startup under strict recovery, so
+// a field added to any embedded type without `#[serde(default)]` (or `Option`)
+// makes old entries fail to deserialize and crashes the controller on upgrade.
+//
+// Each `FIXTURES` entry is a frozen JSON blob for one variant; collections hold at
+// least one element so serde descends into the element structs (an empty Vec/Map
+// would leave them unguarded). They must NOT be regenerated: a failure here means a
+// new field needs `#[serde(default)]`, not a fixture edit. `variant_tag` is an
+// exhaustive match (no `_` arm), so a new `WalOperation` variant breaks compilation
+// until an arm — and a matching frozen fixture — is added.
+//
+// Scope/limits: this guards only the added-non-defaulted-field case (serde ignores
+// unknown fields, so renames/removals are not caught here). The separate snapshot
+// blob (`ClusterSnapshot`, full `Job`/`Node`) is a distinct surface, not covered.
+#[cfg(test)]
+mod backcompat_fixtures {
+    use super::*;
+
+    fn variant_tag(op: &WalOperation) -> &'static str {
+        match op {
+            WalOperation::JobSubmit { .. } => "JobSubmit",
+            WalOperation::JobStateChange { .. } => "JobStateChange",
+            WalOperation::JobStart { .. } => "JobStart",
+            WalOperation::JobComplete { .. } => "JobComplete",
+            WalOperation::JobNodeComplete { .. } => "JobNodeComplete",
+            WalOperation::JobStepComplete { .. } => "JobStepComplete",
+            WalOperation::JobStepCreate { .. } => "JobStepCreate",
+            WalOperation::JobPriorityChange { .. } => "JobPriorityChange",
+            WalOperation::JobPreemptRequeue { .. } => "JobPreemptRequeue",
+            WalOperation::JobSuspend { .. } => "JobSuspend",
+            WalOperation::JobResume { .. } => "JobResume",
+            WalOperation::JobEvict { .. } => "JobEvict",
+            WalOperation::NodeRegister { .. } => "NodeRegister",
+            WalOperation::NodeUpdate { .. } => "NodeUpdate",
+            WalOperation::NodeStateChange { .. } => "NodeStateChange",
+            WalOperation::NodeLabelsUpdate { .. } => "NodeLabelsUpdate",
+            WalOperation::NodeRemove { .. } => "NodeRemove",
+            WalOperation::TokenCreate { .. } => "TokenCreate",
+            WalOperation::TokenRevoke { .. } => "TokenRevoke",
+            WalOperation::ReservationCreate { .. } => "ReservationCreate",
+            WalOperation::ReservationUpdate { .. } => "ReservationUpdate",
+            WalOperation::ReservationDelete { .. } => "ReservationDelete",
+            WalOperation::NodeK0sAssign { .. } => "NodeK0sAssign",
+            WalOperation::K0sSetPhase { .. } => "K0sSetPhase",
+        }
+    }
+
+    const FIXTURES: &[(&str, &str)] = &[
+        (
+            "JobSubmit",
+            r#"{"JobSubmit":{"job_id":7,"spec":{"name":"","partition":null,"account":null,"user":"","uid":0,"gid":0,"num_nodes":1,"num_tasks":1,"tasks_per_node":null,"cpus_per_task":1,"memory_per_node_mb":null,"memory_per_cpu_mb":null,"gres":[],"gpus":null,"gpus_per_node":null,"gpus_per_task":null,"script":null,"argv":[],"script_args":[],"work_dir":"/tmp","stdout_path":null,"stderr_path":null,"stdin_path":null,"environment":{},"time_limit":null,"time_min":null,"qos":null,"priority":null,"reservation":null,"dependency":[],"nodelist":null,"exclude":null,"constraint":null,"mpi":null,"distribution":null,"het_group":null,"array_spec":null,"array_job_id":null,"array_task_id":null,"array_max_concurrent":null,"requeue":false,"exclusive":false,"hold":false,"interactive":false,"srun_job":false,"mail_type":[],"mail_user":null,"comment":null,"wckey":null,"container_image":null,"container_mounts":[],"container_workdir":null,"container_name":null,"container_readonly":false,"container_mount_home":false,"container_env":{},"container_entrypoint":null,"container_remap_root":false,"burst_buffer":null,"begin_time":null,"deadline":null,"spread_job":false,"topology":null,"host_network":false,"privileged":false,"host_ipc":false,"shm_size":null,"extra_resources":{},"open_mode":null,"pty":false}}}"#,
+        ),
+        (
+            "JobStateChange",
+            r#"{"JobStateChange":{"job_id":7,"old_state":"PENDING","new_state":"RUNNING","pending_reason":null,"pending_priority":null}}"#,
+        ),
+        (
+            "JobStart",
+            r#"{"JobStart":{"job_id":7,"nodes":["n0"],"resources":{"cpus":0,"memory_mb":0,"devices":{"gpu":[{"device_id":0,"count":1}]}},"per_node_alloc":{},"srun_step_dispatch":false,"run_attempt":0}}"#,
+        ),
+        (
+            "JobComplete",
+            r#"{"JobComplete":{"job_id":7,"exit_code":0,"state":"COMPLETED"}}"#,
+        ),
+        (
+            "JobNodeComplete",
+            r#"{"JobNodeComplete":{"job_id":7,"node_name":"n0","exit_code":0,"signal":0}}"#,
+        ),
+        (
+            "JobStepComplete",
+            r#"{"JobStepComplete":{"job_id":7,"step_id":0,"exit_code":0}}"#,
+        ),
+        (
+            "JobStepCreate",
+            r#"{"JobStepCreate":{"step":{"job_id":7,"step_id":0,"name":"s","state":"Pending","num_tasks":1,"cpus_per_task":1,"resources":{"cpus":0,"memory_mb":0,"devices":{"gpu":[{"device_id":0,"count":1}]}},"nodes":["n0"],"distribution":"Block","start_time":null,"end_time":null,"exit_code":null}}}"#,
+        ),
+        (
+            "JobPriorityChange",
+            r#"{"JobPriorityChange":{"job_id":7,"old_priority":0,"new_priority":1,"pending_reason":null,"reset_requeue_count":false,"clear_reservation":false}}"#,
+        ),
+        (
+            "JobPreemptRequeue",
+            r#"{"JobPreemptRequeue":{"job_id":7,"begin_time":"2026-01-01T00:00:00Z"}}"#,
+        ),
+        (
+            "JobSuspend",
+            r#"{"JobSuspend":{"job_id":7,"at":"2026-01-01T00:00:00Z"}}"#,
+        ),
+        (
+            "JobResume",
+            r#"{"JobResume":{"job_id":7,"at":"2026-01-01T00:00:00Z"}}"#,
+        ),
+        ("JobEvict", r#"{"JobEvict":{"job_id":7}}"#),
+        (
+            "NodeRegister",
+            r#"{"NodeRegister":{"name":"n0","resources":{"cpus":0,"memory_mb":0,"gpus":[{"device_id":0,"gpu_type":"mi300","memory_mb":0,"peer_gpus":[],"link_type":"PCIe"}],"generic":{}},"address":"1.2.3.4","port":6818,"wg_pubkey":"","version":"","labels":{}}}"#,
+        ),
+        (
+            "NodeUpdate",
+            r#"{"NodeUpdate":{"name":"n0","resources":{"cpus":0,"memory_mb":0,"gpus":[{"device_id":0,"gpu_type":"mi300","memory_mb":0,"peer_gpus":[],"link_type":"PCIe"}],"generic":{}},"address":"1.2.3.4","port":6818,"wg_pubkey":"","version":""}}"#,
+        ),
+        (
+            "NodeStateChange",
+            r#"{"NodeStateChange":{"name":"n0","old_state":"IDLE","new_state":"DOWN","reason":null,"admin_locked":false}}"#,
+        ),
+        (
+            "NodeLabelsUpdate",
+            r#"{"NodeLabelsUpdate":{"name":"n0","set":{},"remove":[]}}"#,
+        ),
+        (
+            "NodeRemove",
+            r#"{"NodeRemove":{"name":"n0","reason":null}}"#,
+        ),
+        (
+            "TokenCreate",
+            r#"{"TokenCreate":{"token":{"id":"tok","secret_hash":"hash","created_at":"2026-01-01T00:00:00Z","expires_at":null,"revoked":false}}}"#,
+        ),
+        ("TokenRevoke", r#"{"TokenRevoke":{"token_id":"tok"}}"#),
+        (
+            "ReservationCreate",
+            r#"{"ReservationCreate":{"reservation":{"name":"r1","start_time":"2026-01-01T00:00:00Z","end_time":"2026-01-01T00:00:00Z","nodes":["n0"],"accounts":[],"users":["alice"],"flags":{"maint":false,"ignore_jobs":false,"no_hold_jobs":false,"overlap":false},"owner":""}}}"#,
+        ),
+        (
+            "ReservationUpdate",
+            r#"{"ReservationUpdate":{"name":"r1","duration_minutes":60,"add_nodes":[],"remove_nodes":[],"add_users":[],"remove_users":[],"add_accounts":[],"remove_accounts":[]}}"#,
+        ),
+        (
+            "ReservationDelete",
+            r#"{"ReservationDelete":{"name":"r1"}}"#,
+        ),
+        (
+            "NodeK0sAssign",
+            r#"{"NodeK0sAssign":{"name":"n0","role":"controller","mesh_ip":"10.0.0.1","pod_cidr":"10.1.0.0/24"}}"#,
+        ),
+        (
+            "K0sSetPhase",
+            r#"{"K0sSetPhase":{"phase":"ready","control_plane_node":null,"reset_requested":false}}"#,
+        ),
+    ];
+
+    #[test]
+    fn every_frozen_fixture_still_deserializes() {
+        for (tag, json) in FIXTURES {
+            let op: WalOperation = serde_json::from_str(json).unwrap_or_else(|e| {
+                panic!("frozen {tag} WAL entry no longer deserializes ({e}); a new field needs #[serde(default)], or a variant/field was renamed or removed — none of which old Raft logs can survive")
+            });
+            assert_eq!(
+                variant_tag(&op),
+                *tag,
+                "fixture keyed {tag} decoded to a different variant"
+            );
+        }
+    }
+
+    // Fails if a variant is missing from FIXTURES. Combined with the exhaustive
+    // `variant_tag` match (which breaks the build on a new variant), this makes a
+    // new WalOperation variant impossible to ship without a frozen fixture.
+    #[test]
+    fn every_variant_has_a_fixture() {
+        let covered: std::collections::HashSet<&str> =
+            FIXTURES.iter().map(|(tag, _)| *tag).collect();
+        assert_eq!(covered.len(), FIXTURES.len(), "duplicate tag in FIXTURES");
+        for op in all_variants() {
+            let tag = variant_tag(&op);
+            assert!(
+                covered.contains(tag),
+                "WalOperation::{tag} has no frozen fixture in FIXTURES"
+            );
+        }
+    }
+
+    // One constructed instance per variant, used only to enumerate the variant set
+    // at runtime. Add a variant here when you add one to `WalOperation`.
+    fn all_variants() -> Vec<WalOperation> {
+        use crate::job::JobSpec;
+        use crate::reservation::Reservation;
+        use crate::resource::{
+            AllocatedDevice, GpuLinkType, GpuResource, ResourceAllocations, ResourceSet,
+        };
+        use crate::step::{JobStep, StepState};
+
+        let dt = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        // Non-empty so serde actually descends into the element structs — an empty
+        // Vec/Map would leave GpuResource/AllocatedDevice untraversed and unguarded.
+        let resource_set = ResourceSet {
+            cpus: 0,
+            memory_mb: 0,
+            gpus: vec![GpuResource {
+                device_id: 0,
+                gpu_type: "mi300".into(),
+                memory_mb: 0,
+                peer_gpus: vec![],
+                link_type: GpuLinkType::PCIe,
+            }],
+            generic: HashMap::new(),
+        };
+        let alloc = ResourceAllocations {
+            cpus: 0,
+            memory_mb: 0,
+            devices: HashMap::from([("gpu".to_string(), vec![AllocatedDevice::injectable(0)])]),
+        };
+        vec![
+            WalOperation::JobSubmit {
+                job_id: 7,
+                spec: Box::new(JobSpec::default()),
+            },
+            WalOperation::job_state_change(7, JobState::Pending, JobState::Running),
+            WalOperation::job_start(7, vec!["n0".into()], alloc.clone(), HashMap::new()),
+            WalOperation::JobComplete {
+                job_id: 7,
+                exit_code: 0,
+                state: JobState::Completed,
+            },
+            WalOperation::JobNodeComplete {
+                job_id: 7,
+                node_name: "n0".into(),
+                exit_code: 0,
+                signal: 0,
+            },
+            WalOperation::JobStepComplete {
+                job_id: 7,
+                step_id: 0,
+                exit_code: 0,
+            },
+            WalOperation::JobStepCreate {
+                step: Box::new(JobStep {
+                    job_id: 7,
+                    step_id: 0,
+                    name: "s".into(),
+                    state: StepState::Pending,
+                    num_tasks: 1,
+                    cpus_per_task: 1,
+                    resources: alloc.clone(),
+                    nodes: vec!["n0".into()],
+                    distribution: Default::default(),
+                    start_time: None,
+                    end_time: None,
+                    exit_code: None,
+                }),
+            },
+            WalOperation::JobPriorityChange {
+                job_id: 7,
+                old_priority: 0,
+                new_priority: 1,
+                pending_reason: None,
+                reset_requeue_count: false,
+                clear_reservation: false,
+            },
+            WalOperation::JobPreemptRequeue {
+                job_id: 7,
+                begin_time: dt,
+            },
+            WalOperation::JobSuspend { job_id: 7, at: dt },
+            WalOperation::JobResume { job_id: 7, at: dt },
+            WalOperation::JobEvict { job_id: 7 },
+            WalOperation::NodeRegister {
+                name: "n0".into(),
+                resources: resource_set.clone(),
+                address: "1.2.3.4".into(),
+                port: 6818,
+                wg_pubkey: String::new(),
+                version: String::new(),
+                labels: HashMap::new(),
+            },
+            WalOperation::NodeUpdate {
+                name: "n0".into(),
+                resources: resource_set.clone(),
+                address: "1.2.3.4".into(),
+                port: 6818,
+                wg_pubkey: String::new(),
+                version: String::new(),
+            },
+            WalOperation::NodeStateChange {
+                name: "n0".into(),
+                old_state: NodeState::Idle,
+                new_state: NodeState::Down,
+                reason: None,
+                admin_locked: false,
+            },
+            WalOperation::NodeLabelsUpdate {
+                name: "n0".into(),
+                set: HashMap::new(),
+                remove: vec![],
+            },
+            WalOperation::NodeRemove {
+                name: "n0".into(),
+                reason: None,
+            },
+            WalOperation::TokenCreate {
+                token: AdmissionToken {
+                    id: "tok".into(),
+                    secret_hash: "hash".into(),
+                    created_at: dt,
+                    expires_at: None,
+                    revoked: false,
+                },
+            },
+            WalOperation::TokenRevoke {
+                token_id: "tok".into(),
+            },
+            WalOperation::ReservationCreate {
+                reservation: Reservation {
+                    name: "r1".into(),
+                    start_time: dt,
+                    end_time: dt,
+                    nodes: vec!["n0".into()],
+                    accounts: vec![],
+                    users: vec!["alice".into()],
+                    flags: Default::default(),
+                    owner: String::new(),
+                },
+            },
+            WalOperation::ReservationUpdate {
+                name: "r1".into(),
+                duration_minutes: 60,
+                add_nodes: vec![],
+                remove_nodes: vec![],
+                add_users: vec![],
+                remove_users: vec![],
+                add_accounts: vec![],
+                remove_accounts: vec![],
+            },
+            WalOperation::ReservationDelete { name: "r1".into() },
+            WalOperation::NodeK0sAssign {
+                name: "n0".into(),
+                role: K0sRole::Controller,
+                mesh_ip: "10.0.0.1".into(),
+                pod_cidr: "10.1.0.0/24".into(),
+            },
+            WalOperation::K0sSetPhase {
+                phase: K0sPhase::Ready,
+                control_plane_node: None,
+                reset_requested: false,
+            },
+        ]
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## What

Adds a backward-compatibility test harness for the Raft WAL log-entry surface in `crates/spur-core/src/wal.rs`.

`spurctld` persists every `WalOperation` as JSON and replays it on startup under strict recovery. A field added to any type reachable from `WalOperation` without `#[serde(default)]` (or `Option`) makes old entries fail to deserialize and crashes the controller on upgrade. A single-variant frozen fixture was recently added for the `JobSpec.pty` incident; this generalizes that guard across the whole log-entry enum.

## Approach

- `FIXTURES`: one frozen JSON blob per `WalOperation` variant, captured from a real serialization. If a new field lands without a serde default, the matching blob stops deserializing and the test fails with an actionable message.
- `variant_tag`: an exhaustive match with **no `_` arm**, so adding a new `WalOperation` variant breaks compilation until an arm — and a matching fixture — is added. `every_variant_has_a_fixture` backs this at runtime.
- Fixture collections carry at least one element (a `GpuResource`, an `AllocatedDevice`) so serde descends into the nested element structs rather than skipping them behind an empty `Vec`/`Map`.

The guard was verified by temporarily adding a non-defaulted field to a nested type and confirming the frozen fixture fails to deserialize with the intended message.

## Scope / known limitations

- **Directional guard.** Catches an *added non-defaulted field* (the crash class). It does not catch a renamed/removed field or variant — serde ignores unknown fields (no `deny_unknown_fields`), and renames/removals are inherently unsafe for old-log replay regardless.
- **Snapshot surface not covered.** The controller also restores a separate `ClusterSnapshot` blob (full `Job`/`Node` structs) under the same strict path. That is a distinct surface needing its own fixture test — tracked as follow-up.

## Testing

`cargo test -p spur-core`, `cargo clippy -p spur-core --all-targets`, and `cargo fmt --check` all pass. The change is test-only — no runtime behavior changes.