### PR TITLE
fix(spur-cli): default srun and salloc --ntasks to one task per node

### DIFF
--- a/crates/spur-cli/src/env_defaults.rs
+++ b/crates/spur-cli/src/env_defaults.rs
@@ -112,9 +112,26 @@ pub fn apply_flag(matches: &ArgMatches, id: &str, names: &[&str], target: &mut b
     }
 }
 
-/// Apply a numeric env default. The error names the specific variable that
-/// supplied the bad value so a misconfigured `SLURM_NNODES=abc` is easy to
-/// diagnose.
+/// Parse the first set variable in `names`. The error names the specific
+/// variable that supplied the bad value so a misconfigured `SLURM_NNODES=abc`
+/// is easy to diagnose.
+fn parse_first_num<T>(names: &[&str]) -> Result<Option<T>>
+where
+    T: FromStr,
+    T::Err: Display,
+{
+    first_set(names)
+        .map(|(name, v)| {
+            // Trim so values with incidental whitespace (e.g. `SLURM_NTASKS="4 "`)
+            // parse instead of erroring.
+            v.trim()
+                .parse()
+                .map_err(|e| anyhow!("invalid value {:?} for {}: {}", v, name, e))
+        })
+        .transpose()
+}
+
+/// Apply a numeric env default to a flag carrying a clap default value.
 pub fn apply_num<T>(matches: &ArgMatches, id: &str, names: &[&str], target: &mut T) -> Result<()>
 where
     T: FromStr,
@@ -123,13 +140,29 @@ where
     if was_cli_set(matches, id) {
         return Ok(());
     }
-    if let Some((name, v)) = first_set(names) {
-        // Trim so values with incidental whitespace (e.g. `SLURM_NTASKS="4 "`)
-        // parse instead of erroring.
-        let trimmed = v.trim();
-        *target = trimmed
-            .parse()
-            .map_err(|e| anyhow!("invalid value {:?} for {}: {}", v, name, e))?;
+    if let Some(v) = parse_first_num(names)? {
+        *target = v;
+    }
+    Ok(())
+}
+
+/// Apply a numeric env default to an `Option<T>` flag, i.e. one with no clap
+/// default where staying unset carries meaning.
+pub fn apply_num_opt<T>(
+    matches: &ArgMatches,
+    id: &str,
+    names: &[&str],
+    target: &mut Option<T>,
+) -> Result<()>
+where
+    T: FromStr,
+    T::Err: Display,
+{
+    if was_cli_set(matches, id) {
+        return Ok(());
+    }
+    if let Some(v) = parse_first_num(names)? {
+        *target = Some(v);
     }
     Ok(())
 }

--- a/crates/spur-cli/src/main.rs
+++ b/crates/spur-cli/src/main.rs
@@ -8,6 +8,8 @@ mod format_engine;
 mod image;
 mod interactive;
 mod k8s;
+#[cfg(test)]
+mod mock_controller;
 mod net;
 mod node;
 mod nodelist;

--- a/crates/spur-cli/src/mock_controller.rs
+++ b/crates/spur-cli/src/mock_controller.rs
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! In-process `SlurmController` mock for exercising CLI code paths that hold a
+//! live [`SlurmControllerClient`].
+//!
+//! Follows the same shape as the `MockAgent` harness in `spurctld`: bind an
+//! ephemeral localhost port, serve a hand-written service on it, and hand the
+//! caller back the address plus a shared record of what the server observed.
+//! Only `CreateJobStep` and `RunStep` are implemented; every other RPC reports
+//! `unimplemented` so an unexpected call fails loudly instead of silently
+//! returning a default.
+
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+
+use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
+use spur_proto::proto::{self, slurm_controller_server};
+use tonic::transport::{Channel, Endpoint};
+
+/// Step id the mock hands back from `CreateJobStep`. Distinctive so tests can
+/// prove it is threaded into the follow-up `RunStep` rather than defaulted.
+pub(crate) const MOCK_STEP_ID: u32 = 4242;
+
+/// Exit code the mock reports from `RunStep`.
+pub(crate) const MOCK_EXIT_CODE: i32 = 7;
+
+/// What the mock controller actually received, shared with the test body.
+#[derive(Clone, Default)]
+pub(crate) struct StepCapture {
+    create_step_num_tasks: Arc<AtomicU32>,
+    run_step_step_id: Arc<AtomicU32>,
+    run_step_calls: Arc<AtomicU32>,
+}
+
+impl StepCapture {
+    /// Task count carried by the most recent `CreateJobStep`.
+    pub(crate) fn create_step_num_tasks(&self) -> u32 {
+        self.create_step_num_tasks.load(Ordering::SeqCst)
+    }
+
+    /// Step id carried by the most recent `RunStep`.
+    pub(crate) fn run_step_step_id(&self) -> u32 {
+        self.run_step_step_id.load(Ordering::SeqCst)
+    }
+
+    /// Number of `RunStep` calls, so tests can assert dispatch stopped early.
+    pub(crate) fn run_step_calls(&self) -> u32 {
+        self.run_step_calls.load(Ordering::SeqCst)
+    }
+}
+
+struct MockController {
+    capture: StepCapture,
+}
+
+/// Emit the whole `impl` block, including the `#[tonic::async_trait]`
+/// attribute. The attribute has to be applied by the macro rather than written
+/// above the invocation: `async_trait` rewrites `async fn` signatures, and it
+/// only sees method bodies that already exist when it runs.
+macro_rules! mock_controller_impl {
+    (
+        implemented { $($implemented:tt)* }
+        unimplemented { $($method:ident($req:ty) -> $resp:ty;)* }
+    ) => {
+        #[tonic::async_trait]
+        impl slurm_controller_server::SlurmController for MockController {
+            $($implemented)*
+            $(
+                async fn $method(
+                    &self,
+                    _request: tonic::Request<$req>,
+                ) -> Result<tonic::Response<$resp>, tonic::Status> {
+                    Err(tonic::Status::unimplemented(stringify!($method)))
+                }
+            )*
+        }
+    };
+}
+
+mock_controller_impl! {
+    implemented {
+        async fn create_job_step(
+            &self,
+            request: tonic::Request<proto::CreateJobStepRequest>,
+        ) -> Result<tonic::Response<proto::CreateJobStepResponse>, tonic::Status> {
+            self.capture
+                .create_step_num_tasks
+                .store(request.into_inner().num_tasks, Ordering::SeqCst);
+            Ok(tonic::Response::new(proto::CreateJobStepResponse {
+                step_id: MOCK_STEP_ID,
+                node_addr: String::new(),
+            }))
+        }
+
+        async fn run_step(
+            &self,
+            request: tonic::Request<proto::RunStepRequest>,
+        ) -> Result<tonic::Response<proto::RunStepResponse>, tonic::Status> {
+            self.capture
+                .run_step_step_id
+                .store(request.into_inner().step_id, Ordering::SeqCst);
+            self.capture.run_step_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(tonic::Response::new(proto::RunStepResponse {
+                exit_code: MOCK_EXIT_CODE,
+                stdout: String::new(),
+                stderr: String::new(),
+                node: String::new(),
+            }))
+        }
+    }
+    unimplemented {
+        submit_job(proto::SubmitJobRequest) -> proto::SubmitJobResponse;
+        get_jobs(proto::GetJobsRequest) -> proto::GetJobsResponse;
+        get_job(proto::GetJobRequest) -> proto::JobInfo;
+        cancel_job(proto::CancelJobRequest) -> ();
+        complete_job(proto::CompleteJobRequest) -> ();
+        suspend_job(proto::SuspendJobRequest) -> ();
+        resume_job(proto::ResumeJobRequest) -> ();
+        update_job(proto::UpdateJobRequest) -> ();
+        get_nodes(proto::GetNodesRequest) -> proto::GetNodesResponse;
+        get_node(proto::GetNodeRequest) -> proto::NodeInfo;
+        update_node(proto::UpdateNodeRequest) -> ();
+        drain_node(proto::DrainNodeRequest) -> proto::DrainNodeResponse;
+        deregister_node(proto::DeregisterNodeRequest) -> proto::DeregisterNodeResponse;
+        deregister_agent(proto::DeregisterAgentRequest) -> ();
+        get_partitions(proto::GetPartitionsRequest) -> proto::GetPartitionsResponse;
+        get_job_steps(proto::GetJobStepsRequest) -> proto::GetJobStepsResponse;
+        ping(()) -> proto::PingResponse;
+        get_job_metrics(()) -> proto::JobMetrics;
+        get_node_metrics(()) -> proto::NodeMetrics;
+        get_rpc_stats(()) -> proto::RpcStats;
+        reset_diag_stats(()) -> ();
+        get_sched_stats(()) -> proto::SchedStats;
+        register_agent(proto::RegisterAgentRequest) -> proto::RegisterAgentResponse;
+        heartbeat(proto::HeartbeatRequest) -> proto::HeartbeatResponse;
+        create_token(proto::CreateTokenRequest) -> proto::CreateTokenResponse;
+        list_tokens(proto::ListTokensRequest) -> proto::ListTokensResponse;
+        revoke_token(proto::RevokeTokenRequest) -> proto::RevokeTokenResponse;
+        report_job_status(proto::ReportJobStatusRequest) -> ();
+        create_reservation(proto::CreateReservationRequest) -> ();
+        update_reservation(proto::UpdateReservationRequest) -> ();
+        delete_reservation(proto::DeleteReservationRequest) -> ();
+        list_reservations(proto::ListReservationsRequest) -> proto::ListReservationsResponse;
+        exec_in_job(proto::ExecInJobRequest) -> proto::ExecInJobResponse;
+        cluster_up(proto::ClusterUpRequest) -> proto::ClusterUpResponse;
+        cluster_down(proto::ClusterDownRequest) -> proto::ClusterDownResponse;
+        cluster_status(proto::ClusterStatusRequest) -> proto::ClusterStatusResponse;
+        cluster_kubeconfig(proto::ClusterKubeconfigRequest) -> proto::ClusterKubeconfigResponse;
+    }
+}
+
+/// Serve the mock on an OS-assigned localhost port.
+pub(crate) async fn spawn() -> (SocketAddr, StepCapture) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("local addr");
+    let capture = StepCapture::default();
+    let service = MockController {
+        capture: capture.clone(),
+    };
+    let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+    tokio::spawn(
+        tonic::transport::Server::builder()
+            .add_service(spur_proto::controller_server(service))
+            .serve_with_incoming(incoming),
+    );
+    (addr, capture)
+}
+
+/// Dial the mock through the same helper production code uses.
+pub(crate) async fn client(addr: SocketAddr) -> SlurmControllerClient<Channel> {
+    let channel = spur_client::connect_channel(&format!("http://{addr}"))
+        .await
+        .expect("connect to mock controller");
+    spur_proto::controller_client(channel)
+}
+
+/// A client whose channel is created without dialing, so the first RPC is what
+/// fails. Lets tests drive the RPC-failure path without a server.
+pub(crate) fn lazy_client(addr: SocketAddr) -> SlurmControllerClient<Channel> {
+    let channel = Endpoint::from_shared(format!("http://{addr}"))
+        .expect("valid endpoint")
+        .connect_lazy();
+    spur_proto::controller_client(channel)
+}
+
+/// Reserve a localhost port and release it, so connecting to it is refused
+/// immediately instead of hanging until the connect timeout.
+pub(crate) async fn unreachable_addr() -> SocketAddr {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral port");
+    listener.local_addr().expect("local addr")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// RPCs the mock does not implement must surface as `Unimplemented` rather
+    /// than a default-valued success, so a test that drifts onto an unmocked
+    /// call fails instead of silently passing.
+    #[tokio::test]
+    async fn unmocked_rpc_reports_unimplemented() {
+        let (addr, _capture) = spawn().await;
+        let status = client(addr)
+            .await
+            .ping(())
+            .await
+            .expect_err("ping is not mocked");
+        assert_eq!(status.code(), tonic::Code::Unimplemented);
+        assert_eq!(status.message(), "ping");
+    }
+}

--- a/crates/spur-cli/src/salloc.rs
+++ b/crates/spur-cli/src/salloc.rs
@@ -557,4 +557,28 @@ mod tests {
         assert_eq!(args.nodes, 1, "nodes must stay at the CLI default");
         assert!(args.job_name.is_none(), "job_name must stay unset");
     }
+
+    /// Drives `main_with_args` far enough to resolve the task count, then stops
+    /// at the controller dial. Guards the argument plumbing between parsing and
+    /// `connect_channel`, which the parse-only tests above never execute.
+    #[tokio::test]
+    #[serial(env_injection)]
+    async fn main_with_args_resolves_request_then_fails_to_connect() {
+        let _env = EnvGuard::new();
+        let addr = crate::mock_controller::unreachable_addr().await;
+        let err = main_with_args(vec![
+            "salloc".into(),
+            "-N".into(),
+            "4".into(),
+            "--controller".into(),
+            format!("http://{addr}"),
+        ])
+        .await
+        .expect_err("connect to a closed port must fail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("failed to connect to spurctld"),
+            "expected a controller connect failure, got: {msg}"
+        );
+    }
 }

--- a/crates/spur-cli/src/salloc.rs
+++ b/crates/spur-cli/src/salloc.rs
@@ -28,9 +28,9 @@ pub struct SallocArgs {
     #[arg(short = 'N', long, default_value = "1")]
     pub nodes: u32,
 
-    /// Number of tasks
-    #[arg(short = 'n', long, default_value = "1")]
-    pub ntasks: u32,
+    /// Number of tasks (default: one per node)
+    #[arg(short = 'n', long)]
+    pub ntasks: Option<u32>,
 
     /// CPUs per task
     #[arg(short = 'c', long, default_value = "1")]
@@ -146,7 +146,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let reservation = args.reservation;
     let partition = args.partition;
     let account = args.account;
-    let ntasks = args.ntasks;
+    let ntasks = crate::sbatch::effective_ntasks(args.ntasks, None, nodes);
     let cpus_per_task = args.cpus_per_task;
 
     let channel = spur_client::connect_channel(&controller)
@@ -413,6 +413,26 @@ mod tests {
                 .expect("parse failed");
         assert_eq!(args.nodelist.as_deref(), Some("node001"));
         assert_eq!(args.exclude.as_deref(), Some("node002"));
+    }
+
+    #[test]
+    fn ntasks_defaults_to_node_count() {
+        let args = SallocArgs::try_parse_from(["salloc", "-N", "4"]).expect("parse failed");
+        assert_eq!(args.ntasks, None);
+        assert_eq!(
+            crate::sbatch::effective_ntasks(args.ntasks, None, args.nodes),
+            4
+        );
+    }
+
+    #[test]
+    fn explicit_ntasks_overrides_node_default() {
+        let args =
+            SallocArgs::try_parse_from(["salloc", "-N", "4", "-n", "2"]).expect("parse failed");
+        assert_eq!(
+            crate::sbatch::effective_ntasks(args.ntasks, None, args.nodes),
+            2
+        );
     }
 
     #[test]

--- a/crates/spur-cli/src/sbatch.rs
+++ b/crates/spur-cli/src/sbatch.rs
@@ -707,7 +707,11 @@ fn candidate_script_path(cli_args: &[String]) -> Option<String> {
 /// scales with `-N` instead of being a fixed 1. `--ntasks-per-node=K` raises
 /// that default to `nodes * K`, keeping `SLURM_NTASKS` and accounting in step
 /// with the number of tasks actually launched.
-fn effective_ntasks(ntasks: Option<u32>, ntasks_per_node: Option<u32>, nodes: u32) -> u32 {
+pub(crate) fn effective_ntasks(
+    ntasks: Option<u32>,
+    ntasks_per_node: Option<u32>,
+    nodes: u32,
+) -> u32 {
     if let Some(n) = ntasks {
         return n;
     }

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -1,7 +1,9 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::env_defaults::{apply_csv, apply_flag, apply_num, apply_str, was_cli_set};
+use crate::env_defaults::{
+    apply_csv, apply_flag, apply_num, apply_num_opt, apply_str, was_cli_set,
+};
 use anyhow::{Context, Result};
 use clap::{ArgMatches, CommandFactory, FromArgMatches, Parser};
 use spur_core::config::HooksConfig;
@@ -37,9 +39,9 @@ pub struct SrunArgs {
     #[arg(short = 'N', long, default_value = "1")]
     pub nodes: u32,
 
-    /// Number of tasks
-    #[arg(short = 'n', long, default_value = "1")]
-    pub ntasks: u32,
+    /// Number of tasks (default: one per node)
+    #[arg(short = 'n', long)]
+    pub ntasks: Option<u32>,
 
     /// CPUs per task
     #[arg(short = 'c', long, default_value = "1")]
@@ -330,7 +332,7 @@ fn resolve_srun_env(matches: &ArgMatches, args: &mut SrunArgs) -> Result<()> {
         ],
         &mut args.nodes,
     )?;
-    apply_num(
+    apply_num_opt(
         matches,
         "ntasks",
         &["SPUR_NTASKS", "SPUR_NPROCS", "SLURM_NTASKS", "SLURM_NPROCS"],
@@ -556,7 +558,7 @@ fn build_srun_job_spec(
         uid: nix::unistd::getuid().as_raw(),
         gid: nix::unistd::getgid().as_raw(),
         num_nodes: args.nodes,
-        num_tasks: args.ntasks,
+        num_tasks: crate::sbatch::effective_ntasks(args.ntasks, None, args.nodes),
         cpus_per_task: args.cpus_per_task,
         memory_per_node_mb: memory_mb,
         gres,
@@ -705,11 +707,12 @@ async fn dispatch_step(
     let work_dir = params.work_dir;
     let io = params.io;
     let step_mpi = params.mpi;
+    let ntasks = crate::sbatch::effective_ntasks(args.ntasks, None, args.nodes);
     let step_id = client
         .create_job_step(CreateJobStepRequest {
             job_id,
             command: args.command.clone(),
-            num_tasks: args.ntasks,
+            num_tasks: ntasks,
             cpus_per_task: args.cpus_per_task,
             overlap: false,
             pty: false,
@@ -726,8 +729,8 @@ async fn dispatch_step(
 
     let environment = srun_dispatch_environment(args);
     warn_unsupported_cpu_bind(&environment);
-    if let Some(err) = spur_core::task_launch::map_cpu_bind_error(&environment, args.ntasks)
-        .or_else(|| spur_core::task_launch::mask_cpu_bind_error(&environment, args.ntasks))
+    if let Some(err) = spur_core::task_launch::map_cpu_bind_error(&environment, ntasks)
+        .or_else(|| spur_core::task_launch::mask_cpu_bind_error(&environment, ntasks))
     {
         anyhow::bail!("{err}");
     }
@@ -1512,6 +1515,34 @@ mod tests {
     }
 
     #[test]
+    fn build_srun_job_spec_ntasks_defaults_to_node_count() {
+        let args = SrunArgs::try_parse_from(["srun", "-N", "4", "hostname"]).expect("parse");
+        assert_eq!(args.ntasks, None);
+        let io = ResolvedIoPaths {
+            stdout: String::new(),
+            stderr: String::new(),
+            stdin: String::new(),
+        };
+        let spec =
+            build_srun_job_spec(&args, "/tmp/work", &io, spur_core::mpi::MPI_NONE).expect("spec");
+        assert_eq!(spec.num_tasks, 4);
+    }
+
+    #[test]
+    fn build_srun_job_spec_explicit_ntasks_overrides_node_default() {
+        let args =
+            SrunArgs::try_parse_from(["srun", "-N", "4", "-n", "2", "hostname"]).expect("parse");
+        let io = ResolvedIoPaths {
+            stdout: String::new(),
+            stderr: String::new(),
+            stdin: String::new(),
+        };
+        let spec =
+            build_srun_job_spec(&args, "/tmp/work", &io, spur_core::mpi::MPI_NONE).expect("spec");
+        assert_eq!(spec.num_tasks, 2);
+    }
+
+    #[test]
     fn parses_qos_short_and_long() {
         let short =
             SrunArgs::try_parse_from(["srun", "-q", "high", "hostname"]).expect("parse short qos");
@@ -1718,7 +1749,7 @@ mod tests {
     fn ntasks_nprocs_fallback() {
         let env = EnvGuard::new();
         env.set("SLURM_NPROCS", "7");
-        assert_eq!(resolve_from(&["srun", "hostname"]).ntasks, 7);
+        assert_eq!(resolve_from(&["srun", "hostname"]).ntasks, Some(7));
     }
 
     #[test]
@@ -1734,7 +1765,7 @@ mod tests {
     fn numeric_env_trims_whitespace() {
         let env = EnvGuard::new();
         env.set("SLURM_NTASKS", " 4 ");
-        assert_eq!(resolve_from(&["srun", "hostname"]).ntasks, 4);
+        assert_eq!(resolve_from(&["srun", "hostname"]).ntasks, Some(4));
     }
 
     #[test]
@@ -1820,7 +1851,7 @@ mod tests {
         let _env = EnvGuard::new();
         let args = resolve_from(&["srun", "hostname"]);
         assert_eq!(args.nodes, 1);
-        assert_eq!(args.ntasks, 1);
+        assert_eq!(args.ntasks, None);
         assert_eq!(args.cpus_per_task, 1);
         assert!(args.partition.is_none());
         assert!(args.mpi.is_none());
@@ -1841,13 +1872,40 @@ mod tests {
         env.set("SLURM_CPUS_PER_TASK", "2");
         env.set("SLURM_JOB_NUM_NODES", "3");
         let args = resolve_from(&["srun", "hostname"]);
-        assert_eq!(args.ntasks, 4);
+        assert_eq!(args.ntasks, Some(4));
         assert_eq!(args.cpus_per_task, 2);
         assert_eq!(args.nodes, 3);
 
         // An explicit CLI value still wins over the inherited allocation env.
         let overridden = resolve_from(&["srun", "-n", "1", "hostname"]);
-        assert_eq!(overridden.ntasks, 1);
+        assert_eq!(overridden.ntasks, Some(1));
+    }
+
+    /// Outside an allocation there is no `SLURM_NTASKS` to inherit, so the task
+    /// count follows the node count — including when `-N` itself came from env.
+    #[test]
+    #[serial(env_injection)]
+    fn ntasks_defaults_to_node_count_from_env() {
+        let env = EnvGuard::new();
+        env.set("SLURM_NNODES", "3");
+        let args = resolve_from(&["srun", "hostname"]);
+        assert_eq!(args.ntasks, None);
+        assert_eq!(
+            crate::sbatch::effective_ntasks(args.ntasks, None, args.nodes),
+            3
+        );
+    }
+
+    #[test]
+    #[serial(env_injection)]
+    fn invalid_ntasks_env_errors() {
+        let env = EnvGuard::new();
+        env.set("SLURM_NTASKS", "abc");
+        let matches = SrunArgs::command()
+            .try_get_matches_from(["srun", "hostname"])
+            .expect("parse failed");
+        let mut args = SrunArgs::from_arg_matches(&matches).expect("from_arg_matches failed");
+        assert!(resolve_srun_env(&matches, &mut args).is_err());
     }
 
     /// Allocation context is exported under the `*_JOB_*` names

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -492,6 +492,7 @@ fn resolve_io_paths(args: &SrunArgs) -> ResolvedIoPaths {
     }
 }
 
+#[derive(Debug)]
 struct StepDispatchResult {
     exit_code: i32,
 }
@@ -1929,6 +1930,112 @@ mod tests {
         // An explicit CLI value still wins over both.
         let overridden = resolve_from(&["srun", "-p", "cli-part", "hostname"]);
         assert_eq!(overridden.partition.as_deref(), Some("cli-part"));
+    }
+
+    fn empty_io() -> ResolvedIoPaths {
+        ResolvedIoPaths {
+            stdout: String::new(),
+            stderr: String::new(),
+            stdin: String::new(),
+        }
+    }
+
+    async fn dispatch_with(
+        client: &mut SlurmControllerClient<tonic::transport::Channel>,
+        cli: &[&str],
+    ) -> Result<StepDispatchResult> {
+        let args = SrunArgs::try_parse_from(cli).expect("parse failed");
+        let io = empty_io();
+        let params = StepDispatchParams {
+            args: &args,
+            work_dir: "/tmp",
+            io: &io,
+            mpi: spur_core::mpi::MPI_NONE,
+        };
+        dispatch_step(client, 1, &params).await
+    }
+
+    /// With no `-n`, the step must ask the controller for one task per node.
+    #[tokio::test]
+    #[serial(env_injection)]
+    async fn dispatch_step_requests_one_task_per_node_by_default() {
+        let _env = EnvGuard::new();
+        let (addr, capture) = crate::mock_controller::spawn().await;
+        let mut client = crate::mock_controller::client(addr).await;
+
+        let result = dispatch_with(&mut client, &["srun", "-N", "3", "hostname"])
+            .await
+            .expect("dispatch should succeed");
+
+        assert_eq!(capture.create_step_num_tasks(), 3);
+        assert_eq!(capture.run_step_calls(), 1);
+        assert_eq!(
+            capture.run_step_step_id(),
+            crate::mock_controller::MOCK_STEP_ID,
+            "RunStep must carry the step id returned by CreateJobStep"
+        );
+        assert_eq!(result.exit_code, crate::mock_controller::MOCK_EXIT_CODE);
+    }
+
+    #[tokio::test]
+    #[serial(env_injection)]
+    async fn dispatch_step_explicit_ntasks_overrides_node_default() {
+        let _env = EnvGuard::new();
+        let (addr, capture) = crate::mock_controller::spawn().await;
+        let mut client = crate::mock_controller::client(addr).await;
+
+        dispatch_with(&mut client, &["srun", "-N", "3", "-n", "2", "hostname"])
+            .await
+            .expect("dispatch should succeed");
+
+        assert_eq!(capture.create_step_num_tasks(), 2);
+    }
+
+    /// The per-node default feeds cpu-bind validation, so a `map_cpu` list
+    /// shorter than the node count is rejected before the step is run.
+    #[tokio::test]
+    #[serial(env_injection)]
+    async fn dispatch_step_rejects_map_cpu_bind_shorter_than_default_ntasks() {
+        let _env = EnvGuard::new();
+        let (addr, capture) = crate::mock_controller::spawn().await;
+        let mut client = crate::mock_controller::client(addr).await;
+
+        let err = dispatch_with(
+            &mut client,
+            &["srun", "-N", "4", "--cpu-bind", "map_cpu:0,1", "hostname"],
+        )
+        .await
+        .expect_err("two CPUs cannot cover four tasks");
+
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("map_cpu lists 2 CPU(s) but the step requires 4 task(s)"),
+            "expected a cpu-bind arity error, got: {msg}"
+        );
+        assert_eq!(capture.create_step_num_tasks(), 4);
+        assert_eq!(
+            capture.run_step_calls(),
+            0,
+            "dispatch must bail before running the step"
+        );
+    }
+
+    #[tokio::test]
+    #[serial(env_injection)]
+    async fn dispatch_step_surfaces_create_job_step_failure() {
+        let _env = EnvGuard::new();
+        let addr = crate::mock_controller::unreachable_addr().await;
+        let mut client = crate::mock_controller::lazy_client(addr);
+
+        let err = dispatch_with(&mut client, &["srun", "-N", "2", "hostname"])
+            .await
+            .expect_err("no server is listening");
+
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("failed to create job step"),
+            "expected a CreateJobStep failure, got: {msg}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What
srun and salloc gave --ntasks a fixed default of 1 regardless of --nodes, so a multi-node job submitted without -n reported a single task for the whole allocation. #522 fixed this for sbatch, leaving the three commands inconsistent for -N — the follow-up @yansun1996 flagged in review there. Confirmed salloc is a real, independently-implemented subcommand here (not an alias of srun), so it needed its own fix.

## Approach
Both now scale the default with -N by reusing sbatch's effective_ntasks helper (made pub(crate)) rather than duplicating it, matching the existing convention where salloc/srun already call other sbatch helpers like parse_gpu_flag. srun's --ntasks also resolves from SLURM_NTASKS/SLURM_NPROCS env vars, so an apply_num_opt variant of the numeric env helper was added for Option<u32> targets, sharing its parse/error logic with the existing apply_num.

## Behavior change
Precedence matches sbatch: explicit -n wins outright, and for srun an inherited SLURM_NTASKS/SLURM_NPROCS still takes priority over the node-count default, so a step inside an existing allocation stays sized to that allocation rather than jumping to the node count.

## Testing
Two new tests per command (node-count default, explicit -n override), plus env-precedence and invalid-env coverage for srun. cargo test -p spur-cli --locked (243 passed), cargo fmt --all --check, and cargo clippy -p spur-cli --all-targets --locked -- -D warnings all clean.