### PR TITLE
fix(spurd): retry RunCommand job lookup until dispatch registers

### DIFF
--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -366,6 +366,12 @@ struct DrainRequest {
 /// past this bound is reclaimed.
 const LAUNCHING_TTL: std::time::Duration = std::time::Duration::from_secs(600);
 
+/// Poll interval and attempt count for `wait_for_running_job`'s retry of a
+/// job that hasn't reached `running` yet. ~3s total, well above the launch
+/// latency skew observed between nodes of the same job under scheduler load.
+const JOB_LOOKUP_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+const JOB_LOOKUP_RETRY_ATTEMPTS: u32 = 30;
+
 /// Reclaim allocations whose job is no longer tracked and is not mid-launch,
 /// using the running set as ground truth. Callers hold the `running` lock
 /// across building `running` and this call so the live set is a consistent
@@ -1481,27 +1487,8 @@ impl SlurmAgent for AgentService {
         };
         let step_id = req.step_id;
 
-        let (gpu_devices, partition, cpus, memory_mb, nodelist, job_mpi) = {
-            let jobs = self.running.lock().await;
-            let tracked = jobs.get(&job_id).ok_or_else(|| {
-                Status::not_found(format!("job {} not running on this node", job_id))
-            })?;
-            let nodelist = if tracked.nodelist.is_empty() {
-                hostname::get()
-                    .map(|h| h.to_string_lossy().to_string())
-                    .unwrap_or_else(|_| "localhost".into())
-            } else {
-                tracked.nodelist.clone()
-            };
-            (
-                tracked.gpu_devices.clone(),
-                tracked.partition.clone(),
-                tracked.cpus,
-                tracked.memory_mb,
-                nodelist,
-                tracked.mpi.clone(),
-            )
-        };
+        let (gpu_devices, partition, cpus, memory_mb, nodelist, job_mpi) =
+            self.wait_for_running_job(job_id).await?;
 
         let agent_hostname = self.reporter.hostname.clone();
         let node_names: Vec<&str> = nodelist.split(',').filter(|s| !s.is_empty()).collect();
@@ -2255,6 +2242,54 @@ impl AgentService {
         });
     }
 
+    /// Look up a job's tracked fields, retrying briefly if it isn't in
+    /// `running` yet.
+    ///
+    /// spurctld marks a job Running (visible to `squeue`/`scontrol`) as soon
+    /// as it assigns nodes, before dispatching `LaunchJob` to any of them —
+    /// dispatch happens concurrently, out of band, and each agent only adds
+    /// the job to `running` after its own local launch pipeline (resource
+    /// allocation, GPU device injection, process/container spawn) finishes.
+    /// A step targeting this node (`srun` from within the batch script, or
+    /// any other RunCommand caller) can therefore arrive here before this
+    /// node's own dispatch has completed, even though the controller already
+    /// reports the job Running. Poll briefly rather than failing on the
+    /// first miss, since the job is expected to appear within one launch
+    /// pipeline's worth of time, not never.
+    async fn wait_for_running_job(
+        &self,
+        job_id: u32,
+    ) -> Result<(Vec<u32>, String, u32, u64, String, String), Status> {
+        for attempt in 0..JOB_LOOKUP_RETRY_ATTEMPTS {
+            let jobs = self.running.lock().await;
+            if let Some(tracked) = jobs.get(&job_id) {
+                let nodelist = if tracked.nodelist.is_empty() {
+                    hostname::get()
+                        .map(|h| h.to_string_lossy().to_string())
+                        .unwrap_or_else(|_| "localhost".into())
+                } else {
+                    tracked.nodelist.clone()
+                };
+                return Ok((
+                    tracked.gpu_devices.clone(),
+                    tracked.partition.clone(),
+                    tracked.cpus,
+                    tracked.memory_mb,
+                    nodelist,
+                    tracked.mpi.clone(),
+                ));
+            }
+            drop(jobs);
+            if attempt + 1 < JOB_LOOKUP_RETRY_ATTEMPTS {
+                tokio::time::sleep(JOB_LOOKUP_RETRY_INTERVAL).await;
+            }
+        }
+        Err(Status::not_found(format!(
+            "job {} not running on this node",
+            job_id
+        )))
+    }
+
     /// Extract a `JobEntry` from a tracked running job for namespace entry.
     async fn job_entry(&self, job_id: u32) -> Result<crate::job_entry::JobEntry, Status> {
         let jobs = self.running.lock().await;
@@ -2902,7 +2937,10 @@ mod tests {
         assert_eq!(err.code(), tonic::Code::InvalidArgument);
     }
 
-    #[tokio::test]
+    // A job that never registers must still fail, just not until the retry
+    // budget (wait_for_running_job) is exhausted. Paused time fast-forwards
+    // through that budget instead of the test actually taking ~3s.
+    #[tokio::test(start_paused = true)]
     async fn run_command_not_found_without_tracked_job() {
         let svc = AgentService::new(
             test_reporter(),
@@ -2921,6 +2959,53 @@ mod tests {
         });
         let err = svc.run_command(req).await.unwrap_err();
         assert_eq!(err.code(), tonic::Code::NotFound);
+        assert!(err.message().contains("not running on this node"));
+    }
+
+    // The startup race this guards against: spurctld marks a job Running
+    // (visible to squeue) before this node's own LaunchJob dispatch has
+    // finished, so a step can land here just ahead of `running` being
+    // populated. Paused time lets the retry loop's sleeps elapse instantly;
+    // the job is inserted while the first attempt's sleep is pending, so the
+    // next poll finds it instead of the call failing outright.
+    #[tokio::test(start_paused = true)]
+    async fn run_command_retries_until_job_registers() {
+        let svc = Arc::new(AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        ));
+        let job_id = 777;
+
+        let svc_call = svc.clone();
+        let call = tokio::spawn(async move {
+            let req = Request::new(RunCommandRequest {
+                command: vec!["echo".into(), "hi".into()],
+                uid: 0,
+                gid: 0,
+                work_dir: String::new(),
+                environment: HashMap::new(),
+                job_id,
+                ..Default::default()
+            });
+            svc_call.run_command(req).await
+        });
+
+        // Let the first (failing) lookup run and start its retry sleep before
+        // the job appears, so this exercises the retry path, not a lucky win
+        // on the first attempt.
+        tokio::task::yield_now().await;
+        svc.insert_test_job(job_id, TrackedJob::dummy(0)).await;
+        tokio::time::advance(JOB_LOOKUP_RETRY_INTERVAL).await;
+
+        let resp = call
+            .await
+            .expect("run_command task panicked")
+            .expect("run_command should succeed once the job registers")
+            .into_inner();
+        assert_eq!(resp.exit_code, 0);
+        assert_eq!(resp.stdout.trim(), "hi");
     }
 
     #[tokio::test]

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -3008,6 +3008,38 @@ mod tests {
         assert_eq!(resp.stdout.trim(), "hi");
     }
 
+    // wait_for_running_job falls back to this node's own hostname only when
+    // the tracked job's nodelist is empty (the case every other run_command
+    // test hits via TrackedJob::dummy). A multi-node job's nodelist is set
+    // by the controller at dispatch time, so it's normally non-empty —
+    // exercise that path explicitly.
+    #[tokio::test]
+    async fn run_command_uses_tracked_job_nodelist_when_set() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        let job_id = 778;
+        let mut tracked = TrackedJob::dummy(0);
+        tracked.nodelist = "node-a,node-b".into();
+        svc.insert_test_job(job_id, tracked).await;
+
+        let req = Request::new(RunCommandRequest {
+            command: vec!["/bin/sh".into(), "-c".into(), "echo $SPUR_NODELIST".into()],
+            uid: 0,
+            gid: 0,
+            work_dir: String::new(),
+            environment: HashMap::new(),
+            job_id,
+            ..Default::default()
+        });
+        let resp = svc.run_command(req).await.unwrap().into_inner();
+        assert_eq!(resp.exit_code, 0);
+        assert_eq!(resp.stdout.trim(), "node-a,node-b");
+    }
+
     #[tokio::test]
     async fn run_command_uses_provided_work_dir() {
         // The bug repro: the user's workflow is `salloc; srun hostname`.


### PR DESCRIPTION
## What

A job step dispatched via `srun` (or any other `RunCommand` caller) targeting a node can fail with `job <id> not running on this node`, even though `squeue`/`scontrol` already report the job as `RUNNING` -- sometimes for several hundred milliseconds after `RUNNING` first becomes visible.

## Approach

`spurctld` transitions a job to `Running` (the state `squeue`/`scontrol` read) synchronously in the scheduler loop, then dispatches `LaunchJob` to each assigned node concurrently and out of band via a spawned task. Each node's `spurd` agent only inserts the job into its local `running` map after its own launch pipeline (resource allocation, GPU device-injection plan, process spawn) finishes. A step targeting that node can therefore arrive before its own dispatch has completed, even though the controller already reports the job `Running` -- there is no signal that bridges "controller says Running" and "this specific node has registered the job locally."

`run_command`'s job lookup previously did a single, non-retried `HashMap::get` and failed immediately on a miss. This extracts that lookup into `wait_for_running_job`, which polls the same map every 100ms for up to ~3s before giving up, on the basis that the job is expected to appear within one launch pipeline's worth of time, not never.

## Behavior change

None for the non-racy path -- a job already in `running` resolves immediately, same as before. A job not yet in `running` now gets a short retry window instead of failing on the first miss; genuinely non-existent jobs still fail, just after the retry budget (~3s) is exhausted rather than instantly.

## Testing

Reproduced live: a 2-node allocation whose script immediately fires `srun` at its peer node while a separate session polls `squeue` at 10Hz. Idle-cluster runs didn't trigger it (dispatch skew was tens of ms); 10 concurrent 2-node allocations (to load the scheduler/agent RPC paths) reproduced it reliably, with the peer node's own script not starting until ~670ms after squeue first reported `RUNNING`, well after the failing node had already been retrying against it.

Added two tests using `tokio::test(start_paused = true)`: one confirms the not-found path still fires correctly once the retry budget is exhausted; one exercises the actual race directly -- spawns the call, lets it hit the first failing lookup and enter its retry sleep, then inserts the job and advances paused time, asserting the retry picks it up on the next poll.

All existing `spurd` tests pass (153 total), `cargo fmt --all --check` clean, `cargo clippy -p spurd --all-targets --locked -- -D warnings` clean.

Note: this is a surgical fix (retry-on-miss) rather than a deeper architectural change (blocking the `Running` transition until nodes confirm dispatch, mirroring the existing `register_allocation_on_nodes` pattern already used for standalone `srun` allocations) -- that alternative would change job-admission latency/scalability tradeoffs and seemed like a maintainer decision rather than something to bake in unilaterally.
