### PR TITLE
fix(spur-cli): sort squeue output and honor -S/--sort

### DIFF
--- a/crates/spur-cli/src/squeue.rs
+++ b/crates/spur-cli/src/squeue.rs
@@ -47,8 +47,8 @@ pub struct SqueueArgs {
     #[arg(short = 'h', long)]
     pub noheader: bool,
 
-    /// Sort by field
-    #[arg(short = 'S', long)]
+    /// Sort by field(s), comma-separated, each optionally prefixed with + (asc) or - (desc)
+    #[arg(short = 'S', long, allow_hyphen_values = true)]
     pub sort: Option<String>,
 
     /// Controller address
@@ -113,7 +113,15 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         .await
         .context("failed to get jobs")?;
 
-    let jobs = response.into_inner().jobs;
+    let mut jobs = response.into_inner().jobs;
+
+    // Slurm sorts client-side; its default job sort is "P,t,-p". The trailing
+    // jobid tiebreak is ours, so equal-priority jobs order deterministically.
+    let sort_keys = match args.sort.as_deref() {
+        Some(s) => parse_sort_arg(s)?,
+        None => default_sort_keys(),
+    };
+    sort_jobs(&mut jobs, &sort_keys);
 
     // Print header
     if !args.noheader {
@@ -171,6 +179,132 @@ fn resolve_job_field(job: &spur_proto::proto::JobInfo, spec: char) -> String {
         }
         _ => "?".into(),
     }
+}
+
+/// One field in a sort spec, with direction.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct SortKey {
+    spec: char,
+    descending: bool,
+}
+
+/// Slurm's documented default job sort: partition asc, state asc, priority desc.
+/// A trailing jobid asc keeps equal-priority jobs deterministically ordered.
+fn default_sort_keys() -> Vec<SortKey> {
+    vec![
+        SortKey {
+            spec: 'P',
+            descending: false,
+        },
+        SortKey {
+            spec: 't',
+            descending: false,
+        },
+        SortKey {
+            spec: 'p',
+            descending: true,
+        },
+        SortKey {
+            spec: 'i',
+            descending: false,
+        },
+    ]
+}
+
+/// Parse `-S` / `--sort`: comma-separated fields, each optionally prefixed with
+/// `+` (asc, default) or `-` (desc). Reuses the format-spec letters.
+fn parse_sort_arg(s: &str) -> Result<Vec<SortKey>> {
+    let mut keys = Vec::new();
+    for token in s.split(',').map(str::trim).filter(|t| !t.is_empty()) {
+        let (descending, rest) = match token.strip_prefix('-') {
+            Some(r) => (true, r),
+            None => (false, token.strip_prefix('+').unwrap_or(token)),
+        };
+        let mut chars = rest.chars();
+        let spec = chars
+            .next()
+            .filter(|_| chars.next().is_none())
+            .ok_or_else(|| anyhow::anyhow!("Invalid sort specification: {token}"))?;
+        if format_engine::squeue_header(spec) == "?" {
+            anyhow::bail!("Invalid sort specification: {token}");
+        }
+        keys.push(SortKey { spec, descending });
+    }
+    if keys.is_empty() {
+        anyhow::bail!("Invalid sort specification: (empty)");
+    }
+    Ok(keys)
+}
+
+fn sort_jobs(jobs: &mut [spur_proto::proto::JobInfo], keys: &[SortKey]) {
+    jobs.sort_by(|a, b| {
+        for key in keys {
+            let ord = compare_field(a, b, key.spec);
+            let ord = if key.descending { ord.reverse() } else { ord };
+            if ord != std::cmp::Ordering::Equal {
+                return ord;
+            }
+        }
+        std::cmp::Ordering::Equal
+    });
+}
+
+/// Compare two jobs on a single field. Numeric fields compare numerically;
+/// timestamps by epoch seconds; everything else lexically on the rendered value.
+fn compare_field(
+    a: &spur_proto::proto::JobInfo,
+    b: &spur_proto::proto::JobInfo,
+    spec: char,
+) -> std::cmp::Ordering {
+    match spec {
+        'i' | 'A' => a.job_id.cmp(&b.job_id),
+        'p' => a.priority.cmp(&b.priority),
+        'D' => a.num_nodes.cmp(&b.num_nodes),
+        'C' => a.cpus_per_task.cmp(&b.cpus_per_task),
+        't' | 'T' => state_sort_rank(a.state).cmp(&state_sort_rank(b.state)),
+        'M' => run_time_secs(a).cmp(&run_time_secs(b)),
+        'l' => time_limit_secs(a).cmp(&time_limit_secs(b)),
+        'S' => ts_secs(a.start_time.as_ref()).cmp(&ts_secs(b.start_time.as_ref())),
+        'V' => ts_secs(a.submit_time.as_ref()).cmp(&ts_secs(b.submit_time.as_ref())),
+        'e' => ts_secs(a.end_time.as_ref()).cmp(&ts_secs(b.end_time.as_ref())),
+        _ => resolve_job_field(a, spec).cmp(&resolve_job_field(b, spec)),
+    }
+}
+
+/// Rank a proto state by Slurm's base job-state order (SUSPENDED sits right
+/// after RUNNING, before the terminal states) so `-S t` matches Slurm.
+fn state_sort_rank(state: i32) -> u8 {
+    use spur_proto::proto::JobState as S;
+    match S::try_from(state) {
+        Ok(S::JobPending) => 0,
+        Ok(S::JobRunning) => 1,
+        Ok(S::JobSuspended) => 2,
+        Ok(S::JobCompleting) => 3,
+        Ok(S::JobCompleted) => 4,
+        Ok(S::JobCancelled) => 5,
+        Ok(S::JobFailed) => 6,
+        Ok(S::JobTimeout) => 7,
+        Ok(S::JobNodeFail) => 8,
+        Ok(S::JobPreempted) => 9,
+        Ok(S::JobDeadline) => 10,
+        Ok(S::JobOutOfMemory) => 11,
+        Err(_) => u8::MAX,
+    }
+}
+
+fn run_time_secs(job: &spur_proto::proto::JobInfo) -> i64 {
+    job.run_time.as_ref().map(|d| d.seconds).unwrap_or(0)
+}
+
+fn time_limit_secs(job: &spur_proto::proto::JobInfo) -> i64 {
+    job.time_limit
+        .as_ref()
+        .map(|d| d.seconds)
+        .unwrap_or(i64::MAX)
+}
+
+fn ts_secs(ts: Option<&prost_types::Timestamp>) -> i64 {
+    ts.map(|t| t.seconds).unwrap_or(0)
 }
 
 fn state_code(state: i32) -> String {
@@ -310,5 +444,145 @@ mod tests {
     fn parse_states_arg_rejects_empty_list() {
         assert!(parse_states_arg("").is_err());
         assert!(parse_states_arg("  ,  ").is_err());
+    }
+
+    fn job(id: u32, partition: &str, state: P, priority: u32) -> spur_proto::proto::JobInfo {
+        spur_proto::proto::JobInfo {
+            job_id: id,
+            partition: partition.into(),
+            state: state as i32,
+            priority,
+            ..Default::default()
+        }
+    }
+
+    fn ids(jobs: &[spur_proto::proto::JobInfo]) -> Vec<u32> {
+        jobs.iter().map(|j| j.job_id).collect()
+    }
+
+    #[test]
+    fn parse_sort_arg_directions() {
+        let keys = parse_sort_arg("P,-p,+i").unwrap();
+        assert_eq!(keys.len(), 3);
+        assert_eq!(
+            keys[0],
+            SortKey {
+                spec: 'P',
+                descending: false
+            }
+        );
+        assert_eq!(
+            keys[1],
+            SortKey {
+                spec: 'p',
+                descending: true
+            }
+        );
+        assert_eq!(
+            keys[2],
+            SortKey {
+                spec: 'i',
+                descending: false
+            }
+        );
+    }
+
+    #[test]
+    fn parse_sort_arg_rejects_bad_tokens() {
+        assert!(parse_sort_arg("").is_err());
+        assert!(parse_sort_arg("ii").is_err());
+        assert!(parse_sort_arg("-").is_err());
+    }
+
+    #[test]
+    fn sort_ascending_and_descending_jobid() {
+        let mut jobs = vec![
+            job(70, "default", P::JobRunning, 100),
+            job(72, "default", P::JobRunning, 100),
+            job(71, "default", P::JobRunning, 100),
+        ];
+        sort_jobs(&mut jobs, &parse_sort_arg("i").unwrap());
+        assert_eq!(ids(&jobs), vec![70, 71, 72]);
+        sort_jobs(&mut jobs, &parse_sort_arg("-i").unwrap());
+        assert_eq!(ids(&jobs), vec![72, 71, 70]);
+    }
+
+    #[test]
+    fn default_sort_matches_slurm_p_t_negp() {
+        // partition asc, then state asc (PD<R), then priority desc, then jobid asc
+        let mut jobs = vec![
+            job(10, "b", P::JobRunning, 100),
+            job(11, "a", P::JobRunning, 50),
+            job(12, "a", P::JobPending, 200),
+            job(13, "a", P::JobRunning, 50),
+        ];
+        sort_jobs(&mut jobs, &default_sort_keys());
+        assert_eq!(ids(&jobs), vec![12, 11, 13, 10]);
+    }
+
+    #[test]
+    fn sort_by_priority_desc_then_jobid_tiebreak() {
+        let mut jobs = vec![
+            job(70, "default", P::JobPending, 100),
+            job(71, "default", P::JobPending, 300),
+            job(72, "default", P::JobPending, 300),
+        ];
+        sort_jobs(&mut jobs, &parse_sort_arg("-p,i").unwrap());
+        assert_eq!(ids(&jobs), vec![71, 72, 70]);
+    }
+
+    #[test]
+    fn parse_sort_arg_rejects_unknown_spec() {
+        let err = parse_sort_arg("x").unwrap_err();
+        assert!(err.to_string().contains("Invalid sort specification"));
+        assert!(parse_sort_arg("-z").is_err());
+        assert!(parse_sort_arg("i,x").is_err());
+    }
+
+    #[test]
+    fn state_sort_places_suspended_after_running() {
+        let mut jobs = vec![
+            job(1, "default", P::JobFailed, 0),
+            job(2, "default", P::JobSuspended, 0),
+            job(3, "default", P::JobRunning, 0),
+            job(4, "default", P::JobPending, 0),
+        ];
+        sort_jobs(&mut jobs, &parse_sort_arg("t").unwrap());
+        assert_eq!(ids(&jobs), vec![4, 3, 2, 1]);
+    }
+
+    #[test]
+    fn sort_by_timelimit_puts_unlimited_last() {
+        let mut a = job(1, "default", P::JobRunning, 0);
+        a.time_limit = Some(prost_types::Duration {
+            seconds: 600,
+            nanos: 0,
+        });
+        let b = job(2, "default", P::JobRunning, 0);
+        let mut c = job(3, "default", P::JobRunning, 0);
+        c.time_limit = Some(prost_types::Duration {
+            seconds: 60,
+            nanos: 0,
+        });
+        let mut jobs = vec![a, b, c];
+        sort_jobs(&mut jobs, &parse_sort_arg("l").unwrap());
+        assert_eq!(ids(&jobs), vec![3, 1, 2]);
+    }
+
+    #[test]
+    fn sort_by_submit_time_ascending() {
+        let mut a = job(1, "default", P::JobPending, 0);
+        a.submit_time = Some(prost_types::Timestamp {
+            seconds: 300,
+            nanos: 0,
+        });
+        let mut b = job(2, "default", P::JobPending, 0);
+        b.submit_time = Some(prost_types::Timestamp {
+            seconds: 100,
+            nanos: 0,
+        });
+        let mut jobs = vec![a, b];
+        sort_jobs(&mut jobs, &parse_sort_arg("V").unwrap());
+        assert_eq!(ids(&jobs), vec![2, 1]);
     }
 }

--- a/crates/spur-cli/src/squeue.rs
+++ b/crates/spur-cli/src/squeue.rs
@@ -264,9 +264,15 @@ fn compare_field(
         't' | 'T' => state_sort_rank(a.state).cmp(&state_sort_rank(b.state)),
         'M' => run_time_secs(a).cmp(&run_time_secs(b)),
         'l' => time_limit_secs(a).cmp(&time_limit_secs(b)),
+        'L' => time_left_secs(a).cmp(&time_left_secs(b)),
         'S' => ts_secs(a.start_time.as_ref()).cmp(&ts_secs(b.start_time.as_ref())),
         'V' => ts_secs(a.submit_time.as_ref()).cmp(&ts_secs(b.submit_time.as_ref())),
         'e' => ts_secs(a.end_time.as_ref()).cmp(&ts_secs(b.end_time.as_ref())),
+        'P' => a.partition.cmp(&b.partition),
+        'u' => a.user.cmp(&b.user),
+        'j' | 'n' => a.name.cmp(&b.name),
+        'a' => a.account.cmp(&b.account),
+        'q' => a.qos.cmp(&b.qos),
         _ => resolve_job_field(a, spec).cmp(&resolve_job_field(b, spec)),
     }
 }
@@ -305,6 +311,15 @@ fn time_limit_secs(job: &spur_proto::proto::JobInfo) -> i64 {
 
 fn ts_secs(ts: Option<&prost_types::Timestamp>) -> i64 {
     ts.map(|t| t.seconds).unwrap_or(0)
+}
+
+// Unlimited time limit sorts last, matching `-S l`.
+fn time_left_secs(job: &spur_proto::proto::JobInfo) -> i64 {
+    let limit = time_limit_secs(job);
+    if limit == i64::MAX {
+        return i64::MAX;
+    }
+    limit.saturating_sub(run_time_secs(job))
 }
 
 fn state_code(state: i32) -> String {
@@ -584,5 +599,42 @@ mod tests {
         let mut jobs = vec![a, b];
         sort_jobs(&mut jobs, &parse_sort_arg("V").unwrap());
         assert_eq!(ids(&jobs), vec![2, 1]);
+    }
+
+    #[test]
+    fn sort_by_partition_orders_lexically() {
+        let mut jobs = vec![
+            job(1, "gamma", P::JobRunning, 0),
+            job(2, "alpha", P::JobRunning, 0),
+            job(3, "beta", P::JobRunning, 0),
+        ];
+        sort_jobs(&mut jobs, &parse_sort_arg("P").unwrap());
+        assert_eq!(ids(&jobs), vec![2, 3, 1]);
+    }
+
+    #[test]
+    fn sort_by_time_left_puts_unlimited_last() {
+        let mut a = job(1, "default", P::JobRunning, 0);
+        a.time_limit = Some(prost_types::Duration {
+            seconds: 600,
+            nanos: 0,
+        });
+        a.run_time = Some(prost_types::Duration {
+            seconds: 60,
+            nanos: 0,
+        });
+        let b = job(2, "default", P::JobRunning, 0);
+        let mut c = job(3, "default", P::JobRunning, 0);
+        c.time_limit = Some(prost_types::Duration {
+            seconds: 600,
+            nanos: 0,
+        });
+        c.run_time = Some(prost_types::Duration {
+            seconds: 500,
+            nanos: 0,
+        });
+        let mut jobs = vec![a, b, c];
+        sort_jobs(&mut jobs, &parse_sort_arg("L").unwrap());
+        assert_eq!(ids(&jobs), vec![3, 1, 2]);
     }
 }

--- a/crates/spur-cli/src/squeue.rs
+++ b/crates/spur-cli/src/squeue.rs
@@ -9,7 +9,8 @@ use crate::format_engine;
 
 /// View information about jobs in the scheduling queue.
 #[derive(Parser, Debug)]
-// -h is squeue's --noheader (Slurm convention), so disable clap's auto -h/--help.
+// -h is squeue's --noheader (Slurm convention), so disable clap's auto -h and
+// re-add --help below as long-only.
 #[command(
     name = "squeue",
     about = "View the job queue",
@@ -51,6 +52,10 @@ pub struct SqueueArgs {
     /// Don't print header
     #[arg(short = 'h', long)]
     pub noheader: bool,
+
+    /// Print help
+    #[arg(long, action = clap::ArgAction::Help)]
+    pub help: Option<bool>,
 
     /// Sort by field(s), comma-separated, each optionally prefixed with + (asc) or - (desc)
     #[arg(short = 'S', long, allow_hyphen_values = true)]
@@ -417,6 +422,19 @@ mod tests {
         // -S -i must parse as a descending sort spec, not a flag (allow_hyphen_values).
         let args = SqueueArgs::try_parse_from(["squeue", "-S", "-i"]).unwrap();
         assert_eq!(args.sort.as_deref(), Some("-i"));
+    }
+
+    #[test]
+    fn long_help_flag_is_preserved() {
+        // -h is reclaimed for --noheader, but --help must still print help.
+        let err = SqueueArgs::try_parse_from(["squeue", "--help"]).unwrap_err();
+        assert_eq!(err.kind(), clap::error::ErrorKind::DisplayHelp);
+    }
+
+    #[test]
+    fn short_h_is_noheader_not_help() {
+        let args = SqueueArgs::try_parse_from(["squeue", "-h"]).unwrap();
+        assert!(args.noheader);
     }
 
     #[test]

--- a/crates/spur-cli/src/squeue.rs
+++ b/crates/spur-cli/src/squeue.rs
@@ -9,7 +9,12 @@ use crate::format_engine;
 
 /// View information about jobs in the scheduling queue.
 #[derive(Parser, Debug)]
-#[command(name = "squeue", about = "View the job queue")]
+// -h is squeue's --noheader (Slurm convention), so disable clap's auto -h/--help.
+#[command(
+    name = "squeue",
+    about = "View the job queue",
+    disable_help_flag = true
+)]
 pub struct SqueueArgs {
     /// Show only jobs for this user
     #[arg(short = 'u', long)]
@@ -84,6 +89,13 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         None => default_squeue_states(),
     };
 
+    // Parse the sort spec before any network I/O so an invalid -S surfaces its own error
+    // rather than a downstream connect failure.
+    let sort_keys = match args.sort.as_deref() {
+        Some(s) => parse_sort_arg(s)?,
+        None => default_sort_keys(),
+    };
+
     // Parse job ID filter
     let job_ids = args
         .jobs
@@ -114,13 +126,6 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         .context("failed to get jobs")?;
 
     let mut jobs = response.into_inner().jobs;
-
-    // Slurm sorts client-side; its default job sort is "P,t,-p". The trailing
-    // jobid tiebreak is ours, so equal-priority jobs order deterministically.
-    let sort_keys = match args.sort.as_deref() {
-        Some(s) => parse_sort_arg(s)?,
-        None => default_sort_keys(),
-    };
     sort_jobs(&mut jobs, &sort_keys);
 
     // Print header
@@ -221,10 +226,10 @@ fn parse_sort_arg(s: &str) -> Result<Vec<SortKey>> {
             None => (false, token.strip_prefix('+').unwrap_or(token)),
         };
         let mut chars = rest.chars();
-        let spec = chars
-            .next()
-            .filter(|_| chars.next().is_none())
-            .ok_or_else(|| anyhow::anyhow!("Invalid sort specification: {token}"))?;
+        let spec = match (chars.next(), chars.next()) {
+            (Some(c), None) => c,
+            _ => anyhow::bail!("Invalid sort specification: {token}"),
+        };
         if format_engine::squeue_header(spec) == "?" {
             anyhow::bail!("Invalid sort specification: {token}");
         }
@@ -277,25 +282,10 @@ fn compare_field(
     }
 }
 
-/// Rank a proto state by Slurm's base job-state order (SUSPENDED sits right
-/// after RUNNING, before the terminal states) so `-S t` matches Slurm.
 fn state_sort_rank(state: i32) -> u8 {
-    use spur_proto::proto::JobState as S;
-    match S::try_from(state) {
-        Ok(S::JobPending) => 0,
-        Ok(S::JobRunning) => 1,
-        Ok(S::JobSuspended) => 2,
-        Ok(S::JobCompleting) => 3,
-        Ok(S::JobCompleted) => 4,
-        Ok(S::JobCancelled) => 5,
-        Ok(S::JobFailed) => 6,
-        Ok(S::JobTimeout) => 7,
-        Ok(S::JobNodeFail) => 8,
-        Ok(S::JobPreempted) => 9,
-        Ok(S::JobDeadline) => 10,
-        Ok(S::JobOutOfMemory) => 11,
-        Err(_) => u8::MAX,
-    }
+    spur_core::job::JobState::from_proto_i32(state)
+        .map(|s| s.sort_rank())
+        .unwrap_or(u8::MAX)
 }
 
 fn run_time_secs(job: &spur_proto::proto::JobInfo) -> i64 {
@@ -313,7 +303,7 @@ fn ts_secs(ts: Option<&prost_types::Timestamp>) -> i64 {
     ts.map(|t| t.seconds).unwrap_or(0)
 }
 
-// Unlimited time limit sorts last, matching `-S l`.
+/// Unlimited time limit sorts last, matching `-S L`.
 fn time_left_secs(job: &spur_proto::proto::JobInfo) -> i64 {
     let limit = time_limit_secs(job);
     if limit == i64::MAX {
@@ -421,6 +411,13 @@ fn format_timestamp(ts: Option<&prost_types::Timestamp>) -> String {
 mod tests {
     use super::*;
     use spur_proto::proto::JobState as P;
+
+    #[test]
+    fn sort_flag_accepts_hyphen_prefixed_value() {
+        // -S -i must parse as a descending sort spec, not a flag (allow_hyphen_values).
+        let args = SqueueArgs::try_parse_from(["squeue", "-S", "-i"]).unwrap();
+        assert_eq!(args.sort.as_deref(), Some("-i"));
+    }
 
     #[test]
     fn default_squeue_states_includes_completing() {

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -71,6 +71,25 @@ impl JobState {
         }
     }
 
+    /// Rank for `squeue -S t` in Slurm's base state order (SUSPENDED after RUNNING),
+    /// which is not the enum's declaration order — hence an explicit match.
+    pub fn sort_rank(&self) -> u8 {
+        match self {
+            Self::Pending => 0,
+            Self::Running => 1,
+            Self::Suspended => 2,
+            Self::Completing => 3,
+            Self::Completed => 4,
+            Self::Cancelled => 5,
+            Self::Failed => 6,
+            Self::Timeout => 7,
+            Self::NodeFail => 8,
+            Self::Preempted => 9,
+            Self::Deadline => 10,
+            Self::OutOfMemory => 11,
+        }
+    }
+
     pub fn is_terminal(&self) -> bool {
         matches!(
             self,
@@ -1892,5 +1911,19 @@ mod tests {
     fn resolved_stdin_none_when_unset() {
         let job = Job::new(1, JobSpec::default());
         assert_eq!(job.resolved_stdin(), None);
+    }
+
+    #[test]
+    fn sort_rank_follows_slurm_state_order_not_enum_order() {
+        // SUSPENDED ranks right after RUNNING and before COMPLETING, unlike the
+        // enum's declaration order (Completing before Suspended).
+        assert!(JobState::Running.sort_rank() < JobState::Suspended.sort_rank());
+        assert!(JobState::Suspended.sort_rank() < JobState::Completing.sort_rank());
+        assert_eq!(JobState::Pending.sort_rank(), 0);
+        // Ranks are unique across all states.
+        let mut ranks: Vec<u8> = JobState::ALL.iter().map(|s| s.sort_rank()).collect();
+        ranks.sort_unstable();
+        ranks.dedup();
+        assert_eq!(ranks.len(), JobState::ALL.len());
     }
 }


### PR DESCRIPTION
Closes #525

## What this fixes

`squeue` had three sorting gaps versus Slurm:

1. **No ordering.** Jobs were printed in the controller's internal `HashMap` iteration order — effectively unsorted, and unstable across restarts.
2. **`-S`/`--sort` was dead.** The flag parsed into a field that nothing ever read, so `-S i` had no effect.
3. **Descending sort wouldn't parse.** `squeue -S -i` failed with `unexpected argument '-i'` because the arg rejected hyphen-prefixed values.

## Approach

Sort **client-side** in `squeue.rs`, matching Slurm's architecture (Slurm's `squeue` sorts locally; every field needed is already on `JobInfo`). This keeps the controller a pure data source and avoids coupling display ordering to the core.

- Parse `-S`/`--sort` as comma-separated fields, each optionally prefixed `+` (ascending, default) or `-` (descending), reusing the existing format-spec letters.
- Apply Slurm's documented default sort `P,t,-p` (partition asc, job-state asc, priority desc) when `-S` is absent, with a trailing job-id tiebreak so equal-priority jobs order deterministically.
- Add `allow_hyphen_values` to the `-S` arg so `-S -i` parses.
- Comparator sorts numerically for numeric fields (job id, priority, nodes, cpus), by epoch seconds for timestamps, by Slurm's base state order for `t`/`T` (so SUSPENDED sorts right after RUNNING, ahead of terminal states), and lexically otherwise.
- Unrecognized sort fields are rejected with an `Invalid sort specification` error.

## Known limitations / deviations

- **Unknown sort field handling is stricter than Slurm.** Slurm silently ignores a genuinely-unknown sort letter (no-op) yet errors on some *format-only* fields; the behavior is inconsistent. This change instead accepts every field Spur can meaningfully sort and returns a clear error for anything unrecognized.
- **`-S` consumes the following token** (a consequence of allowing hyphen-prefixed values). Use the attached form for descending sorts — `-S -i` or `--sort=-i` — not `-S` split from an unrelated following flag.
- Non-sortable/heterogeneous string fields (e.g. the reason/nodelist column) sort lexically on their rendered text.

## Testing

- Unit tests cover sort-spec parsing (direction prefixes, empty/malformed/unknown rejection), ascending/descending job-id, the default `P,t,-p` ordering, priority-desc with job-id tiebreak, state ordering (SUSPENDED placement), time-limit (UNLIMITED sorts last), and timestamp sort.
- `cargo clippy` clean; full `spur-cli` suite passes.
- Validated end-to-end on an isolated multi-node deployment: confirmed the default view is partition-grouped and deterministic, `-S i` / `-S -i` / multi-key `-S P,i` order correctly, unknown fields error, and outcomes match Slurm for the default sort and the `-S` variants.
