### PR TITLE
build: resolve PMIx MPI crate Cargo.lock version mismatch from cross-commit merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3675,7 +3675,7 @@ dependencies = [
 
 [[package]]
 name = "spur-mpi-pmix"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "cc",
  "pkg-config",


### PR DESCRIPTION
## What this fixes

Top-of-tree `main` (commit 3fbc62a, PR #505) fails **every** `--locked` CI job — build, test, clippy, and coverage — with:

```
error: cannot update the lock file /home/runner/work/spur/spur/Cargo.lock because --locked was passed to prevent this
```

## Root cause

The new `spur-mpi-pmix` crate inherits the workspace version via `version.workspace = true` (currently `0.6.0`), but PR #505 committed its `Cargo.lock` entry pinned at the older `0.5.1`. Since CI runs with `--locked`, cargo refuses to reconcile the stale entry and aborts before building.

## Fix

One-line lockfile sync:

```
cargo update -p spur-mpi-pmix --precise 0.6.0
```

## Testing

- Reproduced the failure at `3fbc62a` in an isolated worktree (`cargo metadata --locked` → same error).
- After the fix, `cargo metadata --locked` succeeds, so the `--locked` gate is satisfied for all downstream jobs.