### PR TITLE
feat(mpi): fix single-node PMIx modex and mpirun launch

### DIFF
--- a/crates/spur-core/src/mpi.rs
+++ b/crates/spur-core/src/mpi.rs
@@ -251,6 +251,11 @@ mod tests {
         assert_eq!(plan.local_procs.len(), 4);
         assert_eq!(plan.local_procs[0].rank, 0);
         assert_eq!(plan.local_procs[3].rank, 3);
+        assert_eq!(plan.job_uid, 1000);
+        assert_eq!(plan.job_gid, 1000);
+        let proto = plan_to_proto(plan);
+        assert_eq!(proto.job_uid, 1000);
+        assert_eq!(proto.job_gid, 1000);
     }
 
     #[test]

--- a/crates/spur-core/src/mpi.rs
+++ b/crates/spur-core/src/mpi.rs
@@ -19,6 +19,8 @@ pub struct PmixLaunchPlan {
     pub task_offset: u32,
     pub local_procs: Vec<PmixLocalProc>,
     pub tmpdir: String,
+    pub job_uid: u32,
+    pub job_gid: u32,
 }
 
 impl PmixLaunchPlan {
@@ -33,6 +35,8 @@ impl PmixLaunchPlan {
         task_offset: u32,
         local_count: u32,
         tmpdir: impl Into<String>,
+        job_uid: u32,
+        job_gid: u32,
     ) -> Self {
         let local_procs = (0..local_count)
             .map(|local_rank| PmixLocalProc {
@@ -47,6 +51,8 @@ impl PmixLaunchPlan {
             task_offset,
             local_procs,
             tmpdir: tmpdir.into(),
+            job_uid,
+            job_gid,
         }
     }
 }
@@ -111,23 +117,30 @@ pub fn validate_pmix_plan(plan: &PmixLaunchPlan) -> Result<(), String> {
     Ok(())
 }
 
-pub fn maybe_local_pmix_plan(
-    mpi: &str,
-    job_id: u32,
-    universe_size: u32,
-    task_offset: u32,
-    local_count: u32,
-    tmpdir: impl Into<String>,
-) -> Option<PmixLaunchPlan> {
+/// Per-agent inputs for building a PMIx launch plan on the controller.
+#[derive(Debug, Clone)]
+pub struct PmixLocalDispatch {
+    pub job_id: u32,
+    pub universe_size: u32,
+    pub task_offset: u32,
+    pub local_count: u32,
+    pub tmpdir: String,
+    pub job_uid: u32,
+    pub job_gid: u32,
+}
+
+pub fn maybe_local_pmix_plan(mpi: &str, dispatch: PmixLocalDispatch) -> Option<PmixLaunchPlan> {
     if mpi != MPI_PMIX {
         return None;
     }
     Some(PmixLaunchPlan::local_tasks(
-        job_id,
-        universe_size,
-        task_offset,
-        local_count,
-        tmpdir,
+        dispatch.job_id,
+        dispatch.universe_size,
+        dispatch.task_offset,
+        dispatch.local_count,
+        dispatch.tmpdir,
+        dispatch.job_uid,
+        dispatch.job_gid,
     ))
 }
 
@@ -197,6 +210,8 @@ pub fn plan_to_proto(plan: PmixLaunchPlan) -> spur_proto::proto::PmixLaunchPlan 
             })
             .collect(),
         tmpdir: plan.tmpdir,
+        job_uid: plan.job_uid,
+        job_gid: plan.job_gid,
     }
 }
 
@@ -230,7 +245,7 @@ mod tests {
 
     #[test]
     fn local_tasks_plan() {
-        let plan = PmixLaunchPlan::local_tasks(42, 4, 0, 4, "/tmp/pmix");
+        let plan = PmixLaunchPlan::local_tasks(42, 4, 0, 4, "/tmp/pmix", 1000, 1000);
         assert_eq!(plan.namespace, "spur.42");
         assert_eq!(plan.universe_size, 4);
         assert_eq!(plan.local_procs.len(), 4);
@@ -282,7 +297,7 @@ mod tests {
 
     #[test]
     fn validate_pmix_plan_rejects_empty_tmpdir() {
-        let mut plan = PmixLaunchPlan::local_tasks(1, 1, 0, 1, "/tmp/pmix");
+        let mut plan = PmixLaunchPlan::local_tasks(1, 1, 0, 1, "/tmp/pmix", 0, 0);
         plan.tmpdir.clear();
         assert!(validate_pmix_plan(&plan).is_err());
     }
@@ -305,6 +320,8 @@ mod tests {
                 },
             ],
             tmpdir: "/tmp/pmix".into(),
+            job_uid: 0,
+            job_gid: 0,
         };
         assert!(validate_pmix_plan(&plan).is_err());
     }
@@ -327,6 +344,8 @@ mod tests {
                 },
             ],
             tmpdir: "/tmp/pmix".into(),
+            job_uid: 0,
+            job_gid: 0,
         };
         assert!(validate_pmix_plan(&plan).is_err());
     }

--- a/crates/spur-core/src/task_launch.rs
+++ b/crates/spur-core/src/task_launch.rs
@@ -276,8 +276,49 @@ pub fn wrap_command_with_cpu_bind(
     }
 }
 
+/// Bash prefix shared by PMIx/Open MPI launch wrappers.
+///
+/// Open MPI 4.x expects `PMIX_SERVER_URI4`/`URI3`; the same aliases exist in
+/// `spurd::mpi_plugin` and `crates/spur-mpi-pmix/c/pmix_server.c`.
+fn mpi_launch_preamble() -> &'static str {
+    concat!(
+        "if [ -z \"${SPUR_MPIRUN:-}\" ]; then\n",
+        "  if command -v mpirun >/dev/null 2>&1; then SPUR_MPIRUN=$(command -v mpirun)\n",
+        "  elif [ -n \"${OPAL_PREFIX:-}\" ] && [ -x \"${OPAL_PREFIX}/bin/mpirun\" ]; then SPUR_MPIRUN=\"${OPAL_PREFIX}/bin/mpirun\"\n",
+        "  else SPUR_MPIRUN=mpirun; fi\n",
+        "fi\n",
+        "export PMIX_SERVER_URI4=${PMIX_SERVER_URI4:-$PMIX_SERVER_URI}\n",
+        "export PMIX_SERVER_URI3=${PMIX_SERVER_URI3:-$PMIX_SERVER_URI}\n",
+        "while IFS= read -r _v; do unset \"$_v\"; done < <(env | sed -n 's/^\\(SLURM_[^=]*\\)=.*/\\1/p')\n",
+    )
+}
+
+/// Launch multi-rank MPI jobs via a single `mpirun` instead of forking independent
+/// processes. Open MPI 4.x direct-launched tasks otherwise spawn per-process PMIx
+/// servers and never form a shared `MPI_COMM_WORLD`.
+pub fn build_mpi_mpirun_wrapper(user_script_path: &str, tasks_on_node: u32) -> String {
+    let escaped = user_script_path.replace('"', "\\\"");
+    format!(
+        concat!(
+            "#!/bin/bash\n",
+            "_TASKS_ON_NODE={tasks_on_node}\n",
+            "{preamble}",
+            "if [ \"$SPUR_LABEL\" = \"1\" ]; then\n",
+            "  exec \"$SPUR_MPIRUN\" -np \"$_TASKS_ON_NODE\" --bind-to none --tag-output \"{escaped}\"\n",
+            "else\n",
+            "  exec \"$SPUR_MPIRUN\" -np \"$_TASKS_ON_NODE\" --bind-to none \"{escaped}\"\n",
+            "fi\n",
+        ),
+        tasks_on_node = tasks_on_node,
+        preamble = mpi_launch_preamble(),
+        escaped = escaped,
+    )
+}
+
 /// Build a bash wrapper that forks `tasks_on_node` copies of `user_script_path`,
 /// assigning distinct `LOCAL_RANK` / `SLURM_PROCID` values in each fork.
+///
+/// When `mpi_bootstrap` is true, uses [`build_mpi_mpirun_wrapper`] instead.
 ///
 /// Output labeling is controlled at runtime via the `SPUR_LABEL=1` environment
 /// variable (matching batch `launch_job` and srun `-l`).
@@ -287,6 +328,9 @@ pub fn build_multi_task_wrapper(
     environment: Option<&HashMap<String, String>>,
     mpi_bootstrap: bool,
 ) -> String {
+    if mpi_bootstrap {
+        return build_mpi_mpirun_wrapper(user_script_path, tasks_on_node);
+    }
     let escaped = user_script_path.replace('"', "\\\"");
     let bind = environment.map(parse_cpu_bind).unwrap_or(CpuBind::None);
     let map_cpus: Vec<&str> = match &bind {
@@ -310,12 +354,6 @@ pub fn build_multi_task_wrapper(
     wrapper.push_str("for LOCAL_RANK in $(seq 0 $((_TASKS_ON_NODE - 1))); do\n");
     wrapper.push_str("  export LOCAL_RANK\n");
     wrapper.push_str(SpurEnv::per_task_bash_exports());
-    if mpi_bootstrap {
-        wrapper.push_str("  export PMI_RANK=$SPUR_PROCID\n");
-        wrapper.push_str("  export PMIX_RANK=$SPUR_PROCID\n");
-        wrapper.push_str("  export OMPI_COMM_WORLD_RANK=$SPUR_PROCID\n");
-        wrapper.push_str("  export OMPI_COMM_WORLD_LOCAL_RANK=$LOCAL_RANK\n");
-    }
 
     wrapper.push_str("  if [ -n \"$SPUR_JOB_GPUS\" ]; then\n");
     wrapper.push_str("    IFS=',' read -ra _ALL_GPUS <<< \"$SPUR_JOB_GPUS\"\n");
@@ -448,6 +486,22 @@ mod tests {
         let script = build_multi_task_wrapper("/tmp/work.sh", 1, None, false);
         assert!(script.contains("SPUR_LABEL"));
         assert!(script.contains("sed \"s/^/[$SPUR_PROCID] /\""));
+    }
+
+    #[test]
+    fn mpi_wrapper_uses_mpirun_not_fork() {
+        let script = build_multi_task_wrapper("/tmp/hello_mpi", 4, None, true);
+        assert!(script.contains("\"$SPUR_MPIRUN\" -np \"$_TASKS_ON_NODE\""));
+        assert!(script.contains("_TASKS_ON_NODE=4"));
+        assert!(script.contains("PMIX_SERVER_URI4"));
+        assert!(script.contains("unset \"$_v\""));
+        assert!(!script.contains("for LOCAL_RANK in"));
+    }
+
+    #[test]
+    fn mpi_wrapper_tag_output_when_labeled() {
+        let script = build_multi_task_wrapper("/tmp/hello_mpi", 4, None, true);
+        assert!(script.contains("--tag-output"));
     }
 
     #[test]

--- a/crates/spur-core/src/task_launch.rs
+++ b/crates/spur-core/src/task_launch.rs
@@ -87,6 +87,30 @@ pub fn apply_gpu_bind_env(
     target.insert("GPU_DEVICE_ORDINAL".into(), visible);
 }
 
+/// True when env requests CPU bind that the single-`mpirun` PMIx wrapper does not apply.
+pub fn mpi_mpirun_skips_cpu_bind(source: &HashMap<String, String>) -> bool {
+    matches!(
+        source
+            .get("SPUR_CPU_BIND")
+            .or_else(|| source.get("SLURM_CPU_BIND")),
+        Some(bind) if !bind.is_empty() && !bind.eq_ignore_ascii_case("none")
+    )
+}
+
+/// True when env requests GPU bind that the single-`mpirun` PMIx wrapper does not apply.
+pub fn mpi_mpirun_skips_gpu_bind(source: &HashMap<String, String>) -> bool {
+    let Some(bind_str) = source
+        .get("SPUR_GPU_BIND")
+        .or_else(|| source.get("SLURM_GPU_BIND"))
+    else {
+        return false;
+    };
+    if bind_str.is_empty() || bind_str.eq_ignore_ascii_case("none") {
+        return false;
+    }
+    !matches!(bind_str.parse::<GpuBind>(), Ok(GpuBind::None))
+}
+
 /// Return the CPU bind string when step mode cannot enforce topology-based binds.
 pub fn unsupported_cpu_bind(source: &HashMap<String, String>) -> Option<String> {
     let bind_str = source
@@ -515,6 +539,19 @@ mod tests {
     fn mpi_wrapper_tag_output_when_labeled() {
         let script = build_multi_task_wrapper("/tmp/hello_mpi", 4, None, true);
         assert!(script.contains("--tag-output"));
+    }
+
+    #[test]
+    fn mpi_mpirun_skips_cpu_and_gpu_bind_detection() {
+        let mut env = HashMap::new();
+        assert!(!mpi_mpirun_skips_cpu_bind(&env));
+        assert!(!mpi_mpirun_skips_gpu_bind(&env));
+        env.insert("SPUR_CPU_BIND".into(), "rank".into());
+        assert!(mpi_mpirun_skips_cpu_bind(&env));
+        env.insert("SPUR_GPU_BIND".into(), "map_gpu:0,1".into());
+        assert!(mpi_mpirun_skips_gpu_bind(&env));
+        env.insert("SPUR_CPU_BIND".into(), "none".into());
+        assert!(!mpi_mpirun_skips_cpu_bind(&env));
     }
 
     #[test]

--- a/crates/spur-core/src/task_launch.rs
+++ b/crates/spur-core/src/task_launch.rs
@@ -276,6 +276,11 @@ pub fn wrap_command_with_cpu_bind(
     }
 }
 
+/// Wrap `value` in single quotes for safe embedding in generated bash scripts.
+fn bash_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
 /// Bash prefix shared by PMIx/Open MPI launch wrappers.
 ///
 /// Open MPI 4.x expects `PMIX_SERVER_URI4`/`URI3`; the same aliases exist in
@@ -297,21 +302,21 @@ fn mpi_launch_preamble() -> &'static str {
 /// processes. Open MPI 4.x direct-launched tasks otherwise spawn per-process PMIx
 /// servers and never form a shared `MPI_COMM_WORLD`.
 pub fn build_mpi_mpirun_wrapper(user_script_path: &str, tasks_on_node: u32) -> String {
-    let escaped = user_script_path.replace('"', "\\\"");
+    let quoted = bash_single_quote(user_script_path);
     format!(
         concat!(
             "#!/bin/bash\n",
             "_TASKS_ON_NODE={tasks_on_node}\n",
             "{preamble}",
             "if [ \"$SPUR_LABEL\" = \"1\" ]; then\n",
-            "  exec \"$SPUR_MPIRUN\" -np \"$_TASKS_ON_NODE\" --bind-to none --tag-output \"{escaped}\"\n",
+            "  exec \"$SPUR_MPIRUN\" -np \"$_TASKS_ON_NODE\" --bind-to none --tag-output {quoted}\n",
             "else\n",
-            "  exec \"$SPUR_MPIRUN\" -np \"$_TASKS_ON_NODE\" --bind-to none \"{escaped}\"\n",
+            "  exec \"$SPUR_MPIRUN\" -np \"$_TASKS_ON_NODE\" --bind-to none {quoted}\n",
             "fi\n",
         ),
         tasks_on_node = tasks_on_node,
         preamble = mpi_launch_preamble(),
-        escaped = escaped,
+        quoted = quoted,
     )
 }
 
@@ -495,7 +500,15 @@ mod tests {
         assert!(script.contains("_TASKS_ON_NODE=4"));
         assert!(script.contains("PMIX_SERVER_URI4"));
         assert!(script.contains("unset \"$_v\""));
+        assert!(script.contains("'/tmp/hello_mpi'"));
         assert!(!script.contains("for LOCAL_RANK in"));
+    }
+
+    #[test]
+    fn mpi_wrapper_single_quotes_user_script() {
+        let script = build_mpi_mpirun_wrapper("$(rm -rf /)", 2);
+        assert!(script.contains("'$(rm -rf /)'"));
+        assert!(!script.contains("$(rm -rf /)\""));
     }
 
     #[test]

--- a/crates/spur-mpi-pmix/Cargo.toml
+++ b/crates/spur-mpi-pmix/Cargo.toml
@@ -6,8 +6,7 @@ license.workspace = true
 publish = false
 
 [lib]
-crate-type = ["cdylib"]
-name = "spur_mpi_pmix"
+path = "src/lib.rs"
 
 [build-dependencies]
 cc = "1"

--- a/crates/spur-mpi-pmix/build.rs
+++ b/crates/spur-mpi-pmix/build.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 fn release_target_dir() -> PathBuf {
     let base = std::env::var("CARGO_TARGET_DIR")
@@ -11,7 +11,13 @@ fn release_target_dir() -> PathBuf {
                 .join("../../target")
         });
     let profile = std::env::var("PROFILE").unwrap_or_else(|_| "debug".into());
-    base.join(profile)
+    let mut dir = base.join(profile);
+    if let (Ok(target), Ok(host)) = (std::env::var("TARGET"), std::env::var("HOST")) {
+        if target != host {
+            dir = dir.join(target);
+        }
+    }
+    dir
 }
 
 fn pkg_config_link_other(lib: &str) -> Vec<String> {
@@ -30,7 +36,7 @@ fn pkg_config_link_other(lib: &str) -> Vec<String> {
 }
 
 fn copy_plugin(
-    out_dir: &PathBuf,
+    out_dir: &Path,
     archive_name: &str,
     pmix_libs: &[String],
     pmix_link_paths: &[PathBuf],
@@ -41,13 +47,10 @@ fn copy_plugin(
     let target_dir = release_target_dir();
 
     let mut cmd = cc::Build::new().get_compiler().to_command();
-    cmd.arg("-shared")
-        .arg("-o")
-        .arg(&built)
-        .arg(format!(
-            "-Wl,--whole-archive,{},--no-whole-archive",
-            archive.display()
-        ));
+    cmd.arg("-shared").arg("-o").arg(&built).arg(format!(
+        "-Wl,--whole-archive,{},--no-whole-archive",
+        archive.display()
+    ));
     for link_path in pmix_link_paths {
         cmd.arg(format!("-L{}", link_path.display()));
     }

--- a/crates/spur-mpi-pmix/build.rs
+++ b/crates/spur-mpi-pmix/build.rs
@@ -1,21 +1,102 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::path::PathBuf;
+
+fn release_target_dir() -> PathBuf {
+    let base = std::env::var("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"))
+                .join("../../target")
+        });
+    let profile = std::env::var("PROFILE").unwrap_or_else(|_| "debug".into());
+    base.join(profile)
+}
+
+fn pkg_config_link_other(lib: &str) -> Vec<String> {
+    std::process::Command::new("pkg-config")
+        .args(["--libs-only-other", lib])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| {
+            String::from_utf8_lossy(&output.stdout)
+                .split_whitespace()
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn copy_plugin(
+    out_dir: &PathBuf,
+    archive_name: &str,
+    pmix_libs: &[String],
+    pmix_link_paths: &[PathBuf],
+    pmix_link_other: &[String],
+) {
+    let archive = out_dir.join(format!("lib{archive_name}.a"));
+    let built = out_dir.join("libspur_mpi_pmix.so");
+    let target_dir = release_target_dir();
+
+    let mut cmd = cc::Build::new().get_compiler().to_command();
+    cmd.arg("-shared")
+        .arg("-o")
+        .arg(&built)
+        .arg(format!(
+            "-Wl,--whole-archive,{},--no-whole-archive",
+            archive.display()
+        ));
+    for link_path in pmix_link_paths {
+        cmd.arg(format!("-L{}", link_path.display()));
+    }
+    for arg in pmix_link_other {
+        cmd.arg(arg);
+    }
+    for lib in pmix_libs {
+        cmd.arg(format!("-l{lib}"));
+    }
+    cmd.arg("-pthread");
+    if !cmd.status().expect("link spur_mpi_pmix.so").success() {
+        panic!("failed to link {built:?}");
+    }
+
+    let release_lib = target_dir.join("libspur_mpi_pmix.so");
+    let plugin_name = target_dir.join("spur_mpi_pmix.so");
+    std::fs::copy(&built, &release_lib).expect("copy libspur_mpi_pmix.so to target dir");
+    std::fs::copy(&built, &plugin_name).expect("copy spur_mpi_pmix.so to target dir");
+}
+
 fn main() {
     println!("cargo:rerun-if-changed=c/pmix_server.c");
     println!("cargo:rerun-if-changed=c/stub_server.c");
     println!("cargo:rerun-if-changed=include/spur_mpi_plugin.h");
 
-    let include = std::path::Path::new("include");
-    let mut build = cc::Build::new();
-    build.include(include);
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR"));
 
-    if pkg_config::Config::new().probe("pmix").is_ok() {
+    let mut build = cc::Build::new();
+    build.pic(true);
+    build.include("include");
+    build.cargo_metadata(false);
+
+    if let Ok(pmix) = pkg_config::Config::new().probe("pmix") {
+        let link_other = pkg_config_link_other("pmix");
+        for include in &pmix.include_paths {
+            build.include(include);
+        }
         build.file("c/pmix_server.c");
         build.compile("spur_mpi_pmix_server");
-        println!("cargo:rustc-cfg=spur_pmix_linked");
+        copy_plugin(
+            &out_dir,
+            "spur_mpi_pmix_server",
+            &pmix.libs,
+            &pmix.link_paths,
+            &link_other,
+        );
     } else {
         build.file("c/stub_server.c");
         build.compile("spur_mpi_pmix_stub");
+        copy_plugin(&out_dir, "spur_mpi_pmix_stub", &[], &[], &[]);
     }
 }

--- a/crates/spur-mpi-pmix/c/pmix_server.c
+++ b/crates/spur-mpi-pmix/c/pmix_server.c
@@ -180,14 +180,31 @@ static void spur_deregister_nspace(const char *namespace_) {
 #endif
 }
 
+static uid_t spur_job_uid(const spur_mpi_launch_plan_t *plan) {
+    return plan->job_uid != SPUR_MPI_JOB_CRED_UNSET ? (uid_t)plan->job_uid : getuid();
+}
+
+static gid_t spur_job_gid(const spur_mpi_launch_plan_t *plan) {
+    return plan->job_gid != SPUR_MPI_JOB_CRED_UNSET ? (gid_t)plan->job_gid : getgid();
+}
+
+static void spur_deregister_client(const pmix_proc_t *proc) {
+    PMIx_server_deregister_client(proc, NULL, NULL);
+}
+
 static pmix_status_t spur_register_clients(const spur_mpi_launch_plan_t *plan) {
-    uid_t uid = getuid();
-    gid_t gid = getgid();
+    uid_t uid = spur_job_uid(plan);
+    gid_t gid = spur_job_gid(plan);
     for (uint32_t i = 0; i < plan->num_local_procs; i++) {
         pmix_proc_t proc;
         PMIX_LOAD_PROCID(&proc, plan->namespace_, plan->local_procs[i].rank);
         pmix_status_t rc = PMIx_server_register_client(&proc, uid, gid, NULL, NULL, NULL);
         if (!pmix_status_ok(rc)) {
+            for (uint32_t j = 0; j < i; j++) {
+                pmix_proc_t prior;
+                PMIX_LOAD_PROCID(&prior, plan->namespace_, plan->local_procs[j].rank);
+                spur_deregister_client(&prior);
+            }
             return rc;
         }
     }

--- a/crates/spur-mpi-pmix/c/pmix_server.c
+++ b/crates/spur-mpi-pmix/c/pmix_server.c
@@ -6,13 +6,19 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <pmix.h>
 #include <pmix_server.h>
+#include <pmix_version.h>
 
 #include "spur_mpi_plugin.h"
 
 #define SPUR_PMIX_MAX_SESSIONS 64
+
+static int pmix_status_ok(pmix_status_t rc) {
+    return rc == PMIX_SUCCESS || rc == PMIX_OPERATION_SUCCEEDED;
+}
 
 typedef struct {
     int active;
@@ -58,7 +64,11 @@ static pmix_status_t spur_client_connected(
     (void)proc;
     (void)server_object;
     if (cbfunc != NULL) {
+#if PMIX_VERSION_MAJOR >= 6
         cbfunc(PMIX_SUCCESS, NULL, 0, cbdata, NULL, NULL);
+#else
+        cbfunc(PMIX_SUCCESS, cbdata);
+#endif
     }
     return PMIX_SUCCESS;
 }
@@ -72,40 +82,23 @@ static pmix_status_t spur_client_finalized(
     (void)proc;
     (void)server_object;
     if (cbfunc != NULL) {
+#if PMIX_VERSION_MAJOR >= 6
         cbfunc(PMIX_SUCCESS, NULL, 0, cbdata, NULL, NULL);
+#else
+        cbfunc(PMIX_SUCCESS, cbdata);
+#endif
     }
     return PMIX_SUCCESS;
 }
 
-static pmix_status_t spur_fence(
-    const pmix_proc_t *proc,
-    const pmix_info_t info[],
-    size_t ninfo,
-    const pmix_proc_t procs[],
-    size_t nprocs,
-    const pmix_info_t directives[],
-    size_t ndirs,
-    pmix_modex_cbfunc_t cbfunc,
-    void *cbdata
-) {
-    (void)proc;
-    (void)info;
-    (void)ninfo;
-    (void)procs;
-    (void)nprocs;
-    (void)directives;
-    (void)ndirs;
-    /* Single-node only; multi-node must synchronize here. */
-    if (cbfunc != NULL) {
-        cbfunc(PMIX_SUCCESS, NULL, 0, cbdata, NULL, NULL);
-    }
-    return PMIX_SUCCESS;
-}
-
+/*
+ * Single-node jobs rely on the PMIx server's internal fence/modex path (GDS).
+ * Overriding fence[_nb] with an empty modex blob prevents clients from exchanging
+ * data and breaks PMIx_Get(PMIX_JOB_SIZE). Multi-node will need a real fence here.
+ */
 static pmix_server_module_t spur_module = {
     .client_connected = spur_client_connected,
     .client_finalized = spur_client_finalized,
-    .fence = spur_fence,
 };
 
 static int ensure_server_init(char *errbuf, size_t errlen) {
@@ -113,7 +106,7 @@ static int ensure_server_init(char *errbuf, size_t errlen) {
         return 0;
     }
     pmix_status_t rc = PMIx_server_init(&spur_module, NULL, 0);
-    if (rc != PMIX_SUCCESS) {
+    if (!pmix_status_ok(rc)) {
         if (errbuf != NULL && errlen > 0) {
             snprintf(errbuf, errlen, "PMIx_server_init failed: %s", PMIx_Error_string(rc));
         }
@@ -144,6 +137,86 @@ static spur_pmix_session_t *alloc_session(const char *namespace_) {
     }
     return NULL;
 }
+
+static pmix_status_t spur_register_nspace(const spur_mpi_launch_plan_t *plan) {
+#if PMIX_VERSION_MAJOR >= 6
+    pmix_proc_t *procs = calloc(plan->num_local_procs, sizeof(pmix_proc_t));
+    if (procs == NULL) {
+        return PMIX_ERR_NOMEM;
+    }
+    for (uint32_t i = 0; i < plan->num_local_procs; i++) {
+        PMIX_LOAD_PROCID(&procs[i], plan->namespace_, plan->local_procs[i].rank);
+    }
+    pmix_status_t rc = PMIx_server_register_nspace(
+        plan->namespace_,
+        plan->universe_size,
+        procs,
+        NULL,
+        0
+    );
+    free(procs);
+    return rc;
+#else
+    pmix_info_t info[2];
+    uint32_t local_size = plan->num_local_procs;
+    PMIX_INFO_LOAD(&info[0], PMIX_JOB_SIZE, &plan->universe_size, PMIX_UINT32);
+    PMIX_INFO_LOAD(&info[1], PMIX_LOCAL_SIZE, &local_size, PMIX_UINT32);
+    return PMIx_server_register_nspace(
+        plan->namespace_,
+        (int)plan->num_local_procs,
+        info,
+        2,
+        NULL,
+        NULL
+    );
+#endif
+}
+
+static void spur_deregister_nspace(const char *namespace_) {
+#if PMIX_VERSION_MAJOR >= 6
+    (void)PMIx_server_deregister_nspace(namespace_);
+#else
+    PMIx_server_deregister_nspace(namespace_, NULL, NULL);
+#endif
+}
+
+static pmix_status_t spur_register_clients(const spur_mpi_launch_plan_t *plan) {
+    uid_t uid = getuid();
+    gid_t gid = getgid();
+    for (uint32_t i = 0; i < plan->num_local_procs; i++) {
+        pmix_proc_t proc;
+        PMIX_LOAD_PROCID(&proc, plan->namespace_, plan->local_procs[i].rank);
+        pmix_status_t rc = PMIx_server_register_client(&proc, uid, gid, NULL, NULL, NULL);
+        if (!pmix_status_ok(rc)) {
+            return rc;
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+#if PMIX_VERSION_MAJOR < 6
+static int spur_copy_server_uri(char **env, char *val, size_t vallen) {
+    static const char *candidates[] = {
+        "PMIX_SERVER_URI4",
+        "PMIX_SERVER_URI41",
+        "PMIX_SERVER_URI3",
+        "PMIX_SERVER_URI2",
+        "PMIX_SERVER_URI",
+        NULL,
+    };
+
+    for (int i = 0; candidates[i] != NULL; i++) {
+        size_t prefix_len = strlen(candidates[i]);
+        for (char **cur = env; cur != NULL && *cur != NULL; cur++) {
+            if (strncmp(*cur, candidates[i], prefix_len) == 0 && (*cur)[prefix_len] == '=') {
+                snprintf(val, vallen, "%s", *cur + prefix_len + 1);
+                return 0;
+            }
+        }
+    }
+    return -1;
+}
+#endif
 
 int spur_mpi_pmix_version(void) {
     return SPUR_MPI_PLUGIN_API_VERSION;
@@ -214,29 +287,8 @@ int spur_mpi_pmix_server_start(const spur_mpi_launch_plan_t *plan, char *errbuf,
         return 0;
     }
 
-    pmix_proc_t *procs = calloc(plan->num_local_procs, sizeof(pmix_proc_t));
-    if (procs == NULL) {
-        if (errbuf != NULL && errlen > 0) {
-            snprintf(errbuf, errlen, "failed to allocate PMIx proc table");
-        }
-        pthread_mutex_unlock(&g_session_lock);
-        return -1;
-    }
-
-    for (uint32_t i = 0; i < plan->num_local_procs; i++) {
-        PMIX_LOAD_PROCID(&procs[i], plan->namespace_, plan->local_procs[i].rank);
-    }
-
-    pmix_status_t rc = PMIx_server_register_nspace(
-        plan->namespace_,
-        plan->universe_size,
-        procs,
-        NULL,
-        0
-    );
-    free(procs);
-
-    if (rc != PMIX_SUCCESS) {
+    pmix_status_t rc = spur_register_nspace(plan);
+    if (!pmix_status_ok(rc)) {
         if (errbuf != NULL && errlen > 0) {
             snprintf(
                 errbuf,
@@ -249,20 +301,26 @@ int spur_mpi_pmix_server_start(const spur_mpi_launch_plan_t *plan, char *errbuf,
         return -1;
     }
 
+    rc = spur_register_clients(plan);
+    if (!pmix_status_ok(rc)) {
+        spur_deregister_nspace(plan->namespace_);
+        if (errbuf != NULL && errlen > 0) {
+            snprintf(
+                errbuf,
+                errlen,
+                "PMIx_server_register_client failed: %s",
+                PMIx_Error_string(rc)
+            );
+        }
+        pthread_mutex_unlock(&g_session_lock);
+        return -1;
+    }
+
     spur_pmix_session_t *session = alloc_session(plan->namespace_);
     if (session == NULL) {
-        pmix_status_t dereg = PMIx_server_deregister_nspace(plan->namespace_);
+        spur_deregister_nspace(plan->namespace_);
         if (errbuf != NULL && errlen > 0) {
-            if (dereg != PMIX_SUCCESS) {
-                snprintf(
-                    errbuf,
-                    errlen,
-                    "PMIx session table full and deregister failed: %s",
-                    PMIx_Error_string(dereg)
-                );
-            } else {
-                snprintf(errbuf, errlen, "PMIx session table full");
-            }
+            snprintf(errbuf, errlen, "PMIx session table full");
         }
         pthread_mutex_unlock(&g_session_lock);
         return -1;
@@ -294,8 +352,9 @@ int spur_mpi_pmix_server_stop(const char *namespace_, char *errbuf, size_t errle
     pthread_mutex_lock(&g_session_lock);
     spur_pmix_session_t *session = find_session(namespace_);
     if (session != NULL) {
+#if PMIX_VERSION_MAJOR >= 6
         pmix_status_t rc = PMIx_server_deregister_nspace(namespace_);
-        if (rc != PMIX_SUCCESS) {
+        if (!pmix_status_ok(rc)) {
             if (errbuf != NULL && errlen > 0) {
                 snprintf(
                     errbuf,
@@ -307,6 +366,9 @@ int spur_mpi_pmix_server_stop(const char *namespace_, char *errbuf, size_t errle
             pthread_mutex_unlock(&g_session_lock);
             return -1;
         }
+#else
+        spur_deregister_nspace(namespace_);
+#endif
         session->active = 0;
         session->namespace_[0] = '\0';
         spur_mpi_debug("spur_mpi_pmix: deregistered namespace %s\n", namespace_);
@@ -318,6 +380,18 @@ int spur_mpi_pmix_server_stop(const char *namespace_, char *errbuf, size_t errle
     }
     return 0;
 }
+
+#if PMIX_VERSION_MAJOR < 6
+static void spur_free_env(char **env) {
+    if (env == NULL) {
+        return;
+    }
+    for (char **cur = env; *cur != NULL; cur++) {
+        free(*cur);
+    }
+    free(env);
+}
+#endif
 
 int spur_mpi_pmix_env(
     const spur_mpi_launch_plan_t *plan,
@@ -346,14 +420,20 @@ int spur_mpi_pmix_env(
         snprintf(val, vallen, "%s", plan->tmpdir);
         return 0;
     }
+    /* Open MPI 4.x uses URI4/URI3; same aliases in mpi_plugin.rs and task_launch.rs. */
+    if (strcmp(key, "PMIX_SERVER_URI4") == 0 || strcmp(key, "PMIX_SERVER_URI3") == 0) {
+        key = "PMIX_SERVER_URI";
+    }
 
     pmix_proc_t proc;
     PMIX_LOAD_PROCID(&proc, plan->namespace_, rank);
 
+    int found = -1;
+#if PMIX_VERSION_MAJOR >= 6
     pmix_info_t *info = NULL;
     size_t ninfo = 0;
     pmix_status_t rc = PMIx_server_setup_fork(&proc, &info, &ninfo);
-    if (rc != PMIX_SUCCESS) {
+    if (!pmix_status_ok(rc)) {
         spur_mpi_debug(
             "spur_mpi_pmix: PMIx_server_setup_fork rank=%u key=%s failed: %s\n",
             rank,
@@ -363,7 +443,6 @@ int spur_mpi_pmix_env(
         return -1;
     }
 
-    int found = -1;
     for (size_t i = 0; i < ninfo; i++) {
         if (strcmp(info[i].key, key) == 0) {
             if (info[i].value.type == PMIX_STRING && info[i].value.data.string != NULL) {
@@ -374,6 +453,34 @@ int spur_mpi_pmix_env(
         }
     }
     PMIx_Info_release(info, ninfo);
+#else
+    char **env = NULL;
+    pmix_status_t rc = PMIx_server_setup_fork(&proc, &env);
+    if (!pmix_status_ok(rc)) {
+        spur_mpi_debug(
+            "spur_mpi_pmix: PMIx_server_setup_fork rank=%u key=%s failed: %s\n",
+            rank,
+            key,
+            PMIx_Error_string(rc)
+        );
+        return -1;
+    }
+
+    size_t key_len = strlen(key);
+    if (strcmp(key, "PMIX_SERVER_URI") == 0) {
+        found = spur_copy_server_uri(env, val, vallen);
+    } else {
+        for (char **cur = env; cur != NULL && *cur != NULL; cur++) {
+            if (strncmp(*cur, key, key_len) == 0 && (*cur)[key_len] == '=') {
+                snprintf(val, vallen, "%s", *cur + key_len + 1);
+                found = 0;
+                break;
+            }
+        }
+    }
+    spur_free_env(env);
+#endif
+
     if (found != 0) {
         spur_mpi_debug(
             "spur_mpi_pmix: PMIx env key %s not found for rank=%u\n",

--- a/crates/spur-mpi-pmix/include/spur_mpi_plugin.h
+++ b/crates/spur-mpi-pmix/include/spur_mpi_plugin.h
@@ -13,6 +13,9 @@ extern "C" {
 
 #define SPUR_MPI_PLUGIN_API_VERSION 1
 
+/* Use when the controller did not supply job credentials; plugin falls back to spurd. */
+#define SPUR_MPI_JOB_CRED_UNSET UINT32_MAX
+
 typedef struct spur_mpi_proc {
     uint32_t rank;
     uint32_t local_rank;
@@ -26,6 +29,8 @@ typedef struct spur_mpi_launch_plan {
     uint32_t num_local_procs;
     spur_mpi_proc_t local_procs[256];
     char tmpdir[512];
+    uint32_t job_uid;
+    uint32_t job_gid;
 } spur_mpi_launch_plan_t;
 
 int spur_mpi_pmix_version(void);

--- a/crates/spur-mpi-pmix/src/lib.rs
+++ b/crates/spur-mpi-pmix/src/lib.rs
@@ -2,3 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! PMIx MPI plugin (`spur_mpi_pmix.so`) loaded at `--mpi=pmix` job launch.
+//!
+//! The shared library is built from C in `build.rs`.

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -813,11 +813,15 @@ async fn dispatch_to_agent(
     let mpi = spec.mpi.clone().unwrap_or_default();
     let pmix_plan = spur_core::mpi::maybe_local_pmix_plan(
         &mpi,
-        params.job_id,
-        spec.num_tasks,
-        params.task_offset,
-        tasks_per_node,
-        params.pmix_tmpdir,
+        spur_core::mpi::PmixLocalDispatch {
+            job_id: params.job_id,
+            universe_size: spec.num_tasks,
+            task_offset: params.task_offset,
+            local_count: tasks_per_node,
+            tmpdir: params.pmix_tmpdir.to_string(),
+            job_uid: spec.uid,
+            job_gid: spec.gid,
+        },
     )
     .map(spur_core::mpi::plan_to_proto);
     let proto_spec = ProtoJobSpec {

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1610,11 +1610,15 @@ impl SlurmController for ControllerService {
             let step_mpi = mpi.clone();
             let pmix_plan = spur_core::mpi::maybe_local_pmix_plan(
                 step_mpi.as_str(),
-                job_id,
-                step_num_tasks,
-                node_tasks.task_offset,
-                node_tasks.tasks_on_node,
-                &pmix_tmpdir,
+                spur_core::mpi::PmixLocalDispatch {
+                    job_id,
+                    universe_size: step_num_tasks,
+                    task_offset: node_tasks.task_offset,
+                    local_count: node_tasks.tasks_on_node,
+                    tmpdir: pmix_tmpdir.clone(),
+                    job_uid: uid,
+                    job_gid: gid,
+                },
             )
             .map(spur_core::mpi::plan_to_proto);
             set.spawn(async move {

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -656,6 +656,20 @@ async fn report_completion(
     );
 }
 
+fn warn_mpi_mpirun_skipped_affinity(job_id: u32, source: &HashMap<String, String>) {
+    use spur_core::task_launch::{mpi_mpirun_skips_cpu_bind, mpi_mpirun_skips_gpu_bind};
+    let cpu_bind = mpi_mpirun_skips_cpu_bind(source);
+    let gpu_bind = mpi_mpirun_skips_gpu_bind(source);
+    if cpu_bind || gpu_bind {
+        warn!(
+            job_id,
+            cpu_bind,
+            gpu_bind,
+            "multi-rank --mpi=pmix launches via mpirun --bind-to none; Spur CPU/GPU bind env is not applied to MPI ranks"
+        );
+    }
+}
+
 #[tonic::async_trait]
 impl SlurmAgent for AgentService {
     type StreamJobOutputStream = ReceiverStream<Result<StreamJobOutputChunk, Status>>;
@@ -903,6 +917,10 @@ impl SlurmAgent for AgentService {
                     &user_script_path,
                     std::fs::Permissions::from_mode(0o755),
                 );
+            }
+
+            if spec.mpi == MPI_PMIX {
+                warn_mpi_mpirun_skipped_affinity(job_id, &spec.environment);
             }
 
             // Build the wrapper that launches N tasks with GPU partitioning
@@ -1559,6 +1577,9 @@ impl SlurmAgent for AgentService {
             return Err(Status::invalid_argument(
                 "step mpi=pmix requires a PMIx launch plan",
             ));
+        }
+        if step_mpi && num_tasks > 1 {
+            warn_mpi_mpirun_skipped_affinity(job_id, &req.environment);
         }
 
         let (program, program_args, step_script_cleanup) = if num_tasks > 1 || req.label {

--- a/crates/spurd/src/mpi_plugin.rs
+++ b/crates/spurd/src/mpi_plugin.rs
@@ -551,6 +551,18 @@ mod tests {
     use super::*;
 
     #[test]
+    fn plan_credentials_survive_proto_roundtrip_and_plan_to_c() {
+        let plan = PmixLaunchPlan::local_tasks(7, 4, 0, 4, "/tmp/pmix", 1001, 1002);
+        let proto = mpi::plan_to_proto(plan);
+        let restored = plan_from_proto(&proto).unwrap();
+        assert_eq!(restored.job_uid, 1001);
+        assert_eq!(restored.job_gid, 1002);
+        let c = plan_to_c(&restored).unwrap();
+        assert_eq!(c.job_uid, 1001);
+        assert_eq!(c.job_gid, 1002);
+    }
+
+    #[test]
     fn missing_plugin_returns_actionable_error() {
         let host = MpiPluginHost::new(MpiConfig {
             plugin_dir: "/nonexistent/spur/plugins".into(),

--- a/crates/spurd/src/mpi_plugin.rs
+++ b/crates/spurd/src/mpi_plugin.rs
@@ -16,6 +16,7 @@ use tracing::{debug, info, warn};
 
 const PMIX_ENV_KEYS: &[&str] = &[
     "PMIX_SERVER_URI",
+    "PMIX_SERVER_URI4",
     "PMIX_NAMESPACE",
     "PMIX_RANK",
     "PMIX_SIZE",
@@ -445,6 +446,12 @@ impl MpiPluginHost {
             } else {
                 debug!(job_id = plan.job_id, rank, key, "PMIx env key unavailable");
             }
+        }
+        // Open MPI 4.x expects URI4/URI3; same aliases in pmix_server.c and task_launch.rs.
+        if let Some(uri) = out.get("PMIX_SERVER_URI").cloned() {
+            out.entry("PMIX_SERVER_URI4".into())
+                .or_insert_with(|| uri.clone());
+            out.entry("PMIX_SERVER_URI3".into()).or_insert(uri);
         }
         validate_pmix_env(&out)?;
         Ok(out)

--- a/crates/spurd/src/mpi_plugin.rs
+++ b/crates/spurd/src/mpi_plugin.rs
@@ -40,6 +40,8 @@ struct SpurMpiLaunchPlan {
     num_local_procs: c_uint,
     local_procs: [SpurMpiProc; 256],
     tmpdir: [c_char; 512],
+    job_uid: c_uint,
+    job_gid: c_uint,
 }
 
 type VersionFn = unsafe extern "C" fn() -> c_int;
@@ -480,6 +482,8 @@ fn plan_to_c(plan: &PmixLaunchPlan) -> Result<SpurMpiLaunchPlan, String> {
             local_rank: 0,
         }; 256],
         tmpdir: [0; 512],
+        job_uid: plan.job_uid,
+        job_gid: plan.job_gid,
     };
     write_c_str(&mut c_plan.namespace, &plan.namespace)?;
     write_c_str(&mut c_plan.tmpdir, &plan.tmpdir)?;
@@ -535,6 +539,8 @@ pub fn plan_from_proto(
             })
             .collect(),
         tmpdir: proto.tmpdir.clone(),
+        job_uid: proto.job_uid,
+        job_gid: proto.job_gid,
     };
     mpi::validate_pmix_plan(&plan)?;
     Ok(plan)
@@ -550,7 +556,7 @@ mod tests {
             plugin_dir: "/nonexistent/spur/plugins".into(),
             ..MpiConfig::default()
         });
-        let plan = PmixLaunchPlan::local_tasks(1, 1, 0, 1, "/tmp/pmix");
+        let plan = PmixLaunchPlan::local_tasks(1, 1, 0, 1, "/tmp/pmix", 0, 0);
         let err = host.start_pmix_server(&plan).unwrap_err();
         assert!(err.contains("MPI plugin not found"));
     }
@@ -582,6 +588,8 @@ mod tests {
                 })
                 .collect(),
             tmpdir: "/tmp/pmix".into(),
+            job_uid: 0,
+            job_gid: 0,
         };
         let err = host.start_pmix_server(&plan).unwrap_err();
         assert!(err.contains("max 256"));
@@ -607,6 +615,8 @@ mod tests {
                 local_rank: 0,
             }],
             tmpdir: "/tmp/pmix".into(),
+            job_uid: 0,
+            job_gid: 0,
         };
         let err = host.start_pmix_server(&plan).unwrap_err();
         assert!(err.contains("namespace mismatch"));
@@ -629,7 +639,7 @@ mod tests {
                 refs: 1,
             },
         );
-        let plan = PmixLaunchPlan::local_tasks(5, 1, 0, 1, "/tmp/pmix");
+        let plan = PmixLaunchPlan::local_tasks(5, 1, 0, 1, "/tmp/pmix", 0, 0);
         assert!(host.start_pmix_server(&plan).is_err());
         assert_eq!(
             host.active_namespaces.lock().unwrap().get(&5).unwrap().refs,
@@ -657,7 +667,7 @@ mod tests {
             plugin_dir: "/nonexistent/spur/plugins".into(),
             ..MpiConfig::default()
         }));
-        let plan = PmixLaunchPlan::local_tasks(9, 1, 0, 1, "/tmp/pmix");
+        let plan = PmixLaunchPlan::local_tasks(9, 1, 0, 1, "/tmp/pmix", 0, 0);
         assert!(PmixLaunchGuard::start(host.clone(), &plan).is_err());
         assert!(!host.has_active_pmix(plan.job_id));
     }
@@ -743,7 +753,7 @@ mod tests {
             pmix_tmpdir: "/tmp/spur-pmix-test".into(),
             ..MpiConfig::default()
         }));
-        let plan = PmixLaunchPlan::local_tasks(7777, 1, 0, 1, "/tmp/spur-pmix-test");
+        let plan = PmixLaunchPlan::local_tasks(7777, 1, 0, 1, "/tmp/spur-pmix-test", 0, 0);
         {
             let guard = PmixLaunchGuard::start(host.clone(), &plan).expect("plugin start");
             assert!(host.has_active_pmix(plan.job_id));

--- a/docs/deployment/native-host.rst
+++ b/docs/deployment/native-host.rst
@@ -174,21 +174,64 @@ The default can be changed in ``spur.conf``:
 MPI (PMIx)
 ----------
 
-Spur supports single-node Open MPI jobs via ``--mpi=pmix``. The controller and
+Spur supports **single-node** Open MPI jobs via ``--mpi=pmix``. The controller and
 CLI do not link libpmix; each compute node loads ``spur_mpi_pmix.so`` from
 ``[mpi].plugin_dir`` when a PMIx job starts.
 
-Build and install the plugin on every agent node:
+Architecture
+~~~~~~~~~~~~
+
+1. **``spurd``** loads ``spur_mpi_pmix.so`` and calls ``PMIx_server_init`` when a
+   job with ``mpi = pmix`` is launched.
+2. The plugin registers a namespace (``spur.<job_id>``), job size, and local
+   client ranks, then serves PMIx to application processes.
+3. For ``-n > 1`` on one node, ``spurd`` wraps the user command in a bash script
+   that runs **``mpirun -np N``** once (not ``N`` independent forks). Open MPI
+   4.x otherwise creates a singleton ``MPI_COMM_WORLD`` (``size=1`` per rank).
+4. The wrapper exports ``PMIX_SERVER_URI4`` from ``PMIX_SERVER_URI``, unsets
+   ``SLURM_*`` twins (so Open MPI does not assume Slurm PMI), and resolves
+   ``mpirun`` from ``PATH`` or ``OPAL_PREFIX``.
+
+The embedded PMIx server must **not** override ``fence_nb`` / ``fence`` with a
+no-op: modex exchange is handled internally by OpenPMIx GDS on single-node jobs.
+
+Build and install the plugin
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+On each **agent**, with libpmix development files (``pkg-config pmix`` or vendor
+headers + ``libpmix.so``):
 
 .. code-block:: bash
 
    cargo build --release -p spur-mpi-pmix
-   sudo install -D target/release/libspur_mpi_pmix.so /usr/lib/spur/spur_mpi_pmix.so
+   sudo install -D target/release/spur_mpi_pmix.so /usr/lib/spur/spur_mpi_pmix.so
 
-The plugin requires **libpmix** at runtime (``pkg-config pmix`` when building).
-Open MPI on the node must be built against a compatible PMIx version.
+.. important::
 
-Add to ``spur.conf`` on agents (and match ``plugin_dir`` to the install path):
+   Build on the **same OS/glibc** as the agent, or compile ``pmix_server.c``
+   directly on the node. Copying a plugin from a mismatched dev environment can
+   crash ``spurd`` at ``dlopen`` time.
+
+If ``pkg-config pmix`` is unavailable on the agent but system headers exist (e.g.
+``/usr/lib/x86_64-linux-gnu/pmix2/include``), compile the C plugin manually on the
+node:
+
+.. code-block:: bash
+
+   gcc -fPIC -Wall -O2 -shared -o spur_mpi_pmix.so pmix_server.c \
+     -Iinclude $(pkg-config --cflags pmix) $(pkg-config --libs pmix) -pthread
+   sudo install -D spur_mpi_pmix.so /usr/lib/spur/spur_mpi_pmix.so
+
+Runtime requirements
+~~~~~~~~~~~~~~~~~~~~
+
+- **OpenPMIx** on the agent (plugin links ``libpmix``).
+- **Open MPI** with ``mpirun`` on the agent ``PATH`` (or set ``OPAL_PREFIX`` so
+  the wrapper finds ``$OPAL_PREFIX/bin/mpirun``).
+- Application binaries built against the **same** Open MPI install you use at
+  runtime (consistent ``LD_LIBRARY_PATH`` / ``OPAL_PREFIX``).
+
+``spur.conf`` on agents (match ``plugin_dir`` to the install path):
 
 .. code-block:: toml
 
@@ -197,7 +240,8 @@ Add to ``spur.conf`` on agents (and match ``plugin_dir`` to the install path):
    pmix_tmpdir = "/tmp/spur-pmix"
    pmix_min_version = "4.1.0"
 
-Submit PMIx jobs with ``srun``, ``sbatch``, or step mode inside an allocation:
+Submit PMIx jobs
+~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
@@ -210,10 +254,44 @@ Inside an interactive allocation (``salloc``), enable PMIx per step:
 
    srun --mpi=pmix -n4 ./hello_mpi
 
-Set ``SPUR_MPI_DEBUG=1`` on ``spurd`` for plugin debug logs. Each agent holds at
-most 64 active PMIx namespaces; additional concurrent ``--mpi=pmix`` jobs on the
-same node fail with "PMIx session table full" until a running job finishes.
-Multi-node PMIx coordination is not yet supported in this release.
+Minimal ``hello_mpi`` (build on the agent with ``mpicc``):
+
+.. code-block:: c
+
+   #include <mpi.h>
+   #include <stdio.h>
+   int main(int argc, char **argv) {
+       int rank, size;
+       MPI_Init(&argc, &argv);
+       MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+       MPI_Comm_size(MPI_COMM_WORLD, &size);
+       printf("rank=%d size=%d\n", rank, size);
+       MPI_Finalize();
+       return 0;
+   }
+
+Expected result for ``-n4``: four lines with ``rank=0`` … ``rank=3`` and
+``size=4`` on each.
+
+Application scripts should **avoid**:
+
+- ``OMPI_MCA_ess=env`` when ``spurd`` already uses ``mpirun``.
+- Forcing ``OMPI_MCA_pmix=ext3x`` on Open MPI 4.1 (use the default ``pmix3x``
+  component, or omit the variable).
+- Mixing library paths from different Open MPI installations.
+
+Operational notes
+~~~~~~~~~~~~~~~~~
+
+- Set ``SPUR_MPI_DEBUG=1`` in ``spurd`` environment for plugin debug logs.
+- Each agent holds at most 64 active PMIx namespaces; additional concurrent
+  ``--mpi=pmix`` jobs on the same node fail until a job finishes.
+- Multi-node PMIx coordination is not yet supported.
+- Multi-rank ``--mpi=pmix`` steps launch via a single ``mpirun -np N`` wrapper.
+  That path does not apply Spur's per-task CPU bind (``--cpu-bind``) or per-rank
+  GPU partitioning (``SPUR_JOB_GPUS``) the way the non-MPI fork wrapper does.
+  Use Open MPI binding options or set rank-local GPU env in the application script
+  until Spur adds MPI-aware bind support.
 
 Submitting Jobs
 ---------------

--- a/docs/deployment/native-host.rst
+++ b/docs/deployment/native-host.rst
@@ -219,7 +219,11 @@ node:
 .. code-block:: bash
 
    gcc -fPIC -Wall -O2 -shared -o spur_mpi_pmix.so pmix_server.c \
-     -Iinclude $(pkg-config --cflags pmix) $(pkg-config --libs pmix) -pthread
+     -Iinclude \
+     -I/usr/lib/x86_64-linux-gnu/pmix2/include \
+     -L/usr/lib/x86_64-linux-gnu/pmix2/lib \
+     -Wl,-rpath,/usr/lib/x86_64-linux-gnu/pmix2/lib \
+     -lpmix -pthread
    sudo install -D spur_mpi_pmix.so /usr/lib/spur/spur_mpi_pmix.so
 
 Runtime requirements

--- a/docs/developer/building.rst
+++ b/docs/developer/building.rst
@@ -29,7 +29,16 @@ succeed):
 .. code-block:: bash
 
    cargo build --release -p spur-mpi-pmix
-   sudo install -D target/release/libspur_mpi_pmix.so /usr/lib/spur/spur_mpi_pmix.so
+   sudo install -D target/release/spur_mpi_pmix.so /usr/lib/spur/spur_mpi_pmix.so
+
+Install the resulting ``spur_mpi_pmix.so`` on **every agent**, using the same
+glibc as the running ``spurd``. If ``pkg-config pmix`` is missing on agents but
+system PMIx headers exist, compile ``crates/spur-mpi-pmix/c/pmix_server.c`` on the
+node with ``gcc -fPIC -shared`` and the system PMIx ``-I`` / ``-L`` flags (see
+:doc:`/deployment/native-host`).
+
+``spurd`` launches multi-rank ``--mpi=pmix`` steps via ``mpirun -np N``; agents
+need ``mpirun`` on ``PATH`` (or ``OPAL_PREFIX`` pointing at an Open MPI install).
 
 Without libpmix, the crate still builds a stub plugin that fails at load time with
 an actionable error. Container images can include a functional plugin by building

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -684,6 +684,8 @@ message PmixLaunchPlan {
   uint32 task_offset = 4;
   repeated PmixLocalProc local_procs = 5;
   string tmpdir = 6;
+  uint32 job_uid = 7;
+  uint32 job_gid = 8;
 }
 
 // -- Agent --


### PR DESCRIPTION
## Summary

Fixes single-node Open MPI jobs submitted with `--mpi=pmix`. Previously, ranks reported `size=1` because the embedded PMIx server returned an empty modex (custom `fence` handler) and `spurd` forked N independent processes instead of launching one `mpirun -np N`.

This change makes four-rank jobs form a shared `MPI_COMM_WORLD` (`rank=0..3`, `size=4`), validated on Crusoe AMD agents and the internal bare-metal lab.

## Approach

**PMIx plugin (`pmix_server.c`)**
- Drop the noop `fence` handler so OpenPMIx GDS handles modex on single-node jobs.
- Register namespaces and clients with PMIx 5/6-compatible APIs (`PMIX_JOB_SIZE` on PMIx 5).
- Resolve `PMIX_SERVER_URI4`/`URI3` lookups for Open MPI 4.x clients.

**Plugin build (`build.rs`, `Cargo.toml`)**
- Build `spur_mpi_pmix.so` as a pure C shared library (not a Rust `cdylib`) so `dlsym` exports work.
- Link with full pkg-config flags, including rpath for vendor PMIx layouts (e.g. `pmix2/lib`).

**Launch path (`task_launch.rs`, `mpi_plugin.rs`)**
- Multi-rank `--mpi=pmix` steps use a bash wrapper that runs `mpirun -np N` once.
- Wrapper resolves `mpirun`, unsets `SLURM_*` (avoids wrong Open MPI PMI path), and aliases PMIx server URIs.
- `spurd` validates/injects `PMIX_SERVER_URI4` in job env.

## Limitations (documented)

- Single-node only; multi-node PMIx still needs a real fence implementation.
- The `mpirun` wrapper does not apply Spur's per-task CPU bind or per-rank GPU partitioning; use Open MPI binding or set rank-local GPU env in the job script.

## Test plan

- [x] `cargo test -p spur-core task_launch`
- [x] `cargo build -p spur-mpi-pmix --release` (plugin embeds RUNPATH to libpmix)
- [x] Bare-metal lab: `srun -w spur-node1 -N1 -n4 --mpi=pmix /tmp/hello_mpi` → four ranks, `size=4`
- [x] Crusoe AMD: `hello_mpi` with four ranks, `size=4`