### PR TITLE
fix(spur-cli): honor format= in sacctmgr show account

### DIFF
--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -707,6 +707,15 @@ async fn show(entity: &str, params: &[String], addr: &str) -> Result<()> {
 
     match entity.to_lowercase().as_str() {
         "account" | "accounts" => {
+            let fields = format_engine::resolve_format(
+                p.get("format").map(String::as_str),
+                ACCOUNT_DEFAULT_FORMAT,
+                ACCOUNT_ALL_FORMAT,
+                &account_field_spec,
+                &account_header,
+                "Account, Descr, Org, Parent, Share, GrpTRES, MaxJobs",
+            )?;
+
             let mut client = connect(addr).await?;
             let resp = client
                 .list_accounts(ListAccountsRequest {})
@@ -715,34 +724,13 @@ async fn show(entity: &str, params: &[String], addr: &str) -> Result<()> {
 
             let accounts = resp.into_inner().accounts;
 
-            println!(
-                "{:<20} {:<30} {:<15} {:<10} {:<10} {:<10}",
-                "Account", "Descr", "Org", "Parent", "Share", "GrpTRES"
-            );
-            println!("{}", "-".repeat(100));
+            format_engine::print_header(&fields);
 
-            if accounts.is_empty() {
+            for a in &accounts {
                 println!(
-                    "{:<20} {:<30} {:<15} {:<10} {:<10} {:<10}",
-                    "(no accounts configured)", "", "", "", "", ""
+                    "{}",
+                    format_engine::format_row(&fields, &|spec| resolve_account_field(a, spec))
                 );
-            } else {
-                for a in &accounts {
-                    let parent = if a.parent_account.is_empty() {
-                        ""
-                    } else {
-                        &a.parent_account
-                    };
-                    println!(
-                        "{:<20} {:<30} {:<15} {:<10} {:<10} {:<10}",
-                        a.name,
-                        a.description,
-                        a.organization,
-                        parent,
-                        a.fairshare_weight as u32,
-                        a.grp_tres,
-                    );
-                }
             }
             Ok(())
         }
@@ -858,6 +846,55 @@ async fn show(entity: &str, params: &[String], addr: &str) -> Result<()> {
 fn filter_qos_by_name(qos_list: &mut Vec<QosInfo>, filter: &str) {
     let names: Vec<&str> = filter.split(',').map(str::trim).collect();
     qos_list.retain(|q| names.iter().any(|n| n.eq_ignore_ascii_case(&q.name)));
+}
+
+const ACCOUNT_DEFAULT_FORMAT: &str = "%-20N %-30D %-15O %-10P %-10S %-10G";
+
+const ACCOUNT_ALL_FORMAT: &str = "%-20N %-30D %-15O %-10P %-10S %-10G %-10J";
+
+fn account_header(spec: char) -> &'static str {
+    match spec {
+        'N' => "Account",
+        'D' => "Descr",
+        'O' => "Org",
+        'P' => "Parent",
+        'S' => "Share",
+        'G' => "GrpTRES",
+        'J' => "MaxJobs",
+        _ => "?",
+    }
+}
+
+fn account_field_spec(name: &str) -> Option<char> {
+    match name.to_lowercase().as_str() {
+        "account" | "name" => Some('N'),
+        "description" | "descr" => Some('D'),
+        "organization" | "org" => Some('O'),
+        "parent" | "parentaccount" => Some('P'),
+        "share" | "fairshare" | "fairshareweight" => Some('S'),
+        "grptres" => Some('G'),
+        "maxjobs" | "maxrunningjobs" => Some('J'),
+        _ => None,
+    }
+}
+
+fn resolve_account_field(a: &AccountInfo, spec: char) -> String {
+    match spec {
+        'N' => a.name.clone(),
+        'D' => a.description.clone(),
+        'O' => a.organization.clone(),
+        'P' => a.parent_account.clone(),
+        'S' => (a.fairshare_weight as u32).to_string(),
+        'G' => a.grp_tres.clone(),
+        'J' => {
+            if a.max_running_jobs == 0 {
+                String::new()
+            } else {
+                a.max_running_jobs.to_string()
+            }
+        }
+        _ => String::new(),
+    }
 }
 
 const QOS_DEFAULT_FORMAT: &str = "%-15N %-8p %-10P %-12U %-10J %-10S %-10W %-10w %-20T %-20V %-20G";
@@ -1456,5 +1493,150 @@ mod tests {
 
         assert!(account.is_empty());
         assert_eq!(user, "testuser");
+    }
+
+    fn stub_account() -> AccountInfo {
+        AccountInfo {
+            name: "physics".into(),
+            description: "Physics dept".into(),
+            organization: "sciences".into(),
+            parent_account: "root".into(),
+            fairshare_weight: 5.0,
+            max_running_jobs: 10,
+            grp_tres: "node=4,cpu=256".into(),
+        }
+    }
+
+    #[test]
+    fn account_named_format_selects_and_orders_fields() {
+        let fields = format_engine::parse_named_format(
+            "Account,GrpTRES",
+            &account_field_spec,
+            &account_header,
+        );
+        let specs: Vec<char> = fields
+            .iter()
+            .filter_map(|t| match t {
+                format_engine::FormatToken::Field(f) => Some(f.spec),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(specs, vec!['N', 'G']);
+
+        let a = stub_account();
+        let row = format_engine::format_row(&fields, &|spec| resolve_account_field(&a, spec));
+        assert!(row.contains("physics"), "Account missing: {row}");
+        assert!(row.contains("node=4,cpu=256"), "GrpTRES missing: {row}");
+        assert!(
+            !row.contains("Physics dept"),
+            "Descr should be absent: {row}"
+        );
+    }
+
+    #[test]
+    fn account_format_reorders_columns() {
+        let fields = format_engine::parse_named_format(
+            "GrpTRES,Account",
+            &account_field_spec,
+            &account_header,
+        );
+        let header = format_engine::format_header(&fields);
+        let grp = header.find("GrpTRES").expect("GrpTRES header");
+        let acct = header.find("Account").expect("Account header");
+        assert!(grp < acct, "GrpTRES should precede Account: {header}");
+    }
+
+    #[test]
+    fn account_default_format_matches_legacy_columns() {
+        let fields = format_engine::parse_format(ACCOUNT_DEFAULT_FORMAT, &account_header);
+        let header = format_engine::format_header(&fields);
+        for col in ["Account", "Descr", "Org", "Parent", "Share", "GrpTRES"] {
+            assert!(
+                header.contains(col),
+                "default header missing {col}: {header}"
+            );
+        }
+    }
+
+    #[test]
+    fn account_all_format_includes_maxjobs() {
+        let fields = format_engine::parse_format(ACCOUNT_ALL_FORMAT, &account_header);
+        let header = format_engine::format_header(&fields);
+        assert!(header.contains("MaxJobs"), "all header: {header}");
+    }
+
+    #[test]
+    fn account_field_spec_aliases_are_case_insensitive() {
+        assert_eq!(account_field_spec("account"), account_field_spec("Name"));
+        assert_eq!(
+            account_field_spec("org"),
+            account_field_spec("Organization")
+        );
+        assert_eq!(
+            account_field_spec("parent"),
+            account_field_spec("ParentAccount")
+        );
+        assert_eq!(account_field_spec("share"), account_field_spec("FairShare"));
+    }
+
+    #[test]
+    fn account_field_spec_rejects_unknown_names() {
+        assert_eq!(account_field_spec("bogus"), None);
+        assert_eq!(account_field_spec(""), None);
+    }
+
+    #[test]
+    fn account_resolve_zero_maxjobs_is_blank() {
+        let a = AccountInfo {
+            max_running_jobs: 0,
+            ..stub_account()
+        };
+        assert_eq!(resolve_account_field(&a, 'J'), "");
+    }
+
+    #[test]
+    fn account_resolve_nonzero_maxjobs_renders_value() {
+        let a = AccountInfo {
+            max_running_jobs: 10,
+            ..stub_account()
+        };
+        assert_eq!(resolve_account_field(&a, 'J'), "10");
+    }
+
+    fn account_resolve_format(
+        fmt: Option<&str>,
+    ) -> anyhow::Result<Vec<format_engine::FormatToken>> {
+        format_engine::resolve_format(
+            fmt,
+            ACCOUNT_DEFAULT_FORMAT,
+            ACCOUNT_ALL_FORMAT,
+            &account_field_spec,
+            &account_header,
+            "Account, Descr, Org, Parent, Share, GrpTRES, MaxJobs",
+        )
+    }
+
+    #[test]
+    fn account_resolve_format_all_expands_to_all_columns() {
+        let fields = account_resolve_format(Some("all")).unwrap();
+        let header = format_engine::format_header(&fields);
+        assert!(header.contains("MaxJobs"), "all header: {header}");
+        assert!(header.contains("GrpTRES"), "all header: {header}");
+    }
+
+    #[test]
+    fn account_resolve_format_unknown_field_errors() {
+        assert!(account_resolve_format(Some("bogus")).is_err());
+    }
+
+    #[test]
+    fn account_resolve_format_none_uses_default() {
+        let fields = account_resolve_format(None).unwrap();
+        let header = format_engine::format_header(&fields);
+        assert!(header.contains("Account"), "default header: {header}");
+        assert!(
+            !header.contains("MaxJobs"),
+            "default should omit MaxJobs: {header}"
+        );
     }
 }

--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -707,14 +707,7 @@ async fn show(entity: &str, params: &[String], addr: &str) -> Result<()> {
 
     match entity.to_lowercase().as_str() {
         "account" | "accounts" => {
-            let fields = format_engine::resolve_format(
-                p.get("format").map(String::as_str),
-                ACCOUNT_DEFAULT_FORMAT,
-                ACCOUNT_ALL_FORMAT,
-                &account_field_spec,
-                &account_header,
-                "Account, Descr, Org, Parent, Share, GrpTRES, MaxJobs",
-            )?;
+            let fields = account_format_fields(p.get("format").map(String::as_str))?;
 
             let mut client = connect(addr).await?;
             let resp = client
@@ -878,6 +871,30 @@ fn account_field_spec(name: &str) -> Option<char> {
     }
 }
 
+/// Resolve `show account` output columns from an optional `format=` param. Shared by the handler
+/// and its tests so the default/all formats and the valid-field hint stay in one place.
+fn account_format_fields(
+    format_param: Option<&str>,
+) -> anyhow::Result<Vec<format_engine::FormatToken>> {
+    format_engine::resolve_format(
+        format_param,
+        ACCOUNT_DEFAULT_FORMAT,
+        ACCOUNT_ALL_FORMAT,
+        &account_field_spec,
+        &account_header,
+        "Account, Descr, Org, Parent, Share, GrpTRES, MaxJobs",
+    )
+}
+
+/// Render a numeric limit, blank when zero (Slurm shows "unlimited" as an empty cell).
+fn blank_if_zero(v: u32) -> String {
+    if v == 0 {
+        String::new()
+    } else {
+        v.to_string()
+    }
+}
+
 fn resolve_account_field(a: &AccountInfo, spec: char) -> String {
     match spec {
         'N' => a.name.clone(),
@@ -886,14 +903,8 @@ fn resolve_account_field(a: &AccountInfo, spec: char) -> String {
         'P' => a.parent_account.clone(),
         'S' => (a.fairshare_weight as u32).to_string(),
         'G' => a.grp_tres.clone(),
-        'J' => {
-            if a.max_running_jobs == 0 {
-                String::new()
-            } else {
-                a.max_running_jobs.to_string()
-            }
-        }
-        _ => String::new(),
+        'J' => blank_if_zero(a.max_running_jobs),
+        _ => "?".into(),
     }
 }
 
@@ -948,34 +959,10 @@ fn resolve_qos_field(q: &QosInfo, spec: char) -> String {
         'G' => q.grp_tres.clone(),
         'T' => q.max_tres_per_job.clone(),
         'V' => q.max_tres_per_user.clone(),
-        'J' => {
-            if q.max_jobs_per_user == 0 {
-                String::new()
-            } else {
-                q.max_jobs_per_user.to_string()
-            }
-        }
-        'S' => {
-            if q.max_submit_jobs_per_user == 0 {
-                String::new()
-            } else {
-                q.max_submit_jobs_per_user.to_string()
-            }
-        }
-        'W' => {
-            if q.max_wall_minutes == 0 {
-                String::new()
-            } else {
-                q.max_wall_minutes.to_string()
-            }
-        }
-        'w' => {
-            if q.grp_wall_minutes == 0 {
-                String::new()
-            } else {
-                q.grp_wall_minutes.to_string()
-            }
-        }
+        'J' => blank_if_zero(q.max_jobs_per_user),
+        'S' => blank_if_zero(q.max_submit_jobs_per_user),
+        'W' => blank_if_zero(q.max_wall_minutes),
+        'w' => blank_if_zero(q.grp_wall_minutes),
         _ => "?".into(),
     }
 }
@@ -1603,22 +1590,15 @@ mod tests {
         assert_eq!(resolve_account_field(&a, 'J'), "10");
     }
 
-    fn account_resolve_format(
-        fmt: Option<&str>,
-    ) -> anyhow::Result<Vec<format_engine::FormatToken>> {
-        format_engine::resolve_format(
-            fmt,
-            ACCOUNT_DEFAULT_FORMAT,
-            ACCOUNT_ALL_FORMAT,
-            &account_field_spec,
-            &account_header,
-            "Account, Descr, Org, Parent, Share, GrpTRES, MaxJobs",
-        )
+    #[test]
+    fn account_resolve_unknown_spec_is_visible_marker() {
+        // A header spec missing a resolver renders "?" (not a silently blank column).
+        assert_eq!(resolve_account_field(&stub_account(), 'Z'), "?");
     }
 
     #[test]
     fn account_resolve_format_all_expands_to_all_columns() {
-        let fields = account_resolve_format(Some("all")).unwrap();
+        let fields = account_format_fields(Some("all")).unwrap();
         let header = format_engine::format_header(&fields);
         assert!(header.contains("MaxJobs"), "all header: {header}");
         assert!(header.contains("GrpTRES"), "all header: {header}");
@@ -1626,12 +1606,12 @@ mod tests {
 
     #[test]
     fn account_resolve_format_unknown_field_errors() {
-        assert!(account_resolve_format(Some("bogus")).is_err());
+        assert!(account_format_fields(Some("bogus")).is_err());
     }
 
     #[test]
     fn account_resolve_format_none_uses_default() {
-        let fields = account_resolve_format(None).unwrap();
+        let fields = account_format_fields(None).unwrap();
         let header = format_engine::format_header(&fields);
         assert!(header.contains("Account"), "default header: {header}");
         assert!(

--- a/tests/native_host/e2e/test_accounting.py
+++ b/tests/native_host/e2e/test_accounting.py
@@ -132,6 +132,34 @@ class TestSacctmgrShowQos:
         assert "cpu=32" in row
 
 
+class TestSacctmgrShowAccount:
+    """Verify sacctmgr show account honors format= field selection, the same
+    way show qos does."""
+
+    def test_default_output_shows_legacy_columns(self, accounting_cluster):
+        c = accounting_cluster
+        c.sacctmgr(["add", "account", "name=physics", "description=Physics",
+                     "organization=sciences", "grptres=cpu=16"])
+        time.sleep(15)
+        out = c.sacctmgr(["show", "account"])
+        header = next(line for line in out.splitlines() if line.strip())
+        for column in ("Account", "Descr", "Org", "Parent", "Share", "GrpTRES"):
+            assert column in header, f"missing column {column!r}: {header!r}"
+        assert "physics" in out
+
+    def test_format_selects_specific_fields(self, accounting_cluster):
+        c = accounting_cluster
+        c.sacctmgr(["add", "account", "name=fmtacct", "description=Formatted",
+                     "grptres=cpu=32"])
+        time.sleep(15)
+        out = c.sacctmgr(["show", "account", "format=Account,GrpTRES"])
+        assert "fmtacct" in out
+        assert "cpu=32" in out, f"GrpTRES missing: {out!r}"
+        header = next(line for line in out.splitlines() if line.strip())
+        assert "Descr" not in header, f"Descr should be absent: {header!r}"
+        assert "Org" not in header, f"Org should be absent: {header!r}"
+
+
 class TestQosLimitReasons:
     def test_wall_cap_sets_qos_pending_reason(self, accounting_cluster):
         c = accounting_cluster

--- a/tests/native_host/e2e/test_accounting.py
+++ b/tests/native_host/e2e/test_accounting.py
@@ -140,7 +140,6 @@ class TestSacctmgrShowAccount:
         c = accounting_cluster
         c.sacctmgr(["add", "account", "name=physics", "description=Physics",
                      "organization=sciences", "grptres=cpu=16"])
-        time.sleep(15)
         out = c.sacctmgr(["show", "account"])
         header = next(line for line in out.splitlines() if line.strip())
         for column in ("Account", "Descr", "Org", "Parent", "Share", "GrpTRES"):
@@ -151,7 +150,6 @@ class TestSacctmgrShowAccount:
         c = accounting_cluster
         c.sacctmgr(["add", "account", "name=fmtacct", "description=Formatted",
                      "grptres=cpu=32"])
-        time.sleep(15)
         out = c.sacctmgr(["show", "account", "format=Account,GrpTRES"])
         assert "fmtacct" in out
         assert "cpu=32" in out, f"GrpTRES missing: {out!r}"
@@ -160,15 +158,16 @@ class TestSacctmgrShowAccount:
         assert "Org" not in header, f"Org should be absent: {header!r}"
 
     def test_empty_account_list_is_header_only(self, accounting_cluster):
-        """No accounts prints the header only, not a placeholder or blank row."""
+        """No accounts prints the header + separator only, not a placeholder or data row."""
         c = accounting_cluster
         out = c.sacctmgr(["show", "account"])
         rows = [line for line in out.splitlines() if line.strip()]
-        assert rows, f"expected a header line: {out!r}"
+        assert len(rows) >= 2, f"expected header and separator: {out!r}"
+        header, _separator, *data_rows = rows
         for column in ("Account", "Descr", "Org"):
-            assert column in rows[0], f"missing column {column!r}: {rows[0]!r}"
+            assert column in header, f"missing column {column!r}: {header!r}"
         assert "no accounts configured" not in out
-        assert rows[1:] == [], f"expected no data rows: {rows[1:]!r}"
+        assert data_rows == [], f"expected no data rows: {data_rows!r}"
 
 
 class TestQosLimitReasons:

--- a/tests/native_host/e2e/test_accounting.py
+++ b/tests/native_host/e2e/test_accounting.py
@@ -159,6 +159,17 @@ class TestSacctmgrShowAccount:
         assert "Descr" not in header, f"Descr should be absent: {header!r}"
         assert "Org" not in header, f"Org should be absent: {header!r}"
 
+    def test_empty_account_list_is_header_only(self, accounting_cluster):
+        """No accounts prints the header only, not a placeholder or blank row."""
+        c = accounting_cluster
+        out = c.sacctmgr(["show", "account"])
+        rows = [line for line in out.splitlines() if line.strip()]
+        assert rows, f"expected a header line: {out!r}"
+        for column in ("Account", "Descr", "Org"):
+            assert column in rows[0], f"missing column {column!r}: {rows[0]!r}"
+        assert "no accounts configured" not in out
+        assert rows[1:] == [], f"expected no data rows: {rows[1:]!r}"
+
 
 class TestQosLimitReasons:
     def test_wall_cap_sets_qos_pending_reason(self, accounting_cluster):


### PR DESCRIPTION
## What

`sacctmgr show account` printed a fixed six-column table and ignored a `format=` argument, so users could not select or reorder the displayed fields. `show qos` already routes through the shared format engine (`resolve_format`) to honor `format=`; the account branch did not. Fixes #487.

## Approach

Route the `account` branch of `show` through `format_engine::resolve_format` + `print_header` + `format_row`, mirroring the existing `qos` branch. Adds the account field/header/spec helpers and default/all format strings:

- `format=Account,GrpTRES` selects and narrows columns.
- `format=GrpTRES,Account` reorders them.
- `format=all` expands to every column (adds `MaxJobs`).
- An unrecognized `format=` value errors with the list of valid fields.

Field-name aliases follow the same convention as `qos` (case-insensitive, common Slurm spellings). `MaxJobs` renders blank when unset (0), consistent with the qos zero-handling.

## Behavior change

The empty-account-list placeholder row (`(no accounts configured)`) is removed in favor of header-only output. This matches real `sacctmgr` and the `qos` path; there is no implicit default account to synthesize (unlike the qos `normal` default).

## Testing

- Unit tests for field selection, reordering, default/all format strings, alias case-insensitivity, unknown-field rejection, and the `resolve_format` `all`/error paths.
- An e2e test (`TestSacctmgrShowAccount`) covering default columns and `format=` selection, alongside the existing qos coverage.
- `cargo clippy --workspace --exclude spur-ffi --all-targets` clean, `cargo fmt --check` clean, full `spur-cli` suite passes.
- Exercised end-to-end against an isolated single-node deployment: default output, column selection/reordering, `format=all`, the `list` alias, and the unknown-field error path all behave as expected.