### PR TITLE
fix(dispatch): back off between launch retries and drain unusable nodes

### DIFF
--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -310,10 +310,24 @@ pub struct ControllerConfig {
     /// `[controller] max_launch_backoff_secs` (default: 300).
     #[serde(default = "default_max_launch_backoff_secs")]
     pub max_launch_backoff_secs: u64,
+
+    /// Hold a job at priority 0 when its prolog fails, instead of requeueing it
+    /// for another attempt. On by default: a prolog receives the job's own
+    /// context, so the same failure recurs on every node, and retrying would
+    /// drain one node per attempt. Turning it off restores the retry, bounded by
+    /// `max_batch_requeue`. Configured in TOML as
+    /// `[controller] hold_on_prolog_fail` (default: true). Slurm's equivalent is
+    /// the inverse `SchedulerParameters=nohold_on_prolog_fail`.
+    #[serde(default = "default_hold_on_prolog_fail")]
+    pub hold_on_prolog_fail: bool,
 }
 
 fn default_max_batch_requeue() -> u32 {
     5
+}
+
+fn default_hold_on_prolog_fail() -> bool {
+    true
 }
 
 fn default_max_launch_backoff_secs() -> u64 {
@@ -359,6 +373,7 @@ impl Default for ControllerConfig {
             heartbeat_timeout_secs: None,
             max_batch_requeue: default_max_batch_requeue(),
             max_launch_backoff_secs: default_max_launch_backoff_secs(),
+            hold_on_prolog_fail: default_hold_on_prolog_fail(),
         }
     }
 }
@@ -1764,6 +1779,19 @@ deny_accounts = ["student"]
         assert_eq!(config.heartbeat_timeout_secs, None);
         assert_eq!(config.max_batch_requeue, 5);
         assert_eq!(config.max_launch_backoff_secs, 300);
+        assert!(config.hold_on_prolog_fail);
+    }
+
+    #[test]
+    fn controller_config_parses_hold_on_prolog_fail() {
+        let toml = r#"
+cluster_name = "test"
+
+[controller]
+hold_on_prolog_fail = false
+"#;
+        let config = SlurmConfig::load_from_str(toml).unwrap();
+        assert!(!config.controller.hold_on_prolog_fail);
     }
 
     #[test]

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -303,11 +303,27 @@ pub struct ControllerConfig {
     /// with `JobHoldMaxRequeue`. Configured in TOML as `[controller] max_batch_requeue` (default: 5).
     #[serde(default = "default_max_batch_requeue")]
     pub max_batch_requeue: u32,
+
+    /// Upper bound on the hold placed between automatic requeues after a launch
+    /// failure. The hold doubles per attempt, so this caps how long a job with a
+    /// large `max_batch_requeue` can wait between retries. Configured in TOML as
+    /// `[controller] max_launch_backoff_secs` (default: 300).
+    #[serde(default = "default_max_launch_backoff_secs")]
+    pub max_launch_backoff_secs: u64,
 }
 
 fn default_max_batch_requeue() -> u32 {
     5
 }
+
+fn default_max_launch_backoff_secs() -> u64 {
+    300
+}
+
+/// Upper bound for `max_launch_backoff_secs`. A per-attempt retry hold beyond a
+/// day is not a retry policy, and larger values push the computed hold instant
+/// out of chrono's representable range.
+pub const MAX_LAUNCH_BACKOFF_SECS: u64 = 86_400;
 
 fn default_listen_addr() -> String {
     "[::]:6817".into()
@@ -342,6 +358,7 @@ impl Default for ControllerConfig {
             raft_listen_addr: "[::]:6821".into(),
             heartbeat_timeout_secs: None,
             max_batch_requeue: default_max_batch_requeue(),
+            max_launch_backoff_secs: default_max_launch_backoff_secs(),
         }
     }
 }
@@ -1083,6 +1100,20 @@ impl SlurmConfig {
                 value: "0 (must be at least 1)".into(),
             });
         }
+        // Zero would clamp every launch-failure hold to zero, restoring the tight
+        // re-dispatch loop the backoff exists to prevent. The upper bound keeps
+        // the hold instant representable.
+        if self.controller.max_launch_backoff_secs == 0
+            || self.controller.max_launch_backoff_secs > MAX_LAUNCH_BACKOFF_SECS
+        {
+            return Err(ConfigError::InvalidValue {
+                field: "controller.max_launch_backoff_secs".into(),
+                value: format!(
+                    "{} (must be between 1 and {})",
+                    self.controller.max_launch_backoff_secs, MAX_LAUNCH_BACKOFF_SECS
+                ),
+            });
+        }
         if self.cluster.enabled {
             if self.cluster.distro != "k0s" {
                 return Err(ConfigError::InvalidValue {
@@ -1732,6 +1763,7 @@ deny_accounts = ["student"]
         let config = ControllerConfig::default();
         assert_eq!(config.heartbeat_timeout_secs, None);
         assert_eq!(config.max_batch_requeue, 5);
+        assert_eq!(config.max_launch_backoff_secs, 300);
     }
 
     #[test]
@@ -1757,6 +1789,71 @@ max_batch_requeue = 0
         let err = SlurmConfig::load_from_str(toml).unwrap_err();
         assert!(
             err.to_string().contains("max_batch_requeue"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn controller_config_parses_max_launch_backoff_secs() {
+        let toml = r#"
+cluster_name = "test"
+
+[controller]
+max_launch_backoff_secs = 90
+"#;
+        let config = SlurmConfig::load_from_str(toml).unwrap();
+        assert_eq!(config.controller.max_launch_backoff_secs, 90);
+    }
+
+    #[test]
+    fn controller_config_rejects_out_of_range_max_launch_backoff_secs() {
+        // Past this bound the computed hold instant overflows and panics the
+        // controller, so it must be refused at load rather than at first use.
+        let toml = format!(
+            r#"
+cluster_name = "test"
+
+[controller]
+max_launch_backoff_secs = {}
+"#,
+            MAX_LAUNCH_BACKOFF_SECS + 1
+        );
+        let err = SlurmConfig::load_from_str(&toml).unwrap_err();
+        assert!(
+            err.to_string().contains("max_launch_backoff_secs"),
+            "unexpected error: {err}"
+        );
+
+        let ok = format!(
+            r#"
+cluster_name = "test"
+
+[controller]
+max_launch_backoff_secs = {MAX_LAUNCH_BACKOFF_SECS}
+"#
+        );
+        assert_eq!(
+            SlurmConfig::load_from_str(&ok)
+                .unwrap()
+                .controller
+                .max_launch_backoff_secs,
+            MAX_LAUNCH_BACKOFF_SECS,
+            "the bound itself must be accepted"
+        );
+    }
+
+    #[test]
+    fn controller_config_rejects_zero_max_launch_backoff_secs() {
+        // Zero would clamp every hold to zero and restore the retry storm.
+        let toml = r#"
+cluster_name = "test"
+
+[controller]
+max_launch_backoff_secs = 0
+"#;
+        let err = SlurmConfig::load_from_str(toml).unwrap_err();
+        assert!(
+            err.to_string().contains("max_launch_backoff_secs"),
             "unexpected error: {err}"
         );
     }

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -659,6 +659,13 @@ pub struct Job {
     pub spec: JobSpec,
     pub state: JobState,
     pub pending_reason: PendingReason,
+    /// Slurm's `state_desc`: overrides `pending_reason` in user-facing output
+    /// when set, letting a hold say more than its reason code can. Written only
+    /// through [`Job::set_pending_reason`] and
+    /// [`Job::set_pending_reason_desc`], so it cannot outlive the reason it
+    /// explains.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pending_reason_desc: Option<String>,
     pub priority: u32,
 
     pub submit_time: DateTime<Utc>,
@@ -756,6 +763,7 @@ impl Job {
             spec,
             state,
             pending_reason,
+            pending_reason_desc: None,
             priority,
             submit_time: Utc::now(),
             start_time: None,
@@ -1045,6 +1053,29 @@ impl Job {
     /// during the wait, and only the hold-explaining reasons are worth keeping.
     pub fn reason_explains_begin_hold(&self, now: DateTime<Utc>) -> bool {
         self.is_begin_held(now) && self.pending_reason.explains_begin_hold()
+    }
+
+    /// Set the scheduling reason, dropping any description the previous reason
+    /// carried. Every write to `pending_reason` goes through here or
+    /// [`Job::set_pending_reason_desc`]: a description left behind by an
+    /// earlier reason would mask the new one everywhere it is displayed.
+    pub fn set_pending_reason(&mut self, reason: PendingReason) {
+        self.pending_reason = reason;
+        self.pending_reason_desc = None;
+    }
+
+    /// Set the reason together with a Slurm-style `state_desc` override.
+    pub fn set_pending_reason_desc(&mut self, reason: PendingReason, desc: impl Into<String>) {
+        self.pending_reason = reason;
+        self.pending_reason_desc = Some(desc.into());
+    }
+
+    /// The reason as users see it. Mirrors Slurm, where a `state_desc` wins
+    /// over the reason code in both `squeue` and `scontrol show job`.
+    pub fn state_reason_display(&self) -> &str {
+        self.pending_reason_desc
+            .as_deref()
+            .unwrap_or_else(|| self.pending_reason.display())
     }
 
     /// Attempt a state transition, enforcing the state machine.
@@ -1831,6 +1862,56 @@ mod tests {
         );
         assert_eq!(PendingReason::OutOfMemory.display(), "OutOfMemory");
         assert_eq!(PendingReason::BootFail.display(), "BootFailure");
+    }
+
+    #[test]
+    fn a_description_overrides_the_reason_code_in_user_facing_output() {
+        // Mirrors Slurm, where squeue and scontrol print state_desc when it is
+        // set and fall back to the state_reason code when it is not.
+        let mut job = make_job();
+        job.set_pending_reason(PendingReason::Held);
+        assert_eq!(job.state_reason_display(), "JobHeldUser");
+
+        job.set_pending_reason_desc(PendingReason::Held, "launch failed requeued held");
+        assert_eq!(job.state_reason_display(), "launch failed requeued held");
+        assert_eq!(
+            job.pending_reason,
+            PendingReason::Held,
+            "the description explains the code, it does not replace it"
+        );
+    }
+
+    #[test]
+    fn a_new_reason_never_inherits_the_previous_description() {
+        // The whole point of routing writes through the setters: a description
+        // left behind by an earlier hold would masquerade as the current reason
+        // everywhere the job is displayed.
+        let mut job = make_job();
+        job.set_pending_reason_desc(PendingReason::Held, "launch failed requeued held");
+
+        job.set_pending_reason(PendingReason::JobHoldMaxRequeue);
+
+        assert_eq!(job.pending_reason_desc, None);
+        assert_eq!(job.state_reason_display(), "JobHoldMaxRequeue");
+    }
+
+    #[test]
+    fn a_job_snapshot_without_a_description_still_deserializes() {
+        // Pre-upgrade snapshots carry no pending_reason_desc; they must load
+        // with the field absent rather than failing the whole replay.
+        let mut job = make_job();
+        job.set_pending_reason(PendingReason::Held);
+
+        let mut value = serde_json::to_value(&job).expect("serialize job");
+        assert!(
+            value.get("pending_reason_desc").is_none(),
+            "an absent description must not be written out"
+        );
+        value.as_object_mut().unwrap().remove("pending_reason_desc");
+
+        let back: Job = serde_json::from_value(value).expect("deserialize job");
+        assert_eq!(back.pending_reason_desc, None);
+        assert_eq!(back.state_reason_display(), "JobHeldUser");
     }
 
     #[test]

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -309,6 +309,13 @@ impl PendingReason {
         )
     }
 
+    /// True when this reason is set alongside a `begin_time` hold to explain it.
+    /// Any other reason on a held job is unrelated to the hold, so recomputing
+    /// it loses nothing.
+    pub fn explains_begin_hold(&self) -> bool {
+        matches!(self, Self::BeginTime | Self::JobLaunchFailure)
+    }
+
     pub fn display(&self) -> &'static str {
         match self {
             Self::None => "None",
@@ -1023,6 +1030,23 @@ pub enum TransitionOutcome {
 }
 
 impl Job {
+    /// True while a future `begin_time` defers this job's start, whether it came
+    /// from `--begin`, a preemption requeue, or a launch-failure backoff.
+    pub fn is_begin_held(&self, now: DateTime<Utc>) -> bool {
+        self.spec.begin_time.is_some_and(|begin| now < begin)
+    }
+
+    /// True when this job's `pending_reason` exists to explain an active
+    /// `begin_time` hold, so passes that recompute reasons must leave it alone:
+    /// a generic wait reason would overwrite it before anyone could read it.
+    ///
+    /// Narrower than [`Job::is_begin_held`] on purpose. A `--begin` job still
+    /// needs its real blocking reason (bad partition, unmet dependency) surfaced
+    /// during the wait, and only the hold-explaining reasons are worth keeping.
+    pub fn reason_explains_begin_hold(&self, now: DateTime<Utc>) -> bool {
+        self.is_begin_held(now) && self.pending_reason.explains_begin_hold()
+    }
+
     /// Attempt a state transition, enforcing the state machine.
     pub fn transition(&mut self, to: JobState) -> Result<(), JobTransitionError> {
         let valid = match (self.state, to) {
@@ -1807,6 +1831,26 @@ mod tests {
         );
         assert_eq!(PendingReason::OutOfMemory.display(), "OutOfMemory");
         assert_eq!(PendingReason::BootFail.display(), "BootFailure");
+    }
+
+    #[test]
+    fn is_begin_held_tracks_the_hold_window_regardless_of_reason() {
+        let now = Utc::now();
+        let mut job = make_job();
+
+        assert!(!job.is_begin_held(now), "no begin_time means not held");
+
+        job.spec.begin_time = Some(now + chrono::Duration::seconds(30));
+        assert!(job.is_begin_held(now));
+
+        // The predicate is keyed on the hold window alone: a launch-failure
+        // backoff must be recognised as held even though its reason is not
+        // BeginTime, otherwise the reason gets overwritten while it waits.
+        job.pending_reason = PendingReason::JobLaunchFailure;
+        assert!(job.is_begin_held(now));
+
+        job.spec.begin_time = Some(now - chrono::Duration::seconds(1));
+        assert!(!job.is_begin_held(now), "a lapsed hold no longer defers");
     }
 
     #[test]

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -38,6 +38,10 @@ pub enum WalOperation {
         /// Computed on the leader so every replica applies the same instant.
         #[serde(default)]
         begin_time: Option<chrono::DateTime<chrono::Utc>>,
+        /// Slurm's `state_desc`, travelling with `pending_reason` so both fields
+        /// land together on every replica.
+        #[serde(default)]
+        pending_reason_desc: Option<String>,
     },
     JobStart {
         job_id: JobId,
@@ -212,6 +216,7 @@ impl WalOperation {
             pending_reason: None,
             pending_priority: None,
             begin_time: None,
+            pending_reason_desc: None,
         }
     }
 
@@ -228,6 +233,26 @@ impl WalOperation {
             pending_reason: Some(reason),
             pending_priority: Some(0),
             begin_time: None,
+            pending_reason_desc: None,
+        }
+    }
+
+    /// As [`Self::job_state_change_held_pending`], with a `state_desc` that says
+    /// more about the hold than its reason code can.
+    pub fn job_state_change_held_pending_desc(
+        job_id: JobId,
+        old_state: JobState,
+        reason: PendingReason,
+        desc: impl Into<String>,
+    ) -> Self {
+        Self::JobStateChange {
+            job_id,
+            old_state,
+            new_state: JobState::Pending,
+            pending_reason: Some(reason),
+            pending_priority: Some(0),
+            begin_time: None,
+            pending_reason_desc: Some(desc.into()),
         }
     }
 
@@ -246,6 +271,7 @@ impl WalOperation {
             pending_reason: Some(reason),
             pending_priority: None,
             begin_time: Some(begin_time),
+            pending_reason_desc: None,
         }
     }
 
@@ -288,6 +314,7 @@ mod job_state_change_wal_tests {
                 pending_reason,
                 pending_priority,
                 begin_time,
+                pending_reason_desc,
             } => {
                 assert_eq!(job_id, 1);
                 assert_eq!(old_state, JobState::Preempted);
@@ -295,6 +322,67 @@ mod job_state_change_wal_tests {
                 assert_eq!(pending_reason, Some(PendingReason::JobHoldMaxRequeue));
                 assert_eq!(pending_priority, Some(0));
                 assert_eq!(begin_time, None, "a max-requeue hold has no begin_time");
+                assert_eq!(pending_reason_desc, None);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn a_held_pending_hold_carries_its_description_to_every_replica() {
+        // The reason and its description must travel in one entry: a follower
+        // that applied only the reason would report a bare JobHeldUser and lose
+        // why the job is parked.
+        let op = WalOperation::job_state_change_held_pending_desc(
+            9,
+            JobState::Failed,
+            PendingReason::Held,
+            "launch failed requeued held",
+        );
+        let json = serde_json::to_string(&op).unwrap();
+        let back: WalOperation = serde_json::from_str(&json).unwrap();
+        match back {
+            WalOperation::JobStateChange {
+                new_state,
+                pending_reason,
+                pending_priority,
+                pending_reason_desc,
+                ..
+            } => {
+                assert_eq!(new_state, JobState::Pending);
+                assert_eq!(pending_reason, Some(PendingReason::Held));
+                assert_eq!(pending_priority, Some(0));
+                assert_eq!(
+                    pending_reason_desc.as_deref(),
+                    Some("launch failed requeued held")
+                );
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn a_state_change_written_before_the_description_field_still_replays() {
+        // Pre-upgrade WAL entries have no pending_reason_desc key at all.
+        let op =
+            WalOperation::job_state_change_held_pending(3, JobState::Running, PendingReason::Held);
+        let mut value = serde_json::to_value(&op).unwrap();
+        value["JobStateChange"]
+            .as_object_mut()
+            .unwrap()
+            .remove("pending_reason_desc")
+            .expect("the field must be written, so removing it models an old entry");
+
+        let back: WalOperation =
+            serde_json::from_value(value).expect("old entries must still replay");
+        match back {
+            WalOperation::JobStateChange {
+                pending_reason,
+                pending_reason_desc,
+                ..
+            } => {
+                assert_eq!(pending_reason, Some(PendingReason::Held));
+                assert_eq!(pending_reason_desc, None);
             }
             _ => panic!("wrong variant"),
         }

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -34,6 +34,10 @@ pub enum WalOperation {
         /// When set with `new_state == Pending`, sets priority in the same apply step (e.g. hold at 0).
         #[serde(default)]
         pending_priority: Option<u32>,
+        /// When set with `new_state == Pending`, holds the job until this instant.
+        /// Computed on the leader so every replica applies the same instant.
+        #[serde(default)]
+        begin_time: Option<chrono::DateTime<chrono::Utc>>,
     },
     JobStart {
         job_id: JobId,
@@ -207,6 +211,7 @@ impl WalOperation {
             new_state,
             pending_reason: None,
             pending_priority: None,
+            begin_time: None,
         }
     }
 
@@ -222,6 +227,25 @@ impl WalOperation {
             new_state: JobState::Pending,
             pending_reason: Some(reason),
             pending_priority: Some(0),
+            begin_time: None,
+        }
+    }
+
+    /// Requeue to Pending with a backoff hold and a reason, applied in one step
+    /// so the job is never briefly eligible with no hold.
+    pub fn job_state_change_backoff_pending(
+        job_id: JobId,
+        old_state: JobState,
+        reason: PendingReason,
+        begin_time: chrono::DateTime<chrono::Utc>,
+    ) -> Self {
+        Self::JobStateChange {
+            job_id,
+            old_state,
+            new_state: JobState::Pending,
+            pending_reason: Some(reason),
+            pending_priority: None,
+            begin_time: Some(begin_time),
         }
     }
 
@@ -263,12 +287,14 @@ mod job_state_change_wal_tests {
                 new_state,
                 pending_reason,
                 pending_priority,
+                begin_time,
             } => {
                 assert_eq!(job_id, 1);
                 assert_eq!(old_state, JobState::Preempted);
                 assert_eq!(new_state, JobState::Pending);
                 assert_eq!(pending_reason, Some(PendingReason::JobHoldMaxRequeue));
                 assert_eq!(pending_priority, Some(0));
+                assert_eq!(begin_time, None, "a max-requeue hold has no begin_time");
             }
             _ => panic!("wrong variant"),
         }
@@ -283,10 +309,63 @@ mod job_state_change_wal_tests {
             WalOperation::JobStateChange {
                 pending_reason,
                 pending_priority,
+                begin_time,
                 ..
             } => {
                 assert_eq!(pending_reason, None);
                 assert_eq!(pending_priority, None);
+                assert_eq!(begin_time, None);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn job_state_change_backoff_pending_round_trips() {
+        let hold = chrono::Utc::now() + chrono::Duration::seconds(40);
+        let op = WalOperation::job_state_change_backoff_pending(
+            7,
+            JobState::Failed,
+            PendingReason::JobLaunchFailure,
+            hold,
+        );
+        let json = serde_json::to_string(&op).unwrap();
+        let back: WalOperation = serde_json::from_str(&json).unwrap();
+        match back {
+            WalOperation::JobStateChange {
+                new_state,
+                pending_reason,
+                pending_priority,
+                begin_time,
+                ..
+            } => {
+                assert_eq!(new_state, JobState::Pending);
+                assert_eq!(pending_reason, Some(PendingReason::JobLaunchFailure));
+                assert_eq!(
+                    pending_priority, None,
+                    "a backoff defers the job, it must not zero its priority"
+                );
+                assert_eq!(
+                    begin_time,
+                    Some(hold),
+                    "the leader-computed instant must survive the WAL verbatim"
+                );
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn pre_upgrade_job_state_change_without_begin_time_deserializes() {
+        // A WAL written before the backoff field existed must still replay.
+        let json = r#"{"JobStateChange":{"job_id":3,"old_state":"FAILED","new_state":"PENDING"}}"#;
+        let back: WalOperation = serde_json::from_str(json).unwrap();
+        match back {
+            WalOperation::JobStateChange {
+                job_id, begin_time, ..
+            } => {
+                assert_eq!(job_id, 3);
+                assert_eq!(begin_time, None);
             }
             _ => panic!("wrong variant"),
         }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -44,15 +44,13 @@ use crate::sched_stats::SchedStatsCollector;
 /// so operator runbooks and log greps written against Slurm keep working.
 pub const LAUNCH_FAILURE_HELD_DESC: &str = "launch failed requeued held";
 
-/// Seconds to defer a job by after its `requeue_count`-th launch failure.
+/// Seconds to defer a job by after its `requeue_count`-th launch failure,
+/// doubling per attempt from the same base the preemption requeue uses.
 ///
-/// Doubles per attempt from the same base the preemption requeue uses (two
-/// scheduler cycles plus slack), capped by `max_launch_backoff_secs`. The shift
-/// is clamped because `max_batch_requeue` is operator-supplied and a large one
-/// would otherwise overflow it; the cap makes the clamped value indistinguishable
-/// from the exact one anyway. Config validation rejects a cap above the ceiling,
-/// but an unvalidated config must degrade rather than push the computed instant
-/// out of chrono's range and panic the controller.
+/// The shift is clamped and the result double-capped because `max_batch_requeue`
+/// and the cap are both operator-supplied: an unvalidated config must degrade
+/// rather than push the computed instant out of chrono's range and panic the
+/// controller.
 fn launch_backoff_secs(interval_secs: u32, cap: u64, requeue_count: u32) -> u64 {
     let base = (interval_secs as u64 * 2 + 3).max(5);
     base.saturating_mul(1u64 << requeue_count.min(16))
@@ -1202,12 +1200,10 @@ impl ClusterManager {
     /// Requeue after a dispatch failure, optionally parking the job for an
     /// operator instead of retrying it.
     ///
-    /// `hold` is for failures the job carries with it, so a retry would fail the
-    /// same way on the next node and drain that one too. Such a job skips the
-    /// backoff and the requeue cap (neither means anything to a job that will
-    /// not retry on its own) and waits at priority 0 for `scontrol release`.
-    /// This is Slurm's prolog behavior, and the hold is what bounds the drain to
-    /// one node per failure.
+    /// `hold` is for failures the job carries with it, which would fail the same
+    /// way on the next node and drain that one too. Such a job skips the backoff
+    /// and the requeue cap, neither of which means anything to a job that will
+    /// not retry on its own.
     pub fn requeue_after_launch_failure(&self, job_id: JobId, hold: bool) -> anyhow::Result<()> {
         let (old_state, begin_time) = {
             let jobs = self.jobs.read();
@@ -1269,9 +1265,8 @@ impl ClusterManager {
         Ok(())
     }
 
-    /// Instant until which a job requeued after a launch failure is held.
-    ///
-    /// A user `--begin` further out always wins, so the hold never shortens a
+    /// Instant until which a job requeued after a launch failure is held. A user
+    /// `--begin` further out always wins, so the hold never shortens a
     /// user-supplied constraint. Computed on the leader so every replica applies
     /// one verbatim instant rather than reading its own clock.
     fn launch_backoff_until(&self, job: &Job) -> DateTime<Utc> {

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -39,6 +39,27 @@ use crate::limits_cache::QosCache;
 use crate::raft::{ClientResponse, JobFinalized, SpurRaft, StateMachineApply};
 use crate::sched_stats::SchedStatsCollector;
 
+/// Description shown for a job parked after a launch failure it would carry to
+/// the next node. Byte-exact with the `state_desc` Slurm sets in the same case,
+/// so operator runbooks and log greps written against Slurm keep working.
+pub const LAUNCH_FAILURE_HELD_DESC: &str = "launch failed requeued held";
+
+/// Seconds to defer a job by after its `requeue_count`-th launch failure.
+///
+/// Doubles per attempt from the same base the preemption requeue uses (two
+/// scheduler cycles plus slack), capped by `max_launch_backoff_secs`. The shift
+/// is clamped because `max_batch_requeue` is operator-supplied and a large one
+/// would otherwise overflow it; the cap makes the clamped value indistinguishable
+/// from the exact one anyway. Config validation rejects a cap above the ceiling,
+/// but an unvalidated config must degrade rather than push the computed instant
+/// out of chrono's range and panic the controller.
+fn launch_backoff_secs(interval_secs: u32, cap: u64, requeue_count: u32) -> u64 {
+    let base = (interval_secs as u64 * 2 + 3).max(5);
+    base.saturating_mul(1u64 << requeue_count.min(16))
+        .min(cap)
+        .min(spur_core::config::MAX_LAUNCH_BACKOFF_SECS)
+}
+
 /// Result of recording a per-node completion report.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NodeCompleteResult {
@@ -614,7 +635,7 @@ impl ClusterManager {
             // Record the reason before the terminal transition so any
             // observer (history, audit log, late `squeue` poll) sees DeadLine
             // instead of whatever update_pending_reasons last wrote.
-            job.pending_reason = PendingReason::DeadLine;
+            job.set_pending_reason(PendingReason::DeadLine);
         }
 
         let resp = self.propose(WalOperation::JobComplete {
@@ -1122,7 +1143,7 @@ impl ClusterManager {
     /// Requeue a job if spec.requeue is set and attempt limit not exceeded.
     fn maybe_requeue(&self, job_id: JobId) -> anyhow::Result<()> {
         let max = self.config.controller.max_batch_requeue;
-        let (should_requeue, old_state) = {
+        let (old_state, backoff) = {
             let jobs = self.jobs.read();
             let Some(job) = jobs.get(&job_id) else {
                 return Ok(());
@@ -1140,19 +1161,32 @@ impl ClusterManager {
             if !job.spec.requeue {
                 return Ok(());
             }
-            (true, job.state)
+            // The eviction tagged the cause, so a launch failure gets the same
+            // backoff the all-nodes-failed path gets. Without it a job with one
+            // broken node in its allocation burns its whole requeue budget in
+            // seconds. Node health and timeout requeues keep today's immediate
+            // retry: the blocking condition is already gone by then.
+            let launch_failed = job.pending_reason == PendingReason::JobLaunchFailure;
+            (
+                job.state,
+                launch_failed.then(|| self.launch_backoff_until(job)),
+            )
         };
-        if !should_requeue {
-            return Ok(());
-        }
 
-        self.propose(WalOperation::job_state_change(
-            job_id,
-            old_state,
-            JobState::Pending,
-        ))?;
+        // Computed before the proposal so every replica applies one verbatim
+        // instant rather than reading its own clock.
+        let op = match backoff {
+            Some(hold) => WalOperation::job_state_change_backoff_pending(
+                job_id,
+                old_state,
+                PendingReason::JobLaunchFailure,
+                hold,
+            ),
+            None => WalOperation::job_state_change(job_id, old_state, JobState::Pending),
+        };
+        self.propose(op)?;
 
-        info!(job_id, from = %old_state, "job requeued");
+        info!(job_id, from = %old_state, hold_until = ?backoff, "job requeued");
         Ok(())
     }
 
@@ -1162,6 +1196,19 @@ impl ClusterManager {
     /// (e.g., container image not found) so it can be retried after the
     /// user fixes the issue. (Issue #91)
     pub fn requeue_job(&self, job_id: JobId) -> anyhow::Result<()> {
+        self.requeue_after_launch_failure(job_id, false)
+    }
+
+    /// Requeue after a dispatch failure, optionally parking the job for an
+    /// operator instead of retrying it.
+    ///
+    /// `hold` is for failures the job carries with it, so a retry would fail the
+    /// same way on the next node and drain that one too. Such a job skips the
+    /// backoff and the requeue cap (neither means anything to a job that will
+    /// not retry on its own) and waits at priority 0 for `scontrol release`.
+    /// This is Slurm's prolog behavior, and the hold is what bounds the drain to
+    /// one node per failure.
+    pub fn requeue_after_launch_failure(&self, job_id: JobId, hold: bool) -> anyhow::Result<()> {
         let (old_state, begin_time) = {
             let jobs = self.jobs.read();
             let Some(job) = jobs.get(&job_id) else {
@@ -1170,20 +1217,20 @@ impl ClusterManager {
             if job.state.is_terminal() {
                 return Ok(());
             }
+            if !hold && job.requeue_count >= self.config.controller.max_batch_requeue {
+                drop(jobs);
+                return self.hold_job_at_max_requeue(job_id);
+            }
             // A job that never reached Running has nothing to requeue: Pending ->
             // Failed is not a legal transition and Pending -> Pending applies as a
             // NoOp, so both proposals below would be discarded and the hold lost.
             // Callers that fail before dispatch fall to the next scheduler tick.
             if job.state == JobState::Pending {
-                warn!(
+                debug!(
                     job_id,
                     "requeue requested for a job that never started; no backoff hold applied"
                 );
                 return Ok(());
-            }
-            if job.requeue_count >= self.config.controller.max_batch_requeue {
-                drop(jobs);
-                return self.hold_job_at_max_requeue(job_id);
             }
             (job.state, self.launch_backoff_until(job))
         };
@@ -1195,6 +1242,17 @@ impl ClusterManager {
             exit_code: -1,
             state: JobState::Failed,
         })?;
+
+        if hold {
+            self.propose(WalOperation::job_state_change_held_pending_desc(
+                job_id,
+                JobState::Failed,
+                PendingReason::Held,
+                LAUNCH_FAILURE_HELD_DESC,
+            ))?;
+            info!(job_id, from = %old_state, "job requeued and held after launch failure");
+            return Ok(());
+        }
 
         // Failed → Pending resets allocation fields and makes the job
         // schedulable again, but only once the backoff hold lapses: without it
@@ -1213,21 +1271,15 @@ impl ClusterManager {
 
     /// Instant until which a job requeued after a launch failure is held.
     ///
-    /// Doubles per attempt from the same base the preemption requeue uses (two
-    /// scheduler cycles plus slack), capped by `max_launch_backoff_secs`. A user
-    /// `--begin` further out always wins, so the hold never shortens a
+    /// A user `--begin` further out always wins, so the hold never shortens a
     /// user-supplied constraint. Computed on the leader so every replica applies
     /// one verbatim instant rather than reading its own clock.
     fn launch_backoff_until(&self, job: &Job) -> DateTime<Utc> {
-        let base = (self.config.scheduler.interval_secs as u64 * 2 + 3).max(5);
-        let cap = self.config.controller.max_launch_backoff_secs;
-        // Config validation rejects a cap above the ceiling; clamping again here
-        // keeps an unvalidated config from overflowing the instant below, which
-        // would panic the controller rather than degrade.
-        let hold_secs = base
-            .saturating_mul(1u64 << job.requeue_count.min(16))
-            .min(cap)
-            .min(spur_core::config::MAX_LAUNCH_BACKOFF_SECS);
+        let hold_secs = launch_backoff_secs(
+            self.config.scheduler.interval_secs,
+            self.config.controller.max_launch_backoff_secs,
+            job.requeue_count,
+        );
         let hold = Utc::now() + chrono::Duration::seconds(hold_secs as i64);
         job.spec.begin_time.map_or(hold, |user| user.max(hold))
     }
@@ -2288,7 +2340,7 @@ impl ClusterManager {
             }
             if let Some(job) = jobs.get_mut(id) {
                 job.bb_stage_state = BbStageState::Staging;
-                job.pending_reason = PendingReason::BurstBufferStageIn;
+                job.set_pending_reason(PendingReason::BurstBufferStageIn);
                 remaining = remaining.saturating_sub(req);
                 started.push(*id);
             }
@@ -2337,7 +2389,7 @@ impl ClusterManager {
             if job.state == JobState::Pending && job.bb_stage_state == BbStageState::Staging {
                 job.bb_stage_state = BbStageState::Ready;
                 if job.pending_reason == PendingReason::BurstBufferStageIn {
-                    job.pending_reason = PendingReason::None;
+                    job.set_pending_reason(PendingReason::None);
                 }
                 self.scheduler_notify.notify_one();
                 return true;
@@ -2402,7 +2454,7 @@ impl ClusterManager {
                         && j.pending_reason != PendingReason::DeadLine
                         && !j.reason_explains_begin_hold(Utc::now())
                     {
-                        j.pending_reason = PendingReason::Dependency;
+                        j.set_pending_reason(PendingReason::Dependency);
                     }
                 }
             }
@@ -2460,7 +2512,7 @@ impl ClusterManager {
                     && j.pending_reason != PendingReason::DeadLine
                     && !j.reason_explains_begin_hold(now)
                 {
-                    j.pending_reason = reason;
+                    j.set_pending_reason(reason);
                 }
             }
         }
@@ -2737,7 +2789,7 @@ impl ClusterManager {
                 continue;
             }
             job.priority = 0;
-            job.pending_reason = PendingReason::ReservationDeleted;
+            job.set_pending_reason(PendingReason::ReservationDeleted);
         }
     }
 
@@ -2751,7 +2803,7 @@ impl ClusterManager {
             }
             job.spec.reservation = None;
             if job.pending_reason == PendingReason::ReservationDeleted {
-                job.pending_reason = PendingReason::None;
+                job.set_pending_reason(PendingReason::None);
             }
         }
     }
@@ -2843,7 +2895,7 @@ impl ClusterManager {
             }
 
             if let Some(reason) = reservation_fence_reason(job, cluster_state) {
-                job_entry.pending_reason = reason;
+                job_entry.set_pending_reason(reason);
                 continue;
             }
 
@@ -2869,7 +2921,7 @@ impl ClusterManager {
                             || !node.can_satisfy_request(&required))
                 })
             {
-                job_entry.pending_reason = PendingReason::ReqNodeNotAvail;
+                job_entry.set_pending_reason(PendingReason::ReqNodeNotAvail);
                 continue;
             }
 
@@ -2881,7 +2933,7 @@ impl ClusterManager {
                     .filter(|n| placement.in_partition(n))
                     .count();
 
-                job_entry.pending_reason = if needed > partition_size {
+                job_entry.set_pending_reason(if needed > partition_size {
                     PendingReason::PartitionNodeLimit
                 } else if job.spec.constraint.is_some() && eligible.is_empty() {
                     PendingReason::BadConstraints
@@ -2891,7 +2943,7 @@ impl ClusterManager {
                     PendingReason::ReqNodeNotAvail
                 } else {
                     PendingReason::Resources
-                };
+                });
                 continue;
             }
 
@@ -2899,12 +2951,13 @@ impl ClusterManager {
             // `Allocated` cluster out of NodeDown; a nodelist pin to down nodes
             // is ReqNodeNotAvail (Slurm parity).
             if eligible.iter().all(|n| !n.state.is_up()) {
-                job_entry.pending_reason =
+                job_entry.set_pending_reason(
                     if job.spec.nodelist.as_deref().is_some_and(|s| !s.is_empty()) {
                         PendingReason::ReqNodeNotAvail
                     } else {
                         PendingReason::NodeDown
-                    };
+                    },
+                );
                 continue;
             }
 
@@ -2923,11 +2976,11 @@ impl ClusterManager {
                 })
                 .count();
 
-            job_entry.pending_reason = if free_now < needed {
+            job_entry.set_pending_reason(if free_now < needed {
                 PendingReason::Resources
             } else {
                 PendingReason::Priority
-            };
+            });
         }
     }
 
@@ -3139,7 +3192,7 @@ impl ClusterManager {
         job.allocated_nodes.clear();
         job.allocated_resources = None;
         job.per_node_alloc.clear();
-        job.pending_reason = PendingReason::None;
+        job.set_pending_reason(PendingReason::None);
         // Stale after requeue (points at nodes the job left); next dispatch resets it.
         job.actual_stdout_path = None;
         job.actual_stderr_path = None;
@@ -3183,7 +3236,7 @@ impl ClusterManager {
         }
         job.exit_code = Some(-1);
         job.end_time = Some(timestamp);
-        job.pending_reason = reason;
+        job.set_pending_reason(reason);
         let already_deallocated: Vec<String> = job.node_completions.keys().cloned().collect();
         job.node_completions.clear();
 
@@ -3288,6 +3341,7 @@ impl ClusterManager {
                 pending_reason,
                 pending_priority,
                 begin_time,
+                pending_reason_desc,
                 ..
             } => {
                 if let Some(job) = jobs.get_mut(job_id) {
@@ -3307,7 +3361,11 @@ impl ClusterManager {
                         } else {
                             Self::clear_run_state_for_requeue(job);
                         }
-                        job.pending_reason = pending_reason.clone().unwrap_or(PendingReason::None);
+                        let reason = pending_reason.clone().unwrap_or(PendingReason::None);
+                        match pending_reason_desc {
+                            Some(desc) => job.set_pending_reason_desc(reason, desc.clone()),
+                            None => job.set_pending_reason(reason),
+                        }
                         if let Some(priority) = pending_priority {
                             job.priority = *priority;
                         }
@@ -3353,7 +3411,7 @@ impl ClusterManager {
                     }
                     Self::reset_job_for_preempt_requeue(job);
                     job.spec.begin_time = Some(*begin_time);
-                    job.pending_reason = PendingReason::BeginTime;
+                    job.set_pending_reason(PendingReason::BeginTime);
                 }
                 if let Some(ref total) = allocated_resources {
                     let node_count = freed_nodes.len().max(1) as u32;
@@ -3442,7 +3500,7 @@ impl ClusterManager {
                     job.allocated_nodes = node_names.clone();
                     job.allocated_resources = Some(resources.clone());
                     job.per_node_alloc = per_node_alloc.clone();
-                    job.pending_reason = PendingReason::None;
+                    job.set_pending_reason(PendingReason::None);
                     job.srun_step_dispatch = *srun_step_dispatch;
                     job.run_attempt = *run_attempt;
                 }
@@ -3549,7 +3607,7 @@ impl ClusterManager {
                                 // steps, accumulated live by JobStepComplete; a
                                 // job with no srun steps keeps 0 (Slurm parity),
                                 // not the batch exit. Left as-is here.
-                                job.pending_reason = if oom {
+                                job.set_pending_reason(if oom {
                                     PendingReason::OutOfMemory
                                 } else if final_signal != 0 {
                                     PendingReason::RaisedSignal
@@ -3557,7 +3615,7 @@ impl ClusterManager {
                                     PendingReason::NonZeroExitCode
                                 } else {
                                     PendingReason::None
-                                };
+                                });
                                 job.end_time = Some(timestamp);
                                 job.node_completions.clear();
                                 Some((final_state, final_exit))
@@ -3733,7 +3791,7 @@ impl ClusterManager {
                 if let Some(job) = jobs.get_mut(job_id) {
                     job.priority = *new_priority;
                     if let Some(reason) = pending_reason {
-                        job.pending_reason = reason.clone();
+                        job.set_pending_reason(reason.clone());
                     }
                     if *reset_requeue_count {
                         job.requeue_count = 0;
@@ -6651,6 +6709,31 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_pending_job_at_the_requeue_cap_is_held_not_ignored() {
+        // The cap has to be checked before the never-started bail-out. A job
+        // that exhausts its budget while Pending would otherwise be dropped on
+        // the floor and re-dispatched at full priority every scheduler tick.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+        let max = cm.config.controller.max_batch_requeue;
+
+        let job_id = submit_and_wait(&cm, basic_spec("pending-at-cap"));
+        cm.jobs.write().get_mut(&job_id).unwrap().requeue_count = max;
+
+        cm.requeue_job(job_id).unwrap();
+
+        let job = cm.get_job(job_id).unwrap();
+        assert_eq!(job.state, JobState::Pending);
+        assert_eq!(job.pending_reason, PendingReason::JobHoldMaxRequeue);
+        assert_eq!(job.priority, 0, "a held job must not outrank live work");
+        assert!(
+            !cm.pending_jobs().iter().any(|j| j.job_id == job_id),
+            "the hold must take the job out of scheduling"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn draining_a_node_for_a_launch_failure_still_lets_the_job_requeue() {
         // The agent drains the node on a spool fault. That drain must not
         // finalize the job: it still has to reach Pending so the scheduler can
@@ -6711,18 +6794,46 @@ mod tests {
         assert_eq!(job.requeue_count, 0, "a terminal job is never retried");
     }
 
+    #[test]
+    fn the_backoff_doubles_each_attempt_up_to_the_cap() {
+        // The schedule itself, checked as arithmetic. With the default
+        // interval_secs = 1 the base is 5s, so the five attempts allowed by
+        // max_batch_requeue = 5 wait 5, 10, 20, 40 and 80 seconds: 155s in
+        // total instead of burning the budget in ~5s.
+        let uncapped = spur_core::config::MAX_LAUNCH_BACKOFF_SECS;
+        for (attempt, expected) in [5u64, 10, 20, 40, 80].into_iter().enumerate() {
+            assert_eq!(
+                launch_backoff_secs(1, uncapped, attempt as u32),
+                expected,
+                "attempt {attempt}"
+            );
+        }
+
+        // A cap clamps the doubling without stopping it from reaching the cap.
+        assert_eq!(launch_backoff_secs(1, 12, 0), 5);
+        assert_eq!(launch_backoff_secs(1, 12, 1), 10);
+        assert_eq!(launch_backoff_secs(1, 12, 2), 12);
+
+        // A slow scheduler waits at least two of its own cycles plus slack, and
+        // a zero interval still gets the 5s floor rather than no backoff at all.
+        assert_eq!(launch_backoff_secs(10, uncapped, 0), 23);
+        assert_eq!(launch_backoff_secs(0, uncapped, 0), 5);
+
+        // An operator-supplied max_batch_requeue large enough to overflow the
+        // shift must saturate at the cap, not panic the controller.
+        assert_eq!(launch_backoff_secs(1, 300, u32::MAX), 300);
+        assert_eq!(launch_backoff_secs(1, uncapped, u32::MAX), uncapped);
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn launch_failure_backoff_doubles_each_attempt() {
-        // With the default interval_secs = 1 the base hold is 5s, so the five
-        // attempts allowed by max_batch_requeue = 5 wait 5, 10, 20, 40 and 80
-        // seconds: 155s in total instead of burning the budget in ~5s.
+    async fn launch_failure_backoff_defers_every_attempt_until_the_budget_runs_out() {
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         register_node(&cm, "worker1", 8, 16000);
 
         let job_id = submit_and_wait(&cm, basic_spec("backoff-schedule"));
 
-        for (attempt, expected_secs) in [5i64, 10, 20, 40, 80].into_iter().enumerate() {
+        for attempt in 0..cm.config.controller.max_batch_requeue {
             let resources = scalar_alloc(2, 4000);
             cm.start_job(
                 job_id,
@@ -6733,16 +6844,18 @@ mod tests {
             .unwrap();
             settle(&cm, job_id, JobState::Running);
 
-            let before = Utc::now();
             cm.requeue_job(job_id).unwrap();
             settle(&cm, job_id, JobState::Pending);
 
             let job = cm.get_job(job_id).unwrap();
-            assert_eq!(job.requeue_count, attempt as u32 + 1);
-            let held_for = (job.spec.begin_time.unwrap() - before).num_seconds();
+            assert_eq!(job.requeue_count, attempt + 1);
             assert!(
-                (expected_secs..=expected_secs + 2).contains(&held_for),
-                "attempt {attempt} held {held_for}s, expected ~{expected_secs}s"
+                job.spec.begin_time.is_some_and(|begin| begin > Utc::now()),
+                "attempt {attempt} must defer the retry"
+            );
+            assert!(
+                !cm.pending_jobs().iter().any(|j| j.job_id == job_id),
+                "attempt {attempt} must not leave the job immediately eligible"
             );
 
             lapse_hold(&cm, job_id);
@@ -6764,43 +6877,6 @@ mod tests {
             cm.get_job(job_id).unwrap().pending_reason,
             PendingReason::JobHoldMaxRequeue
         );
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn launch_failure_backoff_is_capped() {
-        let dir = TempDir::new().unwrap();
-        let mut config = test_config();
-        config.controller.max_launch_backoff_secs = 12;
-        let cm = test_cluster_with_config(&dir, config).await;
-        register_node(&cm, "worker1", 8, 16000);
-
-        let job_id = submit_and_wait(&cm, basic_spec("capped-backoff"));
-
-        // Uncapped the third hold would be 20s; the cap clamps it to 12s.
-        for expected_secs in [5i64, 10, 12] {
-            let resources = scalar_alloc(2, 4000);
-            cm.start_job(
-                job_id,
-                vec!["worker1".into()],
-                resources.clone(),
-                per_node_for(&["worker1"], resources),
-            )
-            .unwrap();
-            settle(&cm, job_id, JobState::Running);
-
-            let before = Utc::now();
-            cm.requeue_job(job_id).unwrap();
-            settle(&cm, job_id, JobState::Pending);
-
-            let held_for =
-                (cm.get_job(job_id).unwrap().spec.begin_time.unwrap() - before).num_seconds();
-            assert!(
-                (expected_secs..=expected_secs + 2).contains(&held_for),
-                "held {held_for}s, expected ~{expected_secs}s"
-            );
-
-            lapse_hold(&cm, job_id);
-        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -9168,6 +9244,82 @@ mod tests {
             PendingReason::JobHoldMaxRequeue,
             "one timeout after chronic preemption must not exhaust the failure budget"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_partial_dispatch_failure_backs_off_like_a_total_one() {
+        // Both launch-failure paths must throttle. Without this, a 2-node job
+        // with one broken node evicts, requeues immediately, lands on the same
+        // node and burns its whole requeue budget in seconds.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 4, 8000);
+        register_node(&cm, "n2", 4, 8000);
+
+        let mut spec = basic_spec("partial-backoff");
+        spec.num_nodes = 2;
+        spec.requeue = true;
+        let job_id = submit_and_wait(&cm, spec);
+
+        let alloc = scalar_alloc(2, 4000);
+        cm.start_job(
+            job_id,
+            vec!["n1".into(), "n2".into()],
+            scalar_alloc(4, 8000),
+            per_node_for(&["n1", "n2"], alloc),
+        )
+        .unwrap();
+        settle(&cm, job_id, JobState::Running);
+
+        cm.evict_job(job_id).unwrap();
+        settle(&cm, job_id, JobState::Pending);
+
+        let job = cm.get_job(job_id).unwrap();
+        assert_eq!(job.pending_reason, PendingReason::JobLaunchFailure);
+        assert!(
+            job.spec.begin_time.is_some_and(|begin| begin > Utc::now()),
+            "a launch-failure requeue must carry a future hold"
+        );
+        assert!(
+            !cm.pending_jobs().iter().any(|j| j.job_id == job_id),
+            "the hold must keep the job out of the very next dispatch"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_node_failure_requeue_still_retries_immediately() {
+        // The backoff is scoped to launch failures. A job evicted because its
+        // node died has nothing to back off from: the node is already out of the
+        // candidate set, so delaying the retry only wastes capacity.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 4, 8000);
+        register_node(&cm, "n2", 4, 8000);
+
+        let mut spec = basic_spec("nodedown-requeue");
+        spec.requeue = true;
+        let job_id = submit_and_wait(&cm, spec);
+
+        let alloc = scalar_alloc(2, 4000);
+        cm.start_job(
+            job_id,
+            vec!["n1".into()],
+            alloc.clone(),
+            per_node_for(&["n1"], alloc),
+        )
+        .unwrap();
+        settle(&cm, job_id, JobState::Running);
+
+        if let Some(node) = cm.nodes.write().get_mut("n1") {
+            node.last_heartbeat = Some(Utc::now() - chrono::Duration::seconds(200));
+        }
+        cm.check_node_health(90);
+        settle(&cm, job_id, JobState::Pending);
+
+        let job = cm.get_job(job_id).unwrap();
+        assert_eq!(job.pending_reason, PendingReason::None);
+        assert!(job.spec.begin_time.is_none(), "no hold on a node failure");
+        assert!(cm.pending_jobs().iter().any(|j| j.job_id == job_id));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1162,7 +1162,7 @@ impl ClusterManager {
     /// (e.g., container image not found) so it can be retried after the
     /// user fixes the issue. (Issue #91)
     pub fn requeue_job(&self, job_id: JobId) -> anyhow::Result<()> {
-        let old_state = {
+        let (old_state, begin_time) = {
             let jobs = self.jobs.read();
             let Some(job) = jobs.get(&job_id) else {
                 return Ok(());
@@ -1170,11 +1170,22 @@ impl ClusterManager {
             if job.state.is_terminal() {
                 return Ok(());
             }
+            // A job that never reached Running has nothing to requeue: Pending ->
+            // Failed is not a legal transition and Pending -> Pending applies as a
+            // NoOp, so both proposals below would be discarded and the hold lost.
+            // Callers that fail before dispatch fall to the next scheduler tick.
+            if job.state == JobState::Pending {
+                warn!(
+                    job_id,
+                    "requeue requested for a job that never started; no backoff hold applied"
+                );
+                return Ok(());
+            }
             if job.requeue_count >= self.config.controller.max_batch_requeue {
                 drop(jobs);
                 return self.hold_job_at_max_requeue(job_id);
             }
-            job.state
+            (job.state, self.launch_backoff_until(job))
         };
 
         // transition to Failed via JobComplete so node resources,
@@ -1185,16 +1196,40 @@ impl ClusterManager {
             state: JobState::Failed,
         })?;
 
-        // Failed → Pending resets allocation fields and makes
-        // the job schedulable again.
-        self.propose(WalOperation::job_state_change(
+        // Failed → Pending resets allocation fields and makes the job
+        // schedulable again, but only once the backoff hold lapses: without it
+        // the next scheduler tick re-dispatches to the same node, which for a
+        // node-local fault burns the whole requeue budget in seconds.
+        self.propose(WalOperation::job_state_change_backoff_pending(
             job_id,
             JobState::Failed,
-            JobState::Pending,
+            PendingReason::JobLaunchFailure,
+            begin_time,
         ))?;
 
-        info!(job_id, from = %old_state, "job requeued after dispatch failure");
+        info!(job_id, from = %old_state, hold_until = %begin_time, "job requeued after dispatch failure");
         Ok(())
+    }
+
+    /// Instant until which a job requeued after a launch failure is held.
+    ///
+    /// Doubles per attempt from the same base the preemption requeue uses (two
+    /// scheduler cycles plus slack), capped by `max_launch_backoff_secs`. A user
+    /// `--begin` further out always wins, so the hold never shortens a
+    /// user-supplied constraint. Computed on the leader so every replica applies
+    /// one verbatim instant rather than reading its own clock.
+    fn launch_backoff_until(&self, job: &Job) -> DateTime<Utc> {
+        let base = (self.config.scheduler.interval_secs as u64 * 2 + 3).max(5);
+        let cap = self.config.controller.max_launch_backoff_secs;
+        // Config validation rejects a cap above the ceiling; clamping again here
+        // keeps an unvalidated config from overflowing the instant below, which
+        // would panic the controller rather than degrade.
+        let hold_secs = base
+            .saturating_mul(1u64 << job.requeue_count.min(16))
+            .min(cap)
+            .min(spur_core::config::MAX_LAUNCH_BACKOFF_SECS);
+        let hold = Utc::now() + chrono::Duration::seconds(hold_secs as i64);
+        job.spec.begin_time.map_or(hold, |user| user.max(hold))
     }
 
     /// Evict a running job to NodeFail: frees allocations and feeds the
@@ -1793,11 +1828,17 @@ impl ClusterManager {
         reason: Option<String>,
     ) -> anyhow::Result<(NodeState, u32)> {
         let (old_state, running_count) = {
+            // Lock order is jobs before nodes, matching apply_operation. Taking
+            // nodes first deadlocks against a raft apply that already holds jobs
+            // and is waiting on nodes: parking_lot queues writers ahead of new
+            // readers, so neither side can make progress and the controller
+            // wedges. The agent calls this on a launch failure at the same
+            // instant the requeue is being applied for that job.
+            let jobs = self.jobs.read();
             let nodes = self.nodes.read();
             let node = nodes
                 .get(name)
                 .ok_or_else(|| anyhow::anyhow!("node '{}' not found", name))?;
-            let jobs = self.jobs.read();
             let count = jobs
                 .values()
                 .filter(|j| {
@@ -2354,11 +2395,12 @@ impl ClusterManager {
             let mut jobs = self.jobs.write();
             for id in &to_wait {
                 if let Some(j) = jobs.get_mut(id) {
-                    // Don't clobber Held or DeadLine — matches
-                    // update_pending_reasons().
+                    // Don't clobber Held, DeadLine or a begin-hold reason —
+                    // matches update_pending_reasons().
                     if j.state == JobState::Pending
                         && !j.pending_reason.is_scheduling_hold()
                         && j.pending_reason != PendingReason::DeadLine
+                        && !j.reason_explains_begin_hold(Utc::now())
                     {
                         j.pending_reason = PendingReason::Dependency;
                     }
@@ -2413,12 +2455,10 @@ impl ClusterManager {
             if let Some(j) = jobs.get_mut(&id) {
                 // Re-check under the write lock: the read snapshot was released,
                 // so the job may have started or been held/deadlined since.
-                let begin_held = j.pending_reason == PendingReason::BeginTime
-                    && j.spec.begin_time.is_some_and(|b| now < b);
                 if j.state == JobState::Pending
                     && !j.pending_reason.is_scheduling_hold()
                     && j.pending_reason != PendingReason::DeadLine
-                    && !begin_held
+                    && !j.reason_explains_begin_hold(now)
                 {
                     j.pending_reason = reason;
                 }
@@ -2795,11 +2835,10 @@ impl ClusterManager {
             if job_entry.pending_reason == PendingReason::DeadLine {
                 continue;
             }
-            // Keep an active BeginTime hold (e.g. requeue-by-preemption) until
-            // it lapses, then fall through to the real wait reason.
-            if job_entry.pending_reason == PendingReason::BeginTime
-                && job_entry.spec.begin_time.is_some_and(|b| Utc::now() < b)
-            {
+            // Keep a reason that explains an active begin_time hold (preemption
+            // requeue, launch-failure backoff) until it lapses, then fall through
+            // to the real wait reason.
+            if job_entry.reason_explains_begin_hold(Utc::now()) {
                 continue;
             }
 
@@ -3248,6 +3287,7 @@ impl ClusterManager {
                 new_state,
                 pending_reason,
                 pending_priority,
+                begin_time,
                 ..
             } => {
                 if let Some(job) = jobs.get_mut(job_id) {
@@ -3270,6 +3310,9 @@ impl ClusterManager {
                         job.pending_reason = pending_reason.clone().unwrap_or(PendingReason::None);
                         if let Some(priority) = pending_priority {
                             job.priority = *priority;
+                        }
+                        if let Some(hold) = begin_time {
+                            job.spec.begin_time = Some(*hold);
                         }
                     }
                 }
@@ -5071,13 +5114,11 @@ mod tests {
             job_id: 1,
             spec: Box::new(basic_spec("j")),
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
 
         let job = cm.get_job(1).unwrap();
         assert_eq!(job.state, JobState::Running);
@@ -5123,13 +5164,11 @@ mod tests {
             job_id: 1,
             spec: Box::new(basic_spec("j")),
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
         let alloc = scalar_alloc(4, 8000);
         cm.apply_operation(&WalOperation::JobStart {
             job_id: 1,
@@ -5165,13 +5204,11 @@ mod tests {
             job_id: 1,
             spec: Box::new(basic_spec("s")),
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
         let t0 = chrono::Utc::now();
         cm.apply_operation(&WalOperation::JobSuspend { job_id: 1, at: t0 });
         assert_eq!(cm.get_job(1).unwrap().state, JobState::Suspended);
@@ -5331,13 +5368,11 @@ mod tests {
             job_id: 1,
             spec: Box::new(basic_spec("acc")),
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
         let t0 = chrono::Utc::now();
         // Cycle 1: 10s suspended.
         cm.apply_operation(&WalOperation::JobSuspend { job_id: 1, at: t0 });
@@ -5370,13 +5405,11 @@ mod tests {
             job_id: 1,
             spec: Box::new(basic_spec("cancel-susp")),
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
         // Suspended 30s ago, then cancelled now (JobComplete stamps Utc::now()).
         let since = chrono::Utc::now() - chrono::Duration::seconds(30);
         cm.apply_operation(&WalOperation::JobSuspend {
@@ -5612,13 +5645,11 @@ mod tests {
             job_id: 1,
             spec: Box::new(basic_spec("single-completing")),
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
         let alloc = scalar_alloc(2, 4000);
         cm.apply_operation(&WalOperation::JobStart {
             job_id: 1,
@@ -5655,13 +5686,11 @@ mod tests {
             job_id: 1,
             spec: Box::new(basic_spec("oom")),
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
         let alloc = scalar_alloc(2, 4000);
         cm.apply_operation(&WalOperation::JobStart {
             job_id: 1,
@@ -5699,13 +5728,11 @@ mod tests {
             job_id: 1,
             spec: Box::new(basic_spec("multi-completing")),
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
         let alloc = scalar_alloc(2, 4000);
         cm.apply_operation(&WalOperation::JobStart {
             job_id: 1,
@@ -5767,13 +5794,11 @@ mod tests {
             job_id: 1,
             spec: Box::new(basic_spec("steps")),
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
         cm.apply_operation(&WalOperation::JobStart {
             job_id: 1,
             nodes: vec!["n1".into()],
@@ -5830,13 +5855,11 @@ mod tests {
             job_id: 1,
             spec: Box::new(basic_spec("batch-only")),
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
 
         cm.apply_operation(&WalOperation::JobStepComplete {
             job_id: 1,
@@ -5860,13 +5883,11 @@ mod tests {
             job_id: 1,
             spec: Box::new(basic_spec("finalize-response")),
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
         let alloc = scalar_alloc(2, 4000);
         cm.apply_operation(&WalOperation::JobStart {
             job_id: 1,
@@ -5912,13 +5933,11 @@ mod tests {
             job_id: 1,
             spec: Box::new(basic_spec("job-complete-response")),
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
         let alloc = scalar_alloc(2, 4000);
         cm.apply_operation(&WalOperation::JobStart {
             job_id: 1,
@@ -5953,13 +5972,11 @@ mod tests {
             job_id: 1,
             spec: Box::new(basic_spec("double-complete")),
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
         let alloc = scalar_alloc(2, 4000);
         cm.apply_operation(&WalOperation::JobStart {
             job_id: 1,
@@ -6012,13 +6029,11 @@ mod tests {
             job_id: 1,
             spec: Box::new(basic_spec("penultimate")),
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
         let alloc = scalar_alloc(2, 4000);
         cm.apply_operation(&WalOperation::JobStart {
             job_id: 1,
@@ -6051,13 +6066,11 @@ mod tests {
             job_id: 1,
             spec: Box::new(basic_spec("signal-job")),
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
         cm.apply_operation(&WalOperation::JobStart {
             job_id: 1,
             nodes: vec!["n1".into()],
@@ -6095,13 +6108,11 @@ mod tests {
             job_id: 1,
             spec: Box::new(basic_spec("rpc-signal-job")),
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
         cm.apply_operation(&WalOperation::JobStart {
             job_id: 1,
             nodes: vec!["n1".into()],
@@ -6132,13 +6143,11 @@ mod tests {
             job_id: 1,
             spec: Box::new(basic_spec("exit-job")),
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
         cm.apply_operation(&WalOperation::JobStart {
             job_id: 1,
             nodes: vec!["n1".into()],
@@ -6171,13 +6180,11 @@ mod tests {
             job_id: 1,
             spec: Box::new(basic_spec("stale-job")),
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
         // Re-dispatched run: current epoch is 2.
         cm.apply_operation(&WalOperation::JobStart {
             job_id: 1,
@@ -6212,13 +6219,11 @@ mod tests {
             job_id: 1,
             spec: Box::new(basic_spec("cancel-while-cg")),
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
         let alloc = scalar_alloc(2, 4000);
         cm.apply_operation(&WalOperation::JobStart {
             job_id: 1,
@@ -6281,13 +6286,11 @@ mod tests {
             job_id: 1,
             spec: Box::new(basic_spec("nc-after-cancel")),
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
         let alloc = scalar_alloc(2, 4000);
         cm.apply_operation(&WalOperation::JobStart {
             job_id: 1,
@@ -6585,6 +6588,415 @@ mod tests {
         settle(&cm, job_id, JobState::Running);
     }
 
+    // ── requeue-after-launch-failure backoff ─────────────────────
+
+    /// Let an active hold lapse, exactly as the wall clock would, so the next
+    /// dispatch attempt can proceed without sleeping in the test.
+    fn lapse_hold(cm: &ClusterManager, job_id: JobId) {
+        let mut jobs = cm.jobs.write();
+        let job = jobs.get_mut(&job_id).unwrap();
+        job.spec.begin_time = Some(Utc::now() - chrono::Duration::seconds(1));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn launch_failure_requeue_holds_job_and_reports_reason() {
+        // The dispatch-failure requeue must defer the job and say why. Without
+        // the hold the scheduler re-dispatches on the very next tick, and for a
+        // node-local fault that means the same broken node again.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let job_id = run_job_on(&cm, "launch-fail", "worker1");
+        assert_eq!(cm.node_metrics().alloc_cpus, 2);
+
+        cm.requeue_job(job_id).unwrap();
+        settle(&cm, job_id, JobState::Pending);
+
+        let job = cm.get_job(job_id).unwrap();
+        assert!(job.allocated_nodes.is_empty());
+        assert_eq!(cm.node_metrics().alloc_cpus, 0, "nodes must be freed");
+        assert_eq!(job.requeue_count, 1);
+        assert_eq!(
+            job.pending_reason,
+            PendingReason::JobLaunchFailure,
+            "squeue must show why the job is waiting"
+        );
+        assert!(
+            job.spec.begin_time.is_some_and(|begin| begin > Utc::now()),
+            "requeue must carry a future hold"
+        );
+        assert!(
+            !cm.pending_jobs().iter().any(|j| j.job_id == job_id),
+            "held job must not be eligible for immediate re-dispatch"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn requeueing_a_job_that_never_started_is_a_no_op() {
+        // Pending -> Failed is illegal and Pending -> Pending applies as a NoOp,
+        // so the two proposals would be silently discarded. Bailing out keeps the
+        // caller from logging a hold that was never applied.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let job_id = submit_and_wait(&cm, basic_spec("never-started"));
+        cm.requeue_job(job_id).unwrap();
+
+        let job = cm.get_job(job_id).unwrap();
+        assert_eq!(job.state, JobState::Pending);
+        assert_eq!(job.requeue_count, 0, "no attempt was consumed");
+        assert!(job.spec.begin_time.is_none(), "no hold was applied");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn draining_a_node_for_a_launch_failure_still_lets_the_job_requeue() {
+        // The agent drains the node on a spool fault. That drain must not
+        // finalize the job: it still has to reach Pending so the scheduler can
+        // retry it somewhere healthy.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+        register_node(&cm, "worker2", 8, 16000);
+
+        let job_id = run_job_on(&cm, "spool-fault", "worker1");
+
+        let (state, _) = cm
+            .drain_node("worker1", Some("launch failed: ENOSPC".into()))
+            .unwrap();
+        assert_eq!(state, NodeState::Draining, "the job still holds the node");
+
+        cm.requeue_job(job_id).unwrap();
+        settle(&cm, job_id, JobState::Pending);
+
+        assert_eq!(
+            cm.get_job(job_id).unwrap().pending_reason,
+            PendingReason::JobLaunchFailure
+        );
+        let node = cm.get_node("worker1").unwrap();
+        assert!(
+            node.state.is_admin_hold(),
+            "the broken node must stay excluded from scheduling"
+        );
+        assert_eq!(
+            node.state_reason.as_deref(),
+            Some("launch failed: ENOSPC"),
+            "operators need the fault text"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_completion_report_for_a_launch_failure_strands_the_job() {
+        // Why the agent drains instead of reporting a completion: a completion
+        // finalizes the job, and requeue_job refuses terminal jobs, so the
+        // launch failure would never be retried anywhere.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let job_id = run_job_on(&cm, "stranded", "worker1");
+        cm.node_complete(job_id, "worker1", -1, 0, 0).unwrap();
+        wait_for("job reaches a terminal state", || {
+            cm.get_job(job_id).is_some_and(|j| j.state.is_terminal())
+        });
+
+        cm.requeue_job(job_id).unwrap();
+
+        let job = cm.get_job(job_id).unwrap();
+        assert!(
+            job.state.is_terminal(),
+            "the completion report won the race"
+        );
+        assert_eq!(job.requeue_count, 0, "a terminal job is never retried");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn launch_failure_backoff_doubles_each_attempt() {
+        // With the default interval_secs = 1 the base hold is 5s, so the five
+        // attempts allowed by max_batch_requeue = 5 wait 5, 10, 20, 40 and 80
+        // seconds: 155s in total instead of burning the budget in ~5s.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let job_id = submit_and_wait(&cm, basic_spec("backoff-schedule"));
+
+        for (attempt, expected_secs) in [5i64, 10, 20, 40, 80].into_iter().enumerate() {
+            let resources = scalar_alloc(2, 4000);
+            cm.start_job(
+                job_id,
+                vec!["worker1".into()],
+                resources.clone(),
+                per_node_for(&["worker1"], resources),
+            )
+            .unwrap();
+            settle(&cm, job_id, JobState::Running);
+
+            let before = Utc::now();
+            cm.requeue_job(job_id).unwrap();
+            settle(&cm, job_id, JobState::Pending);
+
+            let job = cm.get_job(job_id).unwrap();
+            assert_eq!(job.requeue_count, attempt as u32 + 1);
+            let held_for = (job.spec.begin_time.unwrap() - before).num_seconds();
+            assert!(
+                (expected_secs..=expected_secs + 2).contains(&held_for),
+                "attempt {attempt} held {held_for}s, expected ~{expected_secs}s"
+            );
+
+            lapse_hold(&cm, job_id);
+        }
+
+        // Budget exhausted: the next failure holds the job for an operator.
+        let resources = scalar_alloc(2, 4000);
+        cm.start_job(
+            job_id,
+            vec!["worker1".into()],
+            resources.clone(),
+            per_node_for(&["worker1"], resources),
+        )
+        .unwrap();
+        settle(&cm, job_id, JobState::Running);
+        cm.requeue_job(job_id).unwrap();
+        settle(&cm, job_id, JobState::Pending);
+        assert_eq!(
+            cm.get_job(job_id).unwrap().pending_reason,
+            PendingReason::JobHoldMaxRequeue
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn launch_failure_backoff_is_capped() {
+        let dir = TempDir::new().unwrap();
+        let mut config = test_config();
+        config.controller.max_launch_backoff_secs = 12;
+        let cm = test_cluster_with_config(&dir, config).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let job_id = submit_and_wait(&cm, basic_spec("capped-backoff"));
+
+        // Uncapped the third hold would be 20s; the cap clamps it to 12s.
+        for expected_secs in [5i64, 10, 12] {
+            let resources = scalar_alloc(2, 4000);
+            cm.start_job(
+                job_id,
+                vec!["worker1".into()],
+                resources.clone(),
+                per_node_for(&["worker1"], resources),
+            )
+            .unwrap();
+            settle(&cm, job_id, JobState::Running);
+
+            let before = Utc::now();
+            cm.requeue_job(job_id).unwrap();
+            settle(&cm, job_id, JobState::Pending);
+
+            let held_for =
+                (cm.get_job(job_id).unwrap().spec.begin_time.unwrap() - before).num_seconds();
+            assert!(
+                (expected_secs..=expected_secs + 2).contains(&held_for),
+                "held {held_for}s, expected ~{expected_secs}s"
+            );
+
+            lapse_hold(&cm, job_id);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn launch_failure_requeue_preserves_later_user_begin() {
+        // The backoff must never shorten a user's --begin constraint.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let user_begin = Utc::now() + chrono::Duration::hours(1);
+        let mut spec = basic_spec("user-begin-launch-fail");
+        spec.begin_time = Some(user_begin);
+        let job_id = submit_and_wait(&cm, spec);
+        let resources = scalar_alloc(2, 4000);
+        cm.start_job(
+            job_id,
+            vec!["worker1".into()],
+            resources.clone(),
+            per_node_for(&["worker1"], resources),
+        )
+        .unwrap();
+        settle(&cm, job_id, JobState::Running);
+
+        cm.requeue_job(job_id).unwrap();
+        settle(&cm, job_id, JobState::Pending);
+
+        assert_eq!(
+            cm.get_job(job_id).unwrap().spec.begin_time,
+            Some(user_begin),
+            "user --begin beyond the hold must be preserved"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn launch_failure_reason_survives_both_pending_reason_passes() {
+        // JobLaunchFailure must outlive every pass that recomputes
+        // pending_reason. The predicate lives in four places; miss one and the
+        // reason is clobbered back to Resources before an operator sees it.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let job_id = run_job_on(&cm, "reason-survives", "worker1");
+        cm.requeue_job(job_id).unwrap();
+        settle(&cm, job_id, JobState::Pending);
+
+        // Both guard sites in tag_blocked_pending_reasons.
+        cm.tag_blocked_pending_reasons();
+        assert_eq!(
+            cm.get_job(job_id).unwrap().pending_reason,
+            PendingReason::JobLaunchFailure,
+            "tag_blocked_pending_reasons must not clobber an active hold"
+        );
+
+        // The guard site in update_pending_reasons. An empty cluster_state would
+        // otherwise force Resources/NodeDown.
+        let empty_state = spur_sched::traits::ClusterState {
+            nodes: &[],
+            partitions: &[],
+            reservations: &[],
+            topology: None,
+        };
+        let snapshot = cm.get_job(job_id).unwrap();
+        cm.update_pending_reasons(&[&snapshot], &empty_state);
+        assert_eq!(
+            cm.get_job(job_id).unwrap().pending_reason,
+            PendingReason::JobLaunchFailure,
+            "update_pending_reasons must not clobber an active hold"
+        );
+
+        // The guard site in cancel_unsatisfiable_dependency_jobs.
+        cm.cancel_unsatisfiable_dependency_jobs();
+        assert_eq!(
+            cm.get_job(job_id).unwrap().pending_reason,
+            PendingReason::JobLaunchFailure,
+            "the dependency pass must not clobber an active hold"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_user_begin_job_still_reports_what_blocks_it() {
+        // A --begin job carries no reason explaining its own hold, so the wait
+        // reason passes must still tag it. Skipping every held job would leave
+        // squeue showing None for as long as the user asked to wait.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let mut spec = basic_spec("begin-blocked");
+        spec.begin_time = Some(Utc::now() + chrono::Duration::hours(1));
+        let job_id = submit_and_wait(&cm, spec);
+        assert!(cm.get_job(job_id).unwrap().is_begin_held(Utc::now()));
+
+        let empty_state = spur_sched::traits::ClusterState {
+            nodes: &[],
+            partitions: &[],
+            reservations: &[],
+            topology: None,
+        };
+        let snapshot = cm.get_job(job_id).unwrap();
+        cm.update_pending_reasons(&[&snapshot], &empty_state);
+
+        let reason = cm.get_job(job_id).unwrap().pending_reason;
+        assert_ne!(
+            reason,
+            PendingReason::None,
+            "a held --begin job must still say what blocks it"
+        );
+        assert!(
+            !reason.explains_begin_hold(),
+            "the hold is not the blocker here, the empty cluster is"
+        );
+        assert!(
+            !cm.pending_jobs().iter().any(|j| j.job_id == job_id),
+            "tagging a reason must not make a held job eligible"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn launch_failure_hold_expires_and_job_reschedules() {
+        // The hold defers the job, it must not strand it.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let job_id = run_job_on(&cm, "hold-lapses", "worker1");
+        cm.requeue_job(job_id).unwrap();
+        settle(&cm, job_id, JobState::Pending);
+        lapse_hold(&cm, job_id);
+
+        assert!(
+            cm.pending_jobs().iter().any(|j| j.job_id == job_id),
+            "job must be eligible again once the hold lapses"
+        );
+
+        let resources = scalar_alloc(2, 4000);
+        cm.start_job(
+            job_id,
+            vec!["worker1".into()],
+            resources.clone(),
+            per_node_for(&["worker1"], resources),
+        )
+        .unwrap();
+        settle(&cm, job_id, JobState::Running);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn replayed_backoff_requeue_does_not_double_count_or_drift() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("backoff-replay")),
+        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
+        cm.apply_operation(&WalOperation::JobComplete {
+            job_id: 1,
+            exit_code: -1,
+            state: JobState::Failed,
+        });
+
+        let hold = Utc::now() + chrono::Duration::seconds(40);
+        let requeue = WalOperation::job_state_change_backoff_pending(
+            1,
+            JobState::Failed,
+            PendingReason::JobLaunchFailure,
+            hold,
+        );
+        cm.apply_operation(&requeue);
+
+        let job = cm.get_job(1).unwrap();
+        assert_eq!(job.state, JobState::Pending);
+        assert_eq!(job.requeue_count, 1);
+        assert_eq!(job.pending_reason, PendingReason::JobLaunchFailure);
+        assert_eq!(job.spec.begin_time, Some(hold));
+
+        // Replay the identical entry: the job is already Pending, so this is a
+        // NoOp. Followers and WAL recovery must not compound the hold.
+        cm.apply_operation(&requeue);
+        let job = cm.get_job(1).unwrap();
+        assert_eq!(
+            job.requeue_count, 1,
+            "replayed requeue must not double-count"
+        );
+        assert_eq!(
+            job.spec.begin_time,
+            Some(hold),
+            "replayed hold instant must not drift"
+        );
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn preempt_job_cancel_terminates_and_frees_nodes() {
         let dir = TempDir::new().unwrap();
@@ -6650,22 +7062,18 @@ mod tests {
             job_id: 1,
             spec: Box::new(basic_spec("replay")),
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
 
         // Re-applying the same running transition is a NoOp, not an error.
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
         assert_eq!(cm.get_job(1).unwrap().state, JobState::Running);
 
         let alloc = scalar_alloc(2, 4000);
@@ -6706,35 +7114,29 @@ mod tests {
             job_id: 1,
             spec: Box::new(basic_spec("requeue-replay")),
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
         cm.apply_operation(&WalOperation::JobComplete {
             job_id: 1,
             exit_code: -1,
             state: JobState::Preempted,
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Preempted,
-            new_state: JobState::Pending,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Preempted,
+            JobState::Pending,
+        ));
         assert_eq!(cm.get_job(1).unwrap().requeue_count, 1);
 
         // Replay the same requeue transition (job already Pending): NoOp.
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Preempted,
-            new_state: JobState::Pending,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Preempted,
+            JobState::Pending,
+        ));
         assert_eq!(
             cm.get_job(1).unwrap().requeue_count,
             1,
@@ -6756,13 +7158,11 @@ mod tests {
             job_id: 1,
             spec: Box::new(basic_spec("preempt-replay")),
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
         let alloc = scalar_alloc(2, 4000);
         cm.apply_operation(&WalOperation::JobStart {
             job_id: 1,
@@ -8480,33 +8880,27 @@ mod tests {
         let cm = test_cluster(&dir).await;
 
         let job_id = submit_and_wait(&cm, basic_spec("preempt-me"));
-        cm.apply_operation(&WalOperation::JobStateChange {
+        cm.apply_operation(&WalOperation::job_state_change(
             job_id,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+            JobState::Pending,
+            JobState::Running,
+        ));
         cm.apply_operation(&WalOperation::JobComplete {
             job_id,
             exit_code: -1,
             state: JobState::Preempted,
         });
         for _ in 0..5 {
-            cm.apply_operation(&WalOperation::JobStateChange {
+            cm.apply_operation(&WalOperation::job_state_change(
                 job_id,
-                old_state: JobState::Preempted,
-                new_state: JobState::Pending,
-                pending_reason: None,
-                pending_priority: None,
-            });
-            cm.apply_operation(&WalOperation::JobStateChange {
+                JobState::Preempted,
+                JobState::Pending,
+            ));
+            cm.apply_operation(&WalOperation::job_state_change(
                 job_id,
-                old_state: JobState::Pending,
-                new_state: JobState::Running,
-                pending_reason: None,
-                pending_priority: None,
-            });
+                JobState::Pending,
+                JobState::Running,
+            ));
             cm.apply_operation(&WalOperation::JobComplete {
                 job_id,
                 exit_code: -1,
@@ -8814,33 +9208,27 @@ mod tests {
         let cm = test_cluster(&dir).await;
 
         let job_id = submit_and_wait(&cm, basic_spec("release-me"));
-        cm.apply_operation(&WalOperation::JobStateChange {
+        cm.apply_operation(&WalOperation::job_state_change(
             job_id,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+            JobState::Pending,
+            JobState::Running,
+        ));
         cm.apply_operation(&WalOperation::JobComplete {
             job_id,
             exit_code: -1,
             state: JobState::Preempted,
         });
         for _ in 0..5 {
-            cm.apply_operation(&WalOperation::JobStateChange {
+            cm.apply_operation(&WalOperation::job_state_change(
                 job_id,
-                old_state: JobState::Preempted,
-                new_state: JobState::Pending,
-                pending_reason: None,
-                pending_priority: None,
-            });
-            cm.apply_operation(&WalOperation::JobStateChange {
+                JobState::Preempted,
+                JobState::Pending,
+            ));
+            cm.apply_operation(&WalOperation::job_state_change(
                 job_id,
-                old_state: JobState::Pending,
-                new_state: JobState::Running,
-                pending_reason: None,
-                pending_priority: None,
-            });
+                JobState::Pending,
+                JobState::Running,
+            ));
             cm.apply_operation(&WalOperation::JobComplete {
                 job_id,
                 exit_code: -1,
@@ -8870,13 +9258,11 @@ mod tests {
         let cm = test_cluster(&dir).await;
         let job_id = submit_and_wait(&cm, basic_spec("cancel-preempted"));
 
-        cm.apply_operation(&WalOperation::JobStateChange {
+        cm.apply_operation(&WalOperation::job_state_change(
             job_id,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+            JobState::Pending,
+            JobState::Running,
+        ));
         cm.apply_operation(&WalOperation::JobComplete {
             job_id,
             exit_code: -1,
@@ -9978,13 +10364,11 @@ mod tests {
             job_id: 1,
             spec: Box::new(basic_spec("parent")),
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
 
         let mut child = basic_spec("child");
         child.dependency = vec!["afterok:1".into()];
@@ -10773,13 +11157,11 @@ mod tests {
         assert_eq!(cm.get_job(id).unwrap().state, JobState::Timeout);
 
         // Requeue: Timeout → Pending should reset allocation fields
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: id,
-            old_state: JobState::Timeout,
-            new_state: JobState::Pending,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            id,
+            JobState::Timeout,
+            JobState::Pending,
+        ));
 
         let job = cm.get_job(id).unwrap();
         assert_eq!(job.state, JobState::Pending);
@@ -11806,13 +12188,11 @@ mod tests {
         // Jobs may only reach Completed/Failed/etc. via Running; cancel is the
         // only legal direct transition out of Pending.
         if state != JobState::Cancelled {
-            cm.apply_operation(&WalOperation::JobStateChange {
-                job_id: id,
-                old_state: JobState::Pending,
-                new_state: JobState::Running,
-                pending_reason: None,
-                pending_priority: None,
-            });
+            cm.apply_operation(&WalOperation::job_state_change(
+                id,
+                JobState::Pending,
+                JobState::Running,
+            ));
         }
         cm.apply_operation(&WalOperation::JobComplete {
             job_id: id,
@@ -11866,13 +12246,11 @@ mod tests {
             spec: Box::new(child),
         });
         // Child is already Running by the time the cancel pass fires.
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 2,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            2,
+            JobState::Pending,
+            JobState::Running,
+        ));
 
         let cancelled = cm.cancel_unsatisfiable_dependency_jobs();
         assert!(cancelled.is_empty(), "running job must not be cancelled");
@@ -11889,13 +12267,11 @@ mod tests {
             job_id: 1,
             spec: Box::new(basic_spec("parent")),
         });
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: 1,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
 
         let mut child = basic_spec("child");
         child.dependency = vec!["afterok:1".into()];
@@ -12609,13 +12985,11 @@ mod tests {
     // ---- Node deregistration tests ----
 
     fn start_job_on(cm: &ClusterManager, id: JobId, node: &str) {
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: id,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            id,
+            JobState::Pending,
+            JobState::Running,
+        ));
         cm.apply_operation(&WalOperation::JobStart {
             job_id: id,
             nodes: vec![node.into()],
@@ -12627,13 +13001,11 @@ mod tests {
     }
 
     fn start_srun_job_on(cm: &ClusterManager, id: JobId, node: &str) {
-        cm.apply_operation(&WalOperation::JobStateChange {
-            job_id: id,
-            old_state: JobState::Pending,
-            new_state: JobState::Running,
-            pending_reason: None,
-            pending_priority: None,
-        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            id,
+            JobState::Pending,
+            JobState::Running,
+        ));
         cm.apply_operation(&WalOperation::JobStart {
             job_id: id,
             nodes: vec![node.into()],

--- a/crates/spurctld/src/rest/convert.rs
+++ b/crates/spurctld/src/rest/convert.rs
@@ -14,7 +14,7 @@ pub fn job_to_json(job: &Job) -> serde_json::Value {
         "partition": job.spec.partition,
         "account": job.spec.account,
         "job_state": job.state.display(),
-        "state_reason": job.pending_reason.display(),
+        "state_reason": job.state_reason_display(),
         "submit_time": job.submit_time.timestamp(),
         "start_time": job.start_time.map(|t| t.timestamp()),
         "end_time": job.end_time.map(|t| t.timestamp()),

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -767,11 +767,36 @@ struct LaunchOutcome {
     stderr_path: String,
 }
 
+/// A failed dispatch, keeping the agent's classification of the failure so the
+/// controller can choose a response rather than string-matching the message.
+enum DispatchError {
+    /// The node ran the job's prolog and it failed. The prolog sees the job's
+    /// own context, so the same failure recurs everywhere: Slurm drains the node
+    /// and holds the job instead of retrying it onto the next one.
+    PrologFailed(String),
+    Other(anyhow::Error),
+}
+
+impl std::fmt::Display for DispatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::PrologFailed(reason) => write!(f, "agent rejected job: {reason}"),
+            Self::Other(e) => write!(f, "{e:#}"),
+        }
+    }
+}
+
+impl<E: Into<anyhow::Error>> From<E> for DispatchError {
+    fn from(e: E) -> Self {
+        Self::Other(e.into())
+    }
+}
+
 /// Send a LaunchJob RPC to a node agent.
 async fn dispatch_to_agent(
     agent_addr: &str,
     params: &AgentDispatchParams<'_>,
-) -> anyhow::Result<LaunchOutcome> {
+) -> Result<LaunchOutcome, DispatchError> {
     let mut client = SlurmAgentClient::connect(agent_addr.to_string())
         .await?
         .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
@@ -919,14 +944,23 @@ async fn dispatch_to_agent(
         .await?;
 
     let inner = response.into_inner();
-    if inner.success {
-        info!(
-            job_id = params.job_id,
-            "job dispatched to agent successfully"
+    if !inner.success {
+        // An agent predating the classification sends UNSPECIFIED, which falls
+        // through to the generic requeue this has always done.
+        return Err(
+            if inner.failure_kind
+                == spur_proto::proto::LaunchFailureKind::LaunchFailureProlog as i32
+            {
+                DispatchError::PrologFailed(inner.error)
+            } else {
+                DispatchError::Other(anyhow::anyhow!("agent rejected job: {}", inner.error))
+            },
         );
-    } else {
-        anyhow::bail!("agent rejected job: {}", inner.error);
     }
+    info!(
+        job_id = params.job_id,
+        "job dispatched to agent successfully"
+    );
 
     Ok(LaunchOutcome {
         stdout_path: inner.stdout_path,
@@ -1105,6 +1139,7 @@ async fn dispatch_job_to_nodes(
     let mut successes = 0u32;
     let mut failures = 0u32;
     let mut succeeded_nodes: Vec<String> = Vec::new();
+    let mut prolog_failed: Vec<(String, String)> = Vec::new();
     let total = dispatch_nodes.len() as u32;
 
     // Batch stdout/stderr live on the primary node (task_offset == 0). Capture
@@ -1171,6 +1206,9 @@ async fn dispatch_job_to_nodes(
             Ok((node_name, _, Err(e))) => {
                 error!(job_id, node = %node_name, error = %e, "dispatch to agent failed");
                 failures += 1;
+                if let DispatchError::PrologFailed(reason) = e {
+                    prolog_failed.push((node_name, reason));
+                }
             }
             Err(e) => {
                 error!(job_id, error = %e, "dispatch task panicked");
@@ -1188,6 +1226,18 @@ async fn dispatch_job_to_nodes(
         }
     }
 
+    // Drain before deciding the job's fate, so the failing node is already out
+    // of the candidate set if the job does go back to Pending. The drain is
+    // issued here rather than by the agent because only the controller can pair
+    // it with the hold that stops the job walking the cluster.
+    let hold = !prolog_failed.is_empty() && cluster.config.controller.hold_on_prolog_fail;
+    for (node_name, reason) in &prolog_failed {
+        warn!(job_id, node = %node_name, reason = %reason, "draining node after prolog failure");
+        if let Err(e) = cluster.drain_node(node_name, Some(reason.clone())) {
+            error!(job_id, node = %node_name, error = %e, "failed to drain node after prolog failure");
+        }
+    }
+
     // If ALL dispatches failed, requeue the job back to Pending
     // so the scheduler can retry (e.g., container image may be
     // imported later, or a transient agent error may resolve) rather
@@ -1197,8 +1247,20 @@ async fn dispatch_job_to_nodes(
             job_id,
             failures, "all dispatches failed — requeueing job to Pending"
         );
-        if let Err(e) = cluster.requeue_job(job_id) {
+        if let Err(e) = finish_failed_dispatch(&cluster, job_id, &spec, hold) {
             error!(job_id, error = %e, "failed to requeue job after dispatch failure");
+        }
+    } else if hold {
+        // Same ordering rationale as the eviction branch below: stop what did
+        // launch before the job can be touched again. Eviction itself is wrong
+        // here, since it routes through maybe_requeue and would drop the hold.
+        warn!(
+            job_id,
+            successes, failures, "prolog failed on part of the allocation — holding job"
+        );
+        cancel_job_on_nodes(&cluster, job_id, &succeeded_nodes, 9).await;
+        if let Err(e) = finish_failed_dispatch(&cluster, job_id, &spec, true) {
+            error!(job_id, error = %e, "failed to hold job after prolog failure");
         }
     } else if failures > 0 {
         // A node that never got the dispatch will never report completion, so evict
@@ -1220,6 +1282,24 @@ async fn dispatch_job_to_nodes(
             error!(job_id, error = %e, "failed to evict job after partial dispatch failure");
         }
     }
+}
+
+/// Settle a job whose dispatch failed: requeue it, or hold it when the failure
+/// would follow it to the next node.
+///
+/// Interactive jobs are cancelled instead of held, matching both Slurm ("only
+/// batch jobs can be requeued, interactive jobs will be cancelled") and the
+/// PrologSlurmctld arm above. Holding one would strand the waiting `srun`.
+fn finish_failed_dispatch(
+    cluster: &ClusterManager,
+    job_id: spur_core::job::JobId,
+    spec: &spur_core::job::JobSpec,
+    hold: bool,
+) -> anyhow::Result<()> {
+    if hold && spec.interactive {
+        return cluster.cancel_job(job_id, &spec.user);
+    }
+    cluster.requeue_after_launch_failure(job_id, hold)
 }
 
 /// Watchdog: gracefully terminate running jobs that exceed their time limit.
@@ -2018,11 +2098,13 @@ mod tests {
         use tonic::transport::server::TcpIncoming;
         use tonic::transport::Server;
 
-        /// Minimal SlurmAgent: always accepts launch_job and counts cancel_job
-        /// calls, so tests can assert the controller actually tried to stop
-        /// the job on nodes that did launch it.
+        /// Minimal SlurmAgent: counts cancel_job calls, so tests can assert the
+        /// controller actually tried to stop the job on nodes that did launch
+        /// it. `reject_launch_as` makes launch_job fail with a given
+        /// classification instead of succeeding.
         struct MockAgent {
             cancel_calls: Arc<AtomicU32>,
+            reject_launch_as: Option<spur_proto::proto::LaunchFailureKind>,
         }
 
         #[tonic::async_trait]
@@ -2037,6 +2119,15 @@ mod tests {
                 request: tonic::Request<spur_proto::proto::LaunchJobRequest>,
             ) -> Result<tonic::Response<spur_proto::proto::LaunchJobResponse>, tonic::Status>
             {
+                if let Some(kind) = self.reject_launch_as {
+                    return Ok(tonic::Response::new(spur_proto::proto::LaunchJobResponse {
+                        success: false,
+                        error: "prolog failed: prolog_slurmd script exited with exit status: 1"
+                            .into(),
+                        failure_kind: kind as i32,
+                        ..Default::default()
+                    }));
+                }
                 // Echo a path keyed by task_offset so tests can assert the
                 // controller keeps the primary node's (task_offset == 0) path.
                 let req = request.into_inner();
@@ -2046,6 +2137,7 @@ mod tests {
                     error: String::new(),
                     stdout_path: path.clone(),
                     stderr_path: path,
+                    ..Default::default()
                 }))
             }
 
@@ -2172,11 +2264,18 @@ mod tests {
         /// Spawn a real MockAgent gRPC server on an OS-assigned localhost
         /// port. Returns the bound address and the shared cancel-call counter.
         async fn spawn_mock_agent() -> (std::net::SocketAddr, Arc<AtomicU32>) {
+            spawn_mock_agent_rejecting(None).await
+        }
+
+        async fn spawn_mock_agent_rejecting(
+            reject_launch_as: Option<spur_proto::proto::LaunchFailureKind>,
+        ) -> (std::net::SocketAddr, Arc<AtomicU32>) {
             let incoming = TcpIncoming::bind("127.0.0.1:0".parse().unwrap()).unwrap();
             let addr = incoming.local_addr().unwrap();
             let cancel_calls = Arc::new(AtomicU32::new(0));
             let agent = MockAgent {
                 cancel_calls: cancel_calls.clone(),
+                reject_launch_as,
             };
             tokio::spawn(async move {
                 let _ = Server::builder()
@@ -2249,7 +2348,14 @@ mod tests {
         }
 
         async fn test_cluster(dir: &TempDir) -> Arc<ClusterManager> {
-            let cm = Arc::new(ClusterManager::new(test_config(), dir.path()).unwrap());
+            test_cluster_with_config(dir, test_config()).await
+        }
+
+        async fn test_cluster_with_config(
+            dir: &TempDir,
+            config: SlurmConfig,
+        ) -> Arc<ClusterManager> {
+            let cm = Arc::new(ClusterManager::new(config, dir.path()).unwrap());
             let handle = crate::raft::start_raft(1, &["[::1]:0".into()], dir.path(), cm.clone())
                 .await
                 .unwrap();
@@ -2761,6 +2867,249 @@ mod tests {
                 "a partial dispatch failure must not record an output path"
             );
             assert!(job.actual_stderr_path.is_none());
+        }
+
+        // ── prolog failure: drain the node, hold the job ──
+
+        /// Start `spec` on `nodes` and run the real dispatch against them.
+        async fn dispatch_started_job(
+            cm: &Arc<ClusterManager>,
+            job_id: spur_core::job::JobId,
+            nodes: &[&str],
+        ) {
+            let nodes: Vec<String> = nodes.iter().map(|n| n.to_string()).collect();
+            let per_node_allocs: HashMap<String, ResourceAllocations> = nodes
+                .iter()
+                .map(|n| (n.clone(), ResourceAllocations::with_scalar(1, 0)))
+                .collect();
+            let run_attempt = cm
+                .start_job(
+                    job_id,
+                    nodes.clone(),
+                    ResourceAllocations::with_scalar(nodes.len() as u32, 0),
+                    per_node_allocs.clone(),
+                )
+                .unwrap();
+            settle(cm, job_id, spur_core::job::JobState::Running);
+
+            let spec = cm.get_job(job_id).unwrap().spec;
+            let nodelist = nodes.join(",");
+            dispatch_job_to_nodes(
+                cm.clone(),
+                job_id,
+                nodes,
+                spec,
+                Vec::new(),
+                per_node_allocs,
+                nodelist,
+                1,
+                run_attempt,
+            )
+            .await;
+        }
+
+        fn batch_spec(name: &str, num_nodes: u32) -> JobSpec {
+            JobSpec {
+                name: name.into(),
+                user: "testuser".into(),
+                num_nodes,
+                num_tasks: num_nodes,
+                cpus_per_task: 1,
+                work_dir: "/tmp".into(),
+                ..Default::default()
+            }
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn a_prolog_failure_drains_the_node_and_parks_the_job() {
+            use spur_core::job::{JobState, PendingReason};
+
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+
+            let (addr, _) = spawn_mock_agent_rejecting(Some(
+                spur_proto::proto::LaunchFailureKind::LaunchFailureProlog,
+            ))
+            .await;
+            register_node_at(&cm, "n1", addr);
+
+            let job_id = submit_and_wait(&cm, batch_spec("prolog-fail", 1));
+            dispatch_started_job(&cm, job_id, &["n1"]).await;
+            settle(&cm, job_id, JobState::Pending);
+
+            let node = cm.get_node("n1").unwrap();
+            assert!(
+                node.state.is_admin_hold(),
+                "the node that ran the failing prolog must stop taking work"
+            );
+            assert!(
+                node.state_reason
+                    .as_deref()
+                    .is_some_and(|r| r.contains("prolog")),
+                "operators need the prolog's own failure, got {:?}",
+                node.state_reason
+            );
+
+            // The hold is what bounds the drain to one node: without it the job
+            // retries onto the next node and drains that one too.
+            let job = cm.get_job(job_id).unwrap();
+            assert_eq!(job.pending_reason, PendingReason::Held);
+            assert_eq!(job.priority, 0);
+            assert_eq!(
+                job.state_reason_display(),
+                crate::cluster::LAUNCH_FAILURE_HELD_DESC
+            );
+            assert!(
+                !cm.pending_jobs().iter().any(|j| j.job_id == job_id),
+                "a held job must not be scheduled anywhere"
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn an_operator_can_release_a_job_held_for_a_prolog_failure() {
+            use spur_core::job::JobState;
+
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+
+            let (addr, _) = spawn_mock_agent_rejecting(Some(
+                spur_proto::proto::LaunchFailureKind::LaunchFailureProlog,
+            ))
+            .await;
+            register_node_at(&cm, "n1", addr);
+
+            let job_id = submit_and_wait(&cm, batch_spec("prolog-release", 1));
+            dispatch_started_job(&cm, job_id, &["n1"]).await;
+            settle(&cm, job_id, JobState::Pending);
+
+            cm.release_job(job_id).unwrap();
+            wait_for("job released", || {
+                cm.get_job(job_id).is_some_and(|j| j.priority > 0)
+            });
+
+            let job = cm.get_job(job_id).unwrap();
+            assert_eq!(
+                job.pending_reason_desc, None,
+                "the release must clear the description with the reason"
+            );
+            assert!(cm.pending_jobs().iter().any(|j| j.job_id == job_id));
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn hold_on_prolog_fail_off_retries_the_job_instead() {
+            use spur_core::job::{JobState, PendingReason};
+
+            let dir = TempDir::new().unwrap();
+            let mut config = test_config();
+            config.controller.hold_on_prolog_fail = false;
+            let cm = test_cluster_with_config(&dir, config).await;
+
+            let (addr, _) = spawn_mock_agent_rejecting(Some(
+                spur_proto::proto::LaunchFailureKind::LaunchFailureProlog,
+            ))
+            .await;
+            register_node_at(&cm, "n1", addr);
+
+            let job_id = submit_and_wait(&cm, batch_spec("prolog-retry", 1));
+            dispatch_started_job(&cm, job_id, &["n1"]).await;
+            settle(&cm, job_id, JobState::Pending);
+
+            // Slurm's nohold_on_prolog_fail: retry, bounded by max_batch_requeue
+            // rather than by a hold. The node still drains.
+            let job = cm.get_job(job_id).unwrap();
+            assert_eq!(job.pending_reason, PendingReason::JobLaunchFailure);
+            assert_ne!(job.priority, 0);
+            assert!(job.spec.begin_time.is_some_and(|b| b > Utc::now()));
+            assert!(cm.get_node("n1").unwrap().state.is_admin_hold());
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn an_interactive_job_is_cancelled_rather_than_held() {
+            use spur_core::job::JobState;
+
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+
+            let (addr, _) = spawn_mock_agent_rejecting(Some(
+                spur_proto::proto::LaunchFailureKind::LaunchFailureProlog,
+            ))
+            .await;
+            register_node_at(&cm, "n1", addr);
+
+            // Holding an interactive job would leave its srun waiting forever
+            // with nothing to wait for. Slurm cancels these too.
+            let mut spec = batch_spec("prolog-interactive", 1);
+            spec.interactive = true;
+            let job_id = submit_and_wait(&cm, spec);
+            dispatch_started_job(&cm, job_id, &["n1"]).await;
+            settle(&cm, job_id, JobState::Cancelled);
+
+            assert!(
+                cm.get_node("n1").unwrap().state.is_admin_hold(),
+                "the node is broken regardless of what happens to the job"
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn an_unclassified_rejection_keeps_the_plain_requeue_path() {
+            use spur_core::job::{JobState, PendingReason};
+
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+
+            // What an agent predating the classification sends.
+            let (addr, _) = spawn_mock_agent_rejecting(Some(
+                spur_proto::proto::LaunchFailureKind::LaunchFailureUnspecified,
+            ))
+            .await;
+            register_node_at(&cm, "n1", addr);
+
+            let job_id = submit_and_wait(&cm, batch_spec("unclassified", 1));
+            dispatch_started_job(&cm, job_id, &["n1"]).await;
+            settle(&cm, job_id, JobState::Pending);
+
+            let job = cm.get_job(job_id).unwrap();
+            assert_eq!(job.pending_reason, PendingReason::JobLaunchFailure);
+            assert_ne!(job.priority, 0, "no hold without a classification");
+            assert!(
+                !cm.get_node("n1").unwrap().state.is_admin_hold(),
+                "an unclassified rejection is not grounds to drain"
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn only_the_node_whose_prolog_failed_drains() {
+            use spur_core::job::{JobState, PendingReason};
+
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+
+            let (good_addr, cancel_calls) = spawn_mock_agent().await;
+            let (bad_addr, _) = spawn_mock_agent_rejecting(Some(
+                spur_proto::proto::LaunchFailureKind::LaunchFailureProlog,
+            ))
+            .await;
+            register_node_at(&cm, "n1", good_addr);
+            register_node_at(&cm, "n2", bad_addr);
+
+            let job_id = submit_and_wait(&cm, batch_spec("prolog-partial", 2));
+            dispatch_started_job(&cm, job_id, &["n1", "n2"]).await;
+            settle(&cm, job_id, JobState::Pending);
+
+            assert!(!cm.get_node("n1").unwrap().state.is_admin_hold());
+            assert!(cm.get_node("n2").unwrap().state.is_admin_hold());
+
+            // The partial branch must hold like the total one; evicting would
+            // route through maybe_requeue and drop the hold.
+            let job = cm.get_job(job_id).unwrap();
+            assert_eq!(job.pending_reason, PendingReason::Held);
+            assert_eq!(job.priority, 0);
+
+            assert_eq!(
+                cancel_calls.load(Ordering::SeqCst),
+                1,
+                "n1 launched the job, so it must be stopped before the job settles"
+            );
         }
     }
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -2232,7 +2232,7 @@ fn job_to_proto(job: &spur_core::job::Job) -> JobInfo {
         partition: job.spec.partition.clone().unwrap_or_default(),
         account: job.spec.account.clone().unwrap_or_default(),
         state: job.state.to_proto_i32(),
-        state_reason: job.pending_reason.display().to_string(),
+        state_reason: job.state_reason_display().to_string(),
         submit_time: Some(datetime_to_proto(job.submit_time)),
         start_time: job.start_time.map(datetime_to_proto),
         end_time: job.end_time.map(datetime_to_proto),

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -798,13 +798,9 @@ fn warn_mpi_mpirun_skipped_affinity(job_id: u32, source: &HashMap<String, String
     }
 }
 
-/// Drain this node without reporting a job completion.
-///
-/// A launch failure is not a completion: the job never ran, and the controller's
-/// dispatch path already owns its fate (requeue when every dispatch failed,
-/// eviction to NodeFail on a partial failure). Reporting an exit code here would
-/// race that path and could finalize a still-retryable job to Failed, which no
-/// requeue path recovers.
+/// Drain this node without reporting a job completion. The controller's dispatch
+/// path already owns the job's fate, so reporting an exit code here would race it
+/// and could finalize a still-retryable job to Failed, which no requeue recovers.
 async fn request_node_drain(controller_addr: &str, node_name: &str, reason: &str, job_id: u32) {
     let result = retry_controller_rpc(move |attempt| async move {
         let channel = spur_client::connect_channel(controller_addr)

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1062,31 +1062,17 @@ impl SlurmAgent for AgentService {
                 memory_mb: spec.memory_per_node_mb,
             };
             if let Err(e) = spur_core::hooks::run_hook(prolog, &ctx).await {
-                let err_msg = format!("prolog failed: {e}");
+                // No completion report and no self-drain: the controller owns
+                // both decisions here, because only it can pair the drain with
+                // the hold that stops the job walking the cluster.
+                let err_msg = format!("prolog failed: {e:#}");
                 error!(job_id, error = %err_msg, "prolog hook failed before launch");
-                let controller = self.reporter.controller_addr.clone();
-                let node_name = self.reporter.hostname.clone();
-                let drain_reason = err_msg.clone();
-                tokio::spawn(async move {
-                    let drain = DrainRequest {
-                        reason: drain_reason.clone(),
-                    };
-                    report_completion(
-                        &controller,
-                        job_id,
-                        -1,
-                        0,
-                        run_attempt,
-                        &node_name,
-                        Some(&drain),
-                    )
-                    .await;
-                });
                 return Ok(Response::new(LaunchJobResponse {
                     success: false,
                     error: err_msg,
                     stdout_path: String::new(),
                     stderr_path: String::new(),
+                    failure_kind: LaunchFailureKind::LaunchFailureProlog as i32,
                 }));
             }
         }
@@ -1225,6 +1211,7 @@ impl SlurmAgent for AgentService {
                         error: "reservation reclaimed during launch".into(),
                         stdout_path: String::new(),
                         stderr_path: String::new(),
+                        failure_kind: LaunchFailureKind::LaunchFailureUnspecified as i32,
                     }));
                 }
 
@@ -1274,11 +1261,18 @@ impl SlurmAgent for AgentService {
                     error: String::new(),
                     stdout_path,
                     stderr_path,
+                    failure_kind: LaunchFailureKind::LaunchFailureUnspecified as i32,
                 }))
             }
             Err(e) => {
                 // reservation_guard releases the allocation and PMI on this return.
                 let drain_reason = e.drain_reason();
+                let failure_kind = match e {
+                    executor::LaunchError::PrologFailed(_) => {
+                        LaunchFailureKind::LaunchFailureProlog
+                    }
+                    _ => LaunchFailureKind::LaunchFailureUnspecified,
+                };
                 let err_msg = e.to_string();
                 error!(job_id, error = %err_msg, "failed to launch job");
 
@@ -1295,6 +1289,7 @@ impl SlurmAgent for AgentService {
                     error: err_msg,
                     stdout_path: String::new(),
                     stderr_path: String::new(),
+                    failure_kind: failure_kind as i32,
                 }))
             }
         }
@@ -2812,6 +2807,109 @@ mod tests {
             String::new(),
             String::new(),
         ))
+    }
+
+    /// An executable script at a temp path that exits with `code`.
+    fn failing_hook_script(code: i32) -> tempfile::TempPath {
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        writeln!(f, "#!/bin/bash\nexit {code}").unwrap();
+        let path = f.into_temp_path();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+
+    #[tokio::test]
+    async fn a_failed_prolog_is_reported_to_the_controller_as_a_prolog_failure() {
+        // The controller drains and holds on this kind, so the launch must come
+        // back classified rather than as an opaque rejection the controller can
+        // only string-match. The agent itself neither drains nor reports a
+        // completion: pairing the drain with the hold is the controller's job.
+        let prolog = failing_hook_script(1);
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig {
+                prolog: Some(prolog.to_str().unwrap().to_string()),
+                ..Default::default()
+            },
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        let resp = svc
+            .launch_job(Request::new(LaunchJobRequest {
+                job_id: 7,
+                spec: Some(JobSpec {
+                    name: "prolog-fail".into(),
+                    script: "#!/bin/bash\ntrue\n".into(),
+                    num_tasks: 1,
+                    num_nodes: 1,
+                    cpus_per_task: 1,
+                    work_dir: std::env::temp_dir().to_string_lossy().into_owned(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }))
+            .await
+            .expect("a prolog failure is a launch outcome, not a transport error")
+            .into_inner();
+
+        assert!(!resp.success);
+        assert_eq!(
+            resp.failure_kind,
+            LaunchFailureKind::LaunchFailureProlog as i32
+        );
+        assert!(
+            resp.error.contains("prolog_slurmd script exited with"),
+            "the operator needs the script's own failure, got {:?}",
+            resp.error
+        );
+    }
+
+    #[tokio::test]
+    async fn a_prolog_that_cannot_even_start_reports_the_underlying_errno() {
+        // Issue 520: `{e}` renders only the outermost context, reducing this to
+        // "prolog_slurmd script failed to execute: ..." and dropping the errno
+        // that says whether the script is missing, unreadable or not executable.
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig {
+                prolog: Some("/nonexistent/prolog.sh".into()),
+                ..Default::default()
+            },
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        let resp = svc
+            .launch_job(Request::new(LaunchJobRequest {
+                job_id: 8,
+                spec: Some(JobSpec {
+                    name: "prolog-missing".into(),
+                    script: "#!/bin/bash\ntrue\n".into(),
+                    num_tasks: 1,
+                    num_nodes: 1,
+                    cpus_per_task: 1,
+                    work_dir: std::env::temp_dir().to_string_lossy().into_owned(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert!(!resp.success);
+        assert_eq!(
+            resp.failure_kind,
+            LaunchFailureKind::LaunchFailureProlog as i32
+        );
+        assert!(
+            resp.error.contains("No such file or directory"),
+            "the cause chain must survive into the reported error, got {:?}",
+            resp.error
+        );
     }
 
     #[tokio::test]

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -458,7 +458,7 @@ impl Drop for LaunchReservationGuard {
     }
 }
 
-fn completion_report_retryable(status: &tonic::Status) -> bool {
+fn controller_rpc_retryable(status: &tonic::Status) -> bool {
     use tonic::Code;
     matches!(
         status.code(),
@@ -468,19 +468,19 @@ fn completion_report_retryable(status: &tonic::Status) -> bool {
 
 #[cfg(test)]
 mod completion_report_tests {
-    use super::completion_report_retryable;
+    use super::controller_rpc_retryable;
     use tonic::Status;
 
     #[test]
     fn permanent_errors_are_not_retryable() {
-        assert!(!completion_report_retryable(&Status::invalid_argument("x")));
-        assert!(!completion_report_retryable(&Status::not_found("x")));
+        assert!(!controller_rpc_retryable(&Status::invalid_argument("x")));
+        assert!(!controller_rpc_retryable(&Status::not_found("x")));
     }
 
     #[test]
     fn transient_errors_are_retryable() {
-        assert!(completion_report_retryable(&Status::unavailable("x")));
-        assert!(completion_report_retryable(&Status::internal("x")));
+        assert!(controller_rpc_retryable(&Status::unavailable("x")));
+        assert!(controller_rpc_retryable(&Status::internal("x")));
     }
 }
 
@@ -618,7 +618,7 @@ async fn report_completion(
                         return;
                     }
                     Err(e) => {
-                        if !completion_report_retryable(&e) {
+                        if !controller_rpc_retryable(&e) {
                             error!(
                                 job_id,
                                 attempt,
@@ -668,6 +668,76 @@ fn warn_mpi_mpirun_skipped_affinity(job_id: u32, source: &HashMap<String, String
             "multi-rank --mpi=pmix launches via mpirun --bind-to none; Spur CPU/GPU bind env is not applied to MPI ranks"
         );
     }
+}
+
+/// Drain this node without reporting a job completion.
+///
+/// A launch failure is not a completion: the job never ran, and the controller's
+/// dispatch path already owns its fate (requeue when every dispatch failed,
+/// eviction to NodeFail on a partial failure). Reporting an exit code here would
+/// race that path and could finalize a still-retryable job to Failed, which no
+/// requeue path recovers.
+async fn request_node_drain(controller_addr: &str, node_name: &str, reason: &str, job_id: u32) {
+    for attempt in 1..=3 {
+        match spur_client::connect_channel(controller_addr).await {
+            Ok(channel) => {
+                let mut client = spur_proto::controller_client(channel);
+                let req = DrainNodeRequest {
+                    name: node_name.to_string(),
+                    reason: reason.to_string(),
+                };
+                match client.drain_node(req).await {
+                    Ok(resp) => {
+                        warn!(
+                            job_id,
+                            node = %node_name,
+                            state = %resp.into_inner().actual_state,
+                            reason,
+                            "requested node drain after launch failure"
+                        );
+                        return;
+                    }
+                    Err(e) => {
+                        if !controller_rpc_retryable(&e) {
+                            error!(
+                                job_id,
+                                node = %node_name,
+                                attempt,
+                                code = ?e.code(),
+                                error = %e,
+                                "DrainNode failed with non-retryable error"
+                            );
+                            return;
+                        }
+                        warn!(
+                            job_id,
+                            node = %node_name,
+                            attempt,
+                            error = %e,
+                            "DrainNode RPC failed"
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                warn!(
+                    job_id,
+                    node = %node_name,
+                    attempt,
+                    error = %e,
+                    "failed to connect to controller for drain request"
+                );
+            }
+        }
+        if attempt < 3 {
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+    }
+    error!(
+        job_id,
+        node = %node_name,
+        "gave up requesting node drain after 3 attempts"
+    );
 }
 
 #[tonic::async_trait]
@@ -1208,28 +1278,15 @@ impl SlurmAgent for AgentService {
             }
             Err(e) => {
                 // reservation_guard releases the allocation and PMI on this return.
-                let is_prolog_failure = matches!(e, executor::LaunchError::PrologFailed(_));
+                let drain_reason = e.drain_reason();
                 let err_msg = e.to_string();
                 error!(job_id, error = %err_msg, "failed to launch job");
 
-                if is_prolog_failure {
+                if let Some(drain_reason) = drain_reason {
                     let controller = self.reporter.controller_addr.clone();
                     let node_name = self.reporter.hostname.clone();
-                    let drain_reason = format!("prolog failed: {}", err_msg);
                     tokio::spawn(async move {
-                        let drain = DrainRequest {
-                            reason: drain_reason.clone(),
-                        };
-                        report_completion(
-                            &controller,
-                            job_id,
-                            -1,
-                            0,
-                            run_attempt,
-                            &node_name,
-                            Some(&drain),
-                        )
-                        .await;
+                        request_node_drain(&controller, &node_name, &drain_reason, job_id).await;
                     });
                 }
 

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -466,9 +466,67 @@ fn controller_rpc_retryable(status: &tonic::Status) -> bool {
     )
 }
 
+const CONTROLLER_RPC_ATTEMPTS: u32 = 3;
+const CONTROLLER_RPC_RETRY_GAP: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// A single failed attempt at a controller RPC.
+enum ControllerRpcError {
+    Connect(tonic::transport::Error),
+    Rpc(tonic::Status),
+}
+
+impl ControllerRpcError {
+    /// A transport failure is always worth another attempt: it says nothing
+    /// about the request, only that no controller answered. A server response
+    /// is worth one only when its code says so.
+    fn retryable(&self) -> bool {
+        match self {
+            Self::Connect(_) => true,
+            Self::Rpc(status) => controller_rpc_retryable(status),
+        }
+    }
+}
+
+impl std::fmt::Display for ControllerRpcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Connect(e) => write!(f, "connect: {e}"),
+            Self::Rpc(status) => write!(f, "{status}"),
+        }
+    }
+}
+
+/// Run `attempt` until it succeeds, fails in a way no retry can fix, or spends
+/// the attempt budget, returning the last failure. A single transient failure
+/// must not lose a job completion or leave a broken node accepting work.
+async fn retry_controller_rpc<T, F, Fut>(mut attempt: F) -> Result<T, ControllerRpcError>
+where
+    F: FnMut(u32) -> Fut,
+    Fut: std::future::Future<Output = Result<T, ControllerRpcError>>,
+{
+    let mut n = 1;
+    loop {
+        match attempt(n).await {
+            Ok(value) => return Ok(value),
+            Err(e) => {
+                if !e.retryable() || n == CONTROLLER_RPC_ATTEMPTS {
+                    return Err(e);
+                }
+                n += 1;
+                tokio::time::sleep(CONTROLLER_RPC_RETRY_GAP).await;
+            }
+        }
+    }
+}
+
 #[cfg(test)]
-mod completion_report_tests {
-    use super::controller_rpc_retryable;
+mod controller_rpc_tests {
+    use super::{
+        controller_rpc_retryable, retry_controller_rpc, ControllerRpcError,
+        CONTROLLER_RPC_ATTEMPTS, CONTROLLER_RPC_RETRY_GAP,
+    };
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::Duration;
     use tonic::Status;
 
     #[test]
@@ -481,6 +539,81 @@ mod completion_report_tests {
     fn transient_errors_are_retryable() {
         assert!(controller_rpc_retryable(&Status::unavailable("x")));
         assert!(controller_rpc_retryable(&Status::internal("x")));
+    }
+
+    /// Drive the retry loop with one scripted outcome per attempt, reporting how
+    /// many attempts it actually made.
+    async fn run_script(script: Vec<Result<(), Status>>) -> (Result<(), ControllerRpcError>, u32) {
+        let calls = AtomicU32::new(0);
+        let result = retry_controller_rpc(|_| {
+            let outcome = script[calls.fetch_add(1, Ordering::SeqCst) as usize].clone();
+            async move { outcome.map_err(ControllerRpcError::Rpc) }
+        })
+        .await;
+        (result, calls.load(Ordering::SeqCst))
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn success_returns_on_the_first_attempt() {
+        let start = tokio::time::Instant::now();
+        let (result, calls) = run_script(vec![
+            Ok(()),
+            Err(Status::unavailable("must not be reached")),
+            Err(Status::unavailable("must not be reached")),
+        ])
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(calls, 1);
+        assert_eq!(start.elapsed(), Duration::ZERO);
+    }
+
+    /// A rejection no retry can fix must not spend the budget: the caller runs in
+    /// a spawned task, and sleeping through attempts delays the drain that stops
+    /// the node taking more work. The trailing successes make a regression here
+    /// surface as a wrong result rather than a short script.
+    #[tokio::test(start_paused = true)]
+    async fn non_retryable_error_gives_up_without_retrying() {
+        let start = tokio::time::Instant::now();
+        let (result, calls) = run_script(vec![
+            Err(Status::invalid_argument("unknown node")),
+            Ok(()),
+            Ok(()),
+        ])
+        .await;
+
+        assert!(matches!(result, Err(ControllerRpcError::Rpc(_))));
+        assert_eq!(calls, 1);
+        assert_eq!(start.elapsed(), Duration::ZERO);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retryable_errors_are_retried_until_one_succeeds() {
+        let start = tokio::time::Instant::now();
+        let (result, calls) = run_script(vec![
+            Err(Status::unavailable("controller restarting")),
+            Err(Status::internal("leader election in progress")),
+            Ok(()),
+        ])
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(calls, CONTROLLER_RPC_ATTEMPTS);
+        assert_eq!(start.elapsed(), 2 * CONTROLLER_RPC_RETRY_GAP);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retryable_errors_give_up_once_the_budget_is_spent() {
+        let start = tokio::time::Instant::now();
+        let script = vec![Err(Status::unavailable("no route")); CONTROLLER_RPC_ATTEMPTS as usize];
+        let (result, calls) = run_script(script).await;
+
+        assert!(matches!(result, Err(ControllerRpcError::Rpc(_))));
+        assert_eq!(calls, CONTROLLER_RPC_ATTEMPTS);
+        assert_eq!(
+            start.elapsed(),
+            (CONTROLLER_RPC_ATTEMPTS - 1) * CONTROLLER_RPC_RETRY_GAP
+        );
     }
 }
 
@@ -590,70 +723,65 @@ async fn report_completion(
     // RaisedSignal outcome from the reported `signal`.
     let state = spur_core::job::JobState::completion_state_for_exit_code(exit_code).to_proto_i32();
 
-    // Retry up to 3 times with 1-second backoff — a single transient failure
-    // must not permanently lose a job completion.
-    for attempt in 1..=3 {
-        match spur_client::connect_channel(controller_addr).await {
-            Ok(channel) => {
-                let mut client = spur_proto::controller_client(channel);
-                let req = ReportJobStatusRequest {
-                    job_id,
-                    state,
-                    exit_code,
-                    signal,
-                    message: format!("exit_code={}", exit_code),
-                    drain_node: drain.is_some(),
-                    drain_reason: drain.as_ref().map(|d| d.reason.clone()).unwrap_or_default(),
-                    reporting_node: reporting_node.to_string(),
-                    run_attempt,
-                };
-                match client.report_job_status(req).await {
-                    Ok(_) => {
-                        info!(
-                            job_id,
-                            exit_code,
-                            controller = %controller_addr,
-                            "reported completion to controller"
-                        );
-                        return;
-                    }
-                    Err(e) => {
-                        if !controller_rpc_retryable(&e) {
-                            error!(
-                                job_id,
-                                attempt,
-                                code = ?e.code(),
-                                error = %e,
-                                "ReportJobStatus failed with non-retryable error"
-                            );
-                            return;
-                        }
-                        warn!(
-                            job_id,
-                            attempt,
-                            error = %e,
-                            "ReportJobStatus RPC failed"
-                        );
-                    }
-                }
-            }
-            Err(e) => {
+    let result = retry_controller_rpc(move |attempt| async move {
+        let channel = spur_client::connect_channel(controller_addr)
+            .await
+            .map_err(|e| {
                 warn!(
                     job_id,
                     attempt,
                     error = %e,
                     "failed to connect to controller for completion report"
                 );
-            }
-        }
-        if attempt < 3 {
-            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-        }
+                ControllerRpcError::Connect(e)
+            })?;
+        let req = ReportJobStatusRequest {
+            job_id,
+            state,
+            exit_code,
+            signal,
+            message: format!("exit_code={}", exit_code),
+            drain_node: drain.is_some(),
+            drain_reason: drain.as_ref().map(|d| d.reason.clone()).unwrap_or_default(),
+            reporting_node: reporting_node.to_string(),
+            run_attempt,
+        };
+        spur_proto::controller_client(channel)
+            .report_job_status(req)
+            .await
+            .map_err(|e| {
+                warn!(
+                    job_id,
+                    attempt,
+                    error = %e,
+                    "ReportJobStatus RPC failed"
+                );
+                ControllerRpcError::Rpc(e)
+            })
+    })
+    .await;
+
+    match result {
+        Ok(_) => info!(
+            job_id,
+            exit_code,
+            controller = %controller_addr,
+            "reported completion to controller"
+        ),
+        Err(e) if e.retryable() => error!(
+            job_id,
+            exit_code,
+            attempts = CONTROLLER_RPC_ATTEMPTS,
+            error = %e,
+            "gave up reporting completion to controller"
+        ),
+        Err(e) => error!(
+            job_id,
+            exit_code,
+            error = %e,
+            "ReportJobStatus failed with non-retryable error"
+        ),
     }
-    error!(
-        job_id,
-        exit_code, "gave up reporting completion after 3 attempts"
-    );
 }
 
 fn warn_mpi_mpirun_skipped_affinity(job_id: u32, source: &HashMap<String, String>) {
@@ -678,48 +806,10 @@ fn warn_mpi_mpirun_skipped_affinity(job_id: u32, source: &HashMap<String, String
 /// race that path and could finalize a still-retryable job to Failed, which no
 /// requeue path recovers.
 async fn request_node_drain(controller_addr: &str, node_name: &str, reason: &str, job_id: u32) {
-    for attempt in 1..=3 {
-        match spur_client::connect_channel(controller_addr).await {
-            Ok(channel) => {
-                let mut client = spur_proto::controller_client(channel);
-                let req = DrainNodeRequest {
-                    name: node_name.to_string(),
-                    reason: reason.to_string(),
-                };
-                match client.drain_node(req).await {
-                    Ok(resp) => {
-                        warn!(
-                            job_id,
-                            node = %node_name,
-                            state = %resp.into_inner().actual_state,
-                            reason,
-                            "requested node drain after launch failure"
-                        );
-                        return;
-                    }
-                    Err(e) => {
-                        if !controller_rpc_retryable(&e) {
-                            error!(
-                                job_id,
-                                node = %node_name,
-                                attempt,
-                                code = ?e.code(),
-                                error = %e,
-                                "DrainNode failed with non-retryable error"
-                            );
-                            return;
-                        }
-                        warn!(
-                            job_id,
-                            node = %node_name,
-                            attempt,
-                            error = %e,
-                            "DrainNode RPC failed"
-                        );
-                    }
-                }
-            }
-            Err(e) => {
+    let result = retry_controller_rpc(move |attempt| async move {
+        let channel = spur_client::connect_channel(controller_addr)
+            .await
+            .map_err(|e| {
                 warn!(
                     job_id,
                     node = %node_name,
@@ -727,17 +817,50 @@ async fn request_node_drain(controller_addr: &str, node_name: &str, reason: &str
                     error = %e,
                     "failed to connect to controller for drain request"
                 );
-            }
-        }
-        if attempt < 3 {
-            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
-        }
+                ControllerRpcError::Connect(e)
+            })?;
+        let req = DrainNodeRequest {
+            name: node_name.to_string(),
+            reason: reason.to_string(),
+        };
+        spur_proto::controller_client(channel)
+            .drain_node(req)
+            .await
+            .map_err(|e| {
+                warn!(
+                    job_id,
+                    node = %node_name,
+                    attempt,
+                    error = %e,
+                    "DrainNode RPC failed"
+                );
+                ControllerRpcError::Rpc(e)
+            })
+    })
+    .await;
+
+    match result {
+        Ok(resp) => warn!(
+            job_id,
+            node = %node_name,
+            state = %resp.into_inner().actual_state,
+            reason = %reason,
+            "requested node drain after launch failure"
+        ),
+        Err(e) if e.retryable() => error!(
+            job_id,
+            node = %node_name,
+            attempts = CONTROLLER_RPC_ATTEMPTS,
+            error = %e,
+            "gave up requesting node drain"
+        ),
+        Err(e) => error!(
+            job_id,
+            node = %node_name,
+            error = %e,
+            "DrainNode failed with non-retryable error"
+        ),
     }
-    error!(
-        job_id,
-        node = %node_name,
-        "gave up requesting node drain after 3 attempts"
-    );
 }
 
 #[tonic::async_trait]

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -18,17 +18,38 @@ use spur_core::config::MemlockLimit;
 use spur_core::job::JobId;
 use spur_spank::{SpankContext, SpankHandle, SpankHost};
 
-/// Typed launch errors so callers can distinguish prolog failure from other failures.
+/// Typed launch errors so callers can distinguish a broken node from a job that
+/// simply cannot run here.
 pub enum LaunchError {
     PrologFailed(anyhow::Error),
+    /// The node itself cannot host work: spurd's own spool filesystem is full or
+    /// read-only, so every subsequent job will fail identically.
+    NodeFault(anyhow::Error),
     Other(anyhow::Error),
 }
 
 impl std::fmt::Display for LaunchError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `{:#}` renders the whole cause chain. Plain `{}` prints only the
+        // outermost context, which would reduce a drain reason to "create job
+        // spool dir" and drop the errno an operator needs to act on.
         match self {
-            Self::PrologFailed(e) => write!(f, "prolog failed: {e}"),
-            Self::Other(e) => write!(f, "{e}"),
+            Self::PrologFailed(e) => write!(f, "prolog failed: {e:#}"),
+            Self::NodeFault(e) => write!(f, "launch failed: {e:#}"),
+            Self::Other(e) => write!(f, "{e:#}"),
+        }
+    }
+}
+
+impl LaunchError {
+    /// Reason to drain this node, or `None` when the failure is not the node's
+    /// fault. Derived from `Display` so the reason and the decision cannot
+    /// disagree, and so callers never re-prefix a message that already carries
+    /// its own prefix.
+    pub fn drain_reason(&self) -> Option<String> {
+        match self {
+            Self::PrologFailed(_) | Self::NodeFault(_) => Some(self.to_string()),
+            Self::Other(_) => None,
         }
     }
 }
@@ -36,6 +57,43 @@ impl std::fmt::Display for LaunchError {
 impl From<anyhow::Error> for LaunchError {
     fn from(e: anyhow::Error) -> Self {
         Self::Other(e)
+    }
+}
+
+/// True when the error chain bottoms out in a filesystem that cannot accept the
+/// write at all, as opposed to a path or permission problem specific to one job.
+///
+/// `EDQUOT` is deliberately absent: a quota is a property of a user on a shared
+/// filesystem, not of the node, and no quota applies to the root-owned spool tree.
+fn is_disk_exhausted(err: &anyhow::Error) -> bool {
+    err.chain()
+        .filter_map(|cause| cause.downcast_ref::<std::io::Error>())
+        .any(is_exhaustion_errno)
+}
+
+fn is_exhaustion_errno(err: &std::io::Error) -> bool {
+    matches!(err.raw_os_error(), Some(libc::ENOSPC) | Some(libc::EROFS))
+}
+
+/// True when `dir` lives in the spool tree spurd owns, as opposed to the
+/// world-writable temp fallback [`create_job_spool_dir`] drops to on a non-root
+/// dev run. Only the owned tree may condemn a node: `/tmp` exhaustion is
+/// something any single job can cause, so draining on it would let one runaway
+/// job take the cluster down node by node.
+fn is_node_owned_spool(dir: &Path) -> bool {
+    dir.starts_with(SPOOL_ROOT)
+}
+
+/// Classify a failed write to a job's spool directory.
+///
+/// Only spool writes may reach this. Writes to the job's `work_dir` must not use
+/// it: that path is user-controlled and frequently a shared mount, where one user
+/// filling their quota would otherwise drain every node in turn.
+fn classify_spool_error(dir: &Path, err: anyhow::Error) -> LaunchError {
+    if is_node_owned_spool(dir) && is_disk_exhausted(&err) {
+        LaunchError::NodeFault(err)
+    } else {
+        LaunchError::Other(err)
     }
 }
 
@@ -386,15 +444,13 @@ pub async fn launch_job(
             .map_err(LaunchError::PrologFailed)?;
     }
 
-    spawn_job_process(cfg, spank)
-        .await
-        .map_err(LaunchError::Other)
+    spawn_job_process(cfg, spank).await
 }
 
 async fn spawn_job_process(
     cfg: &JobLaunchConfig,
     spank: Option<&SpankHost>,
-) -> anyhow::Result<LaunchResult> {
+) -> Result<LaunchResult, LaunchError> {
     let JobLaunchConfig {
         job_id,
         ref script,
@@ -446,9 +502,11 @@ async fn spawn_job_process(
 
     // Script + wrapper live in the node-local spool dir, not work_dir (see
     // SPOOL_ROOT), so root-side writes survive NFS root_squash work_dirs.
-    let spool_dir = create_job_spool_dir(job_id, uid, gid).context("create job spool dir")?;
+    let spool_dir = create_job_spool_dir(job_id, uid, gid)?;
     let script_path = spool_dir.join("spur_job.sh");
-    write_job_scratch(&script_path, script, uid, gid).context("failed to write job script")?;
+    write_job_scratch(&script_path, script, uid, gid)
+        .context("failed to write job script")
+        .map_err(|e| classify_spool_error(&spool_dir, e))?;
 
     // Build resolved output paths (empty for PTY mode since output goes to the terminal).
     let (stdout_resolved, stderr_resolved) = if cfg.io_mode == LaunchIo::Pty {
@@ -472,10 +530,11 @@ async fn spawn_job_process(
             } else {
                 let r = resolve_output_path(cfg, work_dir, stdin_path);
                 if r == stdout_resolved || r == stderr_resolved {
-                    anyhow::bail!(
+                    return Err(anyhow::anyhow!(
                         "stdin path {} overlaps with an output path; this would truncate the input",
                         r
-                    );
+                    )
+                    .into());
                 }
                 Some(r)
             };
@@ -501,7 +560,12 @@ async fn spawn_job_process(
                             || (fgid == gid && mode & 0o040 != 0)
                             || (mode & 0o004 != 0);
                         if !readable {
-                            anyhow::bail!("stdin file {} is not readable by uid {}", resolved, uid);
+                            return Err(anyhow::anyhow!(
+                                "stdin file {} is not readable by uid {}",
+                                resolved,
+                                uid
+                            )
+                            .into());
                         }
                     }
                     let f = std::fs::File::open(resolved)
@@ -583,7 +647,8 @@ async fn spawn_job_process(
             .map(|p| p.visible_devices.as_slice())
             .unwrap_or(&[]);
         let wrapper = build_namespace_wrapper(uid, gid, visible_devices, &script_path);
-        write_job_scratch(&wrapper_path, &wrapper, uid, gid)?;
+        write_job_scratch(&wrapper_path, &wrapper, uid, gid)
+            .map_err(|e| classify_spool_error(&spool_dir, e))?;
         debug!(job_id, "namespace isolation wrapper created");
         (
             "/usr/bin/unshare".to_string(),
@@ -1074,8 +1139,8 @@ fn create_dir_as_user(dir: &Path, uid: u32, gid: u32) -> bool {
 /// `SPOOL_ROOT`; falls back to a temp dir when it isn't writable (e.g. non-root
 /// dev runs). When spurd is root and the job targets a user, the dir is handed
 /// to that user so the job — which runs as the user — can traverse it.
-fn create_job_spool_dir(job_id: JobId, uid: u32, gid: u32) -> anyhow::Result<PathBuf> {
-    let mut last_err = None;
+fn create_job_spool_dir(job_id: JobId, uid: u32, gid: u32) -> Result<PathBuf, LaunchError> {
+    let mut failures = Vec::new();
     for base in [PathBuf::from(SPOOL_ROOT), std::env::temp_dir().join("spur")] {
         let dir = base.join(format!("job{}", job_id));
         match std::fs::create_dir_all(&dir) {
@@ -1092,10 +1157,35 @@ fn create_job_spool_dir(job_id: JobId, uid: u32, gid: u32) -> anyhow::Result<Pat
                 }
                 return Ok(dir);
             }
-            Err(e) => last_err = Some(e),
+            Err(e) => failures.push((dir, e)),
         }
     }
-    bail!("failed to create job spool dir: {last_err:?}")
+    Err(spool_dir_error(failures))
+}
+
+/// Build the error for a spool dir that could not be created under any candidate
+/// root.
+///
+/// Reports the owned root's failure when there is one, in preference to the temp
+/// fallback's: that is the root an operator configured and the only one whose
+/// exhaustion condemns the node, so naming the fallback instead would send them
+/// to inspect the wrong filesystem.
+///
+/// Keeps the `io::Error` as a source rather than formatting it into the message,
+/// because exhaustion is detected by walking the chain and a flattened errno
+/// would silently downgrade a node fault to a job failure, leaving a node
+/// accepting work it cannot run.
+fn spool_dir_error(mut failures: Vec<(PathBuf, std::io::Error)>) -> LaunchError {
+    if failures.is_empty() {
+        return LaunchError::Other(anyhow::anyhow!("no spool root candidates configured"));
+    }
+    let chosen = failures
+        .iter()
+        .position(|(dir, _)| is_node_owned_spool(dir))
+        .unwrap_or(0);
+    let (dir, err) = failures.swap_remove(chosen);
+    let err = anyhow::Error::new(err).context(format!("create job spool dir {}", dir.display()));
+    classify_spool_error(&dir, err)
 }
 
 /// Private per-job directory for srun step scripts under the step work dir.
@@ -1492,6 +1582,193 @@ mod tests {
         assert_eq!(decode_wait_status(WaitStatus::StillAlive), (-1, 0));
     }
 
+    // ── launch error classification / node drain ─────────────────
+
+    fn disk_full_error(context: &str) -> anyhow::Error {
+        // Same shape the production paths produce: an io::Error from the
+        // filesystem, wrapped by the call site's .context().
+        anyhow::Error::new(std::io::Error::from_raw_os_error(libc::ENOSPC))
+            .context(context.to_owned())
+    }
+
+    fn owned_spool() -> PathBuf {
+        PathBuf::from(SPOOL_ROOT).join("job1")
+    }
+
+    fn fallback_spool() -> PathBuf {
+        std::env::temp_dir().join("spur").join("job1")
+    }
+
+    #[test]
+    fn spool_disk_exhaustion_is_a_node_fault_and_drains() {
+        // create_job_spool_dir / write_job_scratch target SPOOL_ROOT, which
+        // spurd owns, so a full filesystem there condemns the node.
+        let err = classify_spool_error(&owned_spool(), disk_full_error("create job spool dir"));
+        assert!(matches!(err, LaunchError::NodeFault(_)));
+        let reason = err.drain_reason().expect("node fault must drain");
+        assert!(reason.contains("No space left on device"), "{reason}");
+    }
+
+    #[test]
+    fn a_full_temp_fallback_spool_does_not_drain() {
+        // The fallback root is world-writable, so any single job can fill it.
+        // Draining on that would let one runaway job walk the cluster, taking
+        // out every node the scheduler retries it on.
+        let err = classify_spool_error(&fallback_spool(), disk_full_error("write job script"));
+        assert!(matches!(err, LaunchError::Other(_)));
+        assert!(
+            err.drain_reason().is_none(),
+            "a full world-writable /tmp must never drain the node"
+        );
+    }
+
+    #[test]
+    fn exhausted_spool_roots_stay_classifiable_as_a_node_fault() {
+        // Every candidate root failing to mkdir is what an exhausted rootfs
+        // looks like, since SPOOL_ROOT and the temp fallback usually share a
+        // filesystem. Formatting the errno into the message here would hide it
+        // from classification, so the node would keep accepting jobs it cannot
+        // launch — the retry storm this whole path exists to stop.
+        let err = spool_dir_error(vec![
+            (
+                owned_spool(),
+                std::io::Error::from_raw_os_error(libc::ENOSPC),
+            ),
+            (
+                fallback_spool(),
+                std::io::Error::from_raw_os_error(libc::ENOSPC),
+            ),
+        ]);
+        assert!(matches!(err, LaunchError::NodeFault(_)));
+        let reason = err.drain_reason().expect("node fault must drain");
+        assert!(
+            reason.contains(&owned_spool().display().to_string()),
+            "the configured spool root must be the one named, got: {reason}"
+        );
+    }
+
+    #[test]
+    fn an_errno_rendered_into_the_message_is_not_recoverable() {
+        // Why spool_dir_error keeps the io::Error as a source. Classification
+        // walks the chain, so an errno turned into text is gone for good; this
+        // is how the all-roots-failed path used to lose node faults.
+        let flattened = anyhow::anyhow!(
+            "failed to create job spool dir: {:?}",
+            std::io::Error::from_raw_os_error(libc::ENOSPC)
+        );
+        assert!(
+            !is_disk_exhausted(&flattened),
+            "an errno in the message text must not be mistaken for a real source"
+        );
+    }
+
+    #[test]
+    fn only_the_fallback_being_full_does_not_drain() {
+        // The owned root failed for its own reason and only the world-writable
+        // fallback is full. The node's own spool is not exhausted, so this is a
+        // job failure, not grounds for taking the node out of service.
+        let err = spool_dir_error(vec![
+            (
+                owned_spool(),
+                std::io::Error::from_raw_os_error(libc::EACCES),
+            ),
+            (
+                fallback_spool(),
+                std::io::Error::from_raw_os_error(libc::ENOSPC),
+            ),
+        ]);
+        assert!(matches!(err, LaunchError::Other(_)));
+        assert!(err.drain_reason().is_none());
+    }
+
+    #[test]
+    fn non_exhaustion_spool_root_failures_do_not_drain() {
+        // A permissions problem is not the filesystem being full, so it must
+        // not take the node offline.
+        let err = spool_dir_error(vec![(
+            owned_spool(),
+            std::io::Error::from_raw_os_error(libc::EACCES),
+        )]);
+        assert!(matches!(err, LaunchError::Other(_)));
+        assert!(err.drain_reason().is_none());
+    }
+
+    #[test]
+    fn write_job_scratch_keeps_the_errno_downcastable() {
+        // The whole classification scheme rests on write_job_scratch leaving a
+        // real io::Error in the chain. If it ever formatted the errno into its
+        // message instead, every classification test above would still pass
+        // while production silently stopped draining broken nodes.
+        let err = write_job_scratch(
+            Path::new("/nonexistent-spur-audit-dir/job.sh"),
+            "#!/bin/sh\n",
+            0,
+            0,
+        )
+        .expect_err("writing under a nonexistent parent must fail");
+        assert!(
+            err.chain()
+                .any(|c| c.downcast_ref::<std::io::Error>().is_some()),
+            "the io::Error must survive as a source, not be flattened into text"
+        );
+    }
+
+    #[test]
+    fn read_only_spool_is_a_node_fault() {
+        let err = classify_spool_error(
+            &owned_spool(),
+            anyhow::Error::new(std::io::Error::from_raw_os_error(libc::EROFS))
+                .context("write job script"),
+        );
+        assert!(matches!(err, LaunchError::NodeFault(_)));
+    }
+
+    #[test]
+    fn output_file_disk_exhaustion_does_not_drain() {
+        // open_job_output writes to paths resolved against the job's work_dir,
+        // which is user-controlled and frequently a shared mount. Its errors
+        // reach the caller through `?`, i.e. From<anyhow::Error>, so they must
+        // classify as Other: draining here would take a healthy node offline,
+        // and the scheduler would then repeat it on every remaining node.
+        let err: LaunchError = disk_full_error("failed to open job output files").into();
+        assert!(matches!(err, LaunchError::Other(_)));
+        assert!(
+            err.drain_reason().is_none(),
+            "a full user filesystem must never drain the node"
+        );
+    }
+
+    #[test]
+    fn user_quota_exhaustion_is_not_a_node_fault() {
+        // EDQUOT is a property of a user on a shared filesystem, not of the
+        // node, and no quota applies to the root-owned spool tree.
+        let err = classify_spool_error(
+            &owned_spool(),
+            anyhow::Error::new(std::io::Error::from_raw_os_error(libc::EDQUOT))
+                .context("write job script"),
+        );
+        assert!(matches!(err, LaunchError::Other(_)));
+        assert!(err.drain_reason().is_none());
+    }
+
+    #[test]
+    fn non_disk_spool_failure_does_not_drain() {
+        let err =
+            classify_spool_error(&owned_spool(), anyhow::anyhow!("container image not found"));
+        assert!(matches!(err, LaunchError::Other(_)));
+        assert!(err.drain_reason().is_none());
+    }
+
+    #[test]
+    fn prolog_drain_reason_is_not_double_prefixed() {
+        let err = LaunchError::PrologFailed(anyhow::anyhow!("exit status 1"));
+        assert_eq!(
+            err.drain_reason().unwrap(),
+            "prolog failed: exit status 1",
+            "reason must come from Display, not a second hand-written prefix"
+        );
+    }
+
     // These exercise the in-process (non-fork) branch of the helpers: as a
     // non-root test runner, should_run_as_user() is false, so no privilege drop
     // or fork happens and behaviour is deterministic regardless of the test uid.
@@ -1625,7 +1902,10 @@ mod tests {
         // A job id unlikely to collide with a real job on the test host; as a
         // non-root runner this resolves to the temp-dir fallback.
         let job_id: JobId = 987_654_321;
-        let dir = create_job_spool_dir(job_id, uid, gid).unwrap();
+        // LaunchError has no Debug impl on purpose (it must not be convertible
+        // back into an anyhow::Error), so report it through Display.
+        let dir = create_job_spool_dir(job_id, uid, gid)
+            .unwrap_or_else(|e| panic!("create spool dir: {e}"));
         assert!(dir.is_dir());
         write_job_scratch(&dir.join("spur_job.sh"), "x", uid, gid).unwrap();
         cleanup_job_spool(job_id);

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -43,15 +43,9 @@ impl std::fmt::Display for LaunchError {
 
 impl LaunchError {
     /// Reason for the agent to drain itself, or `None` when the controller owns
-    /// the decision. Derived from `Display` so the reason and the decision
-    /// cannot disagree, and so callers never re-prefix a message that already
-    /// carries its own prefix.
-    ///
-    /// Only `NodeFault` qualifies: it is gated on a root-owned path with no user
-    /// input, so retrying elsewhere converges and no further node drains. A
-    /// prolog failure also drains, but the controller does it, because only the
-    /// controller can pair the drain with the hold that stops the job walking
-    /// the cluster.
+    /// the decision. A prolog failure drains too, but the controller does it,
+    /// because only the controller can pair the drain with the hold that stops
+    /// the job walking the cluster.
     pub fn drain_reason(&self) -> Option<String> {
         match self {
             Self::NodeFault(_) => Some(self.to_string()),
@@ -69,15 +63,11 @@ impl From<anyhow::Error> for LaunchError {
 /// True when the error chain carries a real OS-level I/O failure that the node
 /// itself is responsible for.
 ///
-/// Structured as an exclusion list, mirroring Slurm's "all others drain the
-/// node" default: the spool tree is root-owned and not user-writable, and every
-/// path under it is built by spurd from the job id alone, so a submission cannot
-/// steer the errno. `EIO`, `EACCES`, `ENOTDIR` and `EPERM` there mean the node
-/// is broken just as surely as `ENOSPC` does.
-///
-/// Requiring a real `raw_os_error` keeps a plain `anyhow!("...")` out.
-/// `EDQUOT` stays excluded: a quota is a property of a user on a shared
-/// filesystem, not of the node.
+/// An exclusion list, mirroring Slurm's "all others drain the node" default: the
+/// spool tree is root-owned and every path under it is built from the job id
+/// alone, so a submission cannot steer the errno. Requiring a real
+/// `raw_os_error` keeps a plain `anyhow!("...")` out, and `EDQUOT` stays
+/// excluded as a property of a user on a shared filesystem, not of the node.
 fn is_node_fault_io_error(err: &anyhow::Error) -> bool {
     err.chain()
         .filter_map(|cause| cause.downcast_ref::<std::io::Error>())
@@ -1179,17 +1169,13 @@ fn create_job_spool_dir(job_id: JobId, uid: u32, gid: u32) -> Result<PathBuf, La
 }
 
 /// Build the error for a spool dir that could not be created under any candidate
-/// root.
+/// root. Prefers the owned root's failure over the temp fallback's, since that
+/// is the one an operator configured and the only one whose failure condemns the
+/// node.
 ///
-/// Reports the owned root's failure when there is one, in preference to the temp
-/// fallback's: that is the root an operator configured and the only one whose
-/// failure condemns the node, so naming the fallback instead would send them
-/// to inspect the wrong filesystem.
-///
-/// Keeps the `io::Error` as a source rather than formatting it into the message,
-/// because the node fault is detected by walking the chain and a flattened errno
-/// would silently downgrade a node fault to a job failure, leaving a node
-/// accepting work it cannot run.
+/// The `io::Error` must stay a source rather than be formatted into the message:
+/// [`is_node_fault_io_error`] detects the fault by walking the chain, so a
+/// flattened errno would silently downgrade a node fault to a job failure.
 fn spool_dir_error(mut failures: Vec<(PathBuf, std::io::Error)>) -> LaunchError {
     if failures.is_empty() {
         return LaunchError::Other(anyhow::anyhow!("no spool root candidates configured"));

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -22,8 +22,8 @@ use spur_spank::{SpankContext, SpankHandle, SpankHost};
 /// simply cannot run here.
 pub enum LaunchError {
     PrologFailed(anyhow::Error),
-    /// The node itself cannot host work: spurd's own spool filesystem is full or
-    /// read-only, so every subsequent job will fail identically.
+    /// The node itself cannot host work: an I/O failure in spurd's own spool
+    /// tree, so every subsequent job will fail identically.
     NodeFault(anyhow::Error),
     Other(anyhow::Error),
 }
@@ -42,14 +42,20 @@ impl std::fmt::Display for LaunchError {
 }
 
 impl LaunchError {
-    /// Reason to drain this node, or `None` when the failure is not the node's
-    /// fault. Derived from `Display` so the reason and the decision cannot
-    /// disagree, and so callers never re-prefix a message that already carries
-    /// its own prefix.
+    /// Reason for the agent to drain itself, or `None` when the controller owns
+    /// the decision. Derived from `Display` so the reason and the decision
+    /// cannot disagree, and so callers never re-prefix a message that already
+    /// carries its own prefix.
+    ///
+    /// Only `NodeFault` qualifies: it is gated on a root-owned path with no user
+    /// input, so retrying elsewhere converges and no further node drains. A
+    /// prolog failure also drains, but the controller does it, because only the
+    /// controller can pair the drain with the hold that stops the job walking
+    /// the cluster.
     pub fn drain_reason(&self) -> Option<String> {
         match self {
-            Self::PrologFailed(_) | Self::NodeFault(_) => Some(self.to_string()),
-            Self::Other(_) => None,
+            Self::NodeFault(_) => Some(self.to_string()),
+            Self::PrologFailed(_) | Self::Other(_) => None,
         }
     }
 }
@@ -60,19 +66,26 @@ impl From<anyhow::Error> for LaunchError {
     }
 }
 
-/// True when the error chain bottoms out in a filesystem that cannot accept the
-/// write at all, as opposed to a path or permission problem specific to one job.
+/// True when the error chain carries a real OS-level I/O failure that the node
+/// itself is responsible for.
 ///
-/// `EDQUOT` is deliberately absent: a quota is a property of a user on a shared
-/// filesystem, not of the node, and no quota applies to the root-owned spool tree.
-fn is_disk_exhausted(err: &anyhow::Error) -> bool {
+/// Structured as an exclusion list, mirroring Slurm's "all others drain the
+/// node" default: the spool tree is root-owned and not user-writable, and every
+/// path under it is built by spurd from the job id alone, so a submission cannot
+/// steer the errno. `EIO`, `EACCES`, `ENOTDIR` and `EPERM` there mean the node
+/// is broken just as surely as `ENOSPC` does.
+///
+/// Requiring a real `raw_os_error` keeps a plain `anyhow!("...")` out.
+/// `EDQUOT` stays excluded: a quota is a property of a user on a shared
+/// filesystem, not of the node.
+fn is_node_fault_io_error(err: &anyhow::Error) -> bool {
     err.chain()
         .filter_map(|cause| cause.downcast_ref::<std::io::Error>())
-        .any(is_exhaustion_errno)
+        .any(is_node_fault_errno)
 }
 
-fn is_exhaustion_errno(err: &std::io::Error) -> bool {
-    matches!(err.raw_os_error(), Some(libc::ENOSPC) | Some(libc::EROFS))
+fn is_node_fault_errno(err: &std::io::Error) -> bool {
+    matches!(err.raw_os_error(), Some(errno) if errno != libc::EDQUOT)
 }
 
 /// True when `dir` lives in the spool tree spurd owns, as opposed to the
@@ -84,13 +97,15 @@ fn is_node_owned_spool(dir: &Path) -> bool {
     dir.starts_with(SPOOL_ROOT)
 }
 
-/// Classify a failed write to a job's spool directory.
+/// Classify a failed write to a job's spool directory. An I/O failure under the
+/// node's own spool root condemns the node; anything else is just this job's
+/// problem.
 ///
 /// Only spool writes may reach this. Writes to the job's `work_dir` must not use
 /// it: that path is user-controlled and frequently a shared mount, where one user
 /// filling their quota would otherwise drain every node in turn.
 fn classify_spool_error(dir: &Path, err: anyhow::Error) -> LaunchError {
-    if is_node_owned_spool(dir) && is_disk_exhausted(&err) {
+    if is_node_owned_spool(dir) && is_node_fault_io_error(&err) {
         LaunchError::NodeFault(err)
     } else {
         LaunchError::Other(err)
@@ -1168,11 +1183,11 @@ fn create_job_spool_dir(job_id: JobId, uid: u32, gid: u32) -> Result<PathBuf, La
 ///
 /// Reports the owned root's failure when there is one, in preference to the temp
 /// fallback's: that is the root an operator configured and the only one whose
-/// exhaustion condemns the node, so naming the fallback instead would send them
+/// failure condemns the node, so naming the fallback instead would send them
 /// to inspect the wrong filesystem.
 ///
 /// Keeps the `io::Error` as a source rather than formatting it into the message,
-/// because exhaustion is detected by walking the chain and a flattened errno
+/// because the node fault is detected by walking the chain and a flattened errno
 /// would silently downgrade a node fault to a job failure, leaving a node
 /// accepting work it cannot run.
 fn spool_dir_error(mut failures: Vec<(PathBuf, std::io::Error)>) -> LaunchError {
@@ -1657,40 +1672,57 @@ mod tests {
             std::io::Error::from_raw_os_error(libc::ENOSPC)
         );
         assert!(
-            !is_disk_exhausted(&flattened),
+            !is_node_fault_io_error(&flattened),
             "an errno in the message text must not be mistaken for a real source"
         );
     }
 
     #[test]
-    fn only_the_fallback_being_full_does_not_drain() {
-        // The owned root failed for its own reason and only the world-writable
-        // fallback is full. The node's own spool is not exhausted, so this is a
-        // job failure, not grounds for taking the node out of service.
-        let err = spool_dir_error(vec![
-            (
-                owned_spool(),
-                std::io::Error::from_raw_os_error(libc::EACCES),
-            ),
-            (
-                fallback_spool(),
-                std::io::Error::from_raw_os_error(libc::ENOSPC),
-            ),
-        ]);
+    fn a_failure_confined_to_the_fallback_root_does_not_drain() {
+        // Only the world-writable fallback failed. The node's own spool is
+        // fine, so this is a job failure, not grounds for taking the node out
+        // of service. This is the path check doing the work, not the errno.
+        let err = spool_dir_error(vec![(
+            fallback_spool(),
+            std::io::Error::from_raw_os_error(libc::ENOSPC),
+        )]);
         assert!(matches!(err, LaunchError::Other(_)));
         assert!(err.drain_reason().is_none());
     }
 
     #[test]
-    fn non_exhaustion_spool_root_failures_do_not_drain() {
-        // A permissions problem is not the filesystem being full, so it must
-        // not take the node offline.
+    fn an_error_with_no_io_source_never_drains() {
+        // Everything under the owned root drains except EDQUOT, so the errno
+        // check is what keeps a plain anyhow error out. Without it a container
+        // or config problem would start condemning nodes.
+        let err =
+            classify_spool_error(&owned_spool(), anyhow::anyhow!("spool root not configured"));
+        assert!(matches!(err, LaunchError::Other(_)));
+        assert!(err.drain_reason().is_none());
+    }
+
+    #[test]
+    fn a_permission_failure_on_the_owned_spool_root_is_a_node_fault() {
+        // The spool tree is root-owned and every path under it is built by
+        // spurd from the job id, so a submission cannot steer the errno. EACCES
+        // there means the node is misconfigured or its filesystem is broken,
+        // and leaving it eligible just feeds it more jobs to fail.
         let err = spool_dir_error(vec![(
             owned_spool(),
             std::io::Error::from_raw_os_error(libc::EACCES),
         )]);
-        assert!(matches!(err, LaunchError::Other(_)));
-        assert!(err.drain_reason().is_none());
+        assert!(matches!(err, LaunchError::NodeFault(_)));
+        assert!(err.drain_reason().is_some());
+    }
+
+    #[test]
+    fn a_hardware_io_error_on_the_owned_spool_root_is_a_node_fault() {
+        let err = classify_spool_error(
+            &owned_spool(),
+            anyhow::Error::new(std::io::Error::from_raw_os_error(libc::EIO))
+                .context("write job script"),
+        );
+        assert!(matches!(err, LaunchError::NodeFault(_)));
     }
 
     #[test]
@@ -1752,7 +1784,7 @@ mod tests {
     }
 
     #[test]
-    fn non_disk_spool_failure_does_not_drain() {
+    fn a_spool_failure_with_no_errno_does_not_drain() {
         let err =
             classify_spool_error(&owned_spool(), anyhow::anyhow!("container image not found"));
         assert!(matches!(err, LaunchError::Other(_)));
@@ -1760,12 +1792,17 @@ mod tests {
     }
 
     #[test]
-    fn prolog_drain_reason_is_not_double_prefixed() {
+    fn the_agent_does_not_self_drain_on_a_prolog_failure() {
+        // The drain still happens, but the controller issues it, so it can pair
+        // it with the hold. An agent-side drain would retry the job elsewhere
+        // and walk a job-caused failure across the cluster.
         let err = LaunchError::PrologFailed(anyhow::anyhow!("exit status 1"));
+        assert!(err.drain_reason().is_none());
         assert_eq!(
-            err.drain_reason().unwrap(),
+            err.to_string(),
             "prolog failed: exit status 1",
-            "reason must come from Display, not a second hand-written prefix"
+            "this text reaches the controller as the launch error and becomes \
+             the drain reason there, so it must not be double-prefixed"
         );
     }
 

--- a/examples/spur.conf
+++ b/examples/spur.conf
@@ -9,6 +9,12 @@ max_batch_requeue = 5
 # 300, range 1-86400). Each retry waits twice as long as the last, so this caps
 # how far the doubling can go before max_batch_requeue is reached.
 max_launch_backoff_secs = 300
+# Hold a job instead of retrying it when its prolog fails (default true). A
+# prolog sees the job's own context, so the same failure repeats on every node
+# and each retry would drain another one. Set false to retry instead, bounded by
+# max_batch_requeue. Slurm's inverse of this is
+# SchedulerParameters=nohold_on_prolog_fail.
+hold_on_prolog_fail = true
 # Controller hostname(s). For an HA quorum, list every controller so clients
 # and agents fail over to a surviving node if one is unreachable. Each host is
 # combined with the port from listen_addr. Equivalent to a comma-separated

--- a/examples/spur.conf
+++ b/examples/spur.conf
@@ -5,6 +5,10 @@ listen_addr = "[::]:6817"
 state_dir = "/var/spool/spur"
 # Maximum automatic requeues before a job is held (default 5).
 max_batch_requeue = 5
+# Upper bound in seconds on the hold between launch-failure retries (default
+# 300, range 1-86400). Each retry waits twice as long as the last, so this caps
+# how far the doubling can go before max_batch_requeue is reached.
+max_launch_backoff_secs = 300
 # Controller hostname(s). For an HA quorum, list every controller so clients
 # and agents fail over to a surviving node if one is unreachable. Each host is
 # combined with the port from listen_addr. Equivalent to a comma-separated

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -707,11 +707,23 @@ message LaunchJobRequest {
   PmixLaunchPlan pmix_plan = 10;
 }
 
+// Why a launch was rejected, when the controller's response depends on it.
+// Only kinds with a live emission path are listed; an agent that predates a
+// kind sends UNSPECIFIED and the controller falls back to its generic handling.
+enum LaunchFailureKind {
+  LAUNCH_FAILURE_UNSPECIFIED = 0;
+  // The node ran the job's prolog and it failed. The controller drains the node
+  // and holds the job rather than retrying, since a prolog sees the job's own
+  // context and so fails the same way everywhere.
+  LAUNCH_FAILURE_PROLOG = 1;
+}
+
 message LaunchJobResponse {
   bool success = 1;
   string error = 2;
   string stdout_path = 3;  // absolute resolved output path on the launching node
   string stderr_path = 4;
+  LaunchFailureKind failure_kind = 5;
 }
 
 message AgentCancelJobRequest {


### PR DESCRIPTION
Fixes #520.

A node whose spool filesystem was read-only or full rejected every launch. The controller re-dispatched to that same node about four times a second, exhausted `max_batch_requeue` in roughly 1.5 seconds, and cancelled the job with no errno for the operator to act on.

## Approach

`LaunchError`'s `Display` now uses `{e:#}`, so the errno reaches the controller instead of being truncated to `create job spool dir`. An I/O failure on the node-owned spool root is classified as a node fault and drains the node, which removes it from the candidate set structurally rather than needing scheduler scoring changes. Requeued jobs carry a `begin_time` hold that doubles per attempt, capped by the new `controller.max_launch_backoff_secs` (default 300).

Pairing a drain with an automatic retry changes what a drain costs: a failure that recurs everywhere drains a node per retry. Slurm bounds this by never letting a drain and an automatic retry coexist unless the failure is provably the node's fault. This PR follows the same rule.

**Node faults retry.** `classify_spool_error` gates on the root-owned spool tree, where every path is built by spurd from the job id and no user input can steer the errno, so a retry elsewhere converges. Structured as an exclusion list (any errno except `EDQUOT`) mirroring Slurm's "all others drain the node" default in `_slurm_rpc_complete_batch_script`. The world-writable `/tmp` fallback and the user-controlled `work_dir` stay excluded: either would let one user drain the cluster node by node.

**Prolog failures hold.** A prolog receives the job's own uid, gid and work_dir, so an unprovisioned account or an unreachable NFS mount fails identically on every node. The agent no longer self-drains or reports a fake completion; it returns a classified rejection (`LaunchFailureKind::PROLOG`) and the controller drains the node and parks the job at priority 0 with Slurm's `state_desc` of `launch failed requeued held`. `scontrol release` resumes it. `controller.hold_on_prolog_fail = false` restores the retry, which is Slurm's `SchedulerParameters=nohold_on_prolog_fail`, still backstopped by `max_batch_requeue`. Interactive jobs are cancelled rather than held, matching Slurm and avoiding a stranded `srun`.

The drain also uses the controller rather than a completion report from the agent: a job that never ran has no exit code, and reporting one races the requeue and can finalize a still-retryable job to Failed. Reaching `drain_node` automatically from the agent opened a deadlock window, so it now takes jobs before nodes to match `apply_operation`.

## Design notes

Slurm keeps two fields for a job's wait reason: `state_reason` (an enum) and `state_desc` (free text that both `squeue` and `scontrol` print in preference to the code). Spur had only the enum, so `Job` gains `pending_reason_desc`. Writes to either field go through `set_pending_reason` / `set_pending_reason_desc`, which move them together, so a description can never outlive the reason it explains.

One deliberate divergence. Slurm applies no backoff to its node-fault requeue, because its drain is synchronous under the job write lock and the broken node is already out of the candidate set before the requeue happens. Spur's node-fault drain is an agent-initiated RPC racing the controller's requeue, so the backoff is what covers that window. Moving that drain controller-side later, as this PR already does for prolog, would restore Slurm's ordering and demote the backoff to a safety net.

One march survives, and Slurm has it too: a prolog script broken cluster-wide drains one node per job until every node is out. The per-job hold bounds each job to a single drain, but nothing bounds the aggregate. A global circuit breaker is the fix and is filed as a follow-up.

## Rolling upgrades

`#[serde(default)]` covers old WAL replayed by a new binary, but a pre-538 follower applying a 538 leader's `JobStateChange` silently drops the unknown `begin_time` field, so on that replica the job is immediately eligible; if it wins leadership mid-upgrade the backoff vanishes. Upgrade all controllers before relying on the backoff. `pending_reason_desc` has the same caveat with only a cosmetic consequence: an old follower reports `JobHeldUser` instead of the description. The hold itself still applies, since the reason and the zeroed priority both survive.

The proto field is additive and degrades cleanly in both directions. An old agent sends `failure_kind = UNSPECIFIED` and its prolog failures keep today's requeue behavior; an old controller ignores the field entirely.

## Behavior change

A batch job whose prolog fails used to end `Failed` and leave the queue. It now parks Pending at priority 0 and stays there until `scontrol release`. That is Slurm's behavior and the reason the drain is bounded, but anything scripted around "prolog failure means the job is gone" needs updating. Interactive jobs are unaffected: they are cancelled, as before.

## Testing

Clippy clean, 2330 tests pass. Verified on a 4 node bare-metal cluster: the node drains with the errno in its reason and the job requeues and completes elsewhere.
