### PR TITLE
fix(spur-cli): apply sinfo --states filter to node query

### DIFF
--- a/crates/spur-cli/src/sinfo.rs
+++ b/crates/spur-cli/src/sinfo.rs
@@ -11,7 +11,11 @@ use crate::format_engine;
 
 /// View information about nodes and partitions.
 #[derive(Parser, Debug)]
-#[command(name = "sinfo", about = "View cluster information")]
+#[command(
+    name = "sinfo",
+    about = "View cluster information",
+    disable_help_flag = true
+)]
 pub struct SinfoArgs {
     /// Show only this partition
     #[arg(short = 'p', long)]
@@ -48,6 +52,10 @@ pub struct SinfoArgs {
         default_value = "http://localhost:6817"
     )]
     pub controller: String,
+
+    /// Print help
+    #[arg(long, action = clap::ArgAction::Help)]
+    pub help: Option<bool>,
 }
 
 pub async fn main() -> Result<()> {
@@ -353,16 +361,8 @@ mod tests {
 
     // --- state filter plumbing tests ---
 
-    /// `-h` is `--noheader` here, so the auto-generated help flag has to be
-    /// dropped before clap will build the command outside of `main`.
     fn parse_sinfo_args(argv: &[&str]) -> SinfoArgs {
-        use clap::{CommandFactory, FromArgMatches};
-
-        let matches = SinfoArgs::command()
-            .disable_help_flag(true)
-            .try_get_matches_from(argv)
-            .unwrap();
-        SinfoArgs::from_arg_matches(&matches).unwrap()
+        SinfoArgs::try_parse_from(argv).unwrap()
     }
 
     #[test]
@@ -420,6 +420,20 @@ mod tests {
         let req = build_get_nodes_request(&args).unwrap();
         assert_eq!(req.partition, "batch");
         assert_eq!(req.nodelist, "n[1-2]");
+    }
+
+    #[test]
+    fn short_h_is_noheader_not_help() {
+        assert!(parse_sinfo_args(&["sinfo", "-h"]).noheader);
+    }
+
+    #[tokio::test]
+    async fn invalid_state_fails_before_connecting() {
+        // Errors while building the request, so no server/network is needed here.
+        let err = main_with_args(vec!["sinfo".into(), "-t".into(), "BOGUS".into()])
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("BOGUS"), "{err}");
     }
 
     #[test]

--- a/crates/spur-cli/src/sinfo.rs
+++ b/crates/spur-cli/src/sinfo.rs
@@ -332,7 +332,11 @@ fn effective_state_str(node: &NodeInfo) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use spur_proto::proto as pb;
+    use spur_proto::proto::slurm_controller_server::SlurmController;
     use spur_proto::proto::NodeState;
+    use std::sync::{Arc, Mutex};
+    use tonic::{Request, Response, Status};
 
     fn make_node(name: &str, state: NodeState, partition: &str) -> NodeInfo {
         NodeInfo {
@@ -434,6 +438,125 @@ mod tests {
             .await
             .unwrap_err();
         assert!(err.to_string().contains("BOGUS"), "{err}");
+    }
+
+    /// Serves the two RPCs sinfo issues and records the `GetNodesRequest` it
+    /// saw, so a test can assert what actually went over the wire.
+    #[derive(Default)]
+    struct StubController {
+        nodes_req: Arc<Mutex<Option<pb::GetNodesRequest>>>,
+    }
+
+    /// Generates the impl so `async_trait` runs after expansion. Only the two
+    /// RPCs sinfo calls need behavior; the rest just have to exist.
+    macro_rules! stub_controller {
+        ($($name:ident($req:ty) -> $resp:ty;)*) => {
+            #[tonic::async_trait]
+            impl SlurmController for StubController {
+                async fn get_partitions(
+                    &self,
+                    _: Request<pb::GetPartitionsRequest>,
+                ) -> Result<Response<pb::GetPartitionsResponse>, Status> {
+                    Ok(Response::new(pb::GetPartitionsResponse {
+                        partitions: vec![make_partition("batch", true)],
+                    }))
+                }
+
+                async fn get_nodes(
+                    &self,
+                    request: Request<pb::GetNodesRequest>,
+                ) -> Result<Response<pb::GetNodesResponse>, Status> {
+                    *self.nodes_req.lock().unwrap() = Some(request.into_inner());
+                    Ok(Response::new(pb::GetNodesResponse {
+                        nodes: vec![make_node("n1", NodeState::NodeIdle, "batch")],
+                    }))
+                }
+
+                $(
+                    async fn $name(&self, _: Request<$req>) -> Result<Response<$resp>, Status> {
+                        Err(Status::unimplemented(stringify!($name)))
+                    }
+                )*
+            }
+        };
+    }
+
+    stub_controller! {
+        submit_job(pb::SubmitJobRequest) -> pb::SubmitJobResponse;
+        get_jobs(pb::GetJobsRequest) -> pb::GetJobsResponse;
+        get_job(pb::GetJobRequest) -> pb::JobInfo;
+        cancel_job(pb::CancelJobRequest) -> ();
+        complete_job(pb::CompleteJobRequest) -> ();
+        suspend_job(pb::SuspendJobRequest) -> ();
+        resume_job(pb::ResumeJobRequest) -> ();
+        update_job(pb::UpdateJobRequest) -> ();
+        get_node(pb::GetNodeRequest) -> pb::NodeInfo;
+        update_node(pb::UpdateNodeRequest) -> ();
+        drain_node(pb::DrainNodeRequest) -> pb::DrainNodeResponse;
+        deregister_node(pb::DeregisterNodeRequest) -> pb::DeregisterNodeResponse;
+        deregister_agent(pb::DeregisterAgentRequest) -> ();
+        get_job_steps(pb::GetJobStepsRequest) -> pb::GetJobStepsResponse;
+        create_job_step(pb::CreateJobStepRequest) -> pb::CreateJobStepResponse;
+        ping(()) -> pb::PingResponse;
+        get_job_metrics(()) -> pb::JobMetrics;
+        get_node_metrics(()) -> pb::NodeMetrics;
+        get_rpc_stats(()) -> pb::RpcStats;
+        reset_diag_stats(()) -> ();
+        get_sched_stats(()) -> pb::SchedStats;
+        register_agent(pb::RegisterAgentRequest) -> pb::RegisterAgentResponse;
+        heartbeat(pb::HeartbeatRequest) -> pb::HeartbeatResponse;
+        create_token(pb::CreateTokenRequest) -> pb::CreateTokenResponse;
+        list_tokens(pb::ListTokensRequest) -> pb::ListTokensResponse;
+        revoke_token(pb::RevokeTokenRequest) -> pb::RevokeTokenResponse;
+        report_job_status(pb::ReportJobStatusRequest) -> ();
+        create_reservation(pb::CreateReservationRequest) -> ();
+        update_reservation(pb::UpdateReservationRequest) -> ();
+        delete_reservation(pb::DeleteReservationRequest) -> ();
+        list_reservations(pb::ListReservationsRequest) -> pb::ListReservationsResponse;
+        exec_in_job(pb::ExecInJobRequest) -> pb::ExecInJobResponse;
+        run_step(pb::RunStepRequest) -> pb::RunStepResponse;
+        cluster_up(pb::ClusterUpRequest) -> pb::ClusterUpResponse;
+        cluster_down(pb::ClusterDownRequest) -> pb::ClusterDownResponse;
+        cluster_status(pb::ClusterStatusRequest) -> pb::ClusterStatusResponse;
+        cluster_kubeconfig(pb::ClusterKubeconfigRequest) -> pb::ClusterKubeconfigResponse;
+    }
+
+    #[tokio::test]
+    async fn stub_controller_rejects_rpcs_sinfo_does_not_use() {
+        let err = StubController::default()
+            .ping(Request::new(()))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unimplemented);
+    }
+
+    #[tokio::test]
+    async fn state_filter_reaches_the_controller() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind ephemeral port");
+        let addr = listener.local_addr().expect("local addr");
+        let stub = StubController::default();
+        let seen = stub.nodes_req.clone();
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        tokio::spawn(
+            tonic::transport::Server::builder()
+                .add_service(spur_proto::controller_server(stub))
+                .serve_with_incoming(incoming),
+        );
+
+        main_with_args(vec![
+            "sinfo".into(),
+            "-t".into(),
+            "idle".into(),
+            "--controller".into(),
+            format!("http://{addr}"),
+        ])
+        .await
+        .expect("sinfo against the stub controller");
+
+        let req = seen.lock().unwrap().clone().expect("get_nodes was called");
+        assert_eq!(req.states, vec![NodeState::NodeIdle as i32]);
     }
 
     #[test]

--- a/crates/spur-cli/src/sinfo.rs
+++ b/crates/spur-cli/src/sinfo.rs
@@ -69,6 +69,9 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
 
     let fields = format_engine::parse_format(&fmt, &format_engine::sinfo_header);
 
+    // Built before connecting so an invalid `-t` fails without a round-trip.
+    let nodes_req = build_get_nodes_request(&args)?;
+
     let channel = spur_client::connect_channel(&args.controller)
         .await
         .context("failed to connect to spurctld")?;
@@ -86,11 +89,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
 
     // Get nodes
     let nodes_resp = client
-        .get_nodes(GetNodesRequest {
-            states: Vec::new(),
-            partition: args.partition.unwrap_or_default(),
-            nodelist: args.nodes.unwrap_or_default(),
-        })
+        .get_nodes(nodes_req)
         .await
         .context("failed to get nodes")?;
 
@@ -105,6 +104,48 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn build_get_nodes_request(args: &SinfoArgs) -> Result<GetNodesRequest> {
+    let states = match args.states.as_deref() {
+        Some(s) => parse_states_arg(s)?,
+        None => Vec::new(),
+    };
+
+    Ok(GetNodesRequest {
+        states: states.iter().map(|s| *s as i32).collect(),
+        partition: args.partition.clone().unwrap_or_default(),
+        nodelist: args.nodes.clone().unwrap_or_default(),
+    })
+}
+
+/// Parse `-t` / `--states` (comma-separated). Whole-string `all` means no state filter.
+/// Unknown tokens are rejected (Slurm exits with an error rather than showing all nodes).
+fn parse_states_arg(s: &str) -> Result<Vec<spur_proto::proto::NodeState>> {
+    use spur_core::node::NodeState;
+
+    let trimmed = s.trim();
+    if trimmed.eq_ignore_ascii_case("all") {
+        return Ok(Vec::new());
+    }
+
+    let tokens: Vec<&str> = trimmed
+        .split(',')
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .collect();
+
+    if tokens.is_empty() {
+        anyhow::bail!("Invalid node state specified: (empty)");
+    }
+
+    let mut states = Vec::with_capacity(tokens.len());
+    for token in tokens {
+        let core = NodeState::from_short_or_name(token)
+            .ok_or_else(|| anyhow::anyhow!("Invalid node state specified: {token}"))?;
+        states.push(core.to_proto());
+    }
+    Ok(states)
 }
 
 fn group_nodes_by_display_state<'a>(nodes: &[&'a NodeInfo]) -> Vec<(String, Vec<&'a NodeInfo>)> {
@@ -308,6 +349,77 @@ mod tests {
             format_engine::SINFO_DEFAULT_FORMAT,
             &format_engine::sinfo_header,
         )
+    }
+
+    // --- state filter plumbing tests ---
+
+    /// `-h` is `--noheader` here, so the auto-generated help flag has to be
+    /// dropped before clap will build the command outside of `main`.
+    fn parse_sinfo_args(argv: &[&str]) -> SinfoArgs {
+        use clap::{CommandFactory, FromArgMatches};
+
+        let matches = SinfoArgs::command()
+            .disable_help_flag(true)
+            .try_get_matches_from(argv)
+            .unwrap();
+        SinfoArgs::from_arg_matches(&matches).unwrap()
+    }
+
+    #[test]
+    fn state_filter_reaches_the_request() {
+        let args = parse_sinfo_args(&["sinfo", "-t", "idle"]);
+        let req = build_get_nodes_request(&args).unwrap();
+        assert_eq!(req.states, vec![NodeState::NodeIdle as i32]);
+    }
+
+    #[test]
+    fn state_filter_accepts_comma_separated_short_and_long_names() {
+        let args = parse_sinfo_args(&["sinfo", "--states", "alloc,DOWN,draining"]);
+        let req = build_get_nodes_request(&args).unwrap();
+        assert_eq!(
+            req.states,
+            vec![
+                NodeState::NodeAllocated as i32,
+                NodeState::NodeDown as i32,
+                NodeState::NodeDraining as i32,
+            ]
+        );
+    }
+
+    #[test]
+    fn no_state_filter_leaves_request_states_empty() {
+        let args = parse_sinfo_args(&["sinfo"]);
+        let req = build_get_nodes_request(&args).unwrap();
+        assert!(req.states.is_empty());
+    }
+
+    #[test]
+    fn state_filter_all_means_no_filter() {
+        for spec in ["all", "ALL"] {
+            let args = parse_sinfo_args(&["sinfo", "-t", spec]);
+            assert!(build_get_nodes_request(&args).unwrap().states.is_empty());
+        }
+    }
+
+    #[test]
+    fn state_filter_rejects_unknown_state() {
+        let args = parse_sinfo_args(&["sinfo", "-t", "BOGUS"]);
+        let err = build_get_nodes_request(&args).unwrap_err();
+        assert!(err.to_string().contains("BOGUS"), "{err}");
+    }
+
+    #[test]
+    fn state_filter_rejects_empty_list() {
+        let args = parse_sinfo_args(&["sinfo", "-t", "  ,  "]);
+        assert!(build_get_nodes_request(&args).is_err());
+    }
+
+    #[test]
+    fn partition_and_nodelist_still_reach_the_request() {
+        let args = parse_sinfo_args(&["sinfo", "-p", "batch", "-n", "n[1-2]"]);
+        let req = build_get_nodes_request(&args).unwrap();
+        assert_eq!(req.partition, "batch");
+        assert_eq!(req.nodelist, "n[1-2]");
     }
 
     #[test]

--- a/crates/spur-core/src/node.rs
+++ b/crates/spur-core/src/node.rs
@@ -194,6 +194,16 @@ impl NodeState {
     pub fn to_proto_i32(self) -> i32 {
         self.to_proto() as i32
     }
+
+    /// Parse from a short sinfo suffix ("idle", "alloc", "mix") or full name
+    /// ("idle", "allocated", "mixed"). Case-insensitive.
+    pub fn from_short_or_name(s: &str) -> Option<Self> {
+        let lower = s.to_lowercase();
+        Self::ALL
+            .iter()
+            .find(|st| st.short() == lower || st.display() == lower)
+            .copied()
+    }
 }
 
 impl std::fmt::Display for NodeState {
@@ -575,5 +585,23 @@ mod tests {
             assert_eq!(NodeState::from_proto_i32(core.to_proto_i32()), Some(core));
             assert_eq!(NodeState::from_proto(core.to_proto()), core);
         }
+    }
+
+    #[test]
+    fn node_state_from_short_or_name_roundtrip() {
+        for &state in &NodeState::ALL {
+            assert_eq!(NodeState::from_short_or_name(state.short()), Some(state));
+            assert_eq!(NodeState::from_short_or_name(state.display()), Some(state));
+            assert_eq!(
+                NodeState::from_short_or_name(&state.short().to_uppercase()),
+                Some(state)
+            );
+        }
+    }
+
+    #[test]
+    fn node_state_from_short_or_name_rejects_unknown() {
+        assert_eq!(NodeState::from_short_or_name("bogus"), None);
+        assert_eq!(NodeState::from_short_or_name(""), None);
     }
 }


### PR DESCRIPTION
## What
sinfo declared -t/--states but never used the parsed value — it sent a hardcoded empty state list in GetNodesRequest, so the filter was silently discarded and sinfo -t idle returned nodes in every state, not just the requested one. spur nodes and spur info alias to sinfo and were affected identically.

## Approach
build_get_nodes_request now parses --states and forwards it, mirroring squeue's existing pattern: parse into typed states before connecting (so an invalid -t fails without a network round-trip), reject unknown tokens rather than silently widening the filter, and treat a whole-string all as no filter. Added NodeState::from_short_or_name in spur-core, directly parallel to the existing JobState::from_code_or_name, accepting both short sinfo suffixes (idle, alloc, mix) and full names (allocated, mixed), case-insensitively.

## Behavior change
sinfo -t <state> (and spur nodes/spur info) now actually filters as documented. Omitting -t still shows all states, so the default output is unchanged. The server-side filter was already correct and is untouched.

## Testing
Seven new CLI tests (including one asserting sinfo -t idle produces states == [NodeIdle]) plus two new core tests for the string/enum mapping. cargo test -p spur-cli --locked (244 passed), cargo fmt --all --check, and cargo clippy -p spur-cli -p spur-core --all-targets --locked -- -D warnings all clean.