### PR TITLE
feat(spurctld): multi-control-plane HA for native k0s clusters

### DIFF
--- a/crates/spur-cli/src/k8s.rs
+++ b/crates/spur-cli/src/k8s.rs
@@ -35,6 +35,13 @@ pub enum K8sCommand {
         /// Control-plane node (default: picked from inventory / [cluster] config).
         #[arg(long)]
         control_plane_node: Option<String>,
+        /// HA control-plane count: 1, 3, or 5 (default: [cluster] config, else 1).
+        #[arg(long)]
+        replicas: Option<u32>,
+        /// Explicit control-plane nodes (repeatable; 1, 3, or 5). First is the etcd bootstrap.
+        /// Overrides --replicas.
+        #[arg(long = "control-plane-nodes", value_delimiter = ',')]
+        control_plane_nodes: Vec<String>,
     },
     /// Tear the k0s cluster down.
     Down {
@@ -74,7 +81,19 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let parsed = K8sArgs::try_parse_from(args)?;
     let controller = parsed.controller;
     match parsed.command {
-        K8sCommand::Up { control_plane_node } => cmd_up(&controller, control_plane_node).await,
+        K8sCommand::Up {
+            control_plane_node,
+            replicas,
+            control_plane_nodes,
+        } => {
+            cmd_up(
+                &controller,
+                control_plane_node,
+                replicas,
+                control_plane_nodes,
+            )
+            .await
+        }
         K8sCommand::Down { reset } => cmd_down(&controller, reset).await,
         K8sCommand::Status => cmd_status(&controller).await,
         K8sCommand::Kubeconfig { user } => cmd_kubeconfig(&controller, user).await,
@@ -104,10 +123,19 @@ async fn cmd_install_k0s(version: &str, path: &str, force: bool) -> Result<()> {
     Ok(())
 }
 
-async fn cmd_up(controller: &str, control_plane_node: Option<String>) -> Result<()> {
+async fn cmd_up(
+    controller: &str,
+    control_plane_node: Option<String>,
+    replicas: Option<u32>,
+    control_plane_nodes: Vec<String>,
+) -> Result<()> {
     let mut client = SlurmControllerClient::new(spur_client::connect_channel(controller).await?);
     let resp = client
-        .cluster_up(ClusterUpRequest { control_plane_node })
+        .cluster_up(ClusterUpRequest {
+            control_plane_node,
+            control_plane_replicas: replicas,
+            control_plane_nodes,
+        })
         .await?
         .into_inner();
     if resp.accepted {
@@ -142,7 +170,9 @@ async fn cmd_status(controller: &str) -> Result<()> {
         .await?
         .into_inner();
     println!("phase: {}", resp.phase);
-    if !resp.control_plane_node.is_empty() {
+    if !resp.control_plane_nodes.is_empty() {
+        println!("control-plane: {}", resp.control_plane_nodes.join(", "));
+    } else if !resp.control_plane_node.is_empty() {
         println!("control-plane: {}", resp.control_plane_node);
     }
     for n in resp.nodes {
@@ -176,9 +206,34 @@ mod tests {
         let args =
             K8sArgs::try_parse_from(["k8s", "up", "--control-plane-node", "head-node"]).unwrap();
         match args.command {
-            K8sCommand::Up { control_plane_node } => {
+            K8sCommand::Up {
+                control_plane_node,
+                replicas,
+                control_plane_nodes,
+            } => {
                 assert_eq!(control_plane_node.as_deref(), Some("head-node"));
+                assert_eq!(replicas, None);
+                assert!(control_plane_nodes.is_empty());
             }
+            _ => panic!("wrong command"),
+        }
+    }
+
+    #[test]
+    fn parses_up_with_replicas_and_node_set() {
+        let args = K8sArgs::try_parse_from(["k8s", "up", "--replicas", "3"]).unwrap();
+        match args.command {
+            K8sCommand::Up { replicas, .. } => assert_eq!(replicas, Some(3)),
+            _ => panic!("wrong command"),
+        }
+        let args =
+            K8sArgs::try_parse_from(["k8s", "up", "--control-plane-nodes", "cp-1,cp-2,cp-3"])
+                .unwrap();
+        match args.command {
+            K8sCommand::Up {
+                control_plane_nodes,
+                ..
+            } => assert_eq!(control_plane_nodes, vec!["cp-1", "cp-2", "cp-3"]),
             _ => panic!("wrong command"),
         }
     }

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -686,6 +686,9 @@ pub struct ClusterConfig {
     /// Hostname of the node that runs the k0s control plane. Empty = pick from inventory.
     #[serde(default)]
     pub control_plane_node: Option<String>,
+    /// HA control-plane count (1, 3, or 5). Overridden per-invocation by `spur k8s up --replicas`.
+    #[serde(default = "default_control_plane_replicas")]
+    pub control_plane_replicas: u32,
     /// k0s release to install/run (e.g. "v1.36.2+k0s.0", or "latest"). Pinned to a known-good
     /// version by default; bumped per spur release. spurd installs this if the binary is missing.
     #[serde(default = "default_k0s_version")]
@@ -715,6 +718,9 @@ fn default_cluster_distro() -> String {
 }
 fn default_k0s_version() -> String {
     crate::k0s::K0S_PINNED_VERSION.into()
+}
+fn default_control_plane_replicas() -> u32 {
+    1
 }
 fn default_k0s_binary() -> String {
     crate::k0s::K0S_DEFAULT_BINARY.into()
@@ -747,6 +753,7 @@ impl Default for ClusterConfig {
             service_cidr: default_service_cidr(),
             cni_mtu: default_cni_mtu(),
             control_plane_node: None,
+            control_plane_replicas: default_control_plane_replicas(),
             k0s_version: default_k0s_version(),
             k0s_binary: default_k0s_binary(),
             cni: default_cni(),
@@ -1136,6 +1143,14 @@ impl SlurmConfig {
                     value: format!("{} (only \"k0s\" is supported)", self.cluster.distro),
                 });
             }
+            if let Err(msg) =
+                crate::k0s::validate_control_plane_replicas(self.cluster.control_plane_replicas)
+            {
+                return Err(ConfigError::InvalidValue {
+                    field: "cluster.control_plane_replicas".into(),
+                    value: msg,
+                });
+            }
             // The mesh CIDR feeds the k0s IPAM (AddressPool) exactly like pod/service, so assert it is
             // a valid IPv4 CIDR in the same pass — otherwise a malformed wg_cidr bypasses validate()
             // and fails every reconcile tick in AddressPool::new, leaving the cluster silently stuck.
@@ -1433,6 +1448,15 @@ cni_mtu = 1400
             "cluster_name=\"t\"\n[cluster]\nenabled=true\ndistro=\"k3s\"\n"
         )
         .is_err());
+        // control_plane_replicas must be 1/3/5 (etcd quorum); even/too-large is rejected.
+        assert!(SlurmConfig::load_from_str(
+            "cluster_name=\"t\"\n[cluster]\nenabled=true\ncontrol_plane_replicas=2\n"
+        )
+        .is_err());
+        assert!(SlurmConfig::load_from_str(
+            "cluster_name=\"t\"\n[cluster]\nenabled=true\ncontrol_plane_replicas=3\n"
+        )
+        .is_ok());
         // Unknown storage provisioner is rejected; "none" and "local-path" are accepted.
         assert!(SlurmConfig::load_from_str(
             "cluster_name=\"t\"\n[cluster]\nenabled=true\nstorage_provisioner=\"nfs\"\n"

--- a/crates/spur-core/src/k0s.rs
+++ b/crates/spur-core/src/k0s.rs
@@ -116,8 +116,7 @@ mod cluster_state_tests {
         assert_eq!(st.phase, K0sPhase::Ready);
         assert!(st.control_plane_nodes.is_empty());
         assert_eq!(st.controllers(), vec!["head-node"]);
-        assert!(st.is_controller("head-node"));
-        assert!(!st.is_controller("worker-1"));
+        assert_eq!(st.bootstrap().as_deref(), Some("head-node"));
     }
 
     #[test]
@@ -129,8 +128,18 @@ mod cluster_state_tests {
             reset_requested: false,
         };
         assert_eq!(st.controllers(), vec!["cp-1", "cp-2", "cp-3"]);
-        assert!(st.is_controller("cp-2"));
-        assert!(st.is_controller("cp-1"));
+        assert_eq!(st.bootstrap().as_deref(), Some("cp-1"));
+    }
+
+    #[test]
+    fn bootstrap_falls_back_to_first_of_set_when_singular_absent() {
+        let st = K0sClusterState {
+            phase: K0sPhase::Ready,
+            control_plane_node: None,
+            control_plane_nodes: vec!["cp-1".into(), "cp-2".into(), "cp-3".into()],
+            reset_requested: false,
+        };
+        assert_eq!(st.bootstrap().as_deref(), Some("cp-1"));
     }
 
     #[test]
@@ -238,9 +247,11 @@ impl K0sClusterState {
         self.control_plane_node.iter().cloned().collect()
     }
 
-    /// True if `node` is a control-plane node (bootstrap or secondary).
-    pub fn is_controller(&self, node: &str) -> bool {
-        self.control_plane_node.as_deref() == Some(node)
-            || self.control_plane_nodes.iter().any(|n| n == node)
+    /// The bootstrap control-plane (etcd seed): the recorded singular node, else the first of the
+    /// set for HA state where the singular field was never written.
+    pub fn bootstrap(&self) -> Option<String> {
+        self.control_plane_node
+            .clone()
+            .or_else(|| self.control_plane_nodes.first().cloned())
     }
 }

--- a/crates/spur-core/src/k0s.rs
+++ b/crates/spur-core/src/k0s.rs
@@ -101,6 +101,45 @@ pub fn k0s_controller_config_yaml(
 }
 
 #[cfg(test)]
+mod cluster_state_tests {
+    use super::{K0sClusterState, K0sPhase};
+
+    // Frozen pre-multi-CP snapshot shape (no control_plane_nodes); must still deserialize or
+    // spurctld crashes restoring an old raft snapshot. Never regenerate.
+    #[test]
+    fn pre_multi_cp_state_deserializes_and_folds_into_controllers() {
+        const PRE_MULTI_CP: &str =
+            r#"{"phase":"ready","control_plane_node":"head-node","reset_requested":false}"#;
+        let st: K0sClusterState = serde_json::from_str(PRE_MULTI_CP).expect(
+            "pre-multi-CP K0sClusterState must deserialize; a new field needs serde(default)",
+        );
+        assert_eq!(st.phase, K0sPhase::Ready);
+        assert!(st.control_plane_nodes.is_empty());
+        assert_eq!(st.controllers(), vec!["head-node"]);
+        assert!(st.is_controller("head-node"));
+        assert!(!st.is_controller("worker-1"));
+    }
+
+    #[test]
+    fn controllers_prefers_the_set_when_present() {
+        let st = K0sClusterState {
+            phase: K0sPhase::Ready,
+            control_plane_node: Some("cp-1".into()),
+            control_plane_nodes: vec!["cp-1".into(), "cp-2".into(), "cp-3".into()],
+            reset_requested: false,
+        };
+        assert_eq!(st.controllers(), vec!["cp-1", "cp-2", "cp-3"]);
+        assert!(st.is_controller("cp-2"));
+        assert!(st.is_controller("cp-1"));
+    }
+
+    #[test]
+    fn controllers_empty_when_down() {
+        assert!(K0sClusterState::default().controllers().is_empty());
+    }
+}
+
+#[cfg(test)]
 mod k0s_config_tests {
     use super::k0s_controller_config_yaml;
 
@@ -139,6 +178,21 @@ mod k0s_config_tests {
     }
 }
 
+/// Valid HA control-plane counts. Odd only (etcd quorum); capped at 5 (diminishing returns, more
+/// etcd write latency). A single control plane (1) is the non-HA default.
+pub const VALID_CONTROL_PLANE_REPLICAS: [u32; 3] = [1, 3, 5];
+
+/// Validate an HA control-plane replica count: must be 1, 3, or 5. Shared by config load and the
+/// `spur k8s up` gRPC boundary so an even/too-large count fails closed with one consistent message.
+pub fn validate_control_plane_replicas(replicas: u32) -> Result<(), String> {
+    if VALID_CONTROL_PLANE_REPLICAS.contains(&replicas) {
+        return Ok(());
+    }
+    Err(format!(
+        "control-plane replicas must be 1, 3, or 5 for etcd quorum (got {replicas})"
+    ))
+}
+
 /// Which k0s role a node's spurd-owned systemd unit runs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -164,8 +218,29 @@ pub enum K0sPhase {
 pub struct K0sClusterState {
     #[serde(default)]
     pub phase: K0sPhase,
+    /// Bootstrap control-plane: seeds etcd (started tokenless), primary endpoint for admin/token RPCs.
     #[serde(default)]
     pub control_plane_node: Option<String>,
+    /// All control-plane nodes (1/3/5). Empty on pre-multi-CP state — read via [`Self::controllers`].
+    #[serde(default)]
+    pub control_plane_nodes: Vec<String>,
     #[serde(default)]
     pub reset_requested: bool,
+}
+
+impl K0sClusterState {
+    /// The control-plane node set, back-compat with pre-multi-CP state: falls back to the singular
+    /// `control_plane_node` when `control_plane_nodes` is empty (old snapshots/WAL entries).
+    pub fn controllers(&self) -> Vec<String> {
+        if !self.control_plane_nodes.is_empty() {
+            return self.control_plane_nodes.clone();
+        }
+        self.control_plane_node.iter().cloned().collect()
+    }
+
+    /// True if `node` is a control-plane node (bootstrap or secondary).
+    pub fn is_controller(&self, node: &str) -> bool {
+        self.control_plane_node.as_deref() == Some(node)
+            || self.control_plane_nodes.iter().any(|n| n == node)
+    }
 }

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -215,6 +215,8 @@ pub enum WalOperation {
         #[serde(default)]
         control_plane_node: Option<String>,
         #[serde(default)]
+        control_plane_nodes: Vec<String>,
+        #[serde(default)]
         reset_requested: bool,
     },
 }
@@ -709,6 +711,7 @@ mod deregistration_wal_tests {
         let op = WalOperation::K0sSetPhase {
             phase: K0sPhase::Ready,
             control_plane_node: Some("head-node".into()),
+            control_plane_nodes: vec!["head-node".into(), "cp-2".into(), "cp-3".into()],
             reset_requested: false,
         };
         let back: WalOperation =
@@ -717,10 +720,36 @@ mod deregistration_wal_tests {
             WalOperation::K0sSetPhase {
                 phase,
                 control_plane_node,
+                control_plane_nodes,
                 reset_requested,
             } => {
                 assert_eq!(phase, K0sPhase::Ready);
                 assert_eq!(control_plane_node.as_deref(), Some("head-node"));
+                assert_eq!(control_plane_nodes, vec!["head-node", "cp-2", "cp-3"]);
+                assert!(!reset_requested);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    // Frozen pre-multi-CP K0sSetPhase entry (no control_plane_nodes field); must still deserialize
+    // or spurctld crashes on upgrade replay. Never regenerate.
+    #[test]
+    fn k0s_set_phase_pre_multi_cp_payload_still_deserializes() {
+        const K0S_SET_PHASE_PRE_MULTI_CP: &str = r#"{"K0sSetPhase":{"phase":"ready","control_plane_node":"head-node","reset_requested":false}}"#;
+        let op: WalOperation = serde_json::from_str(K0S_SET_PHASE_PRE_MULTI_CP).expect(
+            "pre-multi-CP K0sSetPhase must deserialize; a new field needs #[serde(default)]",
+        );
+        match op {
+            WalOperation::K0sSetPhase {
+                phase,
+                control_plane_node,
+                control_plane_nodes,
+                reset_requested,
+            } => {
+                assert_eq!(phase, K0sPhase::Ready);
+                assert_eq!(control_plane_node.as_deref(), Some("head-node"));
+                assert!(control_plane_nodes.is_empty());
                 assert!(!reset_requested);
             }
             _ => panic!("wrong variant"),

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -11087,6 +11087,57 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn provision_derives_bootstrap_from_set_when_singular_absent() {
+        use spur_core::k0s::{K0sPhase, K0sRole};
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        for name in ["cp-a", "cp-b", "cp-c"] {
+            register_node(&cm, name, 4, 8000);
+        }
+        wait_for("all registered", || {
+            ["cp-a", "cp-b", "cp-c"]
+                .iter()
+                .all(|n| cm.get_node(n).is_some())
+        });
+        // HA set recorded bootstrap-first (cp-b) with the singular field unset. The first-of-set must
+        // hold `.1` — cp-b, NOT the sorted-first cp-a, so this fails if bootstrap ignores the set.
+        cm.set_k0s_phase(
+            K0sPhase::Provisioning,
+            None,
+            vec!["cp-b".into(), "cp-a".into(), "cp-c".into()],
+            false,
+        )
+        .unwrap();
+        wait_for("cp set recorded", || {
+            cm.k0s_state().controllers().len() == 3
+        });
+
+        let net = crate::cluster_k8s::ClusterNetworking {
+            mesh_cidr: "10.44.0.0/16".into(),
+            pod_cidr: "10.42.0.0/16".into(),
+            service_cidr: "10.43.0.0/16".into(),
+            cni_mtu: 1450,
+            cni: "kuberouter".into(),
+            control_plane_node: None,
+        };
+        crate::cluster_k8s::provision_assignments(&cm, &net, &cm.k0s_state()).unwrap();
+        wait_for("all assigned", || {
+            ["cp-a", "cp-b", "cp-c"]
+                .iter()
+                .all(|n| cm.get_node(n).and_then(|x| x.k0s_role).is_some())
+        });
+
+        for cp in ["cp-a", "cp-b", "cp-c"] {
+            assert_eq!(cm.get_node(cp).unwrap().k0s_role, Some(K0sRole::Controller));
+        }
+        assert_eq!(
+            cm.get_node("cp-b").unwrap().k0s_mesh_ip.as_deref(),
+            Some("10.44.0.1"),
+            "bootstrap (first of recorded set) holds .1"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn restore_from_snapshot_rejects_corrupt_data() {
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1869,16 +1869,19 @@ impl ClusterManager {
         Ok(())
     }
 
-    /// set the cluster-wide k0s phase (+ optional control-plane node / reset flag).
+    /// set the cluster-wide k0s phase (+ optional control-plane node/set / reset flag). A `None`
+    /// `control_plane_node` or empty `control_plane_nodes` leaves the persisted value untouched.
     pub fn set_k0s_phase(
         &self,
         phase: spur_core::k0s::K0sPhase,
         control_plane_node: Option<String>,
+        control_plane_nodes: Vec<String>,
         reset_requested: bool,
     ) -> anyhow::Result<()> {
         self.propose(WalOperation::K0sSetPhase {
             phase,
             control_plane_node,
+            control_plane_nodes,
             reset_requested,
         })?;
         info!(?phase, "k0s cluster phase set");
@@ -4107,12 +4110,16 @@ impl ClusterManager {
             WalOperation::K0sSetPhase {
                 phase,
                 control_plane_node,
+                control_plane_nodes,
                 reset_requested,
             } => {
                 let mut k0s = self.k0s.write();
                 k0s.phase = *phase;
                 if control_plane_node.is_some() {
                     k0s.control_plane_node = control_plane_node.clone();
+                }
+                if !control_plane_nodes.is_empty() {
+                    k0s.control_plane_nodes = control_plane_nodes.clone();
                 }
                 k0s.reset_requested = *reset_requested;
             }
@@ -10867,7 +10874,7 @@ mod tests {
         register_node(&cm, "n1", 4, 8000);
         cm.assign_node_k0s("n1", K0sRole::Worker, "10.44.0.2", "10.42.2.0/24")
             .unwrap();
-        cm.set_k0s_phase(K0sPhase::Ready, Some("head-node".into()), false)
+        cm.set_k0s_phase(K0sPhase::Ready, Some("head-node".into()), Vec::new(), false)
             .unwrap();
         wait_for("k0s state applied", || {
             cm.k0s_state().phase == K0sPhase::Ready
@@ -10957,7 +10964,7 @@ mod tests {
         register_node(&cm, "node-a", 4, 8000);
         wait_for("registered", || cm.get_node("node-a").is_some());
         // Cluster is Ready with the control plane already recorded, but node-a has no k0s role.
-        cm.set_k0s_phase(K0sPhase::Ready, Some("node-a".into()), false)
+        cm.set_k0s_phase(K0sPhase::Ready, Some("node-a".into()), Vec::new(), false)
             .unwrap();
         wait_for("phase ready", || cm.k0s_state().phase == K0sPhase::Ready);
         assert!(cm.get_node("node-a").and_then(|n| n.k0s_role).is_none());
@@ -11015,6 +11022,68 @@ mod tests {
         assert_ne!(a.k0s_mesh_ip, b.k0s_mesh_ip);
         assert_ne!(a.k0s_pod_cidr, b.k0s_pod_cidr);
         assert_eq!(cm.k0s_state().control_plane_node.as_deref(), Some("node-a"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn provision_assigns_three_controllers_for_ha_set() {
+        use spur_core::k0s::{K0sPhase, K0sRole};
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        for name in ["cp-a", "cp-b", "cp-c", "w-d"] {
+            register_node(&cm, name, 4, 8000);
+        }
+        wait_for("all registered", || {
+            ["cp-a", "cp-b", "cp-c", "w-d"]
+                .iter()
+                .all(|n| cm.get_node(n).is_some())
+        });
+        // A 3-CP HA set recorded up front (as `cluster_up` does), bootstrap cp-a first.
+        cm.set_k0s_phase(
+            K0sPhase::Provisioning,
+            Some("cp-a".into()),
+            vec!["cp-a".into(), "cp-b".into(), "cp-c".into()],
+            false,
+        )
+        .unwrap();
+        wait_for("cp set recorded", || {
+            cm.k0s_state().controllers().len() == 3
+        });
+
+        let net = crate::cluster_k8s::ClusterNetworking {
+            mesh_cidr: "10.44.0.0/16".into(),
+            pod_cidr: "10.42.0.0/16".into(),
+            service_cidr: "10.43.0.0/16".into(),
+            cni_mtu: 1450,
+            cni: "kuberouter".into(),
+            control_plane_node: None,
+        };
+        crate::cluster_k8s::provision_assignments(&cm, &net, &cm.k0s_state()).unwrap();
+        wait_for("all four assigned", || {
+            ["cp-a", "cp-b", "cp-c", "w-d"]
+                .iter()
+                .all(|n| cm.get_node(n).and_then(|x| x.k0s_role).is_some())
+        });
+
+        // All three CP nodes are Controllers; the fourth is a Worker. The bootstrap keeps `.1`.
+        for cp in ["cp-a", "cp-b", "cp-c"] {
+            assert_eq!(
+                cm.get_node(cp).unwrap().k0s_role,
+                Some(K0sRole::Controller),
+                "{cp} is a controller"
+            );
+        }
+        assert_eq!(cm.get_node("w-d").unwrap().k0s_role, Some(K0sRole::Worker));
+        assert_eq!(
+            cm.get_node("cp-a").unwrap().k0s_mesh_ip.as_deref(),
+            Some("10.44.0.1"),
+            "bootstrap holds .1"
+        );
+        // Every node has a distinct mesh IP.
+        let ips: std::collections::HashSet<_> = ["cp-a", "cp-b", "cp-c", "w-d"]
+            .iter()
+            .map(|n| cm.get_node(n).unwrap().k0s_mesh_ip.clone())
+            .collect();
+        assert_eq!(ips.len(), 4, "distinct mesh IPs");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -57,10 +57,9 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>, net: Clust
     info!(mesh = %net.mesh_cidr, pod = %net.pod_cidr, "k0s cluster reconcile loop started");
     let mut interval = tokio::time::interval(RECONCILE_INTERVAL);
     let mut last_mesh: Vec<MeshNode> = Vec::new();
-    // Cache of the worker join token minted per node, so we mint once (not every tick) while a
-    // worker joins — re-minting each tick churns k0s server tokens and races the join. Cleared when
-    // the worker's component reports active.
-    let mut worker_tokens: HashMap<String, String> = HashMap::new();
+    // Cache of the join token minted per node (worker or secondary control-plane), so we mint once
+    // (not every tick) while it joins — re-minting churns k0s server tokens and races the join.
+    let mut join_tokens: HashMap<String, String> = HashMap::new();
     loop {
         interval.tick().await;
         if !raft.is_leader() {
@@ -89,7 +88,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>, net: Clust
         }
         last_mesh = mesh.nodes.clone();
 
-        reconcile_phase(&cluster, &net, &state, &mut worker_tokens).await;
+        reconcile_phase(&cluster, &net, &state, &mut join_tokens).await;
     }
 }
 
@@ -105,7 +104,7 @@ pub(crate) async fn reconcile_phase(
     cluster: &ClusterManager,
     net: &ClusterNetworking,
     state: &K0sClusterState,
-    worker_tokens: &mut HashMap<String, String>,
+    join_tokens: &mut HashMap<String, String>,
 ) {
     match state.phase {
         K0sPhase::Ready | K0sPhase::Provisioning => {
@@ -113,7 +112,7 @@ pub(crate) async fn reconcile_phase(
                 warn!(error = %e, "k0s provisioning assignment failed; will retry next tick");
                 return;
             }
-            converge_provisioning(cluster, net, worker_tokens).await;
+            converge_provisioning(cluster, net, join_tokens).await;
         }
         K0sPhase::Down => stop_all_components(cluster, state.reset_requested).await,
         K0sPhase::Degraded => warn!("k0s cluster degraded"),
@@ -135,27 +134,35 @@ pub(crate) fn provision_assignments(
     }
     nodes.sort_by(|a, b| a.name.cmp(&b.name)); // deterministic
 
-    // Control-plane node. Derive from an ALREADY-ASSIGNED Controller/Single node FIRST: the persisted
-    // role assignment is the durable source of truth. The CP-choice persist below is a separate raft
-    // write that lands *after* the assignment loop, so a crash between the first `assign(CP, .1)` and
-    // that persist would otherwise let a restart (with `state.control_plane_node` still None) pick a
-    // different, lexically-earlier node as CP and hand it the same `.1`/Controller — two controllers
-    // silently sharing the mesh IP across the failover. Fall back to the recorded choice -> config
-    // override -> lexically-first only when nothing is assigned yet.
-    let cp_node = nodes
+    // Bootstrap control-plane (etcd seed, holder of `.1`). Derive from an ALREADY-ASSIGNED
+    // Controller/Single node FIRST: the persisted role assignment is the durable source of truth.
+    // The CP-choice persist below is a separate raft write that lands *after* the assignment loop, so
+    // a crash between the first `assign(CP, .1)` and that persist would otherwise let a restart (with
+    // `state.control_plane_node` still None) pick a different, lexically-earlier node and hand it the
+    // same `.1`. Fall back to the recorded choice -> config override -> lexically-first when nothing
+    // is assigned yet. `.1` follows the bootstrap so a 1->3 CP set keeps its existing address.
+    let bootstrap = nodes
         .iter()
-        .find(|n| {
-            matches!(
-                n.k0s_role,
-                Some(K0sRole::Controller) | Some(K0sRole::Single)
-            )
-        })
+        .find(|n| matches!(n.k0s_role, Some(K0sRole::Single)))
         .map(|n| n.name.clone())
         .or_else(|| state.control_plane_node.clone())
+        .or_else(|| {
+            nodes
+                .iter()
+                .find(|n| matches!(n.k0s_role, Some(K0sRole::Controller)))
+                .map(|n| n.name.clone())
+        })
         .or_else(|| net.control_plane_node.clone())
         .unwrap_or_else(|| nodes[0].name.clone());
 
-    // Re-seed the mesh pool from persisted assignments + reserve .1 for the controller.
+    // Control-plane set: the persisted HA set (from `cluster_up`), or just the bootstrap for the
+    // legacy single-CP path where no set was recorded.
+    let mut cp_set: HashSet<String> = state.controllers().into_iter().collect();
+    if cp_set.is_empty() {
+        cp_set.insert(bootstrap.clone());
+    }
+
+    // Re-seed the mesh pool from persisted assignments + reserve .1 for the bootstrap controller.
     let mut pool = AddressPool::new(&net.mesh_cidr)?;
     let controller_ip = first_host(&net.mesh_cidr)?;
     let _ = pool.allocate_specific(controller_ip); // reserve .1 (ignore if already reserved)
@@ -177,11 +184,18 @@ pub(crate) fn provision_assignments(
         .collect();
 
     let single = nodes.len() == 1;
-    for node in &nodes {
+    // Two passes so control planes take the lowest mesh IPs deterministically (bootstrap keeps `.1`,
+    // secondary CPs `.2`/`.3`...) regardless of where they sort among workers.
+    let ordered: Vec<_> = nodes
+        .iter()
+        .filter(|n| cp_set.contains(&n.name))
+        .chain(nodes.iter().filter(|n| !cp_set.contains(&n.name)))
+        .collect();
+    for node in ordered {
         if node.k0s_role.is_some() {
             continue; // already assigned
         }
-        let is_cp = node.name == cp_node;
+        let is_cp = cp_set.contains(&node.name);
         let role = if is_cp {
             if single {
                 K0sRole::Single
@@ -191,7 +205,7 @@ pub(crate) fn provision_assignments(
         } else {
             K0sRole::Worker
         };
-        let mesh_ip = if is_cp {
+        let mesh_ip = if node.name == bootstrap {
             controller_ip
         } else {
             pool.allocate()?
@@ -202,11 +216,87 @@ pub(crate) fn provision_assignments(
         cluster.assign_node_k0s(&node.name, role, &mesh_ip.to_string(), &pod_cidr)?;
     }
 
-    // Persist the control-plane choice if not already recorded.
-    if state.control_plane_node.as_deref() != Some(cp_node.as_str()) {
-        cluster.set_k0s_phase(K0sPhase::Provisioning, Some(cp_node), false)?;
+    // Persist the bootstrap choice if not already recorded (legacy single-CP path; `cluster_up`
+    // records the full set up front for HA).
+    if state.control_plane_node.as_deref() != Some(bootstrap.as_str()) {
+        cluster.set_k0s_phase(K0sPhase::Provisioning, Some(bootstrap), Vec::new(), false)?;
     }
     Ok(())
+}
+
+/// Resolve the control-plane node set for `spur k8s up`, fail-closed. Given a sorted list of
+/// candidate node names, an optional explicit CP list, an optional pinned bootstrap node, and a
+/// replica count, returns the CP set with the bootstrap node first. Rules:
+/// - an explicit `nodes` list wins (its count must be 1/3/5 and every name must exist);
+/// - otherwise pick the lowest `replicas` candidates (validated 1/3/5), pinned bootstrap first;
+/// - never request more control planes than there are nodes.
+pub(crate) fn resolve_control_plane_set(
+    mut candidates: Vec<String>,
+    explicit: &[String],
+    pinned_bootstrap: Option<&str>,
+    replicas: u32,
+) -> Result<Vec<String>, String> {
+    candidates.sort();
+    candidates.dedup();
+    if !explicit.is_empty() {
+        spur_core::k0s::validate_control_plane_replicas(explicit.len() as u32)?;
+        let mut seen = HashSet::new();
+        for n in explicit {
+            if !candidates.contains(n) {
+                return Err(format!("control-plane node {n} is not a registered node"));
+            }
+            if !seen.insert(n.clone()) {
+                return Err(format!("duplicate control-plane node {n}"));
+            }
+        }
+        // Fail closed on a contradictory bootstrap: if a bootstrap is pinned (operator override or a
+        // previously-recorded CP) but absent from the explicit list, `.1`/etcd-seed would silently
+        // land on a different node than intended.
+        if let Some(boot) = pinned_bootstrap {
+            if !explicit.iter().any(|n| n == boot) {
+                return Err(format!(
+                    "bootstrap control-plane {boot} is not in the requested set [{}]",
+                    explicit.join(", ")
+                ));
+            }
+        }
+        let mut set = explicit.to_vec();
+        order_bootstrap_first(&mut set, pinned_bootstrap);
+        return Ok(set);
+    }
+    spur_core::k0s::validate_control_plane_replicas(replicas)?;
+    if replicas as usize > candidates.len() {
+        return Err(format!(
+            "requested {replicas} control planes but only {} node(s) are registered",
+            candidates.len()
+        ));
+    }
+    // Pin the bootstrap into the set first so `.1` lands on it, then fill from the lowest names.
+    let mut set: Vec<String> = Vec::new();
+    if let Some(boot) = pinned_bootstrap {
+        if candidates.iter().any(|c| c == boot) {
+            set.push(boot.to_string());
+        }
+    }
+    for c in candidates {
+        if set.len() >= replicas as usize {
+            break;
+        }
+        if !set.contains(&c) {
+            set.push(c);
+        }
+    }
+    order_bootstrap_first(&mut set, pinned_bootstrap);
+    Ok(set)
+}
+
+/// Move the pinned bootstrap node to the front of the CP set (it holds `.1` + seeds etcd).
+fn order_bootstrap_first(set: &mut [String], pinned_bootstrap: Option<&str>) {
+    if let Some(boot) = pinned_bootstrap {
+        if let Some(pos) = set.iter().position(|n| n == boot) {
+            set.swap(0, pos);
+        }
+    }
 }
 
 /// The `.1` host of a CIDR (mesh controller IP).
@@ -347,30 +437,47 @@ fn agent_endpoint(cluster: &ClusterManager, node: &str) -> Option<String> {
     Some(format!("http://{}:{}", addr, n.port))
 }
 
-/// Dial the control-plane node's agent, timing out per `AGENT_TIMEOUT`. Errors if no control-plane
-/// node is assigned yet or it has no reachable address.
+/// Dial a healthy control-plane agent, timing out per `AGENT_TIMEOUT`. Tries the bootstrap node
+/// first (its k0s API answers admin/token RPCs) then any other control plane, so admin/kubeconfig/
+/// token minting survive the loss of a single control plane while etcd quorum holds. Errors if no
+/// control-plane node is assigned yet or none is reachable.
 async fn connect_control_plane(
     cluster: &ClusterManager,
 ) -> anyhow::Result<SlurmAgentClient<tonic::transport::Channel>> {
-    let cp = cluster
-        .k0s_state()
-        .control_plane_node
-        .ok_or_else(|| anyhow::anyhow!("no control-plane node assigned yet"))?;
-    let endpoint = agent_endpoint(cluster, &cp)
-        .ok_or_else(|| anyhow::anyhow!("control-plane node {cp} has no agent address"))?;
-    tokio::time::timeout(AGENT_TIMEOUT, SlurmAgentClient::connect(endpoint))
-        .await
-        .map_err(|_| anyhow::anyhow!("connect to control-plane agent timed out"))?
-        .map_err(|e| anyhow::anyhow!("connect to control-plane agent failed: {e}"))
+    let state = cluster.k0s_state();
+    let mut candidates = state.controllers();
+    if candidates.is_empty() {
+        anyhow::bail!("no control-plane node assigned yet");
+    }
+    // Bootstrap node first (stable admin endpoint), then the rest as failover.
+    if let Some(boot) = &state.control_plane_node {
+        if let Some(pos) = candidates.iter().position(|n| n == boot) {
+            candidates.swap(0, pos);
+        }
+    }
+    let mut last_err = String::new();
+    for cp in &candidates {
+        let Some(endpoint) = agent_endpoint(cluster, cp) else {
+            last_err = format!("control-plane node {cp} has no agent address");
+            continue;
+        };
+        match tokio::time::timeout(AGENT_TIMEOUT, SlurmAgentClient::connect(endpoint)).await {
+            Ok(Ok(client)) => return Ok(client),
+            Ok(Err(e)) => last_err = format!("connect to control-plane agent {cp} failed: {e}"),
+            Err(_) => last_err = format!("connect to control-plane agent {cp} timed out"),
+        }
+    }
+    anyhow::bail!("no reachable control-plane agent ({last_err})")
 }
 
-/// Mint a worker join token from the control-plane node's agent (`k0s token create --role worker`).
-/// Errors until the control-plane component is up (its k0s API must answer); the caller retries.
-async fn mint_worker_token(cluster: &ClusterManager) -> anyhow::Result<String> {
+/// Mint a join token of `role` ("worker" | "controller") from a control-plane agent (`k0s token
+/// create --role <role>`). Errors until a control-plane component is up (its k0s API must answer);
+/// the caller retries. A controller token lets a secondary CP join the bootstrap's etcd quorum.
+async fn mint_join_token(cluster: &ClusterManager, role: &str) -> anyhow::Result<String> {
     let mut client = connect_control_plane(cluster).await?;
     let resp = client
         .create_k0s_join_token(CreateK0sJoinTokenRequest {
-            role: "worker".to_string(),
+            role: role.to_string(),
             expiry_seconds: 0, // k0s default lifetime
         })
         .await
@@ -457,11 +564,11 @@ fn controller_k0s_config(net: &ClusterNetworking, node: &spur_core::node::Node) 
 }
 
 /// Start any assigned component that is not yet active; when all are active, mark the cluster Ready.
-/// `worker_tokens` caches each worker's minted join token across ticks so we mint once per join.
+/// `join_tokens` caches each worker's minted join token across ticks so we mint once per join.
 async fn converge_provisioning(
     cluster: &ClusterManager,
     net: &ClusterNetworking,
-    worker_tokens: &mut HashMap<String, String>,
+    join_tokens: &mut HashMap<String, String>,
 ) {
     let assigned: Vec<_> = cluster
         .get_nodes()
@@ -469,71 +576,90 @@ async fn converge_provisioning(
         .filter(|n| n.k0s_role.is_some())
         .collect();
     if assigned.is_empty() {
-        worker_tokens.clear();
+        join_tokens.clear();
         return;
     }
+    let bootstrap = cluster.k0s_state().control_plane_node;
     let mut all_active = true;
-    // Control-plane (controller/single) first: a worker needs the control-plane's k0s API up to
-    // mint its join token, so the control-plane must be started before we try any worker.
+    let mut bootstrap_active = false;
+    // Bootstrap control-plane first: it seeds etcd (tokenless) and its k0s API must answer before any
+    // secondary control-plane or worker can mint a join token. A Single node is always the bootstrap.
     for node in &assigned {
         let role = node.k0s_role.expect("assigned above");
         if role == K0sRole::Worker {
             continue;
         }
+        let is_bootstrap = role == K0sRole::Single || bootstrap.as_deref() == Some(&node.name);
+        if !is_bootstrap {
+            continue;
+        }
         if fetch_component_state(cluster, &node.name).await.as_deref() == Some("active") {
+            bootstrap_active = true;
             continue;
         }
         all_active = false;
         // Mesh-native cluster: generate the k0s config (api on the mesh IP + Calico bird) when
-        // cni=calico; None keeps the default kube-router. Control-plane needs no join token.
+        // cni=calico; None keeps the default kube-router. The bootstrap seeds etcd — no join token.
         let k0s_config = controller_k0s_config(net, node);
         spawn_start_component(cluster, &node.name, role, None, k0s_config, None);
     }
-    // Workers: mint a fresh join token from the control-plane agent, then start with it.
-    // Minting errors until the control-plane's k0s API is reachable — treated as "retry next tick".
+    // Don't touch secondary CPs / workers until the bootstrap's etcd is seeded and its API answers:
+    // a controller token minted before then would race the quorum. Retry on the next tick.
+    if !bootstrap_active {
+        return;
+    }
+    // Secondary control planes: join the bootstrap's etcd quorum with a `controller` token, then
+    // workers with a `worker` token. Both mint from a healthy control-plane agent; minting errors
+    // until that API is reachable — treated as "retry next tick".
     for node in &assigned {
-        if node.k0s_role != Some(K0sRole::Worker) {
-            continue;
+        let role = node.k0s_role.expect("assigned above");
+        let is_bootstrap = role == K0sRole::Single || bootstrap.as_deref() == Some(&node.name);
+        if is_bootstrap {
+            continue; // handled above
         }
         if fetch_component_state(cluster, &node.name).await.as_deref() == Some("active") {
-            worker_tokens.remove(&node.name); // joined — drop the cached token
+            join_tokens.remove(&node.name); // joined — drop the cached token
             continue;
         }
         all_active = false;
-        // For a native-routing CNI, pin the worker's kubelet node-ip to its mesh IP.
+        let token_role = if role == K0sRole::Controller {
+            "controller"
+        } else {
+            "worker"
+        };
+        // For a native-routing CNI, pin the node's kubelet node-ip to its mesh IP.
         let node_ip = if net.cni == "calico" {
             node.k0s_mesh_ip.clone()
         } else {
             None
         };
-        // Mint the worker's join token once and cache it: re-minting every tick churns k0s server
-        // tokens and races the join. Reuse the cached token on later ticks until the worker joins.
-        let token = match worker_tokens.get(&node.name) {
+        // A secondary control-plane also needs its own generated k0s config (API SANs on its mesh IP).
+        let k0s_config = if role == K0sRole::Controller {
+            controller_k0s_config(net, node)
+        } else {
+            None
+        };
+        // Mint the join token once and cache it: re-minting every tick churns k0s server tokens and
+        // races the join. Reuse the cached token on later ticks until the node joins.
+        let token = match join_tokens.get(&node.name) {
             Some(cached) => cached.clone(),
-            None => match mint_worker_token(cluster).await {
+            None => match mint_join_token(cluster, token_role).await {
                 Ok(token) => {
-                    worker_tokens.insert(node.name.clone(), token.clone());
+                    join_tokens.insert(node.name.clone(), token.clone());
                     token
                 }
                 Err(e) => {
-                    warn!(node = %node.name, error = %e, "could not mint worker join token yet; will retry");
+                    warn!(node = %node.name, error = %e, "could not mint {token_role} join token yet; will retry");
                     continue;
                 }
             },
         };
-        spawn_start_component(
-            cluster,
-            &node.name,
-            K0sRole::Worker,
-            Some(token),
-            None,
-            node_ip,
-        );
+        spawn_start_component(cluster, &node.name, role, Some(token), k0s_config, node_ip);
     }
     // Only transition on the edge — this reconcile also runs every tick while already Ready (to
     // heal re-added nodes), so an unconditional set would churn a WAL write + log line each tick.
     if all_active && cluster.k0s_state().phase != K0sPhase::Ready {
-        match cluster.set_k0s_phase(K0sPhase::Ready, None, false) {
+        match cluster.set_k0s_phase(K0sPhase::Ready, None, Vec::new(), false) {
             Ok(()) => info!("k0s cluster converged: all components active -> Ready"),
             Err(e) => warn!(error = %e, "failed to mark k0s cluster Ready"),
         }
@@ -720,6 +846,99 @@ mod tests {
         let used: HashSet<u32> = [0, 1, 3].into_iter().collect();
         assert_eq!(next_free_ordinal(&used), 2);
         assert_eq!(next_free_ordinal(&HashSet::new()), 0);
+    }
+
+    fn names(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn resolve_cp_set_replicas_picks_lowest_bootstrap_first() {
+        let set =
+            resolve_control_plane_set(names(&["d", "b", "a", "c", "e"]), &[], None, 3).unwrap();
+        // lowest 3 names, sorted; no pin so bootstrap-first is a no-op.
+        assert_eq!(set, names(&["a", "b", "c"]));
+    }
+
+    #[test]
+    fn resolve_cp_set_pins_bootstrap_to_front_and_into_the_set() {
+        let set =
+            resolve_control_plane_set(names(&["a", "b", "c", "d"]), &[], Some("c"), 3).unwrap();
+        assert_eq!(set[0], "c", "pinned bootstrap leads (holds .1)");
+        assert_eq!(set.len(), 3);
+        assert!(set.contains(&"a".to_string()) && set.contains(&"b".to_string()));
+    }
+
+    #[test]
+    fn resolve_cp_set_explicit_list_wins_and_orders_bootstrap() {
+        let set = resolve_control_plane_set(
+            names(&["a", "b", "c", "d", "e"]),
+            &names(&["e", "c", "a"]),
+            Some("c"),
+            5, // ignored when explicit list is present
+        )
+        .unwrap();
+        assert_eq!(set[0], "c");
+        assert_eq!(set.len(), 3);
+    }
+
+    #[test]
+    fn resolve_cp_set_rejects_even_count() {
+        assert!(resolve_control_plane_set(names(&["a", "b"]), &[], None, 2).is_err());
+        assert!(
+            resolve_control_plane_set(names(&["a", "b", "c", "d"]), &names(&["a", "b"]), None, 1)
+                .is_err(),
+            "explicit even list rejected"
+        );
+    }
+
+    #[test]
+    fn resolve_cp_set_rejects_more_cps_than_nodes() {
+        let err = resolve_control_plane_set(names(&["a", "b"]), &[], None, 3).unwrap_err();
+        assert!(err.contains("only 2 node"), "got: {err}");
+    }
+
+    #[test]
+    fn resolve_cp_set_rejects_unknown_or_duplicate_explicit_node() {
+        assert!(
+            resolve_control_plane_set(names(&["a", "b", "c"]), &names(&["a", "x", "c"]), None, 3)
+                .is_err(),
+            "unknown node rejected"
+        );
+        assert!(
+            resolve_control_plane_set(names(&["a", "b"]), &names(&["a", "a", "b"]), None, 3)
+                .is_err(),
+            "duplicate node rejected"
+        );
+    }
+
+    #[test]
+    fn resolve_cp_set_rejects_pinned_bootstrap_outside_explicit_list() {
+        // A recorded/overridden bootstrap not in the requested set would silently move `.1`.
+        let err = resolve_control_plane_set(
+            names(&["a", "b", "c", "d"]),
+            &names(&["a", "b", "c"]),
+            Some("d"),
+            3,
+        )
+        .unwrap_err();
+        assert!(err.contains("bootstrap control-plane d"), "got: {err}");
+        // In-list pinned bootstrap is fine and leads the set.
+        let set = resolve_control_plane_set(
+            names(&["a", "b", "c"]),
+            &names(&["a", "b", "c"]),
+            Some("b"),
+            3,
+        )
+        .unwrap();
+        assert_eq!(set[0], "b");
+    }
+
+    #[test]
+    fn resolve_cp_set_legacy_single_cp_reup_is_idempotent() {
+        // A 1-CP cluster re-upped with replicas=1 resolves to the same single-node set (guard allows).
+        let set = resolve_control_plane_set(names(&["a", "b"]), &[], Some("a"), 1).unwrap();
+        assert_eq!(set, names(&["a"]));
     }
 
     #[test]

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -135,16 +135,13 @@ pub(crate) fn provision_assignments(
     nodes.sort_by(|a, b| a.name.cmp(&b.name)); // deterministic
 
     // Bootstrap control-plane (etcd seed, holder of `.1`). Recorded bootstrap outranks a scanned
-    // `Controller` (secondary CPs also carry that role); `.1` follows it so a 1->3 set stays stable.
-    let bootstrap = nodes
-        .iter()
-        .find(|n| matches!(n.k0s_role, Some(K0sRole::Single)))
-        .map(|n| n.name.clone())
-        .or_else(|| state.control_plane_node.clone())
+    // role (secondary CPs also carry `Controller`) so `.1` stays put across a 1->3 grow.
+    let bootstrap = state
+        .bootstrap()
         .or_else(|| {
             nodes
                 .iter()
-                .find(|n| matches!(n.k0s_role, Some(K0sRole::Controller)))
+                .find(|n| matches!(n.k0s_role, Some(K0sRole::Single | K0sRole::Controller)))
                 .map(|n| n.name.clone())
         })
         .or_else(|| net.control_plane_node.clone())
@@ -219,12 +216,8 @@ pub(crate) fn provision_assignments(
     Ok(())
 }
 
-/// Resolve the control-plane node set for `spur k8s up`, fail-closed. Given a sorted list of
-/// candidate node names, an optional explicit CP list, an optional pinned bootstrap node, and a
-/// replica count, returns the CP set with the bootstrap node first. Rules:
-/// - an explicit `nodes` list wins (its count must be 1/3/5 and every name must exist);
-/// - otherwise pick the lowest `replicas` candidates (validated 1/3/5), pinned bootstrap first;
-/// - never request more control planes than there are nodes.
+/// Resolve the control-plane set for `spur k8s up`, fail-closed, bootstrap node first: an explicit
+/// `nodes` list wins, else the lowest `replicas` candidates. Count must be 1/3/5 and fit the nodes.
 pub(crate) fn resolve_control_plane_set(
     mut candidates: Vec<String>,
     explicit: &[String],
@@ -574,7 +567,7 @@ async fn converge_provisioning(
         join_tokens.clear();
         return;
     }
-    let bootstrap = cluster.k0s_state().control_plane_node;
+    let bootstrap = cluster.k0s_state().bootstrap();
     let mut all_active = true;
     let mut bootstrap_active = false;
     // Bootstrap control-plane first: it seeds etcd (tokenless) and its k0s API must answer before any
@@ -603,9 +596,8 @@ async fn converge_provisioning(
     if !bootstrap_active {
         return;
     }
-    // Secondary control planes: join the bootstrap's etcd quorum with a `controller` token, then
-    // workers with a `worker` token. Both mint from a healthy control-plane agent; minting errors
-    // until that API is reachable — treated as "retry next tick".
+    // Secondary CPs join the etcd quorum with a `controller` token, then workers with a `worker`
+    // token; both mint from a healthy CP agent, and a minting error just retries next tick.
     for node in &assigned {
         let role = node.k0s_role.expect("assigned above");
         let is_bootstrap = role == K0sRole::Single || bootstrap.as_deref() == Some(&node.name);

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -134,13 +134,8 @@ pub(crate) fn provision_assignments(
     }
     nodes.sort_by(|a, b| a.name.cmp(&b.name)); // deterministic
 
-    // Bootstrap control-plane (etcd seed, holder of `.1`). Derive from an ALREADY-ASSIGNED
-    // Controller/Single node FIRST: the persisted role assignment is the durable source of truth.
-    // The CP-choice persist below is a separate raft write that lands *after* the assignment loop, so
-    // a crash between the first `assign(CP, .1)` and that persist would otherwise let a restart (with
-    // `state.control_plane_node` still None) pick a different, lexically-earlier node and hand it the
-    // same `.1`. Fall back to the recorded choice -> config override -> lexically-first when nothing
-    // is assigned yet. `.1` follows the bootstrap so a 1->3 CP set keeps its existing address.
+    // Bootstrap control-plane (etcd seed, holder of `.1`). Recorded bootstrap outranks a scanned
+    // `Controller` (secondary CPs also carry that role); `.1` follows it so a 1->3 set stays stable.
     let bootstrap = nodes
         .iter()
         .find(|n| matches!(n.k0s_role, Some(K0sRole::Single)))

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -319,6 +319,7 @@ async fn main() -> anyhow::Result<()> {
         rpc_stats,
         sched_stats,
         accounting_pool,
+        config.cluster.control_plane_replicas,
     )
     .await?;
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1801,21 +1801,14 @@ impl SlurmController for ControllerService {
         }
         let req = request.into_inner();
         let state = self.cluster.k0s_state();
-        let assigned = self
-            .cluster
-            .get_nodes()
-            .iter()
-            .any(|n| n.k0s_role.is_some());
+        let nodes = self.cluster.get_nodes();
+        let assigned = nodes.iter().any(|n| n.k0s_role.is_some());
 
         // Resolve the HA control-plane set fail-closed BEFORE recording intent: an explicit node
-        // list wins, else `--replicas` (or the config default) picks the lowest-named nodes. Pin the
-        // bootstrap to the operator override / recorded CP so `.1` and the etcd seed are stable.
-        let candidates: Vec<String> = self
-            .cluster
-            .get_nodes()
-            .into_iter()
-            .map(|n| n.name)
-            .collect();
+        // list wins, else `--replicas` (or the config default) picks the lowest-named nodes.
+        let candidates: Vec<String> = nodes.into_iter().map(|n| n.name).collect();
+        let explicit_override =
+            !req.control_plane_nodes.is_empty() || req.control_plane_replicas.is_some();
         let replicas = req
             .control_plane_replicas
             .filter(|r| *r > 0)
@@ -1824,18 +1817,22 @@ impl SlurmController for ControllerService {
             .control_plane_node
             .clone()
             .or_else(|| state.control_plane_node.clone());
-        let cp_set = crate::cluster_k8s::resolve_control_plane_set(
-            candidates,
-            &req.control_plane_nodes,
-            pinned.as_deref(),
-            replicas,
-        )
-        .map_err(Status::invalid_argument)?;
+        // A bare re-up of an assigned cluster targets the recorded set, so it stays idempotent
+        // regardless of the config default; an explicit list/replica count is resolved and enforced.
+        let cp_set = if assigned && !explicit_override {
+            state.controllers()
+        } else {
+            crate::cluster_k8s::resolve_control_plane_set(
+                candidates,
+                &req.control_plane_nodes,
+                pinned.as_deref(),
+                replicas,
+            )
+            .map_err(Status::invalid_argument)?
+        };
 
-        // Reject a control-plane change once roles are assigned: provisioning skips already-assigned
-        // nodes, so moving/growing the control plane here would leave an inconsistent topology (an old
-        // controller still Controller, a would-be CP a Worker). Tear the cluster down
-        // (`spur k8s down --reset`) to re-elect. A matching set (idempotent re-up) is allowed.
+        // A control-plane change after roles are assigned would leave an inconsistent topology
+        // (provisioning skips assigned nodes); require `spur k8s down --reset` to re-elect.
         if assigned {
             let mut current = state.controllers();
             let mut want = cp_set.clone();
@@ -2951,6 +2948,78 @@ mod tests {
             }))
             .await
             .expect_err("a still-Pending job must not accept a new step");
+        assert_eq!(err.code(), Code::FailedPrecondition);
+    }
+
+    async fn assign_ha_control_plane(svc: &ControllerService) {
+        use spur_core::k0s::{K0sPhase, K0sRole};
+        use spur_core::node::NodeSource;
+        for (i, name) in ["cp-a", "cp-b", "cp-c"].iter().enumerate() {
+            svc.cluster
+                .register_node(
+                    (*name).into(),
+                    spur_core::resource::ResourceSet {
+                        cpus: 4,
+                        memory_mb: 8000,
+                        ..Default::default()
+                    },
+                    "127.0.0.1".into(),
+                    6818 + i as u16,
+                    String::new(),
+                    String::new(),
+                    NodeSource::NativeHost,
+                    std::collections::HashMap::new(),
+                )
+                .unwrap();
+            svc.cluster
+                .assign_node_k0s(
+                    name,
+                    K0sRole::Controller,
+                    &format!("10.44.0.{}", i + 1),
+                    "10.42.0.0/24",
+                )
+                .unwrap();
+        }
+        svc.cluster
+            .set_k0s_phase(
+                K0sPhase::Ready,
+                Some("cp-a".into()),
+                vec!["cp-a".into(), "cp-b".into(), "cp-c".into()],
+                false,
+            )
+            .unwrap();
+    }
+
+    // A bare `spur k8s up` (no flags) on an assigned 3-CP cluster is idempotent: it must target the
+    // recorded set, not re-resolve against the replicas=1 config default and spuriously reject.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cluster_up_bare_reup_on_ha_cluster_is_idempotent() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        assign_ha_control_plane(&svc).await;
+
+        let resp = svc
+            .cluster_up(Request::new(ClusterUpRequest::default()))
+            .await
+            .expect("bare re-up of an assigned HA cluster must be accepted")
+            .into_inner();
+        assert!(resp.accepted);
+    }
+
+    // An explicit replica count that doesn't match the assigned set is still rejected.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cluster_up_mismatched_replicas_on_ha_cluster_is_rejected() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        assign_ha_control_plane(&svc).await;
+
+        let err = svc
+            .cluster_up(Request::new(ClusterUpRequest {
+                control_plane_replicas: Some(1),
+                ..Default::default()
+            }))
+            .await
+            .expect_err("shrinking an assigned 3-CP cluster must be rejected");
         assert_eq!(err.code(), Code::FailedPrecondition);
     }
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -40,6 +40,9 @@ pub struct ControllerService {
     client_addrs: BTreeMap<u64, String>,
     rpc_stats: Arc<RpcStatsCollector>,
     sched_stats: Arc<SchedStatsCollector>,
+    /// Default HA control-plane count (`[cluster] control_plane_replicas`) when `spur k8s up`
+    /// requests neither `--replicas` nor an explicit node set.
+    control_plane_replicas: u32,
 }
 
 struct LeaderProxy {
@@ -1797,29 +1800,63 @@ impl SlurmController for ControllerService {
             }
         }
         let req = request.into_inner();
+        let state = self.cluster.k0s_state();
+        let assigned = self
+            .cluster
+            .get_nodes()
+            .iter()
+            .any(|n| n.k0s_role.is_some());
+
+        // Resolve the HA control-plane set fail-closed BEFORE recording intent: an explicit node
+        // list wins, else `--replicas` (or the config default) picks the lowest-named nodes. Pin the
+        // bootstrap to the operator override / recorded CP so `.1` and the etcd seed are stable.
+        let candidates: Vec<String> = self
+            .cluster
+            .get_nodes()
+            .into_iter()
+            .map(|n| n.name)
+            .collect();
+        let replicas = req
+            .control_plane_replicas
+            .filter(|r| *r > 0)
+            .unwrap_or(self.control_plane_replicas);
+        let pinned = req
+            .control_plane_node
+            .clone()
+            .or_else(|| state.control_plane_node.clone());
+        let cp_set = crate::cluster_k8s::resolve_control_plane_set(
+            candidates,
+            &req.control_plane_nodes,
+            pinned.as_deref(),
+            replicas,
+        )
+        .map_err(Status::invalid_argument)?;
+
         // Reject a control-plane change once roles are assigned: provisioning skips already-assigned
-        // nodes, so moving the control plane here would only rewrite the recorded CP and leave the
-        // old controller a Controller and the new node a Worker (inconsistent topology). Tear the
-        // cluster down (`spur k8s down --reset`) to re-elect a control plane.
-        if let Some(new_cp) = req.control_plane_node.as_deref() {
-            let state = self.cluster.k0s_state();
-            let assigned = self
-                .cluster
-                .get_nodes()
-                .iter()
-                .any(|n| n.k0s_role.is_some());
-            if assigned && state.control_plane_node.as_deref() != Some(new_cp) {
+        // nodes, so moving/growing the control plane here would leave an inconsistent topology (an old
+        // controller still Controller, a would-be CP a Worker). Tear the cluster down
+        // (`spur k8s down --reset`) to re-elect. A matching set (idempotent re-up) is allowed.
+        if assigned {
+            let mut current = state.controllers();
+            let mut want = cp_set.clone();
+            current.sort();
+            want.sort();
+            if current != want {
                 return Err(Status::failed_precondition(format!(
-                    "control-plane node is already assigned ({}); tear the cluster down \
-                     (spur k8s down --reset) before changing it to {new_cp}",
-                    state.control_plane_node.as_deref().unwrap_or("<none>"),
+                    "control plane is already assigned ({}); tear the cluster down \
+                     (spur k8s down --reset) before changing it to [{}]",
+                    state.controllers().join(", "),
+                    cp_set.join(", "),
                 )));
             }
         }
+
+        let bootstrap = cp_set.first().cloned();
         self.cluster
             .set_k0s_phase(
                 spur_core::k0s::K0sPhase::Provisioning,
-                req.control_plane_node.clone(),
+                bootstrap,
+                cp_set,
                 false,
             )
             .map_err(|e| Status::internal(format!("set k0s phase: {e}")))?;
@@ -1849,7 +1886,7 @@ impl SlurmController for ControllerService {
         }
         let req = request.into_inner();
         self.cluster
-            .set_k0s_phase(spur_core::k0s::K0sPhase::Down, None, req.reset)
+            .set_k0s_phase(spur_core::k0s::K0sPhase::Down, None, Vec::new(), req.reset)
             .map_err(|e| Status::internal(format!("set k0s phase: {e}")))?;
         Ok(Response::new(ClusterDownResponse {
             accepted: true,
@@ -1868,9 +1905,11 @@ impl SlurmController for ControllerService {
             return client.cluster_status(fwd).await;
         }
         let state = self.cluster.k0s_state();
+        let control_plane_nodes = state.controllers();
         Ok(Response::new(ClusterStatusResponse {
             phase: crate::cluster_k8s::phase_str(state.phase),
             control_plane_node: state.control_plane_node.unwrap_or_default(),
+            control_plane_nodes,
             nodes: crate::cluster_k8s::live_node_statuses(&self.cluster).await,
         }))
     }
@@ -1918,6 +1957,7 @@ pub async fn serve(
     rpc_stats: Arc<RpcStatsCollector>,
     sched_stats: Arc<SchedStatsCollector>,
     accounting_pool: Option<sqlx::PgPool>,
+    control_plane_replicas: u32,
 ) -> anyhow::Result<()> {
     let client_addrs: BTreeMap<u64, String> = raft_handle
         .peers
@@ -1941,6 +1981,7 @@ pub async fn serve(
         leader_proxy,
         rpc_stats: rpc_stats.clone(),
         sched_stats: sched_stats.clone(),
+        control_plane_replicas,
     };
 
     let stats_layer = RpcStatsLayer::new(rpc_stats, raft_handle);
@@ -2643,6 +2684,7 @@ mod tests {
             client_addrs,
             rpc_stats: Arc::new(RpcStatsCollector::new()),
             sched_stats: Arc::new(SchedStatsCollector::new("sched/backfill")),
+            control_plane_replicas: 1,
         }
     }
 
@@ -2755,6 +2797,7 @@ mod tests {
             client_addrs: BTreeMap::new(),
             rpc_stats: std::sync::Arc::new(RpcStatsCollector::new()),
             sched_stats: std::sync::Arc::new(SchedStatsCollector::new("backfill")),
+            control_plane_replicas: 1,
         }
     }
 

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -781,6 +781,11 @@ message ClusterUpRequest {
   // Override the control-plane node; empty = pick from [cluster] config / inventory.
   optional string control_plane_node = 1;
   reserved 2; // was install_arc — ARC is not installed by spur/k0s
+  // HA control-plane count (1, 3, or 5). 0/absent = the [cluster] config default. Ignored if
+  // control_plane_nodes is set.
+  optional uint32 control_plane_replicas = 3;
+  // Explicit control-plane node names (1, 3, or 5). First is the etcd bootstrap node.
+  repeated string control_plane_nodes = 4;
 }
 message ClusterUpResponse {
   bool accepted = 1;
@@ -803,6 +808,8 @@ message ClusterStatusResponse {
   string phase = 1;
   string control_plane_node = 2;
   repeated ClusterNodeStatus nodes = 3;
+  // All control-plane nodes (HA). Bootstrap node first; empty pre-multi-CP (see control_plane_node).
+  repeated string control_plane_nodes = 4;
 }
 
 message ClusterNodeStatus {

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -442,6 +442,54 @@ class SpurCluster:
     def scontrol(self, *args: str) -> str:
         return self.cli(["scontrol"] + list(args))
 
+    # --- Native k0s cluster (spur k8s) wrappers ---
+
+    def k8s_up(self, args: list[str] | None = None) -> str:
+        return self.cli(["spur", "k8s", "up"] + (args or []))
+
+    def k8s_down(self, reset: bool = True) -> str:
+        extra = ["--reset"] if reset else []
+        return self.cli(["spur", "k8s", "down"] + extra)
+
+    def k8s_status(self) -> str:
+        return self.cli(["spur", "k8s", "status"])
+
+    def k8s_control_planes(self) -> list[str]:
+        """Parse the control-plane node list from `spur k8s status`."""
+        for line in self.k8s_status().splitlines():
+            if line.startswith("control-plane:"):
+                names = line.split(":", 1)[1].strip()
+                return [n.strip() for n in names.split(",") if n.strip()]
+        return []
+
+    def k8s_active_controllers(self) -> list[str]:
+        """Node names whose `spur k8s status` row is role=controller/single and active."""
+        out = []
+        for line in self.k8s_status().splitlines():
+            fields = line.split()
+            if len(fields) >= 3 and fields[1] in ("controller", "single") and fields[2] == "active":
+                out.append(fields[0])
+        return out
+
+    def wait_k8s_phase(self, phase: str, timeout: int = 600) -> str:
+        """Poll `spur k8s status` until it reports the given phase."""
+        deadline = time.time() + timeout
+        last = ""
+        while time.time() < deadline:
+            last = self.k8s_status()
+            for line in last.splitlines():
+                if line.startswith("phase:") and line.split(":", 1)[1].strip() == phase:
+                    return last
+            time.sleep(5)
+        raise TimeoutError(f"k0s phase did not reach {phase} within {timeout}s:\n{last}")
+
+    def etcd_member_count(self, node_index: int = 0) -> int:
+        """Ground-truth etcd quorum size via `k0s etcd member-list` on a control plane."""
+        out = self.nodes[node_index].exec_allow_fail(
+            f"{self._sudo_prefix()}k0s etcd member-list 2>/dev/null"
+        )
+        return len(re.findall(r"https?://[^\"]+:2380", out))
+
     def sacct(self, args: list[str]) -> str:
         return self.cli(["sacct"] + args)
 

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -483,12 +483,20 @@ class SpurCluster:
             time.sleep(5)
         raise TimeoutError(f"k0s phase did not reach {phase} within {timeout}s:\n{last}")
 
-    def etcd_member_count(self, node_index: int = 0) -> int:
-        """Ground-truth etcd quorum size via `k0s etcd member-list` on a control plane."""
-        out = self.nodes[node_index].exec_allow_fail(
-            f"{self._sudo_prefix()}k0s etcd member-list 2>/dev/null"
-        )
-        return len(re.findall(r"https?://[^\"]+:2380", out))
+    def etcd_member_count(self) -> int:
+        """Ground-truth etcd quorum size via `k0s etcd member-list`. Runs on a control-plane node
+        (etcd only exists there; node 0 may be a worker since CPs are chosen by lexical order)."""
+        cps = set(self.k8s_control_planes())
+        for i, name in enumerate(self.node_names):
+            if name not in cps:
+                continue
+            out = self.nodes[i].exec_allow_fail(
+                f"{self._sudo_prefix()}k0s etcd member-list 2>/dev/null"
+            )
+            members = re.findall(r"https?://[^\"]+:2380", out)
+            if members:
+                return len(members)
+        return 0
 
     def sacct(self, args: list[str]) -> str:
         return self.cli(["sacct"] + args)

--- a/tests/native_host/e2e/conftest.py
+++ b/tests/native_host/e2e/conftest.py
@@ -23,6 +23,10 @@ def pytest_configure(config):
         "markers",
         "mpi: MPI end-to-end tests requiring spur_mpi_pmix.so, libpmix, and mpicc",
     )
+    config.addinivalue_line(
+        "markers",
+        "k0s: native spur-managed k0s cluster tests (rootful spurd + systemd + etcd; slow)",
+    )
 
 
 def _get_nodes_config() -> list[str]:

--- a/tests/native_host/e2e/conftest.py
+++ b/tests/native_host/e2e/conftest.py
@@ -193,6 +193,34 @@ def multi_node_cluster(ssh_nodes, remote_bin_dir, cluster_config_overrides):
 
 
 @pytest.fixture
+def k8s_multicp_cluster(ssh_nodes, remote_bin_dir):
+    """Native k0s enabled, spurd rootful. Skips unless >= 3 nodes (etcd quorum) + sudo."""
+    if len(ssh_nodes) < 3:
+        pytest.skip(
+            f"multi-CP k0s tests require at least 3 nodes for an etcd quorum "
+            f"(got {len(ssh_nodes)})"
+        )
+    c = SpurCluster(ssh_nodes, make_remote_dir(), remote_bin_dir)
+    c.provision()
+    c.root_agent_preflight()
+    try:
+        c.start(
+            config_overrides={"cluster": {"enabled": True, "cni": "kuberouter"}},
+            agent_as_root=True,
+        )
+    except Exception:
+        c.teardown()
+        raise
+    yield c
+    try:
+        c.k8s_down(reset=True)
+        c.wait_k8s_phase("down", timeout=180)
+    except Exception:
+        pass
+    c.teardown()
+
+
+@pytest.fixture
 def accounting_cluster(ssh_nodes, remote_bin_dir, cluster_config_overrides):
     """
     Per-test fixture: a running cluster with Postgres on node 0.

--- a/tests/native_host/e2e/test_k8s_multicp.py
+++ b/tests/native_host/e2e/test_k8s_multicp.py
@@ -12,7 +12,7 @@ class TestK8sMultiControlPlane:
         cluster = k8s_multicp_cluster
 
         out = cluster.k8s_up(["--replicas", "3"])
-        assert "requested" in out or "up" in out.lower(), out
+        assert "provisioning requested" in out, out
 
         cluster.wait_k8s_phase("ready", timeout=600)
 

--- a/tests/native_host/e2e/test_k8s_multicp.py
+++ b/tests/native_host/e2e/test_k8s_multicp.py
@@ -3,7 +3,10 @@
 
 """Multi-control-plane (HA) native k0s E2E tests (needs >= 3 nodes for etcd quorum)."""
 
+import pytest
 
+
+@pytest.mark.k0s
 class TestK8sMultiControlPlane:
     def test_three_control_planes_form_etcd_quorum(self, k8s_multicp_cluster):
         cluster = k8s_multicp_cluster

--- a/tests/native_host/e2e/test_k8s_multicp.py
+++ b/tests/native_host/e2e/test_k8s_multicp.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Multi-control-plane (HA) native k0s E2E tests (needs >= 3 nodes for etcd quorum)."""
+
+
+class TestK8sMultiControlPlane:
+    def test_three_control_planes_form_etcd_quorum(self, k8s_multicp_cluster):
+        cluster = k8s_multicp_cluster
+
+        out = cluster.k8s_up(["--replicas", "3"])
+        assert "requested" in out or "up" in out.lower(), out
+
+        cluster.wait_k8s_phase("ready", timeout=600)
+
+        # Three distinct nodes were assigned the control-plane role.
+        cps = cluster.k8s_control_planes()
+        assert len(cps) == 3, f"expected 3 control planes, got {cps}"
+        assert len(set(cps)) == 3, f"control planes not distinct: {cps}"
+
+        # All three report an active controller component.
+        active = cluster.k8s_active_controllers()
+        assert len(active) == 3, f"expected 3 active controllers, got {active}"
+
+        # Ground truth: the embedded etcd formed a real 3-member quorum.
+        assert cluster.etcd_member_count() == 3, (
+            f"expected a 3-member etcd quorum\n{cluster.k8s_status()}"
+        )
+
+    def test_even_replica_count_rejected(self, k8s_multicp_cluster):
+        cluster = k8s_multicp_cluster
+        out = cluster.cli_allow_fail(["spur", "k8s", "up", "--replicas", "2"])
+        assert "1, 3, or 5" in out, f"even replica count must be rejected: {out}"


### PR DESCRIPTION
## Summary

`spur k8s up` previously provisioned a single k0s control plane — the data model, role assignment, and etcd were all single-CP. This adds HA multi-control-plane support (SPUR-107):

- `spur k8s up --replicas {1,3,5}` or `spur k8s up --control-plane-nodes a,b,c` provisions N control planes forming an etcd quorum.
- The first "bootstrap" CP seeds etcd (started tokenless); secondary CPs join its quorum with a `controller` join token; workers join with a `worker` token.
- Admin/kubeconfig/join-token RPCs fail over across control-plane agents, so they survive the loss of a single CP while quorum holds.
- `spur k8s status` now lists all control-plane nodes.

## Approach

The k0s bring-up primitives (`k0s token create --role controller`, `k0s controller --token-file`) were already role-agnostic on the agent side, so the change lives almost entirely in controller orchestration and the persisted state:

- **State/persistence** — `K0sClusterState` gains a `control_plane_nodes` set and the `K0sSetPhase` WAL variant carries it; both are `#[serde(default)]`, and the singular `control_plane_node` is retained as the bootstrap/back-compat field. `controllers()` folds the singular field in for pre-multi-CP state.
- **Resolution/validation** — `resolve_control_plane_set` picks the CP set fail-closed: replica count must be 1/3/5 (etcd quorum), never more CPs than nodes, explicit lists validated for membership/uniqueness, and a pinned bootstrap must be consistent with an explicit list. Validated at both the config-load and gRPC boundaries.
- **IPAM** — each CP gets a distinct mesh IP; the bootstrap keeps `.1` so a set stays address-stable.
- **Bring-up sequencing** — the reconcile loop starts the bootstrap first and only proceeds to secondary CPs/workers once the bootstrap's API is active, so a controller token is never minted against an unseeded quorum.

## Key design choices / trade-offs

- **CP count is fixed at bring-up.** Changing it requires `spur k8s down --reset`. Online grow/shrink was intentionally scoped out.
- **Endpoint strategy is client-side failover** across CP agents rather than a VIP/LB — no new infra, and it covers the "lose one CP" case that HA is for.

## Known limitations

- No online control-plane add/remove (needs `down --reset`).
- No automatic re-election / self-healing: losing etcd quorum, or losing the bootstrap CP mid-provision, leaves the cluster needing a manual `down --reset`. Auto-recovery (member prune + replacement) is a follow-up.
- **Control-plane nodes are not drained from batch scheduling.** A node running the k0s control plane still shows `idle` in `sinfo` and remains schedulable for Spur jobs — the k0s reconcile loop never touches scheduler node state. A heavy job co-scheduled onto a control-plane node can contend with etcd/apiserver. Draining control-plane nodes (while leaving workers dual-use for pods + jobs) is a follow-up.
- **`cluster_up` / `cluster_down` have no per-user authorization** (only a leader check). The managed k0s cluster is a single global resource per Spur deployment — there is no per-user cluster, and any caller can bring it up or tear it down. Gating cluster lifecycle to admins is a follow-up. (Multi-tenancy is per-namespace via scoped kubeconfigs, not per-cluster.)

## Test plan

- [x] Unit: CP-set resolution (replicas/explicit/pinned-bootstrap/even-rejection/over-provision), 3-CP quorum role+IPAM assignment, replica validation at the config boundary, and WAL/state back-compat via frozen pre-multi-CP fixtures.
- [x] `cargo clippy --workspace --exclude spur-ffi --all-targets` clean; `cargo fmt --all --check` clean.
- [x] The k0s controller-join → 3-member etcd quorum primitive was validated directly in containers.
- [x] Added a native-host e2e (`test_k8s_multicp.py`, requires >= 3 nodes) that brings up 3 control planes and asserts a real 3-member etcd quorum via `k0s etcd member-list`. Skips on smaller topologies.

## Live validation

Validated end-to-end on an isolated multi-node deployment (3 control planes + 1 worker), on non-production ports/state:

**Multi-CP bring-up (`spur k8s up --replicas 3`)**
- Role assignment: 3 nodes assigned `controller`, 1 assigned `worker`; each control plane got a distinct mesh IP.
- A real 3-member etcd quorum formed via the `controller` join-token path (`k0s etcd member-list` returns all three control-plane peers on `:2380`).
- The worker joined and reports `Ready` in `kubectl get nodes`; cluster phase reached `ready` with all four components active.
- Fail-closed validation confirmed live: `--replicas 2` and `--replicas 4` rejected (even count), `--replicas 5` rejected (more CPs than nodes), and an unknown node in `--control-plane-nodes` rejected.
- Restarting `spurctld` mid-run replayed the persisted control-plane set from the Raft log and returned the cluster to `ready` with the quorum intact — exercising the WAL/state back-compat path against real persisted state.

**Quota user-scoped kubeconfig (`spur k8s kubeconfig --user <u>`)**
- Resolved the user → account namespace + per-user ServiceAccount, created the SA, and minted a namespace-scoped kubeconfig.
- Confirmed scoping: the scoped kubeconfig carries a ServiceAccount bearer token (no cluster-admin client cert), and `kubectl auth whoami` reports the namespaced SA identity (`system:serviceaccount:<ns>:<sa>`), not cluster-admin.
- Note: the scoped path requires the account namespace to exist first (created by the quota tenancy path); requesting a scoped kubeconfig before the namespace exists fails closed with a clear error rather than falling back to a broader credential.

