### PR TITLE
build(spur-mpi-pmix): derive plugin target dir from OUT_DIR

### DIFF
--- a/crates/spur-mpi-pmix/build.rs
+++ b/crates/spur-mpi-pmix/build.rs
@@ -66,6 +66,7 @@ fn copy_plugin(
         return;
     }
     let Some(target_dir) = profile_target_dir(out_dir) else {
+        println!("cargo:warning=could not locate profile dir from OUT_DIR {out_dir:?}; plugin not staged");
         return;
     };
     for name in ["libspur_mpi_pmix.so", "spur_mpi_pmix.so"] {

--- a/crates/spur-mpi-pmix/build.rs
+++ b/crates/spur-mpi-pmix/build.rs
@@ -3,21 +3,17 @@
 
 use std::path::{Path, PathBuf};
 
-fn release_target_dir() -> PathBuf {
-    let base = std::env::var("CARGO_TARGET_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"))
-                .join("../../target")
-        });
-    let profile = std::env::var("PROFILE").unwrap_or_else(|_| "debug".into());
-    let mut dir = base.join(profile);
-    if let (Ok(target), Ok(host)) = (std::env::var("TARGET"), std::env::var("HOST")) {
-        if target != host {
-            dir = dir.join(target);
+/// Profile output dir derived from `OUT_DIR` so it honors `--target-dir`
+/// (e.g. `cargo llvm-cov`) instead of a guessed path that need not exist.
+fn profile_target_dir(out_dir: &Path) -> Option<PathBuf> {
+    let mut dir = out_dir;
+    while let Some(parent) = dir.parent() {
+        if parent.file_name().is_some_and(|n| n == "build") {
+            return parent.parent().map(Path::to_path_buf);
         }
+        dir = parent;
     }
-    dir
+    None
 }
 
 fn pkg_config_link_other(lib: &str) -> Vec<String> {
@@ -44,7 +40,6 @@ fn copy_plugin(
 ) {
     let archive = out_dir.join(format!("lib{archive_name}.a"));
     let built = out_dir.join("libspur_mpi_pmix.so");
-    let target_dir = release_target_dir();
 
     let mut cmd = cc::Build::new().get_compiler().to_command();
     cmd.arg("-shared").arg("-o").arg(&built).arg(format!(
@@ -65,10 +60,19 @@ fn copy_plugin(
         panic!("failed to link {built:?}");
     }
 
-    let release_lib = target_dir.join("libspur_mpi_pmix.so");
-    let plugin_name = target_dir.join("spur_mpi_pmix.so");
-    std::fs::copy(&built, &release_lib).expect("copy libspur_mpi_pmix.so to target dir");
-    std::fs::copy(&built, &plugin_name).expect("copy spur_mpi_pmix.so to target dir");
+    // Release-only, best-effort: place the plugin next to the release binaries
+    // for packaging/e2e without dropping uninstrumented .so where llvm-cov scans.
+    if std::env::var("PROFILE").as_deref() != Ok("release") {
+        return;
+    }
+    let Some(target_dir) = profile_target_dir(out_dir) else {
+        return;
+    };
+    for name in ["libspur_mpi_pmix.so", "spur_mpi_pmix.so"] {
+        if let Err(e) = std::fs::copy(&built, target_dir.join(name)) {
+            println!("cargo:warning=failed to stage {name} into {target_dir:?}: {e}");
+        }
+    }
 }
 
 fn main() {


### PR DESCRIPTION
> **Pure build/tooling fix — no product code changes.** This touches only the `spur-mpi-pmix` Cargo build script (compile-time artifact placement). No runtime behavior in `spurctld`/`spurd`/`spur`, no scheduler/gRPC/CLI/plugin logic, and nothing ships to the deployed binaries. Scoped `build(...)` so it stays out of the release changelog.

## What

The coverage CI job on `main` is failing. `cargo llvm-cov` aborts while compiling `spur-mpi-pmix` with:

```
thread 'main' panicked at crates/spur-mpi-pmix/build.rs:70:41:
copy libspur_mpi_pmix.so to target dir: Os { code: 2, kind: NotFound, ... }
```

Because the coverage build never finishes, no `lcov.info` is produced and the codecov upload then reports "No coverage reports found" — so the surface symptom (a codecov failure) is one step removed from the real cause (a build-script panic).

## Root cause

`build.rs` reconstructed the profile output dir by hand:

```rust
let base = CARGO_TARGET_DIR.unwrap_or(CARGO_MANIFEST_DIR/../../target);
let dir = base.join(PROFILE);          // -> <repo>/target/debug
std::fs::copy(&built, dir.join(...)).expect(...);   // panics if dir is absent
```

`cargo llvm-cov` builds with `--target-dir target/llvm-cov-target` but does **not** export `CARGO_TARGET_DIR`, so the guessed `../../target/<profile>` path is not the real output dir and need not exist on the runner. The `.expect()` then panics.

## Why this wasn't caught before it merged, and only appeared after

- **The build-script's own PR CI passed.** A normal `cargo build` / `cargo test` uses the default `target/`, where `target/debug` already exists — so the guessed path happened to be valid and the copy succeeded. The bug only triggers under a **custom `--target-dir`**, which in this repo is used exclusively by the coverage job.
- **The coverage job runs post-merge on `main`, not as a required gate on the feature PR**, so the one configuration that exercises the broken path didn't run (or wasn't blocking) until the change was already on `main`.
- **The failure also depends on the runner not having a pre-existing `target/debug`.** Locally, anyone who has done a plain debug build masks it (the guessed dir exists); a clean CI runner does not — which is why it reproduces in CI but not always on a developer machine.

Net: a path-assumption that holds for the default layout but breaks under `--target-dir`, exercised only by a non-gating post-merge job on a clean runner — three conditions that together let it land green.

## Approach

- Derive the profile dir from `OUT_DIR` (`<target>/<profile>/build/<pkg>/out`), which cargo always sets correctly regardless of `--target-dir`. Returns `Option`; unexpected layouts are skipped rather than panicking.
- Gate the copy to `PROFILE == "release"`. The copy exists only so packaging and the native-host e2e can read the plugin from `target/release/` (per `docs/deployment/native-host.rst` and `tests/native_host/e2e/cluster.py`); debug/coverage builds have no consumer and should not drop an uninstrumented `.so` into a dir that `llvm-cov` scans for objects.
- Make the copy best-effort, emitting `cargo:warning=` on failure instead of aborting the build.

## Behavior

- Release builds still stage `target/release/{lib,}spur_mpi_pmix.so` exactly as before.
- Debug and coverage builds no longer attempt the copy (previously they did unconditionally). No workflow reads the plugin from `target/debug/` — every consumer uses `target/release/` — so this is not a regression.

## Testing

- Reproduced the exact CI panic locally by running the coverage command with no pre-existing `target/debug`: old code panics at `build.rs:70`, patched code completes and produces `lcov.info`.
- Confirmed a release build still stages both `.so` artifacts at their documented path, and a debug build no longer creates them.
- `cargo clippy -p spur-mpi-pmix --all-targets --locked` clean, `cargo fmt --check` clean.
