### PR TITLE
fix(accounting): preserve unset fields on sacctmgr modify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,51 @@ jobs:
       - name: Test
         run: cargo test --locked
 
+  test-db:
+    name: DB tests (accounting)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    services:
+      postgres:
+        image: postgres:16@sha256:33f923b05f64ca54ac4401c01126a6b92afe839a0aa0a52bc5aeb5cc958e5f20
+        env:
+          POSTGRES_USER: spur_ci
+          POSTGRES_PASSWORD: spur_ci
+          POSTGRES_DB: spur_acct_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U spur_ci -d spur_acct_ci"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install protobuf compiler
+        run: sudo apt-get install -y protobuf-compiler
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ github.job }}-
+            ${{ runner.os }}-cargo-
+
+      - name: Run accounting DB integration tests
+        env:
+          DATABASE_URL: postgres://spur_ci:spur_ci@localhost:5432/spur_acct_ci
+        run: cargo test --locked -p spurctld -- --ignored --test-threads=1
+
   coverage:
     runs-on: ubuntu-latest
     env:

--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -198,6 +198,34 @@ fn parse_wall_limit(key: &str, val: &str) -> Result<u32> {
     parse_wall_time(val).ok_or_else(|| anyhow::anyhow!("invalid value for {key}=: '{val}'"))
 }
 
+/// Parse a floating-point field (e.g. `fairshare=`/`usagefactor=`), failing
+/// loudly instead of silently defaulting so a typo never quietly changes a
+/// weight on a partial `modify`.
+fn parse_f64(key: &str, val: &str) -> Result<f64> {
+    val.parse()
+        .map_err(|_| anyhow::anyhow!("invalid value for {key}=: '{val}'"))
+}
+
+/// Parse a signed integer field (e.g. `priority=`), failing loudly rather than
+/// silently defaulting, for the same reason as `parse_f64`.
+fn parse_i32(key: &str, val: &str) -> Result<i32> {
+    val.parse()
+        .map_err(|_| anyhow::anyhow!("invalid value for {key}=: '{val}'"))
+}
+
+/// Look up a field by its accepted aliases in priority order, returning the key
+/// the caller actually wrote alongside its value. Parsers use the returned key
+/// so an invalid-value error names the exact parameter the user passed (e.g.
+/// `maxrunningjobs`) rather than a canonical alias (`maxjobs`).
+fn find_alias<'a>(
+    p: &'a std::collections::HashMap<String, String>,
+    keys: &[&'a str],
+) -> Option<(&'a str, &'a str)> {
+    keys.iter()
+        .copied()
+        .find_map(|k| p.get(k).map(|v| (k, v.as_str())))
+}
+
 /// Fields shared by `add user` and `modify user` (both upsert via the same
 /// `AddUserRequest`).
 #[derive(Debug, PartialEq)]
@@ -214,6 +242,26 @@ struct UserUpsertFields {
     max_wall_minutes: u32,
 }
 
+/// Resolve the association account for `add`/`modify user`. `account=` picks the
+/// association to write and `defaultaccount=` marks the user's default; both map
+/// to one `(account, is_default)` pair, so two different accounts are rejected —
+/// honoring it would modify one association while silently clearing the default.
+fn resolve_user_account(p: &std::collections::HashMap<String, String>) -> Result<String> {
+    let account = match (p.get("account"), p.get("defaultaccount")) {
+        (Some(a), Some(d)) if a != d => bail!(
+            "account={a} and defaultaccount={d} name different accounts; \
+             set the default with defaultaccount= alone or a matching account="
+        ),
+        (Some(a), _) => a,
+        (None, Some(d)) => d,
+        (None, None) => bail!("account= required"),
+    };
+    if account.is_empty() {
+        bail!("account= must not be empty");
+    }
+    Ok(account.clone())
+}
+
 /// Parse the key=value params for `add user`/`modify user` into the shared
 /// upsert shape. Numeric/TRES aliases mirror `add account`'s
 /// `maxrunningjobs`/`maxjobs` and `add qos`'s `maxwall` for consistency
@@ -227,11 +275,7 @@ fn build_add_user_request(
         .or_else(|| p.get("user"))
         .ok_or_else(|| anyhow::anyhow!("name= required"))?
         .clone();
-    let account = p
-        .get("account")
-        .or_else(|| p.get("defaultaccount"))
-        .ok_or_else(|| anyhow::anyhow!("account= required"))?
-        .clone();
+    let account = resolve_user_account(p)?;
     let admin = p
         .get("adminlevel")
         .cloned()
@@ -247,10 +291,8 @@ fn build_add_user_request(
     {
         bail!("defaultqos={default_qos} must be included in qos={allowed_qos}");
     }
-    let max_running_jobs: u32 = p
-        .get("maxrunningjobs")
-        .or_else(|| p.get("maxjobs"))
-        .map(|v| parse_limit("maxjobs", v))
+    let max_running_jobs: u32 = find_alias(p, &["maxrunningjobs", "maxjobs"])
+        .map(|(k, v)| parse_limit(k, v))
         .transpose()?
         .unwrap_or(0);
     let max_submit_jobs: u32 = p
@@ -260,10 +302,8 @@ fn build_add_user_request(
         .unwrap_or(0);
     let max_tres_per_job = p.get("maxtresperjob").cloned().unwrap_or_default();
     let grp_tres = p.get("grptres").cloned().unwrap_or_default();
-    let max_wall_minutes: u32 = p
-        .get("maxwall")
-        .or_else(|| p.get("maxwallduration"))
-        .map(|v| parse_wall_limit("maxwall", v))
+    let max_wall_minutes: u32 = find_alias(p, &["maxwall", "maxwallduration"])
+        .map(|(k, v)| parse_wall_limit(k, v))
         .transpose()?
         .unwrap_or(0);
 
@@ -308,10 +348,8 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
                 .get("fairshare")
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(1.0);
-            let max_jobs: u32 = p
-                .get("maxrunningjobs")
-                .or_else(|| p.get("maxjobs"))
-                .map(|v| parse_limit("maxjobs", v))
+            let max_jobs: u32 = find_alias(&p, &["maxrunningjobs", "maxjobs"])
+                .map(|(k, v)| parse_limit(k, v))
                 .transpose()?
                 .unwrap_or(0);
             let grp_tres = p.get("grptres").cloned().unwrap_or_default();
@@ -320,12 +358,12 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
             client
                 .create_account(CreateAccountRequest {
                     name: name.clone(),
-                    description: desc.clone(),
-                    organization: org.clone(),
-                    parent_account: parent.clone(),
-                    fairshare_weight: fairshare,
-                    max_running_jobs: max_jobs,
-                    grp_tres,
+                    description: Some(desc.clone()),
+                    organization: Some(org.clone()),
+                    parent_account: Some(parent.clone()),
+                    fairshare_weight: Some(fairshare),
+                    max_running_jobs: Some(max_jobs),
+                    grp_tres: Some(grp_tres),
                 })
                 .await
                 .context("CreateAccount RPC failed")?;
@@ -349,18 +387,19 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
                 .add_user(AddUserRequest {
                     user: fields.name.clone(),
                     account: fields.account.clone(),
-                    admin_level: fields.admin.clone(),
-                    is_default: p
-                        .get("defaultaccount")
-                        .map(|da| da == &fields.account)
-                        .unwrap_or(true),
-                    default_qos: fields.default_qos.clone(),
-                    allowed_qos: fields.allowed_qos.clone(),
-                    max_running_jobs: fields.max_running_jobs,
-                    max_submit_jobs: fields.max_submit_jobs,
-                    max_tres_per_job: fields.max_tres_per_job.clone(),
-                    grp_tres: fields.grp_tres.clone(),
-                    max_wall_minutes: fields.max_wall_minutes,
+                    admin_level: Some(fields.admin.clone()),
+                    is_default: Some(
+                        p.get("defaultaccount")
+                            .map(|da| da == &fields.account)
+                            .unwrap_or(true),
+                    ),
+                    default_qos: Some(fields.default_qos.clone()),
+                    allowed_qos: Some(fields.allowed_qos.clone()),
+                    max_running_jobs: Some(fields.max_running_jobs),
+                    max_submit_jobs: Some(fields.max_submit_jobs),
+                    max_tres_per_job: Some(fields.max_tres_per_job.clone()),
+                    grp_tres: Some(fields.grp_tres.clone()),
+                    max_wall_minutes: Some(fields.max_wall_minutes),
                 })
                 .await
                 .context("AddUser RPC failed")?;
@@ -409,10 +448,8 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
                 .get("usagefactor")
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(1.0);
-            let max_jobs: u32 = p
-                .get("maxjobsperuser")
-                .or_else(|| p.get("maxjobspu"))
-                .map(|v| parse_limit("maxjobsperuser", v))
+            let max_jobs: u32 = find_alias(&p, &["maxjobsperuser", "maxjobspu"])
+                .map(|(k, v)| parse_limit(k, v))
                 .transpose()?
                 .unwrap_or(0);
             let max_wall: u32 = p
@@ -431,21 +468,22 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
             client
                 .create_qos(CreateQosRequest {
                     name: name.clone(),
-                    description: desc,
-                    priority,
-                    preempt_mode: preempt.clone(),
-                    usage_factor,
-                    max_jobs_per_user: max_jobs,
-                    max_wall_minutes: max_wall,
-                    max_tres_per_job: max_tres,
-                    max_submit_jobs_per_user: p
-                        .get("maxsubmitjobsperuser")
-                        .map(|v| parse_limit("maxsubmitjobsperuser", v))
-                        .transpose()?
-                        .unwrap_or(0),
-                    max_tres_per_user: p.get("maxtresperuser").cloned().unwrap_or_default(),
-                    grp_tres: p.get("grptres").cloned().unwrap_or_default(),
-                    grp_wall_minutes: grp_wall,
+                    description: Some(desc),
+                    priority: Some(priority),
+                    preempt_mode: Some(preempt.clone()),
+                    usage_factor: Some(usage_factor),
+                    max_jobs_per_user: Some(max_jobs),
+                    max_wall_minutes: Some(max_wall),
+                    max_tres_per_job: Some(max_tres),
+                    max_submit_jobs_per_user: Some(
+                        p.get("maxsubmitjobsperuser")
+                            .map(|v| parse_limit("maxsubmitjobsperuser", v))
+                            .transpose()?
+                            .unwrap_or(0),
+                    ),
+                    max_tres_per_user: Some(p.get("maxtresperuser").cloned().unwrap_or_default()),
+                    grp_tres: Some(p.get("grptres").cloned().unwrap_or_default()),
+                    grp_wall_minutes: Some(grp_wall),
                 })
                 .await
                 .context("CreateQos RPC failed")?;
@@ -531,171 +569,158 @@ async fn delete(entity: &str, params: &[String], addr: &str) -> Result<()> {
     }
 }
 
-async fn modify(entity: &str, params: &[String], addr: &str) -> Result<()> {
-    let mut p = parse_params(params);
+/// Build a partial-patch `CreateAccountRequest` for `modify account`: a field
+/// is `Some` only when the command restated it (so the server leaves every
+/// other column untouched), and an explicitly empty value clears it.
+fn build_modify_account_request(
+    p: &std::collections::HashMap<String, String>,
+) -> Result<CreateAccountRequest> {
+    reject_unknown_keys(p, ACCOUNT_KEYS)?;
+    let name = p
+        .get("name")
+        .or_else(|| p.get("account"))
+        .ok_or_else(|| anyhow::anyhow!("name= required"))?
+        .clone();
+    Ok(CreateAccountRequest {
+        name,
+        description: p.get("description").cloned(),
+        organization: p.get("organization").cloned(),
+        parent_account: p.get("parent").cloned(),
+        fairshare_weight: p
+            .get("fairshare")
+            .map(|v| parse_f64("fairshare", v))
+            .transpose()?,
+        max_running_jobs: find_alias(p, &["maxrunningjobs", "maxjobs"])
+            .map(|(k, v)| parse_limit(k, v))
+            .transpose()?,
+        grp_tres: p.get("grptres").cloned(),
+    })
+}
 
-    // Modify is an upsert — same RPCs as add, just re-sends the record
+/// Build a partial-patch `CreateQosRequest` for `modify qos` (see
+/// `build_modify_account_request` for the presence contract).
+fn build_modify_qos_request(
+    p: &std::collections::HashMap<String, String>,
+) -> Result<CreateQosRequest> {
+    reject_unknown_keys(p, QOS_KEYS)?;
+    let name = p
+        .get("name")
+        .or_else(|| p.get("qos"))
+        .ok_or_else(|| anyhow::anyhow!("name= required"))?
+        .clone();
+    Ok(CreateQosRequest {
+        name,
+        description: p.get("description").cloned(),
+        priority: p
+            .get("priority")
+            .map(|v| parse_i32("priority", v))
+            .transpose()?,
+        preempt_mode: p.get("preemptmode").cloned(),
+        usage_factor: p
+            .get("usagefactor")
+            .map(|v| parse_f64("usagefactor", v))
+            .transpose()?,
+        max_jobs_per_user: find_alias(p, &["maxjobsperuser", "maxjobspu"])
+            .map(|(k, v)| parse_limit(k, v))
+            .transpose()?,
+        max_wall_minutes: p
+            .get("maxwall")
+            .map(|v| parse_wall_limit("maxwall", v))
+            .transpose()?,
+        max_tres_per_job: p.get("maxtresperjob").cloned(),
+        max_submit_jobs_per_user: p
+            .get("maxsubmitjobsperuser")
+            .map(|v| parse_limit("maxsubmitjobsperuser", v))
+            .transpose()?,
+        max_tres_per_user: p.get("maxtresperuser").cloned(),
+        grp_tres: p.get("grptres").cloned(),
+        grp_wall_minutes: p
+            .get("grpwall")
+            .map(|v| parse_wall_limit("grpwall", v))
+            .transpose()?,
+    })
+}
+
+/// Build a partial-patch `AddUserRequest` for `modify user` (see
+/// `build_modify_account_request` for the presence contract). Unlike `add user`,
+/// an omitted `qos`/`defaultqos` stays `None` so the server keeps the stored
+/// value; the default-in-allow-list check runs only when both are restated.
+fn build_modify_user_request(
+    p: &std::collections::HashMap<String, String>,
+) -> Result<AddUserRequest> {
+    reject_unknown_keys(p, USER_KEYS)?;
+    let user = p
+        .get("name")
+        .or_else(|| p.get("user"))
+        .ok_or_else(|| anyhow::anyhow!("name= required"))?
+        .clone();
+    let account = resolve_user_account(p)?;
+    let default_qos = p.get("defaultqos").cloned();
+    let allowed_qos = p.get("qos").cloned();
+    if let (Some(dq), Some(list)) = (default_qos.as_deref(), allowed_qos.as_deref()) {
+        if !dq.is_empty() && !list.is_empty() && !list.split(',').map(str::trim).any(|q| q == dq) {
+            bail!("defaultqos={dq} must be included in qos={list}");
+        }
+    }
+    Ok(AddUserRequest {
+        user,
+        is_default: p.get("defaultaccount").map(|da| da == &account),
+        account,
+        admin_level: p.get("adminlevel").cloned(),
+        default_qos,
+        allowed_qos,
+        max_running_jobs: find_alias(p, &["maxrunningjobs", "maxjobs"])
+            .map(|(k, v)| parse_limit(k, v))
+            .transpose()?,
+        max_submit_jobs: p
+            .get("maxsubmitjobs")
+            .map(|v| parse_limit("maxsubmitjobs", v))
+            .transpose()?,
+        max_tres_per_job: p.get("maxtresperjob").cloned(),
+        grp_tres: p.get("grptres").cloned(),
+        max_wall_minutes: find_alias(p, &["maxwall", "maxwallduration"])
+            .map(|(k, v)| parse_wall_limit(k, v))
+            .transpose()?,
+    })
+}
+
+/// Modify shares `add`'s upsert RPCs, but sends only the restated fields
+/// (proto3 presence) so the server preserves every unstated column.
+async fn modify(entity: &str, params: &[String], addr: &str) -> Result<()> {
+    let p = parse_params(params);
+
     match entity.to_lowercase().as_str() {
         "account" => {
-            reject_unknown_keys(&p, ACCOUNT_KEYS)?;
-            let name = p
-                .get("name")
-                .or_else(|| p.get("account"))
-                .ok_or_else(|| anyhow::anyhow!("name= required"))?;
-
+            let req = build_modify_account_request(&p)?;
+            let name = req.name.clone();
             let mut client = connect(addr).await?;
             client
-                .create_account(CreateAccountRequest {
-                    name: name.clone(),
-                    description: p.get("description").cloned().unwrap_or_default(),
-                    organization: p.get("organization").cloned().unwrap_or_default(),
-                    parent_account: p.get("parent").cloned().unwrap_or_default(),
-                    fairshare_weight: p
-                        .get("fairshare")
-                        .and_then(|v| v.parse().ok())
-                        .unwrap_or(1.0),
-                    max_running_jobs: p
-                        .get("maxrunningjobs")
-                        .or_else(|| p.get("maxjobs"))
-                        .map(|v| parse_limit("maxjobs", v))
-                        .transpose()?
-                        .unwrap_or(0),
-                    grp_tres: p.get("grptres").cloned().unwrap_or_default(),
-                })
+                .create_account(req)
                 .await
                 .context("CreateAccount (modify) RPC failed")?;
-
             println!(" Modified account '{}'.", name);
             Ok(())
         }
         "qos" => {
-            reject_unknown_keys(&p, QOS_KEYS)?;
-            let name = p
-                .get("name")
-                .or_else(|| p.get("qos"))
-                .ok_or_else(|| anyhow::anyhow!("name= required"))?;
-
+            let req = build_modify_qos_request(&p)?;
+            let name = req.name.clone();
             let mut client = connect(addr).await?;
             client
-                .create_qos(CreateQosRequest {
-                    name: name.clone(),
-                    description: p.get("description").cloned().unwrap_or_default(),
-                    priority: p.get("priority").and_then(|v| v.parse().ok()).unwrap_or(0),
-                    preempt_mode: p
-                        .get("preemptmode")
-                        .cloned()
-                        .unwrap_or_else(|| "off".into()),
-                    usage_factor: p
-                        .get("usagefactor")
-                        .and_then(|v| v.parse().ok())
-                        .unwrap_or(1.0),
-                    max_jobs_per_user: p
-                        .get("maxjobsperuser")
-                        .or_else(|| p.get("maxjobspu"))
-                        .map(|v| parse_limit("maxjobsperuser", v))
-                        .transpose()?
-                        .unwrap_or(0),
-                    max_wall_minutes: p
-                        .get("maxwall")
-                        .map(|v| parse_wall_limit("maxwall", v))
-                        .transpose()?
-                        .unwrap_or(0),
-                    max_tres_per_job: p.get("maxtresperjob").cloned().unwrap_or_default(),
-                    max_submit_jobs_per_user: p
-                        .get("maxsubmitjobsperuser")
-                        .map(|v| parse_limit("maxsubmitjobsperuser", v))
-                        .transpose()?
-                        .unwrap_or(0),
-                    max_tres_per_user: p.get("maxtresperuser").cloned().unwrap_or_default(),
-                    grp_tres: p.get("grptres").cloned().unwrap_or_default(),
-                    grp_wall_minutes: p
-                        .get("grpwall")
-                        .map(|v| parse_wall_limit("grpwall", v))
-                        .transpose()?
-                        .unwrap_or(0),
-                })
+                .create_qos(req)
                 .await
                 .context("CreateQos (modify) RPC failed")?;
-
             println!(" Modified QOS '{}'.", name);
             Ok(())
         }
         "user" => {
+            let req = build_modify_user_request(&p)?;
+            let name = req.user.clone();
             let mut client = connect(addr).await?;
-
-            // `modify user` resends the whole association record (it shares
-            // AddUserRequest with `add user`), so a QOS field left out of
-            // this command must keep its stored value, not silently reset
-            // to unrestricted — unlike a resource limit, an omitted QOS
-            // field would otherwise widen the association's access.
-            if !p.contains_key("qos") || !p.contains_key("defaultqos") {
-                let name = p
-                    .get("name")
-                    .or_else(|| p.get("user"))
-                    .cloned()
-                    .unwrap_or_default();
-                let account = p.get("account").cloned().unwrap_or_default();
-                let existing = client
-                    .list_users(ListUsersRequest {
-                        account: account.clone(),
-                        user: name.clone(),
-                    })
-                    .await
-                    .context("ListUsers (modify lookup) RPC failed")?
-                    .into_inner()
-                    .users
-                    .into_iter()
-                    .find(|u| u.name == name && u.account == account);
-                if let Some(existing) = existing {
-                    p.entry("qos".to_string()).or_insert(existing.allowed_qos);
-                    p.entry("defaultqos".to_string())
-                        .or_insert(existing.default_qos);
-                }
-            }
-
-            let fields = build_add_user_request(&p)?;
             client
-                .add_user(AddUserRequest {
-                    user: fields.name.clone(),
-                    account: fields.account.clone(),
-                    admin_level: fields.admin.clone(),
-                    is_default: p
-                        .get("defaultaccount")
-                        .map(|da| da == &fields.account)
-                        .unwrap_or(true),
-                    default_qos: fields.default_qos.clone(),
-                    allowed_qos: fields.allowed_qos.clone(),
-                    max_running_jobs: fields.max_running_jobs,
-                    max_submit_jobs: fields.max_submit_jobs,
-                    max_tres_per_job: fields.max_tres_per_job.clone(),
-                    grp_tres: fields.grp_tres.clone(),
-                    max_wall_minutes: fields.max_wall_minutes,
-                })
+                .add_user(req)
                 .await
                 .context("AddUser (modify) RPC failed")?;
-
-            println!(" Modified user '{}'.", fields.name);
-            if !fields.allowed_qos.is_empty() {
-                println!("  QOS        = {}", fields.allowed_qos);
-            }
-            if !fields.default_qos.is_empty() {
-                println!("  DefQOS     = {}", fields.default_qos);
-            }
-            if fields.max_running_jobs > 0 {
-                println!("  MaxJobs    = {}", fields.max_running_jobs);
-            }
-            if fields.max_submit_jobs > 0 {
-                println!("  MaxSubmit  = {}", fields.max_submit_jobs);
-            }
-            if fields.max_wall_minutes > 0 {
-                println!("  MaxWall    = {} min", fields.max_wall_minutes);
-            }
-            if !fields.max_tres_per_job.is_empty() {
-                println!("  MaxTRES    = {}", fields.max_tres_per_job);
-            }
-            if !fields.grp_tres.is_empty() {
-                println!("  GrpTRES    = {}", fields.grp_tres);
-            }
+            println!(" Modified user '{}'.", name);
             Ok(())
         }
         other => bail!("sacctmgr: unknown entity type '{}'", other),
@@ -1310,25 +1335,194 @@ mod tests {
     }
 
     #[test]
-    fn build_add_user_request_add_and_modify_produce_the_same_shape() {
-        // add and modify both funnel through the same helper, so `sacctmgr
-        // add user name=X account=Y defaultqos=Z` and `sacctmgr modify user
-        // name=X account=Y set defaultqos=Z` build identical requests.
-        let add_params = parse_params(&[
-            "name=testuser".into(),
-            "account=testacct".into(),
-            "defaultqos=highprio".into(),
-        ]);
-        let modify_params = parse_params(&[
-            "name=testuser".into(),
-            "account=testacct".into(),
-            "set".into(),
-            "defaultqos=highprio".into(),
-        ]);
+    fn build_modify_account_request_omits_unrestated_fields() {
+        // The core of SPUR-96: `modify account name=X set fairshare=2` must
+        // send only fairshare; every other field is None so the server leaves
+        // it untouched.
+        let p = parse_params(&["name=physics".into(), "set".into(), "fairshare=2".into()]);
+        let req = build_modify_account_request(&p).unwrap();
+        assert_eq!(req.name, "physics");
+        assert_eq!(req.fairshare_weight, Some(2.0));
+        assert_eq!(req.description, None);
+        assert_eq!(req.organization, None);
+        assert_eq!(req.parent_account, None);
+        assert_eq!(req.max_running_jobs, None);
+        assert_eq!(req.grp_tres, None);
+    }
+
+    #[test]
+    fn build_modify_account_request_explicit_empty_clears() {
+        // An explicit `grptres=` is a request to clear, distinct from omitting
+        // it (which preserves).
+        let p = parse_params(&["name=physics".into(), "grptres=".into()]);
+        let req = build_modify_account_request(&p).unwrap();
+        assert_eq!(req.grp_tres, Some(String::new()));
+    }
+
+    #[test]
+    fn build_modify_account_request_rejects_invalid_fairshare() {
+        let p = parse_params(&["name=physics".into(), "fairshare=abc".into()]);
+        assert!(build_modify_account_request(&p).is_err());
+    }
+
+    #[test]
+    fn find_alias_returns_the_key_the_caller_wrote() {
+        // The priority alias wins and is reported as written.
+        let p = parse_params(&["maxrunningjobs=3".into()]);
         assert_eq!(
-            build_add_user_request(&add_params).unwrap(),
-            build_add_user_request(&modify_params).unwrap()
+            find_alias(&p, &["maxrunningjobs", "maxjobs"]),
+            Some(("maxrunningjobs", "3"))
         );
+        // The fallback alias is reported under its own name, not the canonical.
+        let p = parse_params(&["maxjobs=4".into()]);
+        assert_eq!(
+            find_alias(&p, &["maxrunningjobs", "maxjobs"]),
+            Some(("maxjobs", "4"))
+        );
+        // No alias present.
+        let p = parse_params(&["other=1".into()]);
+        assert_eq!(find_alias(&p, &["maxrunningjobs", "maxjobs"]), None);
+    }
+
+    #[test]
+    fn build_modify_account_request_error_names_the_typed_alias() {
+        // An invalid maxrunningjobs must report that key, not the canonical
+        // `maxjobs` the user never typed.
+        let p = parse_params(&["name=physics".into(), "maxrunningjobs=abc".into()]);
+        let msg = build_modify_account_request(&p).unwrap_err().to_string();
+        assert!(msg.contains("maxrunningjobs"), "got: {msg}");
+        assert!(
+            !msg.contains("maxjobs"),
+            "reported canonical alias instead: {msg}"
+        );
+
+        // The fallback alias is reported under its own name too.
+        let p = parse_params(&["name=physics".into(), "maxjobs=abc".into()]);
+        let msg = build_modify_account_request(&p).unwrap_err().to_string();
+        assert!(msg.contains("maxjobs"), "got: {msg}");
+    }
+
+    #[test]
+    fn build_modify_qos_request_error_names_the_typed_alias() {
+        let p = parse_params(&["name=normal".into(), "maxjobspu=abc".into()]);
+        let msg = build_modify_qos_request(&p).unwrap_err().to_string();
+        assert!(msg.contains("maxjobspu"), "got: {msg}");
+        assert!(
+            !msg.contains("maxjobsperuser"),
+            "reported canonical alias instead: {msg}"
+        );
+    }
+
+    #[test]
+    fn build_modify_user_request_error_names_the_typed_alias() {
+        let p = parse_params(&[
+            "name=alice".into(),
+            "account=physics".into(),
+            "maxwallduration=nope".into(),
+        ]);
+        let msg = build_modify_user_request(&p).unwrap_err().to_string();
+        assert!(msg.contains("maxwallduration"), "got: {msg}");
+    }
+
+    #[test]
+    fn build_modify_qos_request_omits_unrestated_fields() {
+        let p = parse_params(&["name=normal".into(), "set".into(), "priority=10".into()]);
+        let req = build_modify_qos_request(&p).unwrap();
+        assert_eq!(req.name, "normal");
+        assert_eq!(req.priority, Some(10));
+        assert_eq!(req.description, None);
+        assert_eq!(req.grp_tres, None);
+        assert_eq!(req.max_tres_per_job, None);
+        assert_eq!(req.preempt_mode, None);
+        assert_eq!(req.usage_factor, None);
+    }
+
+    #[test]
+    fn build_modify_user_request_omits_unrestated_limits_and_qos() {
+        // `modify user ... set maxjobs=5` must not touch the QOS allow-list or
+        // the other limits — the association-limit half of SPUR-96.
+        let p = parse_params(&[
+            "name=alice".into(),
+            "account=physics".into(),
+            "set".into(),
+            "maxjobs=5".into(),
+        ]);
+        let req = build_modify_user_request(&p).unwrap();
+        assert_eq!(req.user, "alice");
+        assert_eq!(req.account, "physics");
+        assert_eq!(req.max_running_jobs, Some(5));
+        assert_eq!(req.default_qos, None);
+        assert_eq!(req.allowed_qos, None);
+        assert_eq!(req.grp_tres, None);
+        assert_eq!(req.max_submit_jobs, None);
+        assert_eq!(req.admin_level, None);
+        assert_eq!(req.is_default, None);
+    }
+
+    #[test]
+    fn build_modify_user_request_explicit_empty_qos_clears() {
+        let p = parse_params(&["name=alice".into(), "account=physics".into(), "qos=".into()]);
+        let req = build_modify_user_request(&p).unwrap();
+        assert_eq!(req.allowed_qos, Some(String::new()));
+    }
+
+    #[test]
+    fn build_modify_user_request_rejects_default_outside_restated_list() {
+        let p = parse_params(&[
+            "name=alice".into(),
+            "account=physics".into(),
+            "qos=a,b".into(),
+            "defaultqos=c".into(),
+        ]);
+        assert!(build_modify_user_request(&p).is_err());
+    }
+
+    #[test]
+    fn build_modify_user_request_defaultaccount_alone_marks_default() {
+        let p = parse_params(&["name=alice".into(), "defaultaccount=physics".into()]);
+        let req = build_modify_user_request(&p).unwrap();
+        assert_eq!(req.account, "physics");
+        assert_eq!(req.is_default, Some(true));
+    }
+
+    #[test]
+    fn build_modify_user_request_matching_account_and_defaultaccount_marks_default() {
+        let p = parse_params(&[
+            "name=alice".into(),
+            "account=physics".into(),
+            "defaultaccount=physics".into(),
+        ]);
+        let req = build_modify_user_request(&p).unwrap();
+        assert_eq!(req.account, "physics");
+        assert_eq!(req.is_default, Some(true));
+    }
+
+    #[test]
+    fn build_modify_user_request_rejects_conflicting_account_and_defaultaccount() {
+        // Two different accounts can't collapse into one association without
+        // silently clearing the default, so the command must fail loudly.
+        let p = parse_params(&[
+            "name=alice".into(),
+            "account=physics".into(),
+            "defaultaccount=chemistry".into(),
+        ]);
+        assert!(build_modify_user_request(&p).is_err());
+    }
+
+    #[test]
+    fn build_modify_user_request_rejects_empty_account() {
+        let p = parse_params(&["name=alice".into(), "account=".into()]);
+        assert!(build_modify_user_request(&p).is_err());
+    }
+
+    #[test]
+    fn build_add_user_request_rejects_conflicting_account_and_defaultaccount() {
+        let p = parse_params(&[
+            "name=alice".into(),
+            "account=physics".into(),
+            "defaultaccount=chemistry".into(),
+        ]);
+        assert!(build_add_user_request(&p).is_err());
     }
 
     fn stub_qos() -> QosInfo {

--- a/crates/spur-cli/src/sacctmgr.rs
+++ b/crates/spur-cli/src/sacctmgr.rs
@@ -388,11 +388,9 @@ async fn add(entity: &str, params: &[String], addr: &str) -> Result<()> {
                     user: fields.name.clone(),
                     account: fields.account.clone(),
                     admin_level: Some(fields.admin.clone()),
-                    is_default: Some(
-                        p.get("defaultaccount")
-                            .map(|da| da == &fields.account)
-                            .unwrap_or(true),
-                    ),
+                    // Like `modify`, send None when defaultaccount= is absent so a
+                    // plain add can't silently demote a default the user already has.
+                    is_default: p.get("defaultaccount").map(|da| da == &fields.account),
                     default_qos: Some(fields.default_qos.clone()),
                     allowed_qos: Some(fields.allowed_qos.clone()),
                     max_running_jobs: Some(fields.max_running_jobs),
@@ -1164,7 +1162,7 @@ mod tests {
     #[test]
     fn reject_unknown_keys_accepts_every_parsed_account_field() {
         // Every key the add/modify account handlers read must be allowlisted,
-        // otherwise reject_unknown_keys bounces it (the grpwall regression class).
+        // otherwise reject_unknown_keys would bounce a valid field.
         let parsed_fields = [
             "name",
             "account",
@@ -1336,9 +1334,8 @@ mod tests {
 
     #[test]
     fn build_modify_account_request_omits_unrestated_fields() {
-        // The core of SPUR-96: `modify account name=X set fairshare=2` must
-        // send only fairshare; every other field is None so the server leaves
-        // it untouched.
+        // `modify account name=X set fairshare=2` must send only fairshare;
+        // every other field is None so the server leaves it untouched.
         let p = parse_params(&["name=physics".into(), "set".into(), "fairshare=2".into()]);
         let req = build_modify_account_request(&p).unwrap();
         assert_eq!(req.name, "physics");
@@ -1440,7 +1437,7 @@ mod tests {
     #[test]
     fn build_modify_user_request_omits_unrestated_limits_and_qos() {
         // `modify user ... set maxjobs=5` must not touch the QOS allow-list or
-        // the other limits — the association-limit half of SPUR-96.
+        // the other limits.
         let p = parse_params(&[
             "name=alice".into(),
             "account=physics".into(),

--- a/crates/spur-core/src/account_limits.rs
+++ b/crates/spur-core/src/account_limits.rs
@@ -4,7 +4,7 @@
 //! Account/association resource limit enforcement.
 //!
 //! Mirrors `qos::check_qos_limits` one layer up the hierarchy: limits here
-//! come from `AccountLimits` on a user's `Association` with an account,
+//! come from `AccountLimits` on a user's association with an account,
 //! rather than from a `Qos`. Unlike QOS, associations have no separate
 //! per-user TRES cap distinct from the per-job one — `max_tres_per_job`
 //! bounds a single job and `grp_tres` bounds the account's aggregate usage

--- a/crates/spur-core/src/accounting.rs
+++ b/crates/spur-core/src/accounting.rs
@@ -136,17 +136,6 @@ pub struct AccountLimits {
     pub max_wall_minutes: Option<u32>,
 }
 
-/// A user-account association.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Association {
-    pub user: String,
-    pub account: String,
-    pub partition: Option<String>,
-    pub fairshare_weight: u32,
-    pub limits: AccountLimits,
-    pub is_default: bool,
-}
-
 /// Quality of Service definition.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Qos {

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -267,7 +267,7 @@ pub enum PendingReason {
     JobHoldMaxRequeue,
 
     // Account/association-level limit parity (mirrors the QOS additions
-    // above, one layer up the hierarchy: `AccountLimits` on `Association`).
+    // above, one layer up the hierarchy: `AccountLimits` on an association).
     AssocMaxJobsLimit,
     AssocMaxSubmitJobLimit,
     AssocMaxCpuPerJobLimit,

--- a/crates/spur-proto/build.rs
+++ b/crates/spur-proto/build.rs
@@ -2,13 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let protos = ["../../proto/slurm.proto", "../../proto/raft_internal.proto"];
+    // The .proto files live outside this crate's directory, so cargo's default
+    // "rerun if a crate file changed" heuristic never watches them. Track them
+    // explicitly, otherwise editing a proto leaves the generated code stale.
+    for proto in &protos {
+        println!("cargo:rerun-if-changed={proto}");
+    }
     tonic_prost_build::configure()
         .protoc_arg("--experimental_allow_proto3_optional")
         .build_server(true)
         .build_client(true)
-        .compile_protos(
-            &["../../proto/slurm.proto", "../../proto/raft_internal.proto"],
-            &["../../proto"],
-        )?;
+        .compile_protos(&protos, &["../../proto"])?;
     Ok(())
 }

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -7,11 +7,27 @@ use chrono::{DateTime, Utc};
 use sqlx::postgres::{PgConnection, PgRow};
 use sqlx::{PgPool, QueryBuilder, Row};
 
-/// Run database migrations (create tables if they don't exist).
+/// Apply the database schema, serialized across controllers by a fixed advisory
+/// lock: migrate now also rewrites data (default-account dedup) and builds a
+/// unique index, so concurrent runs against a shared database must not overlap.
+/// The lock is transaction-scoped, so it releases even if the apply fails.
 pub async fn migrate(pool: &PgPool) -> anyhow::Result<()> {
-    sqlx::raw_sql(SCHEMA).execute(pool).await?;
+    let mut tx = pool.begin().await?;
+    sqlx::query("SELECT pg_advisory_xact_lock($1, $2)")
+        .bind(SCHEMA_LOCK_CLASS)
+        .bind(SCHEMA_LOCK_OBJ)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::raw_sql(SCHEMA).execute(&mut *tx).await?;
+    tx.commit().await?;
     Ok(())
 }
+
+// Advisory-lock keys that serialize `migrate` across controllers. The two-int4
+// form is a distinct lock space from the single-bigint per-user locks
+// `add_user` takes, so the keys can never collide.
+const SCHEMA_LOCK_CLASS: i32 = 0x5350_5552; // 'SPUR'
+const SCHEMA_LOCK_OBJ: i32 = 1;
 
 const SCHEMA: &str = r#"
 CREATE TABLE IF NOT EXISTS jobs (
@@ -92,7 +108,6 @@ CREATE TABLE IF NOT EXISTS associations (
     account         TEXT NOT NULL REFERENCES accounts(name),
     partition_name  TEXT,
     fairshare_weight INTEGER NOT NULL DEFAULT 1,
-    is_default      BOOLEAN NOT NULL DEFAULT false,
     max_running_jobs INTEGER,
     max_submit_jobs INTEGER,
     max_tres_per_job TEXT,
@@ -129,6 +144,26 @@ ALTER TABLE associations ADD COLUMN IF NOT EXISTS default_qos TEXT;
 ALTER TABLE associations ADD COLUMN IF NOT EXISTS allowed_qos TEXT;
 ALTER TABLE qos ADD COLUMN IF NOT EXISTS grp_wall_min INTEGER;
 ALTER TABLE accounts ADD COLUMN IF NOT EXISTS grp_tres TEXT;
+
+-- users.default_account is the single source of truth for a user's default
+-- account (the scheduler reads it via the association cache). associations
+-- once carried a redundant is_default flag that nothing read; drop it so the
+-- two representations can't drift.
+ALTER TABLE associations DROP COLUMN IF EXISTS is_default;
+
+-- One default account per user. Pre-fix rows could mark several accounts
+-- default; collapse each user to one (the lowest account name) before the index
+-- below, which would otherwise fail to build. Idempotent: a no-op once clean.
+UPDATE users u SET default_account = NULL
+WHERE default_account IS NOT NULL
+  AND EXISTS (
+    SELECT 1 FROM users o
+    WHERE o.name = u.name
+      AND o.default_account IS NOT NULL
+      AND o.account < u.account
+  );
+CREATE UNIQUE INDEX IF NOT EXISTS one_default_account_per_user
+    ON users (name) WHERE default_account IS NOT NULL;
 "#;
 
 /// Record a job start in the database.
@@ -486,32 +521,145 @@ use chrono::Timelike;
 // Account / User / QOS management (sacctmgr operations)
 // ============================================================
 
-/// Create or update an account. Like `upsert_qos`/`add_user`, this is a full
-/// resend on modify, not a partial patch: a `None` `grp_tres` clears it.
-#[allow(clippy::too_many_arguments)]
-pub async fn upsert_account(
+/// A single bound value in a dynamically built accounting write. The variant
+/// carries the concrete type so one builder can mix columns; the `Null*`
+/// variants bind SQL `NULL` for `None`, which is how a nullable column is
+/// cleared.
+#[derive(Clone, Copy)]
+enum SqlVal<'a> {
+    Text(&'a str),
+    NullText(Option<&'a str>),
+    Int(i32),
+    NullInt(Option<i32>),
+    Real(f64),
+}
+
+fn push_bound(qb: &mut QueryBuilder<sqlx::Postgres>, val: SqlVal<'_>) {
+    match val {
+        SqlVal::Text(v) => qb.push_bind(v),
+        SqlVal::NullText(v) => qb.push_bind(v),
+        SqlVal::Int(v) => qb.push_bind(v),
+        SqlVal::NullInt(v) => qb.push_bind(v),
+        SqlVal::Real(v) => qb.push_bind(v),
+    };
+}
+
+/// The tables `upsert_row` can target. A closed set of variants (not a free
+/// `&str`) so the table name and ON CONFLICT target spliced into the SQL text
+/// can only ever be known literals — no caller can route user input into a
+/// SQL identifier position, even by mistake in future edits.
+#[derive(Clone, Copy)]
+enum UpsertTable {
+    Accounts,
+    Qos,
+}
+
+impl UpsertTable {
+    fn name(self) -> &'static str {
+        match self {
+            UpsertTable::Accounts => "accounts",
+            UpsertTable::Qos => "qos",
+        }
+    }
+
+    fn conflict_target(self) -> &'static str {
+        match self {
+            UpsertTable::Accounts | UpsertTable::Qos => "name",
+        }
+    }
+}
+
+/// Insert `keys` + `updates`, updating only `updates` columns on conflict
+/// (identity `keys` never overwritten; absent columns keep their stored value,
+/// take the schema default on insert — the partial-patch contract). No `updates`
+/// = create-if-absent. Table is a closed enum, columns `&'static str` — injection-safe.
+async fn upsert_row(
     pool: &PgPool,
-    name: &str,
-    description: &str,
-    organization: &str,
-    parent: Option<&str>,
-    fairshare: i32,
-    max_running_jobs: Option<i32>,
-    grp_tres: Option<&str>,
+    table: UpsertTable,
+    keys: &[(&'static str, SqlVal<'_>)],
+    updates: &[(&'static str, SqlVal<'_>)],
 ) -> anyhow::Result<()> {
-    sqlx::query(
-        r#"
-        INSERT INTO accounts (name, description, organization, parent_account, fairshare_weight, max_running_jobs, grp_tres)
-        VALUES ($1, $2, $3, $4, $5, $6, $7)
-        ON CONFLICT (name) DO UPDATE SET
-            description = $2, organization = $3, parent_account = $4,
-            fairshare_weight = $5, max_running_jobs = $6, grp_tres = $7
-        "#,
-    )
-    .bind(name).bind(description).bind(organization)
-    .bind(parent).bind(fairshare).bind(max_running_jobs).bind(grp_tres)
-    .execute(pool).await?;
+    let mut qb: QueryBuilder<sqlx::Postgres> = QueryBuilder::new("INSERT INTO ");
+    qb.push(table.name()).push(" (");
+    let mut first = true;
+    for (col, _) in keys.iter().chain(updates.iter()) {
+        if !first {
+            qb.push(", ");
+        }
+        first = false;
+        qb.push(*col);
+    }
+    qb.push(") VALUES (");
+    first = true;
+    for (_, val) in keys.iter().chain(updates.iter()) {
+        if !first {
+            qb.push(", ");
+        }
+        first = false;
+        push_bound(&mut qb, *val);
+    }
+    qb.push(") ON CONFLICT (")
+        .push(table.conflict_target())
+        .push(")");
+    if updates.is_empty() {
+        qb.push(" DO NOTHING");
+    } else {
+        qb.push(" DO UPDATE SET ");
+        first = true;
+        for (col, _) in updates {
+            if !first {
+                qb.push(", ");
+            }
+            first = false;
+            qb.push(*col).push(" = EXCLUDED.").push(*col);
+        }
+    }
+    qb.build().execute(pool).await?;
     Ok(())
+}
+
+/// Partial-patch fields for [`upsert_account`]. Outer `None` leaves the column
+/// unchanged (partial patch on modify); for nullable columns the inner `None`
+/// clears it to SQL `NULL`.
+#[derive(Default)]
+pub struct AccountUpdate<'a> {
+    pub description: Option<&'a str>,
+    pub organization: Option<&'a str>,
+    pub parent: Option<Option<&'a str>>,
+    pub fairshare: Option<i32>,
+    pub max_running_jobs: Option<Option<i32>>,
+    pub grp_tres: Option<Option<&'a str>>,
+}
+
+/// Create or update an account, writing only the fields set in `u`. `modify`
+/// sends just the restated fields, so unset columns are preserved; `add` sets
+/// all of them.
+pub async fn upsert_account<'a>(
+    pool: &PgPool,
+    name: &'a str,
+    u: AccountUpdate<'a>,
+) -> anyhow::Result<()> {
+    let keys = [("name", SqlVal::Text(name))];
+    let mut updates: Vec<(&'static str, SqlVal)> = Vec::new();
+    if let Some(v) = u.description {
+        updates.push(("description", SqlVal::Text(v)));
+    }
+    if let Some(v) = u.organization {
+        updates.push(("organization", SqlVal::Text(v)));
+    }
+    if let Some(v) = u.parent {
+        updates.push(("parent_account", SqlVal::NullText(v)));
+    }
+    if let Some(v) = u.fairshare {
+        updates.push(("fairshare_weight", SqlVal::Int(v)));
+    }
+    if let Some(v) = u.max_running_jobs {
+        updates.push(("max_running_jobs", SqlVal::NullInt(v)));
+    }
+    if let Some(v) = u.grp_tres {
+        updates.push(("grp_tres", SqlVal::NullText(v)));
+    }
+    upsert_row(pool, UpsertTable::Accounts, &keys, &updates).await
 }
 
 /// Delete an account.
@@ -555,94 +703,148 @@ pub struct AccountRecord {
     pub grp_tres: Option<String>,
 }
 
-/// Add a user-account association. Like `upsert_account`/`upsert_qos`, this
-/// is a full resend on modify, not a partial patch: an empty `default_qos`,
-/// or a `None`/zero limit, clears any existing value rather than preserving
-/// it. Numeric limits use `None` (not 0) for "no limit", matching how
-/// `list_associations`/`AssociationCache` read an unset limit back out.
-#[allow(clippy::too_many_arguments)]
-pub async fn add_user(
-    pool: &PgPool,
+/// Update the partition-less association's provided columns, inserting the row
+/// if none exists. Serialized per (user, account) by the caller's advisory lock
+/// so a concurrent first-time write can't double-insert: `partition_name` is
+/// nullable (NULL != NULL), so `ON CONFLICT` can't dedupe it here.
+async fn upsert_association(
+    conn: &mut PgConnection,
     user: &str,
     account: &str,
-    admin_level: &str,
-    is_default: bool,
-    default_qos: &str,
-    allowed_qos: &str,
-    max_running_jobs: Option<i32>,
-    max_submit_jobs: Option<i32>,
-    max_tres_per_job: Option<&str>,
-    grp_tres: Option<&str>,
-    max_wall_min: Option<i32>,
+    updates: &[(&'static str, SqlVal<'_>)],
 ) -> anyhow::Result<()> {
-    sqlx::query(
-        r#"
-        INSERT INTO users (name, account, admin_level, default_account)
-        VALUES ($1, $2, $3, CASE WHEN $4 THEN $2 ELSE NULL END)
-        ON CONFLICT (name, account) DO UPDATE SET admin_level = $3
-        "#,
-    )
-    .bind(user)
-    .bind(account)
-    .bind(admin_level)
-    .bind(is_default)
-    .execute(pool)
-    .await?;
+    let mut qb: QueryBuilder<sqlx::Postgres> = QueryBuilder::new("UPDATE associations SET ");
+    let mut first = true;
+    for (col, val) in updates {
+        if !first {
+            qb.push(", ");
+        }
+        first = false;
+        qb.push(*col).push(" = ");
+        push_bound(&mut qb, *val);
+    }
+    qb.push(" WHERE user_name = ").push_bind(user);
+    qb.push(" AND account = ").push_bind(account);
+    qb.push(" AND (partition_name IS NULL OR partition_name = '')");
+    let updated = qb.build().execute(&mut *conn).await?;
+    if updated.rows_affected() > 0 {
+        return Ok(());
+    }
 
-    // partition_name is nullable (NULL != NULL), so ON CONFLICT on it can't
-    // upsert; update explicitly, serialized per (user, account) so two
-    // concurrent first-time calls can't both insert.
+    let mut qb: QueryBuilder<sqlx::Postgres> =
+        QueryBuilder::new("INSERT INTO associations (user_name, account");
+    for (col, _) in updates {
+        qb.push(", ").push(*col);
+    }
+    qb.push(") VALUES (");
+    qb.push_bind(user).push(", ").push_bind(account);
+    for (_, val) in updates {
+        qb.push(", ");
+        push_bound(&mut qb, *val);
+    }
+    qb.push(")");
+    qb.build().execute(&mut *conn).await?;
+    Ok(())
+}
+
+/// Partial-patch fields for [`add_user`]. Outer `None` leaves the field
+/// unchanged (partial patch on modify); for nullable columns the inner `None`
+/// clears it. Numeric limits use `None` (not 0) for "no limit", matching how
+/// `list_associations`/`AssociationCache` read an unset limit back out.
+#[derive(Default)]
+pub struct UserUpdate<'a> {
+    pub admin_level: Option<&'a str>,
+    pub is_default: Option<bool>,
+    pub default_qos: Option<Option<&'a str>>,
+    pub allowed_qos: Option<Option<&'a str>>,
+    pub max_running_jobs: Option<Option<i32>>,
+    pub max_submit_jobs: Option<Option<i32>>,
+    pub max_tres_per_job: Option<Option<&'a str>>,
+    pub grp_tres: Option<Option<&'a str>>,
+    pub max_wall_min: Option<Option<i32>>,
+}
+
+/// Add or modify a user-account association, writing only the fields set in `u`
+/// (partial patch: `modify` restates a subset, `add` sets all). The users row is
+/// ensured; limits/QOS live in a separate association row. `is_default = Some(true)`
+/// demotes the user's other accounts, so at most one is ever the default.
+pub async fn add_user<'a>(
+    pool: &PgPool,
+    user: &'a str,
+    account: &'a str,
+    u: UserUpdate<'a>,
+) -> anyhow::Result<()> {
+    // Per-user advisory lock so concurrent modifies of two different accounts
+    // for the same user serialize — otherwise both could win the demote race
+    // below and end up default. Cheap: add_user is admin-path.
     let mut tx = pool.begin().await?;
-    sqlx::query("SELECT pg_advisory_xact_lock(hashtext($1 || ':' || $2)::bigint)")
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtext($1)::bigint)")
         .bind(user)
-        .bind(account)
         .execute(&mut *tx)
         .await?;
 
-    let updated = sqlx::query(
-        r#"
-        UPDATE associations SET is_default = $3, default_qos = NULLIF($4, ''),
-            allowed_qos = NULLIF($5, ''),
-            max_running_jobs = $6, max_submit_jobs = $7, max_tres_per_job = $8,
-            grp_tres = $9, max_wall_min = $10
-        WHERE user_name = $1 AND account = $2
-          AND (partition_name IS NULL OR partition_name = '')
-        "#,
-    )
-    .bind(user)
-    .bind(account)
-    .bind(is_default)
-    .bind(default_qos)
-    .bind(allowed_qos)
-    .bind(max_running_jobs)
-    .bind(max_submit_jobs)
-    .bind(max_tres_per_job)
-    .bind(grp_tres)
-    .bind(max_wall_min)
-    .execute(&mut *tx)
-    .await?;
-
-    if updated.rows_affected() == 0 {
+    // Clear the default on the user's other rows *before* the upsert sets it
+    // here, so the `one_default_account_per_user` unique index never sees two
+    // non-null default_account rows mid-transaction.
+    if u.is_default == Some(true) {
         sqlx::query(
-            r#"
-            INSERT INTO associations (user_name, account, is_default, default_qos,
-                allowed_qos, max_running_jobs, max_submit_jobs, max_tres_per_job,
-                grp_tres, max_wall_min)
-            VALUES ($1, $2, $3, NULLIF($4, ''), NULLIF($5, ''), $6, $7, $8, $9, $10)
-            "#,
+            "UPDATE users SET default_account = NULL \
+             WHERE name = $1 AND account <> $2 AND default_account IS NOT NULL",
         )
         .bind(user)
         .bind(account)
-        .bind(is_default)
-        .bind(default_qos)
-        .bind(allowed_qos)
-        .bind(max_running_jobs)
-        .bind(max_submit_jobs)
-        .bind(max_tres_per_job)
-        .bind(grp_tres)
-        .bind(max_wall_min)
         .execute(&mut *tx)
         .await?;
+    }
+
+    // Partial-patch contract: COALESCE/CASE keep the stored admin_level and
+    // default_account when the request omits them ($3/$4 NULL). is_default = true
+    // makes this account the default, false clears it.
+    sqlx::query(
+        r#"
+        INSERT INTO users (name, account, admin_level, default_account)
+        VALUES ($1, $2, COALESCE($3, 'none'), CASE WHEN $4::bool THEN $2 END)
+        ON CONFLICT (name, account) DO UPDATE SET
+            admin_level = COALESCE($3, users.admin_level),
+            default_account = CASE
+                WHEN $4::bool IS NULL THEN users.default_account
+                WHEN $4::bool THEN $2
+                ELSE NULL
+            END
+        "#,
+    )
+    .bind(user)
+    .bind(account)
+    .bind(u.admin_level)
+    .bind(u.is_default)
+    .execute(&mut *tx)
+    .await?;
+
+    let mut assoc: Vec<(&'static str, SqlVal)> = Vec::new();
+    if let Some(v) = u.default_qos {
+        assoc.push(("default_qos", SqlVal::NullText(v)));
+    }
+    if let Some(v) = u.allowed_qos {
+        assoc.push(("allowed_qos", SqlVal::NullText(v)));
+    }
+    if let Some(v) = u.max_running_jobs {
+        assoc.push(("max_running_jobs", SqlVal::NullInt(v)));
+    }
+    if let Some(v) = u.max_submit_jobs {
+        assoc.push(("max_submit_jobs", SqlVal::NullInt(v)));
+    }
+    if let Some(v) = u.max_tres_per_job {
+        assoc.push(("max_tres_per_job", SqlVal::NullText(v)));
+    }
+    if let Some(v) = u.grp_tres {
+        assoc.push(("grp_tres", SqlVal::NullText(v)));
+    }
+    if let Some(v) = u.max_wall_min {
+        assoc.push(("max_wall_min", SqlVal::NullInt(v)));
+    }
+    // Touch the association row (limits/QOS) only when a field was restated.
+    if !assoc.is_empty() {
+        upsert_association(&mut tx, user, account, &assoc).await?;
     }
 
     tx.commit().await?;
@@ -758,51 +960,64 @@ pub struct AssociationRecord {
     pub max_wall_min: Option<i32>,
 }
 
-/// Create or update a QOS.
-#[allow(clippy::too_many_arguments)]
-pub async fn upsert_qos(
-    pool: &PgPool,
-    name: &str,
-    description: &str,
-    priority: i32,
-    preempt_mode: &str,
-    usage_factor: f64,
-    max_jobs_per_user: Option<i32>,
-    max_wall_min: Option<i32>,
-    max_tres_per_job: Option<&str>,
-    max_submit_per_user: Option<i32>,
-    max_tres_per_user: Option<&str>,
-    grp_tres: Option<&str>,
-    grp_wall_min: Option<i32>,
-) -> anyhow::Result<()> {
-    sqlx::query(
-        r#"
-        INSERT INTO qos (name, description, priority, preempt_mode, usage_factor,
-                         max_jobs_per_user, max_wall_min, max_tres_per_job,
-                         max_submit_per_user, max_tres_per_user, grp_tres, grp_wall_min)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
-        ON CONFLICT (name) DO UPDATE SET
-            description = $2, priority = $3, preempt_mode = $4, usage_factor = $5,
-            max_jobs_per_user = $6, max_wall_min = $7, max_tres_per_job = $8,
-            max_submit_per_user = $9, max_tres_per_user = $10, grp_tres = $11,
-            grp_wall_min = $12
-        "#,
-    )
-    .bind(name)
-    .bind(description)
-    .bind(priority)
-    .bind(preempt_mode)
-    .bind(usage_factor)
-    .bind(max_jobs_per_user)
-    .bind(max_wall_min)
-    .bind(max_tres_per_job)
-    .bind(max_submit_per_user)
-    .bind(max_tres_per_user)
-    .bind(grp_tres)
-    .bind(grp_wall_min)
-    .execute(pool)
-    .await?;
-    Ok(())
+/// Partial-patch fields for [`upsert_qos`]. Outer `None` leaves the column
+/// unchanged (partial patch on modify); for nullable columns the inner `None`
+/// clears it to SQL `NULL`.
+#[derive(Default)]
+pub struct QosUpdate<'a> {
+    pub description: Option<&'a str>,
+    pub priority: Option<i32>,
+    pub preempt_mode: Option<&'a str>,
+    pub usage_factor: Option<f64>,
+    pub max_jobs_per_user: Option<Option<i32>>,
+    pub max_wall_min: Option<Option<i32>>,
+    pub max_tres_per_job: Option<Option<&'a str>>,
+    pub max_submit_per_user: Option<Option<i32>>,
+    pub max_tres_per_user: Option<Option<&'a str>>,
+    pub grp_tres: Option<Option<&'a str>>,
+    pub grp_wall_min: Option<Option<i32>>,
+}
+
+/// Create or update a QOS, writing only the fields set in `u`. `modify` sends
+/// just the restated fields, so unset columns are preserved; `add` sets all of
+/// them.
+pub async fn upsert_qos<'a>(pool: &PgPool, name: &'a str, u: QosUpdate<'a>) -> anyhow::Result<()> {
+    let keys = [("name", SqlVal::Text(name))];
+    let mut updates: Vec<(&'static str, SqlVal)> = Vec::new();
+    if let Some(v) = u.description {
+        updates.push(("description", SqlVal::Text(v)));
+    }
+    if let Some(v) = u.priority {
+        updates.push(("priority", SqlVal::Int(v)));
+    }
+    if let Some(v) = u.preempt_mode {
+        updates.push(("preempt_mode", SqlVal::Text(v)));
+    }
+    if let Some(v) = u.usage_factor {
+        updates.push(("usage_factor", SqlVal::Real(v)));
+    }
+    if let Some(v) = u.max_jobs_per_user {
+        updates.push(("max_jobs_per_user", SqlVal::NullInt(v)));
+    }
+    if let Some(v) = u.max_wall_min {
+        updates.push(("max_wall_min", SqlVal::NullInt(v)));
+    }
+    if let Some(v) = u.max_tres_per_job {
+        updates.push(("max_tres_per_job", SqlVal::NullText(v)));
+    }
+    if let Some(v) = u.max_submit_per_user {
+        updates.push(("max_submit_per_user", SqlVal::NullInt(v)));
+    }
+    if let Some(v) = u.max_tres_per_user {
+        updates.push(("max_tres_per_user", SqlVal::NullText(v)));
+    }
+    if let Some(v) = u.grp_tres {
+        updates.push(("grp_tres", SqlVal::NullText(v)));
+    }
+    if let Some(v) = u.grp_wall_min {
+        updates.push(("grp_wall_min", SqlVal::NullInt(v)));
+    }
+    upsert_row(pool, UpsertTable::Qos, &keys, &updates).await
 }
 
 /// Delete a QOS.
@@ -823,6 +1038,25 @@ pub async fn qos_exists(pool: &PgPool, name: &str) -> anyhow::Result<bool> {
         .fetch_optional(pool)
         .await?;
     Ok(row.is_some())
+}
+
+/// Of the given QOS names, return those that don't exist, in input order.
+/// A single query regardless of list length, so validating a user's allow-list
+/// doesn't scale DB round-trips with the number of names in it.
+pub async fn missing_qos(pool: &PgPool, names: &[&str]) -> anyhow::Result<Vec<String>> {
+    if names.is_empty() {
+        return Ok(Vec::new());
+    }
+    let existing: Vec<String> = sqlx::query_scalar("SELECT name FROM qos WHERE name = ANY($1)")
+        .bind(names)
+        .fetch_all(pool)
+        .await?;
+    Ok(names
+        .iter()
+        .copied()
+        .filter(|n| !existing.iter().any(|e| e == n))
+        .map(str::to_string)
+        .collect())
 }
 
 /// List all QOS.
@@ -1155,17 +1389,19 @@ mod job_history_tests {
         upsert_qos(
             &pool,
             &name,
-            "d",
-            5,
-            "cluster",
-            1.5,
-            Some(3),
-            Some(60),
-            Some("cpu=2"),
-            Some(4),
-            Some("cpu=16"),
-            Some("cpu=64"),
-            Some(120),
+            QosUpdate {
+                description: Some("d"),
+                priority: Some(5),
+                preempt_mode: Some("cluster"),
+                usage_factor: Some(1.5),
+                max_jobs_per_user: Some(Some(3)),
+                max_wall_min: Some(Some(60)),
+                max_tres_per_job: Some(Some("cpu=2")),
+                max_submit_per_user: Some(Some(4)),
+                max_tres_per_user: Some(Some("cpu=16")),
+                grp_tres: Some(Some("cpu=64")),
+                grp_wall_min: Some(Some(120)),
+            },
         )
         .await?;
 
@@ -1217,14 +1453,36 @@ mod job_history_tests {
             .execute(&pool)
             .await?;
 
-        upsert_account(&pool, &account, "d", "o", None, 1, None, None).await?;
+        upsert_account(
+            &pool,
+            &account,
+            AccountUpdate {
+                description: Some("d"),
+                organization: Some("o"),
+                ..Default::default()
+            },
+        )
+        .await?;
         upsert_qos(
-            &pool, &qos_name, "d", 0, "off", 1.0, None, None, None, None, None, None, None,
+            &pool,
+            &qos_name,
+            QosUpdate {
+                description: Some("d"),
+                ..Default::default()
+            },
         )
         .await?;
 
         add_user(
-            &pool, &user, &account, "none", true, &qos_name, "", None, None, None, None, None,
+            &pool,
+            &user,
+            &account,
+            UserUpdate {
+                admin_level: Some("none"),
+                is_default: Some(true),
+                default_qos: Some(Some(&qos_name)),
+                ..Default::default()
+            },
         )
         .await?;
         let got = list_users(&pool, Some(&account), None)
@@ -1234,10 +1492,35 @@ mod job_history_tests {
             .expect("user present");
         assert_eq!(got.default_qos.as_deref(), Some(qos_name.as_str()));
 
-        // Upsert again with an empty default_qos: clears it (full resend,
-        // not a partial patch — matches modify account/qos semantics).
+        // A partial update that doesn't restate default_qos must preserve it
+        // (the core SPUR-96 guarantee), while still applying the field it did
+        // restate.
         add_user(
-            &pool, &user, &account, "none", true, "", "", None, None, None, None, None,
+            &pool,
+            &user,
+            &account,
+            UserUpdate {
+                max_running_jobs: Some(Some(5)),
+                ..Default::default()
+            },
+        )
+        .await?;
+        let got = list_users(&pool, Some(&account), None)
+            .await?
+            .into_iter()
+            .find(|u| u.name == user)
+            .expect("user present");
+        assert_eq!(got.default_qos.as_deref(), Some(qos_name.as_str()));
+
+        // An explicit empty default_qos clears it.
+        add_user(
+            &pool,
+            &user,
+            &account,
+            UserUpdate {
+                default_qos: Some(None),
+                ..Default::default()
+            },
         )
         .await?;
         let got = list_users(&pool, Some(&account), None)
@@ -1268,6 +1551,412 @@ mod job_history_tests {
 
     #[tokio::test]
     #[ignore = "requires DATABASE_URL and PostgreSQL"]
+    async fn add_user_is_default_patches_default_account_only_when_restated() -> anyhow::Result<()>
+    {
+        let pool = test_pool().await?;
+        let pid = std::process::id();
+        let user = format!("spur_defacct_user_{pid}");
+        let account = format!("spur_defacct_acct_{pid}");
+
+        sqlx::query("DELETE FROM associations WHERE user_name = $1")
+            .bind(&user)
+            .execute(&pool)
+            .await?;
+        sqlx::query("DELETE FROM users WHERE name = $1")
+            .bind(&user)
+            .execute(&pool)
+            .await?;
+        sqlx::query("DELETE FROM accounts WHERE name = $1")
+            .bind(&account)
+            .execute(&pool)
+            .await?;
+
+        upsert_account(
+            &pool,
+            &account,
+            AccountUpdate {
+                description: Some("d"),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        let default_account = |pool: PgPool, account: String, user: String| async move {
+            list_users(&pool, Some(&account), None)
+                .await
+                .unwrap()
+                .into_iter()
+                .find(|u| u.name == user)
+                .expect("user present")
+                .default_account
+        };
+
+        // add with is_default=true records this account as the user's default.
+        add_user(
+            &pool,
+            &user,
+            &account,
+            UserUpdate {
+                is_default: Some(true),
+                ..Default::default()
+            },
+        )
+        .await?;
+        assert_eq!(
+            default_account(pool.clone(), account.clone(), user.clone())
+                .await
+                .as_deref(),
+            Some(account.as_str())
+        );
+
+        // A partial update that doesn't restate is_default must preserve
+        // default_account (the reported bug cleared it via the ON CONFLICT gap).
+        add_user(
+            &pool,
+            &user,
+            &account,
+            UserUpdate {
+                max_running_jobs: Some(Some(5)),
+                ..Default::default()
+            },
+        )
+        .await?;
+        assert_eq!(
+            default_account(pool.clone(), account.clone(), user.clone())
+                .await
+                .as_deref(),
+            Some(account.as_str()),
+            "unrestated is_default must not touch default_account"
+        );
+
+        // Restating is_default=false clears it — this is the change the old
+        // UPDATE dropped on the floor.
+        add_user(
+            &pool,
+            &user,
+            &account,
+            UserUpdate {
+                is_default: Some(false),
+                ..Default::default()
+            },
+        )
+        .await?;
+        assert_eq!(
+            default_account(pool.clone(), account.clone(), user.clone()).await,
+            None
+        );
+
+        // Restating is_default=true sets it back.
+        add_user(
+            &pool,
+            &user,
+            &account,
+            UserUpdate {
+                is_default: Some(true),
+                ..Default::default()
+            },
+        )
+        .await?;
+        assert_eq!(
+            default_account(pool.clone(), account.clone(), user.clone())
+                .await
+                .as_deref(),
+            Some(account.as_str())
+        );
+
+        sqlx::query("DELETE FROM associations WHERE user_name = $1")
+            .bind(&user)
+            .execute(&pool)
+            .await?;
+        sqlx::query("DELETE FROM users WHERE name = $1")
+            .bind(&user)
+            .execute(&pool)
+            .await?;
+        sqlx::query("DELETE FROM accounts WHERE name = $1")
+            .bind(&account)
+            .execute(&pool)
+            .await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL and PostgreSQL"]
+    async fn add_user_default_account_is_unique_per_user() -> anyhow::Result<()> {
+        let pool = test_pool().await?;
+        let pid = std::process::id();
+        let user = format!("spur_1def_user_{pid}");
+        let acct_a = format!("spur_1def_a_{pid}");
+        let acct_b = format!("spur_1def_b_{pid}");
+
+        sqlx::query("DELETE FROM associations WHERE user_name = $1")
+            .bind(&user)
+            .execute(&pool)
+            .await?;
+        sqlx::query("DELETE FROM users WHERE name = $1")
+            .bind(&user)
+            .execute(&pool)
+            .await?;
+        for a in [&acct_a, &acct_b] {
+            sqlx::query("DELETE FROM accounts WHERE name = $1")
+                .bind(a)
+                .execute(&pool)
+                .await?;
+            upsert_account(
+                &pool,
+                a,
+                AccountUpdate {
+                    description: Some("d"),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        }
+
+        // alice's default starts as account A, then B is made the default.
+        add_user(
+            &pool,
+            &user,
+            &acct_a,
+            UserUpdate {
+                is_default: Some(true),
+                ..Default::default()
+            },
+        )
+        .await?;
+        add_user(
+            &pool,
+            &user,
+            &acct_b,
+            UserUpdate {
+                is_default: Some(true),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        // Only B remains the user's default in the users table; A is demoted.
+        let users = list_users(&pool, None, Some(&user)).await?;
+        let a_row = users
+            .iter()
+            .find(|u| u.account == acct_a)
+            .expect("A row present");
+        let b_row = users
+            .iter()
+            .find(|u| u.account == acct_b)
+            .expect("B row present");
+        assert_eq!(
+            a_row.default_account, None,
+            "A must be demoted when B becomes default"
+        );
+        assert_eq!(b_row.default_account.as_deref(), Some(acct_b.as_str()));
+
+        sqlx::query("DELETE FROM associations WHERE user_name = $1")
+            .bind(&user)
+            .execute(&pool)
+            .await?;
+        sqlx::query("DELETE FROM users WHERE name = $1")
+            .bind(&user)
+            .execute(&pool)
+            .await?;
+        for a in [&acct_a, &acct_b] {
+            sqlx::query("DELETE FROM accounts WHERE name = $1")
+                .bind(a)
+                .execute(&pool)
+                .await?;
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL and PostgreSQL"]
+    async fn migrate_upgrades_pre_fix_default_account_schema() -> anyhow::Result<()> {
+        let pool = test_pool().await?;
+        let pid = std::process::id();
+        let user = format!("spur_dedup_user_{pid}");
+        // Names chosen so acct_a sorts before acct_b: the dedup keeps the lowest.
+        let acct_a = format!("spur_dedup_a_{pid}");
+        let acct_b = format!("spur_dedup_b_{pid}");
+
+        sqlx::query("DELETE FROM associations WHERE user_name = $1")
+            .bind(&user)
+            .execute(&pool)
+            .await?;
+        sqlx::query("DELETE FROM users WHERE name = $1")
+            .bind(&user)
+            .execute(&pool)
+            .await?;
+        for a in [&acct_a, &acct_b] {
+            sqlx::query("DELETE FROM accounts WHERE name = $1")
+                .bind(a)
+                .execute(&pool)
+                .await?;
+            upsert_account(
+                &pool,
+                a,
+                AccountUpdate {
+                    description: Some("d"),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        }
+
+        // Reconstruct a pre-fix database: the dead is_default column present and
+        // two rows marked default (which the live index forbids). Drop the index,
+        // restore the column, inject the rows, then let migrate() run the upgrade.
+        sqlx::query("DROP INDEX IF EXISTS one_default_account_per_user")
+            .execute(&pool)
+            .await?;
+        sqlx::query(
+            "ALTER TABLE associations \
+             ADD COLUMN IF NOT EXISTS is_default BOOLEAN NOT NULL DEFAULT false",
+        )
+        .execute(&pool)
+        .await?;
+        for a in [&acct_a, &acct_b] {
+            sqlx::query(
+                "INSERT INTO users (name, account, admin_level, default_account) \
+                 VALUES ($1, $2, 'none', $2)",
+            )
+            .bind(&user)
+            .bind(a)
+            .execute(&pool)
+            .await?;
+            sqlx::query(
+                "INSERT INTO associations (user_name, account, is_default) VALUES ($1, $2, true)",
+            )
+            .bind(&user)
+            .bind(a)
+            .execute(&pool)
+            .await?;
+        }
+
+        // Re-running the schema drops the dead column, collapses the duplicates,
+        // then rebuilds the index on the now-clean data.
+        migrate(&pool).await?;
+
+        let has_is_default: bool = sqlx::query_scalar(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.columns \
+             WHERE table_name = 'associations' AND column_name = 'is_default')",
+        )
+        .fetch_one(&pool)
+        .await?;
+        assert!(
+            !has_is_default,
+            "migrate must drop the redundant is_default column"
+        );
+
+        let users = list_users(&pool, None, Some(&user)).await?;
+        let with_default: Vec<&str> = users
+            .iter()
+            .filter(|u| u.default_account.is_some())
+            .map(|u| u.account.as_str())
+            .collect();
+        assert_eq!(
+            with_default,
+            vec![acct_a.as_str()],
+            "exactly one default survives, the lowest account name"
+        );
+
+        // The rebuilt index now rejects a second default for the user.
+        let dup = sqlx::query(
+            "UPDATE users SET default_account = account WHERE name = $1 AND account = $2",
+        )
+        .bind(&user)
+        .bind(&acct_b)
+        .execute(&pool)
+        .await;
+        assert!(
+            dup.is_err(),
+            "unique index must reject a second default account"
+        );
+
+        sqlx::query("DELETE FROM associations WHERE user_name = $1")
+            .bind(&user)
+            .execute(&pool)
+            .await?;
+        sqlx::query("DELETE FROM users WHERE name = $1")
+            .bind(&user)
+            .execute(&pool)
+            .await?;
+        for a in [&acct_a, &acct_b] {
+            sqlx::query("DELETE FROM accounts WHERE name = $1")
+                .bind(a)
+                .execute(&pool)
+                .await?;
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL and PostgreSQL"]
+    async fn migrate_serializes_concurrent_runs() -> anyhow::Result<()> {
+        // Two controllers booting against one database run migrate() at once;
+        // the advisory lock must serialize them so neither errors nor deadlocks.
+        let pool = test_pool().await?;
+        let (first, second) = tokio::join!(migrate(&pool), migrate(&pool));
+        first?;
+        second?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL and PostgreSQL"]
+    async fn missing_qos_reports_only_absent_names() -> anyhow::Result<()> {
+        let pool = test_pool().await?;
+        let pid = std::process::id();
+        let present_a = format!("spur_mq_a_{pid}");
+        let present_b = format!("spur_mq_b_{pid}");
+        let absent = format!("spur_mq_absent_{pid}");
+
+        for q in [&present_a, &present_b, &absent] {
+            sqlx::query("DELETE FROM qos WHERE name = $1")
+                .bind(q)
+                .execute(&pool)
+                .await?;
+        }
+        for q in [&present_a, &present_b] {
+            upsert_qos(
+                &pool,
+                q,
+                QosUpdate {
+                    description: Some("d"),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        }
+
+        // Empty input short-circuits without a query and reports nothing.
+        assert!(missing_qos(&pool, &[]).await?.is_empty());
+
+        // Only the absent name is returned, preserving input order and
+        // ignoring existing names in any position.
+        let missing = missing_qos(
+            &pool,
+            &[present_a.as_str(), absent.as_str(), present_b.as_str()],
+        )
+        .await?;
+        assert_eq!(missing, vec![absent.clone()]);
+
+        // All-present resolves to no missing.
+        assert!(
+            missing_qos(&pool, &[present_a.as_str(), present_b.as_str()])
+                .await?
+                .is_empty()
+        );
+
+        for q in [&present_a, &present_b, &absent] {
+            sqlx::query("DELETE FROM qos WHERE name = $1")
+                .bind(q)
+                .execute(&pool)
+                .await?;
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL and PostgreSQL"]
     async fn add_user_round_trips_account_limits() -> anyhow::Result<()> {
         let pool = test_pool().await?;
         let pid = std::process::id();
@@ -1287,21 +1976,31 @@ mod job_history_tests {
             .execute(&pool)
             .await?;
 
-        upsert_account(&pool, &account, "d", "o", None, 1, None, None).await?;
+        upsert_account(
+            &pool,
+            &account,
+            AccountUpdate {
+                description: Some("d"),
+                organization: Some("o"),
+                ..Default::default()
+            },
+        )
+        .await?;
 
         add_user(
             &pool,
             &user,
             &account,
-            "none",
-            true,
-            "",
-            "",
-            Some(2),
-            Some(4),
-            Some("cpu=8"),
-            Some("cpu=32"),
-            Some(60),
+            UserUpdate {
+                admin_level: Some("none"),
+                is_default: Some(true),
+                max_running_jobs: Some(Some(2)),
+                max_submit_jobs: Some(Some(4)),
+                max_tres_per_job: Some(Some("cpu=8")),
+                grp_tres: Some(Some("cpu=32")),
+                max_wall_min: Some(Some(60)),
+                ..Default::default()
+            },
         )
         .await?;
 
@@ -1316,21 +2015,16 @@ mod job_history_tests {
         assert_eq!(got.grp_tres.as_deref(), Some("cpu=32"));
         assert_eq!(got.max_wall_min, Some(60));
 
-        // Upsert again with different non-zero limits: the UPDATE branch
-        // must overwrite the existing values, not merge with them.
+        // A partial update that restates only max_running_jobs must overwrite
+        // that one limit while preserving every limit it didn't restate.
         add_user(
             &pool,
             &user,
             &account,
-            "none",
-            true,
-            "",
-            "",
-            Some(10),
-            Some(20),
-            Some("cpu=16"),
-            Some("cpu=64"),
-            Some(120),
+            UserUpdate {
+                max_running_jobs: Some(Some(10)),
+                ..Default::default()
+            },
         )
         .await?;
         let got = list_associations(&pool)
@@ -1339,15 +2033,24 @@ mod job_history_tests {
             .find(|a| a.user_name == user && a.account == account)
             .expect("association present");
         assert_eq!(got.max_running_jobs, Some(10));
-        assert_eq!(got.max_submit_jobs, Some(20));
-        assert_eq!(got.max_tres_per_job.as_deref(), Some("cpu=16"));
-        assert_eq!(got.grp_tres.as_deref(), Some("cpu=64"));
-        assert_eq!(got.max_wall_min, Some(120));
+        assert_eq!(got.max_submit_jobs, Some(4));
+        assert_eq!(got.max_tres_per_job.as_deref(), Some("cpu=8"));
+        assert_eq!(got.grp_tres.as_deref(), Some("cpu=32"));
+        assert_eq!(got.max_wall_min, Some(60));
 
-        // Upsert again with no limits: clears them (full resend, not a
-        // partial patch — matches every other field on this association).
+        // Explicitly clearing each limit (inner None) sets it back to no-limit.
         add_user(
-            &pool, &user, &account, "none", true, "", "", None, None, None, None, None,
+            &pool,
+            &user,
+            &account,
+            UserUpdate {
+                max_running_jobs: Some(None),
+                max_submit_jobs: Some(None),
+                max_tres_per_job: Some(None),
+                grp_tres: Some(None),
+                max_wall_min: Some(None),
+                ..Default::default()
+            },
         )
         .await?;
         let got = list_associations(&pool)
@@ -1400,35 +2103,36 @@ mod job_history_tests {
             .execute(&pool)
             .await?;
 
-        upsert_account(&pool, &account, "d", "o", None, 1, None, None).await?;
+        upsert_account(
+            &pool,
+            &account,
+            AccountUpdate {
+                description: Some("d"),
+                organization: Some("o"),
+                ..Default::default()
+            },
+        )
+        .await?;
         add_user(
             &pool,
             &matching_user,
             &account,
-            "none",
-            true,
-            "",
-            "",
-            None,
-            None,
-            None,
-            None,
-            None,
+            UserUpdate {
+                admin_level: Some("none"),
+                is_default: Some(true),
+                ..Default::default()
+            },
         )
         .await?;
         add_user(
             &pool,
             &other_user,
             &account,
-            "none",
-            true,
-            "",
-            "",
-            None,
-            None,
-            None,
-            None,
-            None,
+            UserUpdate {
+                admin_level: Some("none"),
+                is_default: Some(true),
+                ..Default::default()
+            },
         )
         .await?;
 
@@ -1483,29 +2187,33 @@ mod job_history_tests {
             .execute(&pool)
             .await?;
 
-        upsert_account(&pool, &account, "d", "o", None, 1, None, None).await?;
+        upsert_account(
+            &pool,
+            &account,
+            AccountUpdate {
+                description: Some("d"),
+                organization: Some("o"),
+                ..Default::default()
+            },
+        )
+        .await?;
 
-        add_user(
-            &pool, &user, &account, "none", true, "", "", None, None, None, None, None,
-        )
-        .await?;
-        add_user(
-            &pool, &user, &account, "none", true, "", "", None, None, None, None, None,
-        )
-        .await?;
+        let base = || UserUpdate {
+            admin_level: Some("none"),
+            is_default: Some(true),
+            max_running_jobs: Some(Some(1)),
+            ..Default::default()
+        };
+        add_user(&pool, &user, &account, base()).await?;
+        add_user(&pool, &user, &account, base()).await?;
         add_user(
             &pool,
             &user,
             &account,
-            "none",
-            true,
-            "highprio-does-not-need-to-exist",
-            "",
-            None,
-            None,
-            None,
-            None,
-            None,
+            UserUpdate {
+                default_qos: Some(Some("highprio-does-not-need-to-exist")),
+                ..base()
+            },
         )
         .await?;
 
@@ -1560,7 +2268,16 @@ mod job_history_tests {
             .execute(&pool)
             .await?;
 
-        upsert_account(&pool, &account, "d", "o", None, 1, None, None).await?;
+        upsert_account(
+            &pool,
+            &account,
+            AccountUpdate {
+                description: Some("d"),
+                organization: Some("o"),
+                ..Default::default()
+            },
+        )
+        .await?;
         sqlx::query("INSERT INTO users (name, account, admin_level) VALUES ($1, $2, 'none')")
             .bind(&user)
             .bind(&account)
@@ -1614,7 +2331,16 @@ mod job_history_tests {
             .execute(&pool)
             .await?;
 
-        upsert_account(&pool, &account, "d", "o", None, 1, None, None).await?;
+        upsert_account(
+            &pool,
+            &account,
+            AccountUpdate {
+                description: Some("d"),
+                organization: Some("o"),
+                ..Default::default()
+            },
+        )
+        .await?;
         sqlx::query(
             "INSERT INTO associations \
              (user_name, account, max_running_jobs, max_submit_jobs, max_tres_per_job, grp_tres, max_wall_min) \
@@ -1649,7 +2375,7 @@ mod job_history_tests {
 
     #[tokio::test]
     #[ignore = "requires DATABASE_URL and PostgreSQL"]
-    async fn account_grp_tres_round_trips_and_clears() -> anyhow::Result<()> {
+    async fn account_grp_tres_preserves_on_omit_and_clears_on_explicit() -> anyhow::Result<()> {
         let pool = test_pool().await?;
         let account = format!("spur_acct_grptres_{}", std::process::id());
         sqlx::query("DELETE FROM accounts WHERE name = $1")
@@ -1660,12 +2386,12 @@ mod job_history_tests {
         upsert_account(
             &pool,
             &account,
-            "d",
-            "o",
-            None,
-            1,
-            None,
-            Some("cpu=16,mem=32768,gres/gpu=8"),
+            AccountUpdate {
+                description: Some("d"),
+                organization: Some("o"),
+                grp_tres: Some(Some("cpu=16,mem=32768,gres/gpu=8")),
+                ..Default::default()
+            },
         )
         .await?;
         let got = list_accounts(&pool)
@@ -1675,8 +2401,35 @@ mod job_history_tests {
             .expect("account present");
         assert_eq!(got.grp_tres.as_deref(), Some("cpu=16,mem=32768,gres/gpu=8"));
 
-        // Full-resend upsert with no allocation clears it (same contract as qos/user).
-        upsert_account(&pool, &account, "d", "o", None, 1, None, None).await?;
+        // A partial update that doesn't restate grp_tres preserves it (the
+        // SPUR-96 fix) while applying the field it does restate.
+        upsert_account(
+            &pool,
+            &account,
+            AccountUpdate {
+                fairshare: Some(5),
+                ..Default::default()
+            },
+        )
+        .await?;
+        let got = list_accounts(&pool)
+            .await?
+            .into_iter()
+            .find(|a| a.name == account)
+            .expect("account present");
+        assert_eq!(got.grp_tres.as_deref(), Some("cpu=16,mem=32768,gres/gpu=8"));
+        assert_eq!(got.fairshare_weight, 5);
+
+        // An explicit empty grp_tres (inner None) clears it.
+        upsert_account(
+            &pool,
+            &account,
+            AccountUpdate {
+                grp_tres: Some(None),
+                ..Default::default()
+            },
+        )
+        .await?;
         let got = list_accounts(&pool)
             .await?
             .into_iter()

--- a/crates/spurctld/src/accounting/db.rs
+++ b/crates/spurctld/src/accounting/db.rs
@@ -703,10 +703,10 @@ pub struct AccountRecord {
     pub grp_tres: Option<String>,
 }
 
-/// Update the partition-less association's provided columns, inserting the row
-/// if none exists. Serialized per (user, account) by the caller's advisory lock
-/// so a concurrent first-time write can't double-insert: `partition_name` is
-/// nullable (NULL != NULL), so `ON CONFLICT` can't dedupe it here.
+/// Update the partition-less association's columns, inserting the row if none
+/// exists. `partition_name` is nullable (NULL != NULL), so `ON CONFLICT` can't
+/// dedupe; the caller's per-user advisory lock serializes concurrent `add_user`s
+/// so two can't double-insert. (`remove_user` takes no lock but only deletes.)
 async fn upsert_association(
     conn: &mut PgConnection,
     user: &str,
@@ -765,9 +765,9 @@ pub struct UserUpdate<'a> {
 }
 
 /// Add or modify a user-account association, writing only the fields set in `u`
-/// (partial patch: `modify` restates a subset, `add` sets all). The users row is
-/// ensured; limits/QOS live in a separate association row. `is_default = Some(true)`
-/// demotes the user's other accounts, so at most one is ever the default.
+/// (partial patch). `is_default`: `Some(true)` makes this the default (demoting the
+/// user's others), `Some(false)` clears it, `None` preserves it but still defaults a
+/// brand-new user's first account. Limits/QOS live in a separate association row.
 pub async fn add_user<'a>(
     pool: &PgPool,
     user: &'a str,
@@ -797,13 +797,17 @@ pub async fn add_user<'a>(
         .await?;
     }
 
-    // Partial-patch contract: COALESCE/CASE keep the stored admin_level and
-    // default_account when the request omits them ($3/$4 NULL). is_default = true
-    // makes this account the default, false clears it.
+    // Partial-patch: COALESCE/CASE keep stored admin_level/default_account when
+    // omitted ($3/$4 NULL); a brand-new user's first row still claims the default.
     sqlx::query(
         r#"
         INSERT INTO users (name, account, admin_level, default_account)
-        VALUES ($1, $2, COALESCE($3, 'none'), CASE WHEN $4::bool THEN $2 END)
+        VALUES ($1, $2, COALESCE($3, 'none'), CASE
+            WHEN $4::bool THEN $2
+            WHEN $4::bool IS NULL AND NOT EXISTS (
+                SELECT 1 FROM users WHERE name = $1 AND default_account IS NOT NULL
+            ) THEN $2
+        END)
         ON CONFLICT (name, account) DO UPDATE SET
             admin_level = COALESCE($3, users.admin_level),
             default_account = CASE
@@ -1492,9 +1496,8 @@ mod job_history_tests {
             .expect("user present");
         assert_eq!(got.default_qos.as_deref(), Some(qos_name.as_str()));
 
-        // A partial update that doesn't restate default_qos must preserve it
-        // (the core SPUR-96 guarantee), while still applying the field it did
-        // restate.
+        // An unrestated default_qos must be preserved while the restated field
+        // is still applied.
         add_user(
             &pool,
             &user,
@@ -1609,8 +1612,7 @@ mod job_history_tests {
             Some(account.as_str())
         );
 
-        // A partial update that doesn't restate is_default must preserve
-        // default_account (the reported bug cleared it via the ON CONFLICT gap).
+        // An unrestated is_default must leave default_account untouched.
         add_user(
             &pool,
             &user,
@@ -1629,8 +1631,7 @@ mod job_history_tests {
             "unrestated is_default must not touch default_account"
         );
 
-        // Restating is_default=false clears it — this is the change the old
-        // UPDATE dropped on the floor.
+        // Restating is_default=false clears default_account.
         add_user(
             &pool,
             &user,
@@ -1749,6 +1750,80 @@ mod job_history_tests {
             "A must be demoted when B becomes default"
         );
         assert_eq!(b_row.default_account.as_deref(), Some(acct_b.as_str()));
+
+        sqlx::query("DELETE FROM associations WHERE user_name = $1")
+            .bind(&user)
+            .execute(&pool)
+            .await?;
+        sqlx::query("DELETE FROM users WHERE name = $1")
+            .bind(&user)
+            .execute(&pool)
+            .await?;
+        for a in [&acct_a, &acct_b] {
+            sqlx::query("DELETE FROM accounts WHERE name = $1")
+                .bind(a)
+                .execute(&pool)
+                .await?;
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL and PostgreSQL"]
+    async fn add_user_defaults_first_account_and_later_adds_dont_demote() -> anyhow::Result<()> {
+        let pool = test_pool().await?;
+        let pid = std::process::id();
+        let user = format!("spur_defadd_user_{pid}");
+        let acct_a = format!("spur_defadd_a_{pid}");
+        let acct_b = format!("spur_defadd_b_{pid}");
+
+        sqlx::query("DELETE FROM associations WHERE user_name = $1")
+            .bind(&user)
+            .execute(&pool)
+            .await?;
+        sqlx::query("DELETE FROM users WHERE name = $1")
+            .bind(&user)
+            .execute(&pool)
+            .await?;
+        for a in [&acct_a, &acct_b] {
+            sqlx::query("DELETE FROM accounts WHERE name = $1")
+                .bind(a)
+                .execute(&pool)
+                .await?;
+            upsert_account(
+                &pool,
+                a,
+                AccountUpdate {
+                    description: Some("d"),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        }
+
+        // A plain add (is_default = None) makes a user's first account the default.
+        add_user(&pool, &user, &acct_a, UserUpdate::default()).await?;
+        // A later plain add to another account must not demote that default.
+        add_user(&pool, &user, &acct_b, UserUpdate::default()).await?;
+
+        let users = list_users(&pool, None, Some(&user)).await?;
+        let a_row = users
+            .iter()
+            .find(|u| u.account == acct_a)
+            .expect("A row present");
+        let b_row = users
+            .iter()
+            .find(|u| u.account == acct_b)
+            .expect("B row present");
+        assert_eq!(
+            a_row.default_account.as_deref(),
+            Some(acct_a.as_str()),
+            "a user's first account must become the default"
+        );
+        assert_eq!(
+            b_row.default_account, None,
+            "a plain add must not steal the default from an existing account"
+        );
 
         sqlx::query("DELETE FROM associations WHERE user_name = $1")
             .bind(&user)
@@ -2401,8 +2476,8 @@ mod job_history_tests {
             .expect("account present");
         assert_eq!(got.grp_tres.as_deref(), Some("cpu=16,mem=32768,gres/gpu=8"));
 
-        // A partial update that doesn't restate grp_tres preserves it (the
-        // SPUR-96 fix) while applying the field it does restate.
+        // An unrestated grp_tres must be preserved while the restated field is
+        // still applied.
         upsert_account(
             &pool,
             &account,

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -22,6 +22,39 @@ fn validate_tres(field: &str, raw: &str) -> Result<(), Status> {
         .map_err(|e| Status::invalid_argument(format!("invalid {field}: {e}")))
 }
 
+/// Map an optional TRES/text proto field to a nullable-column patch: unset ->
+/// keep, empty -> clear (SQL NULL), otherwise -> set.
+fn nullable_str(field: &Option<String>) -> Option<Option<&str>> {
+    field
+        .as_deref()
+        .map(|s| if s.is_empty() { None } else { Some(s) })
+}
+
+/// Map an optional u32 limit proto field to a nullable-int patch: unset ->
+/// keep, 0 -> clear (no limit), n -> set. Errors if `n` overflows i32.
+fn nullable_limit(field: Option<u32>, what: &str) -> Result<Option<Option<i32>>, Status> {
+    match field {
+        None => Ok(None),
+        Some(0) => Ok(Some(None)),
+        Some(n) => Ok(Some(Some(i32::try_from(n).map_err(|_| {
+            Status::invalid_argument(format!("{what} exceeds i32::MAX"))
+        })?))),
+    }
+}
+
+/// Fairshare is a whole share count stored as `INTEGER`, but the proto carries
+/// it as `double` (kept for wire stability). Reject a fractional, negative, or
+/// out-of-range value rather than silently truncating it (e.g. 2.9 -> 2).
+fn fairshare_to_i32(v: f64) -> Result<i32, Status> {
+    if !v.is_finite() || v.fract() != 0.0 || v < 0.0 || v > f64::from(i32::MAX) {
+        return Err(Status::invalid_argument(format!(
+            "fairshare must be a whole number in [0, {}], got {v}",
+            i32::MAX
+        )));
+    }
+    Ok(v as i32)
+}
+
 pub(crate) struct AccountingService {
     pool: PgPool,
 }
@@ -293,34 +326,20 @@ impl SlurmAccounting for AccountingService {
         request: Request<CreateAccountRequest>,
     ) -> Result<Response<()>, Status> {
         let req = request.into_inner();
-        validate_tres("grptres", &req.grp_tres)?;
-        let parent = if req.parent_account.is_empty() {
-            None
-        } else {
-            Some(req.parent_account.as_str())
+        if let Some(g) = &req.grp_tres {
+            validate_tres("grptres", g)?;
+        }
+        let update = db::AccountUpdate {
+            description: req.description.as_deref(),
+            organization: req.organization.as_deref(),
+            parent: nullable_str(&req.parent_account),
+            fairshare: req.fairshare_weight.map(fairshare_to_i32).transpose()?,
+            max_running_jobs: nullable_limit(req.max_running_jobs, "max_running_jobs")?,
+            grp_tres: nullable_str(&req.grp_tres),
         };
-        let max_running = if req.max_running_jobs == 0 {
-            None
-        } else {
-            Some(req.max_running_jobs as i32)
-        };
-        let grp_tres = if req.grp_tres.is_empty() {
-            None
-        } else {
-            Some(req.grp_tres.as_str())
-        };
-        db::upsert_account(
-            &self.pool,
-            &req.name,
-            &req.description,
-            &req.organization,
-            parent,
-            req.fairshare_weight as i32,
-            max_running,
-            grp_tres,
-        )
-        .await
-        .map_err(|e| Status::internal(e.to_string()))?;
+        db::upsert_account(&self.pool, &req.name, update)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
         Ok(Response::new(()))
     }
 
@@ -361,99 +380,78 @@ impl SlurmAccounting for AccountingService {
 
     async fn add_user(&self, request: Request<AddUserRequest>) -> Result<Response<()>, Status> {
         let req = request.into_inner();
-        // Validated against the live DB, not QosCache: a QOS created just
-        // now may not have reached the cache's next refresh yet, same
-        // inherent lag job submission already accepts for QosCache reads.
-        if !req.default_qos.is_empty() {
-            let exists = db::qos_exists(&self.pool, &req.default_qos)
-                .await
-                .map_err(|e| Status::internal(e.to_string()))?;
-            if !exists {
-                return Err(Status::not_found(format!(
-                    "QOS '{}' does not exist",
-                    req.default_qos
+        // QOS references are validated against the live DB, not QosCache: a QOS
+        // created just now may not have reached the cache's next refresh yet,
+        // the same lag job submission already accepts for QosCache reads. Each
+        // check runs only for a field the request actually restated.
+        if let Some(dq) = req.default_qos.as_deref() {
+            if !dq.is_empty() {
+                let exists = db::qos_exists(&self.pool, dq)
+                    .await
+                    .map_err(|e| Status::internal(e.to_string()))?;
+                if !exists {
+                    return Err(Status::not_found(format!("QOS '{dq}' does not exist")));
+                }
+            }
+        }
+        // Normalize + validate an explicitly restated allow-list. `None` leaves
+        // the stored allow-list untouched; an explicit empty clears it.
+        let allowed_qos_normalized: Option<String> = match req.allowed_qos.as_deref() {
+            None => None,
+            Some(list) => {
+                let names: Vec<&str> = list
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .collect();
+                let missing = db::missing_qos(&self.pool, &names)
+                    .await
+                    .map_err(|e| Status::internal(e.to_string()))?;
+                if let Some(name) = missing.first() {
+                    return Err(Status::not_found(format!("QOS '{name}' does not exist")));
+                }
+                Some(names.join(","))
+            }
+        };
+        // Cross-check the default is in the allow-list only when both are
+        // restated here; a preserved (unset) side can't be validated without a
+        // read and is left to the stored value.
+        if let (Some(dq), Some(list)) = (
+            req.default_qos.as_deref(),
+            allowed_qos_normalized.as_deref(),
+        ) {
+            if !dq.is_empty() && !list.is_empty() && !list.split(',').any(|q| q == dq) {
+                return Err(Status::invalid_argument(format!(
+                    "default QOS '{dq}' must be included in qos={list}"
                 )));
             }
         }
-        let allowed_qos: Vec<&str> = req
-            .allowed_qos
-            .split(',')
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-            .collect();
-        for name in &allowed_qos {
-            let exists = db::qos_exists(&self.pool, name)
-                .await
-                .map_err(|e| Status::internal(e.to_string()))?;
-            if !exists {
-                return Err(Status::not_found(format!("QOS '{name}' does not exist")));
-            }
+        if let Some(t) = &req.max_tres_per_job {
+            validate_tres("maxtresperjob", t)?;
         }
-        if !req.default_qos.is_empty()
-            && !allowed_qos.is_empty()
-            && !allowed_qos.contains(&req.default_qos.as_str())
-        {
-            return Err(Status::invalid_argument(format!(
-                "default QOS '{}' must be included in qos={}",
-                req.default_qos, req.allowed_qos
-            )));
+        if let Some(t) = &req.grp_tres {
+            validate_tres("grptres", t)?;
         }
-        let max_running_jobs = if req.max_running_jobs == 0 {
-            None
-        } else {
-            Some(
-                i32::try_from(req.max_running_jobs)
-                    .map_err(|_| Status::invalid_argument("max_running_jobs exceeds i32::MAX"))?,
-            )
+        let update = db::UserUpdate {
+            admin_level: req.admin_level.as_deref(),
+            is_default: req.is_default,
+            default_qos: nullable_str(&req.default_qos),
+            allowed_qos: allowed_qos_normalized.as_deref().map(|s| {
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(s)
+                }
+            }),
+            max_running_jobs: nullable_limit(req.max_running_jobs, "max_running_jobs")?,
+            max_submit_jobs: nullable_limit(req.max_submit_jobs, "max_submit_jobs")?,
+            max_tres_per_job: nullable_str(&req.max_tres_per_job),
+            grp_tres: nullable_str(&req.grp_tres),
+            max_wall_min: nullable_limit(req.max_wall_minutes, "max_wall_minutes")?,
         };
-        let max_submit_jobs = if req.max_submit_jobs == 0 {
-            None
-        } else {
-            Some(
-                i32::try_from(req.max_submit_jobs)
-                    .map_err(|_| Status::invalid_argument("max_submit_jobs exceeds i32::MAX"))?,
-            )
-        };
-        validate_tres("maxtresperjob", &req.max_tres_per_job)?;
-        validate_tres("grptres", &req.grp_tres)?;
-        let max_tres_per_job = if req.max_tres_per_job.is_empty() {
-            None
-        } else {
-            Some(req.max_tres_per_job.as_str())
-        };
-        let grp_tres = if req.grp_tres.is_empty() {
-            None
-        } else {
-            Some(req.grp_tres.as_str())
-        };
-        let max_wall_minutes = if req.max_wall_minutes == 0 {
-            None
-        } else {
-            Some(
-                i32::try_from(req.max_wall_minutes)
-                    .map_err(|_| Status::invalid_argument("max_wall_minutes exceeds i32::MAX"))?,
-            )
-        };
-        // Store the trimmed/filtered form, not the raw request string, so
-        // `sacctmgr show user` echoes back what was actually validated
-        // above rather than stray whitespace or empty entries.
-        let allowed_qos_normalized = allowed_qos.join(",");
-        db::add_user(
-            &self.pool,
-            &req.user,
-            &req.account,
-            &req.admin_level,
-            req.is_default,
-            &req.default_qos,
-            &allowed_qos_normalized,
-            max_running_jobs,
-            max_submit_jobs,
-            max_tres_per_job,
-            grp_tres,
-            max_wall_minutes,
-        )
-        .await
-        .map_err(|e| Status::internal(e.to_string()))?;
+        db::add_user(&self.pool, &req.user, &req.account, update)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
         Ok(Response::new(()))
     }
 
@@ -504,72 +502,34 @@ impl SlurmAccounting for AccountingService {
 
     async fn create_qos(&self, request: Request<CreateQosRequest>) -> Result<Response<()>, Status> {
         let req = request.into_inner();
-        validate_tres("maxtresperjob", &req.max_tres_per_job)?;
-        validate_tres("maxtresperuser", &req.max_tres_per_user)?;
-        validate_tres("grptres", &req.grp_tres)?;
-        let max_jobs = if req.max_jobs_per_user == 0 {
-            None
-        } else {
-            Some(
-                i32::try_from(req.max_jobs_per_user)
-                    .map_err(|_| Status::invalid_argument("max_jobs_per_user exceeds i32::MAX"))?,
-            )
+        if let Some(t) = &req.max_tres_per_job {
+            validate_tres("maxtresperjob", t)?;
+        }
+        if let Some(t) = &req.max_tres_per_user {
+            validate_tres("maxtresperuser", t)?;
+        }
+        if let Some(t) = &req.grp_tres {
+            validate_tres("grptres", t)?;
+        }
+        let update = db::QosUpdate {
+            description: req.description.as_deref(),
+            priority: req.priority,
+            preempt_mode: req.preempt_mode.as_deref(),
+            usage_factor: req.usage_factor,
+            max_jobs_per_user: nullable_limit(req.max_jobs_per_user, "max_jobs_per_user")?,
+            max_wall_min: nullable_limit(req.max_wall_minutes, "max_wall_minutes")?,
+            max_tres_per_job: nullable_str(&req.max_tres_per_job),
+            max_submit_per_user: nullable_limit(
+                req.max_submit_jobs_per_user,
+                "max_submit_jobs_per_user",
+            )?,
+            max_tres_per_user: nullable_str(&req.max_tres_per_user),
+            grp_tres: nullable_str(&req.grp_tres),
+            grp_wall_min: nullable_limit(req.grp_wall_minutes, "grp_wall_minutes")?,
         };
-        let max_wall = if req.max_wall_minutes == 0 {
-            None
-        } else {
-            Some(
-                i32::try_from(req.max_wall_minutes)
-                    .map_err(|_| Status::invalid_argument("max_wall_minutes exceeds i32::MAX"))?,
-            )
-        };
-        let max_tres = if req.max_tres_per_job.is_empty() {
-            None
-        } else {
-            Some(req.max_tres_per_job.as_str())
-        };
-        let max_submit = if req.max_submit_jobs_per_user == 0 {
-            None
-        } else {
-            Some(i32::try_from(req.max_submit_jobs_per_user).map_err(|_| {
-                Status::invalid_argument("max_submit_jobs_per_user exceeds i32::MAX")
-            })?)
-        };
-        let max_tres_user = if req.max_tres_per_user.is_empty() {
-            None
-        } else {
-            Some(req.max_tres_per_user.as_str())
-        };
-        let grp_tres = if req.grp_tres.is_empty() {
-            None
-        } else {
-            Some(req.grp_tres.as_str())
-        };
-        let grp_wall = if req.grp_wall_minutes == 0 {
-            None
-        } else {
-            Some(
-                i32::try_from(req.grp_wall_minutes)
-                    .map_err(|_| Status::invalid_argument("grp_wall_minutes exceeds i32::MAX"))?,
-            )
-        };
-        db::upsert_qos(
-            &self.pool,
-            &req.name,
-            &req.description,
-            req.priority,
-            &req.preempt_mode,
-            req.usage_factor,
-            max_jobs,
-            max_wall,
-            max_tres,
-            max_submit,
-            max_tres_user,
-            grp_tres,
-            grp_wall,
-        )
-        .await
-        .map_err(|e| Status::internal(e.to_string()))?;
+        db::upsert_qos(&self.pool, &req.name, update)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
         Ok(Response::new(()))
     }
 
@@ -685,5 +645,34 @@ mod tests {
     fn validate_tres_rejects_unknown_type() {
         let err = validate_tres("maxtresperuser", "bogus=5").unwrap_err();
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn fairshare_to_i32_accepts_whole_numbers() {
+        assert_eq!(fairshare_to_i32(0.0).unwrap(), 0);
+        assert_eq!(fairshare_to_i32(2.0).unwrap(), 2);
+        assert_eq!(fairshare_to_i32(f64::from(i32::MAX)).unwrap(), i32::MAX);
+    }
+
+    #[test]
+    fn fairshare_to_i32_rejects_fractional_instead_of_truncating() {
+        // The bug this guards: 2.9 must not silently become 2.
+        let err = fairshare_to_i32(2.9).unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(err.message().contains("whole number"));
+    }
+
+    #[test]
+    fn fairshare_to_i32_rejects_negative_and_out_of_range() {
+        assert_eq!(
+            fairshare_to_i32(-1.0).unwrap_err().code(),
+            tonic::Code::InvalidArgument
+        );
+        assert_eq!(
+            fairshare_to_i32(f64::from(i32::MAX) + 1.0)
+                .unwrap_err()
+                .code(),
+            tonic::Code::InvalidArgument
+        );
     }
 }

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -1066,14 +1066,18 @@ message ReportJobStatusRequest {
 // Account/User/QOS Management (sacctmgr)
 // ============================================================
 
+// Add or modify an account (proto3 presence: unset = leave unchanged on modify,
+// set = write; `add` sets every field). Empty/0 clears parent_account, grp_tres,
+// and max_running_jobs to NULL; description, organization, and fairshare_weight
+// store their literal value (0 is a real weight, not a clear).
 message CreateAccountRequest {
   string name = 1;
-  string description = 2;
-  string organization = 3;
-  string parent_account = 4;
-  double fairshare_weight = 5;
-  uint32 max_running_jobs = 6;
-  string grp_tres = 7;
+  optional string description = 2;
+  optional string organization = 3;
+  optional string parent_account = 4;
+  optional double fairshare_weight = 5;
+  optional uint32 max_running_jobs = 6;
+  optional string grp_tres = 7;
 }
 
 message DeleteAccountRequest {
@@ -1096,27 +1100,29 @@ message AccountInfo {
   string grp_tres = 7;
 }
 
+// Add or modify a user-account association (proto3 presence: unset = leave
+// unchanged on modify, set = write; `add` sets every field). The limit/QOS
+// fields below are nullable and clear to NULL when set empty/0; admin_level is
+// non-nullable, storing the literal sent (unset keeps it, 'none' on create).
 message AddUserRequest {
   string user = 1;
   string account = 2;
-  string admin_level = 3;
-  bool is_default = 4;
-  // Default QOS for this user's association with `account`. Like every
-  // other field here, this is a full resend on upsert, not a partial
-  // patch: empty clears an existing default (matches modify account/qos).
-  string default_qos = 5;
-  // Association-level resource limits for `user` within `account`. Same
-  // full-resend semantics as default_qos: 0/empty clears an existing
-  // limit rather than leaving it unchanged.
-  uint32 max_running_jobs = 6;
-  uint32 max_submit_jobs = 7;
-  string max_tres_per_job = 8;
-  string grp_tres = 9;
-  uint32 max_wall_minutes = 10;
-  // Comma-separated QOS names this association may use. Same full-resend
-  // semantics: empty clears an existing allow-list back to unrestricted.
-  // default_qos must be a member when both are set.
-  string allowed_qos = 11;
+  optional string admin_level = 3;
+  optional bool is_default = 4;
+  // Default QOS for this user's association with `account`. Unset preserves
+  // the stored default; explicit empty clears it.
+  optional string default_qos = 5;
+  // Association-level resource limits for `user` within `account`. Unset
+  // preserves the stored limit; an explicit 0/empty clears it (no limit).
+  optional uint32 max_running_jobs = 6;
+  optional uint32 max_submit_jobs = 7;
+  optional string max_tres_per_job = 8;
+  optional string grp_tres = 9;
+  optional uint32 max_wall_minutes = 10;
+  // Comma-separated QOS names this association may use. Unset preserves the
+  // stored allow-list; explicit empty clears it back to unrestricted.
+  // default_qos must be a member when both are set in the same request.
+  optional string allowed_qos = 11;
 }
 
 message RemoveUserRequest {
@@ -1142,19 +1148,23 @@ message UserInfo {
   string allowed_qos = 6;
 }
 
+// Add or modify a QOS (proto3 presence: unset = leave unchanged on modify, set =
+// write; `add` sets every field). Empty/0 clears the nullable limits
+// (max_*_per_user, *_wall_minutes, max_tres_*, grp_tres) to NULL; description,
+// preempt_mode, priority, and usage_factor store their literal value (0 is real).
 message CreateQosRequest {
   string name = 1;
-  string description = 2;
-  int32 priority = 3;
-  string preempt_mode = 4;
-  double usage_factor = 5;
-  uint32 max_jobs_per_user = 6;
-  uint32 max_wall_minutes = 7;
-  string max_tres_per_job = 8;
-  uint32 max_submit_jobs_per_user = 9;
-  string max_tres_per_user = 10;
-  string grp_tres = 11;
-  uint32 grp_wall_minutes = 12;
+  optional string description = 2;
+  optional int32 priority = 3;
+  optional string preempt_mode = 4;
+  optional double usage_factor = 5;
+  optional uint32 max_jobs_per_user = 6;
+  optional uint32 max_wall_minutes = 7;
+  optional string max_tres_per_job = 8;
+  optional uint32 max_submit_jobs_per_user = 9;
+  optional string max_tres_per_user = 10;
+  optional string grp_tres = 11;
+  optional uint32 grp_wall_minutes = 12;
 }
 
 message DeleteQosRequest {

--- a/tests/native_host/e2e/test_accounting.py
+++ b/tests/native_host/e2e/test_accounting.py
@@ -685,6 +685,84 @@ class TestSacctmgrQosAuthorization:
         c.scancel(str(job_id))
 
 
+class TestSacctmgrModifyPartialPatch:
+    """SPUR-96: `sacctmgr modify` restates only the fields it names; every
+    unstated field keeps its stored value, and an explicitly empty field
+    clears it. Covers accounts and QOS (the user-QOS case is covered by
+    TestSacctmgrQosAuthorization)."""
+
+    def _row(self, cluster, entity_show_args, needle):
+        out = cluster.sacctmgr(entity_show_args)
+        return next(
+            (line for line in out.splitlines() if needle in line),
+            None,
+        )
+
+    def test_modify_account_preserves_unstated_fields_and_clears_explicit(
+        self, accounting_cluster
+    ):
+        c = accounting_cluster
+        c.sacctmgr(
+            [
+                "add",
+                "account",
+                "name=patchacct",
+                "description=PhysicsDept",
+                "organization=Science",
+                "grptres=cpu=32",
+            ]
+        )
+
+        # Unrelated modify: only fairshare is restated. grptres/description
+        # must survive (the SPUR-96 regression).
+        c.sacctmgr(["modify", "account", "name=patchacct", "set", "fairshare=7"])
+        row = self._row(c, ["show", "account"], "patchacct")
+        assert row is not None, "patchacct not found after modify"
+        assert "cpu=32" in row, f"grptres cleared by an unrelated modify: {row!r}"
+        assert "PhysicsDept" in row, f"description cleared by an unrelated modify: {row!r}"
+        assert "7" in row.split(), f"fairshare not applied: {row!r}"
+
+        # Explicit empty grptres clears just that field; description survives.
+        c.sacctmgr(["modify", "account", "name=patchacct", "set", "grptres="])
+        row = self._row(c, ["show", "account"], "patchacct")
+        assert row is not None
+        assert "cpu=32" not in row, f"explicit grptres= did not clear it: {row!r}"
+        assert "PhysicsDept" in row, f"description lost on explicit grptres clear: {row!r}"
+
+    def test_modify_qos_preserves_unstated_limits_and_clears_explicit(
+        self, accounting_cluster
+    ):
+        c = accounting_cluster
+        c.sacctmgr(
+            [
+                "add",
+                "qos",
+                "name=patchqos",
+                "priority=10",
+                "grptres=cpu=32",
+                "maxwall=30",
+            ]
+        )
+
+        fmt = "format=Name,Priority,GrpTRES,MaxWall"
+        # Unrelated modify: only priority is restated. grptres/maxwall must
+        # survive.
+        c.sacctmgr(["modify", "qos", "name=patchqos", "set", "priority=99"])
+        row = self._row(c, ["show", "qos", fmt], "patchqos")
+        assert row is not None, "patchqos not found after modify"
+        assert "cpu=32" in row, f"grptres cleared by an unrelated modify: {row!r}"
+        assert "30" in row.split(), f"maxwall cleared by an unrelated modify: {row!r}"
+        assert "99" in row.split(), f"priority not applied: {row!r}"
+
+        # Explicit empty grptres clears just that field; maxwall/priority stay.
+        c.sacctmgr(["modify", "qos", "name=patchqos", "set", "grptres="])
+        row = self._row(c, ["show", "qos", fmt], "patchqos")
+        assert row is not None
+        assert "cpu=32" not in row, f"explicit grptres= did not clear it: {row!r}"
+        assert "30" in row.split(), f"maxwall lost on explicit grptres clear: {row!r}"
+        assert "99" in row.split(), f"priority lost on explicit grptres clear: {row!r}"
+
+
 class TestSacctmgrInvalidInput:
     def test_add_qos_with_non_numeric_limit_fails_cleanly(self, accounting_cluster):
         c = accounting_cluster

--- a/tests/native_host/e2e/test_accounting.py
+++ b/tests/native_host/e2e/test_accounting.py
@@ -686,9 +686,9 @@ class TestSacctmgrQosAuthorization:
 
 
 class TestSacctmgrModifyPartialPatch:
-    """SPUR-96: `sacctmgr modify` restates only the fields it names; every
-    unstated field keeps its stored value, and an explicitly empty field
-    clears it. Covers accounts and QOS (the user-QOS case is covered by
+    """`sacctmgr modify` restates only the fields it names; every unstated
+    field keeps its stored value, and an explicitly empty field clears it.
+    Covers accounts and QOS (the user-QOS case is covered by
     TestSacctmgrQosAuthorization)."""
 
     def _row(self, cluster, entity_show_args, needle):
@@ -713,8 +713,8 @@ class TestSacctmgrModifyPartialPatch:
             ]
         )
 
-        # Unrelated modify: only fairshare is restated. grptres/description
-        # must survive (the SPUR-96 regression).
+        # Unrelated modify: only fairshare is restated; grptres/description
+        # must survive.
         c.sacctmgr(["modify", "account", "name=patchacct", "set", "fairshare=7"])
         row = self._row(c, ["show", "account"], "patchacct")
         assert row is not None, "patchacct not found after modify"


### PR DESCRIPTION
## Summary

`sacctmgr modify <entity> set <field>=<val>` reset every field the command
didn't mention back to its default instead of leaving it untouched — so
changing one attribute silently wiped the rest ([SPUR-96]). This makes
`modify` a true partial patch and hardens the accounting write path around it.

## Approach

Partial-patch semantics, end to end:

- **CLI** (`sacctmgr`) sends only the fields the user restated, via proto3
  field presence; `add` still sets everything.
- **Proto** marks settable fields `optional` — unset means "leave unchanged",
  set means "write" (per-field clear-vs-store semantics documented inline).
- **Controller** maps that presence onto a dynamic `INSERT ... ON CONFLICT DO
  UPDATE` that touches only the provided columns and preserves the rest with
  `COALESCE`/`CASE`.

## Also in this PR

- **One default account per user**: enforced with a partial unique index plus a
  dedup + column-drop backfill in `migrate()`, serialized by a
  transaction-scoped advisory lock. `add_user` demotes the user's other rows
  before the upsert. Drops the redundant, write-only `associations.is_default`
  so `users.default_account` is the single source of truth.
- **QOS allow-list validation** collapsed from N+1 lookups to one batch query.
- **SQL-injection hardening**: table and conflict targets are closed enums, so
  dynamically built SQL can only ever splice known literals.
- **Fail-loud parsing**: bad numeric fields error instead of silently
  defaulting; fairshare rejects fractional/out-of-range values instead of
  truncating; errors name the exact alias the user typed.
- **Dead code**: removed the unused `spur-core::Association` type.
- **CI**: a new `test-db` job runs the (normally `#[ignore]`d) accounting DB
  tests against an ephemeral, pinned, secret-free Postgres service.

## Design notes

- Kept `users.default_account` denormalized (dropped the duplicate flag rather
  than normalizing into its own table) — removes drift with a minimal change.
- The migration rewrites data and rebuilds the index in a single transaction
  under a fixed advisory lock, so HA controllers can't apply it concurrently.

## Testing

- `cargo clippy` (no warnings), `cargo fmt --check`, and `cargo test`.
- Accounting DB integration tests against a real Postgres: partial-patch
  preservation, default-account demotion, the migration/dedup upgrade path,
  concurrent `migrate()` serialization, and batch QOS validation.
- e2e accounting tests assert `modify` leaves unrelated fields intact.

[SPUR-96]: https://amd.atlassian.net/browse/SPUR-96