### PR TITLE
fix(spur-cli): honor SPUR_* env-var twins in sbatch

### DIFF
--- a/crates/spur-cli/src/env_defaults.rs
+++ b/crates/spur-cli/src/env_defaults.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Environment-variable defaults for `srun` and `salloc` flags.
+//! Environment-variable defaults for `srun`, `salloc`, and `sbatch` flags.
 //!
 //! clap's `#[arg(env = ...)]` accepts a single variable name, but Slurm
 //! defines several aliases per flag (e.g. `--nodes` reads `SLURM_NNODES` and
@@ -136,10 +136,10 @@ where
 
 /// Test-only guard that isolates env-var tests from the runner's environment.
 ///
-/// Clears every `SPUR_/SLURM_/SALLOC_/SRUN_`-prefixed variable on construction
-/// and on drop, so a CI runner that injects `SLURM_*` vars cannot perturb the
-/// resolvers and a panicking test cannot leak state into the next one. Tests
-/// using it must be `#[serial]`.
+/// Clears every `SPUR_/SLURM_/SALLOC_/SRUN_/SBATCH_`-prefixed variable on
+/// construction and on drop, so a CI runner that injects `SLURM_*` vars cannot
+/// perturb the resolvers and a panicking test cannot leak state into the next
+/// one. Tests using it must be `#[serial]`.
 #[cfg(test)]
 pub(crate) struct EnvGuard;
 
@@ -162,6 +162,7 @@ impl EnvGuard {
                     || k.starts_with("SLURM_")
                     || k.starts_with("SALLOC_")
                     || k.starts_with("SRUN_")
+                    || k.starts_with("SBATCH_")
             })
             .collect();
         for k in stale {

--- a/crates/spur-cli/src/sbatch.rs
+++ b/crates/spur-cli/src/sbatch.rs
@@ -1,9 +1,10 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::env_defaults::{apply_csv, apply_str, apply_string, env_first, was_cli_set};
 use anyhow::{bail, Context, Result};
 use clap::parser::ValueSource;
-use clap::{CommandFactory, FromArgMatches, Parser};
+use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser};
 use spur_proto::proto::{JobSpec, SubmitJobRequest};
 use std::collections::HashMap;
 
@@ -11,31 +12,23 @@ use std::collections::HashMap;
 #[derive(Parser, Debug)]
 #[command(name = "sbatch", about = "Submit a batch job script")]
 pub struct SbatchArgs {
-    // Precedence is CLI > env (SBATCH_*) > #SBATCH directive, matching Slurm;
-    // `resolve_sbatch_args` enforces it. `overrides_with = "self"` gives
-    // repeated flags last-wins semantics (gres included). The remaining Vec
-    // args (licenses, container_mounts, container_env) have no `overrides_with`
-    // because they accumulate by design.
+    // Precedence is CLI > env > #SBATCH directive, matching Slurm;
+    // `resolve_sbatch_args` enforces it. Env defaults are resolved by
+    // `resolve_sbatch_env` rather than clap's `env` attribute, which accepts
+    // only one variable name per flag and so cannot honor the `SPUR_*` twins.
+    // `overrides_with = "self"` gives repeated flags last-wins semantics (gres
+    // included). The remaining Vec args (licenses, container_mounts,
+    // container_env) have no `overrides_with` because they accumulate by design.
     /// Job name
-    #[arg(
-        short = 'J',
-        long,
-        env = "SBATCH_JOB_NAME",
-        overrides_with = "job_name"
-    )]
+    #[arg(short = 'J', long, overrides_with = "job_name")]
     pub job_name: Option<String>,
 
     /// Partition
-    #[arg(
-        short = 'p',
-        long,
-        env = "SBATCH_PARTITION",
-        overrides_with = "partition"
-    )]
+    #[arg(short = 'p', long, overrides_with = "partition")]
     pub partition: Option<String>,
 
     /// Account
-    #[arg(short = 'A', long, env = "SBATCH_ACCOUNT", overrides_with = "account")]
+    #[arg(short = 'A', long, overrides_with = "account")]
     pub account: Option<String>,
 
     /// Number of nodes
@@ -60,22 +53,17 @@ pub struct SbatchArgs {
     pub cpus_per_task: u32,
 
     /// Memory per node (e.g., "4G", "4096M", "4096")
-    #[arg(long, env = "SBATCH_MEM", overrides_with = "mem")]
+    #[arg(long, overrides_with = "mem")]
     pub mem: Option<String>,
 
     /// Memory per CPU
-    #[arg(long, env = "SBATCH_MEM_PER_CPU", overrides_with = "mem_per_cpu")]
+    #[arg(long, overrides_with = "mem_per_cpu")]
     pub mem_per_cpu: Option<String>,
 
     /// Generic resources (e.g., "gpu:4", "gpu:mi300x:8")
     // Matches Slurm: `value_delimiter` keeps a single comma-list cumulative,
     // while `overrides_with` makes a repeated --gres replace instead of append.
-    #[arg(
-        long,
-        env = "SBATCH_GRES",
-        value_delimiter = ',',
-        overrides_with = "gres"
-    )]
+    #[arg(long, value_delimiter = ',', overrides_with = "gres")]
     pub gres: Vec<String>,
 
     /// Licenses (e.g., "fluent:5", "matlab:1")
@@ -95,7 +83,7 @@ pub struct SbatchArgs {
     pub gpus_per_task: Option<String>,
 
     /// Time limit (e.g., "4:00:00", "1-00:00:00")
-    #[arg(short = 't', long, env = "SBATCH_TIMELIMIT", overrides_with = "time")]
+    #[arg(short = 't', long, overrides_with = "time")]
     pub time: Option<String>,
 
     /// Minimum time limit
@@ -107,15 +95,15 @@ pub struct SbatchArgs {
     pub chdir: Option<String>,
 
     /// Stdout file
-    #[arg(short = 'o', long, env = "SBATCH_OUTPUT", overrides_with = "output")]
+    #[arg(short = 'o', long, overrides_with = "output")]
     pub output: Option<String>,
 
     /// Stderr file
-    #[arg(short = 'e', long, env = "SBATCH_ERROR", overrides_with = "error")]
+    #[arg(short = 'e', long, overrides_with = "error")]
     pub error: Option<String>,
 
     /// QoS
-    #[arg(short = 'q', long, env = "SBATCH_QOS", overrides_with = "qos")]
+    #[arg(short = 'q', long, overrides_with = "qos")]
     pub qos: Option<String>,
 
     /// Job dependency (e.g., "afterok:123")
@@ -126,7 +114,6 @@ pub struct SbatchArgs {
     #[arg(
         short = 'w',
         long,
-        env = "SBATCH_NODELIST",
         overrides_with_all = ["nodelist", "nodefile"]
     )]
     pub nodelist: Option<String>,
@@ -140,20 +127,15 @@ pub struct SbatchArgs {
     pub nodefile: Option<String>,
 
     /// Exclude nodes
-    #[arg(short = 'x', long, env = "SBATCH_EXCLUDE", overrides_with = "exclude")]
+    #[arg(short = 'x', long, overrides_with = "exclude")]
     pub exclude: Option<String>,
 
     /// Required node features (e.g., "mi300x,nvlink")
-    #[arg(
-        short = 'C',
-        long,
-        env = "SBATCH_CONSTRAINT",
-        overrides_with = "constraint"
-    )]
+    #[arg(short = 'C', long, overrides_with = "constraint")]
     pub constraint: Option<String>,
 
     /// Target a named reservation
-    #[arg(long, env = "SBATCH_RESERVATION", overrides_with = "reservation")]
+    #[arg(long, overrides_with = "reservation")]
     pub reservation: Option<String>,
 
     /// Job array (e.g., "0-99%10")
@@ -161,12 +143,7 @@ pub struct SbatchArgs {
     pub array: Option<String>,
 
     /// Task distribution (block, cyclic, plane, arbitrary)
-    #[arg(
-        short = 'm',
-        long,
-        env = "SBATCH_DISTRIBUTION",
-        overrides_with = "distribution"
-    )]
+    #[arg(short = 'm', long, overrides_with = "distribution")]
     pub distribution: Option<String>,
 
     /// Heterogeneous job component index (0 = first component)
@@ -226,12 +203,7 @@ pub struct SbatchArgs {
     pub mail_user: Option<String>,
 
     /// Export environment variables
-    #[arg(
-        long,
-        env = "SBATCH_EXPORT",
-        default_value = "ALL",
-        overrides_with = "export"
-    )]
+    #[arg(long, default_value = "ALL", overrides_with = "export")]
     pub export: String,
 
     // Container
@@ -352,13 +324,15 @@ pub fn parse_sbatch_directives(script: &str) -> Vec<String> {
     args
 }
 
-/// Resolve `SbatchArgs` with Slurm precedence: CLI > env (SBATCH_*) > #SBATCH
-/// directive > default.
+/// Resolve `SbatchArgs` with Slurm precedence: CLI > env > #SBATCH directive >
+/// default.
 ///
-/// clap resolves CLI > env in one parse, but directives fed as argv are tagged
-/// `CommandLine` and would outrank env. So we parse CLI and directives
-/// separately and merge per field: keep the CLI/env value when set, else the
-/// directive.
+/// Directives fed as argv are tagged `CommandLine` and so cannot be
+/// distinguished from real CLI args in a single parse. We therefore parse CLI
+/// and directives separately and merge per field, keeping the CLI value when
+/// set, else the directive. Env is applied last over that merge, but only to
+/// fields the CLI did not set — which lands each field on exactly one of
+/// CLI, env, directive, in that order.
 pub fn resolve_sbatch_args(
     directives: &[String],
     cli_args: &[String],
@@ -370,11 +344,126 @@ pub fn resolve_sbatch_args(
     directive_argv.extend(directives.iter().cloned());
     let dir = SbatchArgs::try_parse_from(&directive_argv)?;
 
-    Ok(merge_resolved(&cli_matches, cli, dir))
+    let mut resolved = merge_resolved(&cli_matches, cli, dir);
+    resolve_sbatch_env(&cli_matches, &mut resolved);
+    Ok(resolved)
+}
+
+/// Apply `SBATCH_*` environment-variable defaults, each preceded by its
+/// `SPUR_*` native twin, to any flag not set on the command line.
+///
+/// Runs after the directive merge so an env value overrides a `#SBATCH`
+/// directive, and skips CLI-set flags so the command line still wins.
+///
+/// Flags whose `SPUR_*` twin is also injected into every running job's
+/// environment (`SPUR_JOB_NAME`, `SPUR_NODELIST`) take the `SBATCH_*` name
+/// only: reading the twin would make an `sbatch` submitted from inside a job
+/// silently inherit the enclosing job's name or node placement. Real Slurm
+/// does not inherit either for `sbatch`.
+fn resolve_sbatch_env(matches: &ArgMatches, args: &mut SbatchArgs) {
+    apply_str(
+        matches,
+        "job_name",
+        &["SBATCH_JOB_NAME"],
+        &mut args.job_name,
+    );
+    apply_str(
+        matches,
+        "partition",
+        &["SPUR_PARTITION", "SBATCH_PARTITION"],
+        &mut args.partition,
+    );
+    apply_str(
+        matches,
+        "account",
+        &["SPUR_ACCOUNT", "SBATCH_ACCOUNT"],
+        &mut args.account,
+    );
+    apply_str(
+        matches,
+        "mem",
+        &["SPUR_MEM_PER_NODE", "SBATCH_MEM"],
+        &mut args.mem,
+    );
+    apply_str(
+        matches,
+        "mem_per_cpu",
+        &["SPUR_MEM_PER_CPU", "SBATCH_MEM_PER_CPU"],
+        &mut args.mem_per_cpu,
+    );
+    apply_csv(
+        matches,
+        "gres",
+        &["SPUR_GRES", "SBATCH_GRES"],
+        &mut args.gres,
+    );
+    apply_str(
+        matches,
+        "time",
+        &["SPUR_TIMELIMIT", "SBATCH_TIMELIMIT"],
+        &mut args.time,
+    );
+    apply_str(
+        matches,
+        "output",
+        &["SPUR_OUTPUT", "SBATCH_OUTPUT"],
+        &mut args.output,
+    );
+    apply_str(
+        matches,
+        "error",
+        &["SPUR_ERROR", "SBATCH_ERROR"],
+        &mut args.error,
+    );
+    apply_str(matches, "qos", &["SPUR_QOS", "SBATCH_QOS"], &mut args.qos);
+    apply_str(
+        matches,
+        "exclude",
+        &["SPUR_EXCLUDE", "SBATCH_EXCLUDE"],
+        &mut args.exclude,
+    );
+    apply_str(
+        matches,
+        "constraint",
+        &["SPUR_CONSTRAINT", "SBATCH_CONSTRAINT"],
+        &mut args.constraint,
+    );
+    apply_str(
+        matches,
+        "reservation",
+        &["SPUR_RESERVATION", "SBATCH_RESERVATION"],
+        &mut args.reservation,
+    );
+    apply_str(
+        matches,
+        "distribution",
+        &["SPUR_DISTRIBUTION", "SBATCH_DISTRIBUTION"],
+        &mut args.distribution,
+    );
+    apply_string(
+        matches,
+        "export",
+        &["SPUR_EXPORT", "SBATCH_EXPORT"],
+        &mut args.export,
+    );
+
+    // --nodelist and --nodefile are two spellings of one choice, so the env
+    // nodelist has to displace a directive nodefile to actually take effect,
+    // and must stay out of the way when either spelling came from the CLI.
+    if !was_cli_set(matches, "nodelist") && !was_cli_set(matches, "nodefile") {
+        if let Some(nodelist) = env_first(&["SBATCH_NODELIST"]) {
+            args.nodelist = Some(nodelist);
+            args.nodefile = None;
+        }
+    }
 }
 
 /// True when neither the CLI nor an env var set the field. `value_source` is
 /// `None` for absent args with no default, which counts the same as a default.
+///
+/// `--controller` is the one flag clap still resolves from the environment
+/// itself, so the `EnvVariable` arm keeps `SPUR_CONTROLLER_ADDR` ahead of a
+/// `#SBATCH` directive.
 fn is_default(matches: &clap::ArgMatches, id: &str) -> bool {
     !matches!(
         matches.value_source(id),
@@ -382,8 +471,8 @@ fn is_default(matches: &clap::ArgMatches, id: &str) -> bool {
     )
 }
 
-/// `cli` already has env values folded in by clap, so falling back to the
-/// directive value only when `is_default` holds yields CLI > env > directive.
+/// Merge CLI over directive values. `resolve_sbatch_env` then layers env
+/// between the two, so the merge only has to prefer the CLI value when present.
 fn merge_resolved(cli_matches: &clap::ArgMatches, cli: SbatchArgs, dir: SbatchArgs) -> SbatchArgs {
     let mut out = cli;
 
@@ -1036,8 +1125,12 @@ echo "hello world"
         assert!(args.exclusive);
     }
 
+    // Guarded because `--time` also resolves from SPUR_TIMELIMIT, which a test
+    // runner's environment could otherwise supply.
     #[test]
+    #[serial(env_injection)]
     fn test_directive_only_when_no_cli_override() {
+        let _env = EnvGuard::new();
         let args = parse_merged(&["--nodes=2", "--time=1:00:00"], &["sbatch"]);
         assert_eq!(args.nodes, 2);
         assert_eq!(args.time.as_deref(), Some("1:00:00"));
@@ -1071,9 +1164,9 @@ echo "hello world"
     #[tokio::test]
     #[serial(env_injection)]
     async fn test_submit_path_builds_spec_with_defaulted_ntasks() {
-        // Guarded because a stray SBATCH_* var in the runner's environment
-        // could fail the parse long before the spec is built.
-        let _env = SbatchEnvGuard::new();
+        // Guarded because a stray SBATCH_*/SPUR_* var in the runner's
+        // environment could fail the parse long before the spec is built.
+        let _env = EnvGuard::new();
         let err = main_with_args(vec![
             "sbatch".into(),
             "--controller".into(),
@@ -1165,7 +1258,9 @@ echo "hello world"
     }
 
     #[test]
+    #[serial(env_injection)]
     fn test_partial_override_preserves_other_directives() {
+        let _env = EnvGuard::new();
         // CLI overrides nodes but leaves time/job-name from directives.
         let args = parse_merged(
             &["--nodes=2", "--time=1:00:00", "--job-name=script-name"],
@@ -1206,48 +1301,18 @@ echo "hello world"
         assert_eq!(args.cpus_per_task, 8);
     }
 
-    // SBATCH_* env vars provide defaults (CLI > env > directive). These tests
-    // mutate process-global env vars, so they run serially and use
-    // SbatchEnvGuard to stay independent of the runner's environment.
+    // SBATCH_*/SPUR_* env vars provide defaults (CLI > env > directive). These
+    // tests mutate process-global env vars, so they run serially and use the
+    // shared EnvGuard, which clears every SPUR_/SLURM_/SALLOC_/SRUN_/SBATCH_-
+    // prefixed var on construction and drop to stay independent of the runner's
+    // environment.
+    use crate::env_defaults::EnvGuard;
     use serial_test::serial;
-
-    /// Clears every SBATCH_* var on construction and on drop, so an assertion
-    /// panic can never leak env state into the next test in this process.
-    struct SbatchEnvGuard;
-
-    impl SbatchEnvGuard {
-        fn new() -> Self {
-            Self::clear();
-            SbatchEnvGuard
-        }
-
-        fn set(&self, key: &str, val: &str) {
-            std::env::set_var(key, val);
-        }
-
-        /// The set of SBATCH_* vars is derived from the `env=` attributes on
-        /// SbatchArgs so it cannot drift as flags are added or removed.
-        fn clear() {
-            for arg in SbatchArgs::command().get_arguments() {
-                let Some(env) = arg.get_env() else { continue };
-                let name = env.to_string_lossy();
-                if name.starts_with("SBATCH_") {
-                    std::env::remove_var(name.as_ref());
-                }
-            }
-        }
-    }
-
-    impl Drop for SbatchEnvGuard {
-        fn drop(&mut self) {
-            Self::clear();
-        }
-    }
 
     #[test]
     #[serial(env_injection)]
     fn test_env_provides_default() {
-        let env = SbatchEnvGuard::new();
+        let env = EnvGuard::new();
         env.set("SBATCH_PARTITION", "gpu");
         let args = parse_merged(&[], &["sbatch"]);
         assert_eq!(args.partition.as_deref(), Some("gpu"));
@@ -1256,7 +1321,7 @@ echo "hello world"
     #[test]
     #[serial(env_injection)]
     fn test_cli_overrides_env() {
-        let env = SbatchEnvGuard::new();
+        let env = EnvGuard::new();
         env.set("SBATCH_PARTITION", "gpu");
         let args = parse_merged(&[], &["sbatch", "--partition=cpu"]);
         assert_eq!(args.partition.as_deref(), Some("cpu"));
@@ -1265,7 +1330,7 @@ echo "hello world"
     #[test]
     #[serial(env_injection)]
     fn test_env_overrides_directive() {
-        let env = SbatchEnvGuard::new();
+        let env = EnvGuard::new();
         env.set("SBATCH_PARTITION", "gpu");
         let args = parse_merged(&["--partition=script-part"], &["sbatch"]);
         assert_eq!(
@@ -1278,7 +1343,7 @@ echo "hello world"
     #[test]
     #[serial(env_injection)]
     fn test_directive_used_when_no_env_or_cli() {
-        let _env = SbatchEnvGuard::new();
+        let _env = EnvGuard::new();
         let args = parse_merged(&["--partition=script-part"], &["sbatch"]);
         assert_eq!(args.partition.as_deref(), Some("script-part"));
     }
@@ -1286,7 +1351,7 @@ echo "hello world"
     #[test]
     #[serial(env_injection)]
     fn test_env_gres_comma_split() {
-        let env = SbatchEnvGuard::new();
+        let env = EnvGuard::new();
         env.set("SBATCH_GRES", "gpu:1,license:x");
         let args = parse_merged(&[], &["sbatch"]);
         assert_eq!(args.gres, vec!["gpu:1", "license:x"]);
@@ -1295,7 +1360,7 @@ echo "hello world"
     #[test]
     #[serial(env_injection)]
     fn test_env_gres_overrides_directive() {
-        let env = SbatchEnvGuard::new();
+        let env = EnvGuard::new();
         env.set("SBATCH_GRES", "gpu:2");
         let args = parse_merged(&["--gres=gpu:8"], &["sbatch"]);
         assert_eq!(
@@ -1308,10 +1373,121 @@ echo "hello world"
     #[test]
     #[serial(env_injection)]
     fn test_cli_gres_replaces_directive_and_ignores_env() {
-        let env = SbatchEnvGuard::new();
+        let env = EnvGuard::new();
         env.set("SBATCH_GRES", "gpu:1");
         let args = parse_merged(&["--gres=gpu:mi300x:8"], &["sbatch", "--gres=gpu:2"]);
         assert_eq!(args.gres, vec!["gpu:2"]);
+    }
+
+    // --- SPUR_* native twins ---
+
+    #[test]
+    #[serial(env_injection)]
+    fn test_spur_twin_provides_default() {
+        let env = EnvGuard::new();
+        env.set("SPUR_PARTITION", "gpu");
+        let args = parse_merged(&[], &["sbatch"]);
+        assert_eq!(
+            args.partition.as_deref(),
+            Some("gpu"),
+            "SPUR_PARTITION must apply to sbatch as it does to srun/salloc"
+        );
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn test_spur_twin_takes_precedence_over_sbatch_var() {
+        let env = EnvGuard::new();
+        env.set("SPUR_PARTITION", "spur-part");
+        env.set("SBATCH_PARTITION", "sbatch-part");
+        let args = parse_merged(&[], &["sbatch"]);
+        assert_eq!(args.partition.as_deref(), Some("spur-part"));
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn test_spur_twin_overrides_directive_but_not_cli() {
+        let env = EnvGuard::new();
+        env.set("SPUR_TIMELIMIT", "2:00:00");
+        assert_eq!(
+            parse_merged(&["--time=1:00:00"], &["sbatch"])
+                .time
+                .as_deref(),
+            Some("2:00:00")
+        );
+        assert_eq!(
+            parse_merged(&["--time=1:00:00"], &["sbatch", "--time=8:00:00"])
+                .time
+                .as_deref(),
+            Some("8:00:00")
+        );
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn test_spur_twins_cover_every_env_backed_flag() {
+        let env = EnvGuard::new();
+        env.set("SPUR_ACCOUNT", "proj");
+        env.set("SPUR_QOS", "high");
+        env.set("SPUR_MEM_PER_NODE", "8G");
+        env.set("SPUR_MEM_PER_CPU", "512M");
+        env.set("SPUR_GRES", "gpu:2,fpga:1");
+        env.set("SPUR_OUTPUT", "out.log");
+        env.set("SPUR_ERROR", "err.log");
+        env.set("SPUR_EXCLUDE", "node003");
+        env.set("SPUR_CONSTRAINT", "mi300x");
+        env.set("SPUR_RESERVATION", "maint");
+        env.set("SPUR_DISTRIBUTION", "cyclic");
+        env.set("SPUR_EXPORT", "NONE");
+        let args = parse_merged(&[], &["sbatch"]);
+        assert_eq!(args.account.as_deref(), Some("proj"));
+        assert_eq!(args.qos.as_deref(), Some("high"));
+        assert_eq!(args.mem.as_deref(), Some("8G"));
+        assert_eq!(args.mem_per_cpu.as_deref(), Some("512M"));
+        assert_eq!(args.gres, vec!["gpu:2", "fpga:1"]);
+        assert_eq!(args.output.as_deref(), Some("out.log"));
+        assert_eq!(args.error.as_deref(), Some("err.log"));
+        assert_eq!(args.exclude.as_deref(), Some("node003"));
+        assert_eq!(args.constraint.as_deref(), Some("mi300x"));
+        assert_eq!(args.reservation.as_deref(), Some("maint"));
+        assert_eq!(args.distribution.as_deref(), Some("cyclic"));
+        assert_eq!(args.export, "NONE");
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn test_allocation_output_vars_are_not_inherited() {
+        let env = EnvGuard::new();
+        // Both are injected into every running job, so an sbatch submitted from
+        // inside a job must not pick up the enclosing job's name or nodes.
+        env.set("SPUR_JOB_NAME", "parent-job");
+        env.set("SPUR_NODELIST", "node001,node002");
+        let args = parse_merged(&[], &["sbatch"]);
+        assert!(args.job_name.is_none());
+        assert!(args.nodelist.is_none());
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn test_env_nodelist_displaces_directive_nodefile() {
+        let env = EnvGuard::new();
+        env.set("SBATCH_NODELIST", "node001");
+        let args = parse_merged(&["--nodefile=nodes.txt"], &["sbatch"]);
+        assert_eq!(args.nodelist.as_deref(), Some("node001"));
+        assert!(
+            args.nodefile.is_none(),
+            "env nodelist must not leave the directive nodefile in play"
+        );
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn test_cli_nodefile_wins_over_env_nodelist() {
+        let env = EnvGuard::new();
+        env.set("SBATCH_NODELIST", "node001");
+        let args = parse_merged(&[], &["sbatch", "-F", "nodes.txt"]);
+        assert_eq!(args.nodefile.as_deref(), Some("nodes.txt"));
+        assert!(args.nodelist.is_none());
     }
 
     // --- sbatch --wrap ---


### PR DESCRIPTION
Fixes #448.

`SPUR_PARTITION` sets the default partition for `srun` and `salloc` but had no effect on `sbatch`. The cause is that `sbatch` declared each env default with clap's `#[arg(env = "SBATCH_...")]` attribute, which accepts exactly one variable name per flag. `srun`/`salloc` outgrew that in #421, which moved them to a shared resolver that walks an ordered list of candidate names so each flag honors both the Slurm-style name and Spur's native `SPUR_*` twin. `sbatch` never moved, so its twins were silently ignored.

## Approach

`sbatch` now resolves env defaults through the same `env_defaults` helpers, with the `SPUR_*` twin listed ahead of the `SBATCH_*` name, matching the ordering `srun`/`salloc` already use. Twin names reuse the ones those commands accept (`SPUR_MEM_PER_NODE`, `SPUR_TIMELIMIT`) rather than introducing parallel spellings.

`sbatch` has a third precedence tier the others do not: CLI > env > `#SBATCH` directive. That previously worked only because clap tags env-sourced values as `ValueSource::EnvVariable`, which the directive merge treated as already-set. With env resolved outside clap, `resolve_sbatch_args` applies env *after* the CLI-over-directive merge and only to flags the CLI did not set, so each field lands on exactly one tier in that order. `--controller` keeps its clap `env` attribute, since `SPUR_CONTROLLER_ADDR` is already a native name and this matches how `srun`/`salloc` declare the same flag.

## Design choices

`SPUR_JOB_NAME` and `SPUR_NODELIST` are deliberately **not** read. Both are injected into every running job's environment by `spurd`, `salloc`, and the K8s agent, so honoring them would make an `sbatch` submitted from inside a job silently inherit the enclosing job's name and node placement. Real Slurm's `sbatch` inherits neither. Those two flags keep their `SBATCH_*` name only, and a test pins the behavior. Every other previously env-backed flag gains its twin.

`--nodelist` and `--nodefile` are two spellings of one choice, so an env nodelist has to clear a directive nodefile to take effect, and must stand down when either spelling came from the command line.

This also replaces `sbatch.rs`'s local `SbatchEnvGuard` test guard with the shared `EnvGuard`, now extended to the `SBATCH_` prefix. The local guard derived the variables to clear from the clap `env=` attributes, so removing those attributes would have left it clearing nothing and made the env tests read the runner's environment.

## Follow-up

Unrelated but noticed while mapping the variables: `--mem` reads `SBATCH_MEM`, whereas Slurm's name is `SBATCH_MEM_PER_NODE`, so a migrating user with the real name exported gets silence. Left out of scope here; worth its own issue.

## Testing

Nine tests added, covering the twins, `SPUR_*` taking precedence over `SBATCH_*`, env beating a directive but losing to the CLI, non-inheritance of the two allocation-output variables, and the nodelist/nodefile interaction.

- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test --locked` — passes, except six pre-existing `spurd` failures in my sandbox (cgroup creation and `openpty` denied), reproduced identically on pristine `main` with the change stashed.
