### PR TITLE
test(spur-cli): guard nodefile directive test against env injection

### DIFF
--- a/crates/spur-cli/src/sbatch.rs
+++ b/crates/spur-cli/src/sbatch.rs
@@ -1337,7 +1337,11 @@ echo "hello world"
     }
 
     #[test]
+    #[serial(env_injection)]
     fn test_nodefile_directive_is_parsed() {
+        // Guarded because SBATCH_NODELIST clears a directive nodefile, so a
+        // stray or concurrently-set var would empty the field under test.
+        let _env = EnvGuard::new();
         let args = parse_merged(&["--nodefile=nodes.txt"], &["sbatch"]);
         assert_eq!(args.nodefile.as_deref(), Some("nodes.txt"));
         assert!(args.nodelist.is_none());


### PR DESCRIPTION
## What this fixes

`sbatch::tests::test_nodefile_directive_is_parsed` is flaky. It fails 64 out of 100 full-suite runs on a 16-core machine.

## Why it fails

`resolve_sbatch_args` reads the live process environment, and `SBATCH_NODELIST` does not merely fill an empty slot, it clears `nodefile` outright:

```rust
if !was_cli_set(matches, "nodelist") && !was_cli_set(matches, "nodefile") {
    if let Some(nodelist) = env_first(&["SBATCH_NODELIST"]) {
        args.nodelist = Some(nodelist);
        args.nodefile = None;
    }
}
```

There is no `SBATCH_NODEFILE` counterpart, so the environment can only destroy that field, never repopulate it. The test asserts a directive-level outcome with no CLI override, which is the one precedence rung env sits directly above with nothing in between. It carried neither `#[serial(env_injection)]` nor an `EnvGuard`, unlike every sibling in that group.

Two things violate its unstated precondition that `SBATCH_NODELIST` is unset:

[1] `test_env_nodelist_displaces_directive_nodefile` and `test_cli_nodefile_wins_over_env_nodelist` both set the var via `std::env::set_var`. The `serial` tag is opt-in and only serializes tests carrying it, so an untagged test runs concurrently with those writers.

[2] An ambient var from the developer's shell or a CI runner. `SBATCH_NODELIST=node001 cargo test` fails the test even single-threaded, which is a false failure rather than a real defect.

The failure is always the same assertion, with `nodefile` empty:

```
assertion `left == right` failed
  left: None
 right: Some("nodes.txt")
```

## Approach

Add `#[serial(env_injection)]` and `EnvGuard::new()`, matching the convention already used by every other env-sensitive test in the file. Both halves are needed: `EnvGuard` alone still loses the race, since a sibling can set the var between the clear and the parse, and `serial` alone still inherits a polluted ambient environment.

The sibling tests that assert CLI-level outcomes are not affected, because the `was_cli_set` check short-circuits the env branch for them.

## Trade-off

This keeps the existing opt-in `serial` convention rather than changing it. That convention is inherently fragile: any new test asserting an env-backed field is silently exposed unless the author remembers the tag. The sturdier fix is to thread an explicit env source into `resolve_sbatch_args` so tests never mutate process-global state, which would remove the whole class of race. That is a wider refactor across `sbatch`, `srun`, and `salloc`, so it is left as a follow-up.

## Testing

Ran the `spur-cli` test binary directly, 16 threads by default.

| Configuration | Before | After |
|---|---|---|
| Full suite, default threads | 64 / 100 failed | 0 / 100 failed |
| Only `nodefile`+`nodelist` tests, parallel | 55 / 60 failed | 0 / 60 failed |
| Test alone, exact filter | 0 / 100 failed | 0 / 100 failed |
| Full suite, `--test-threads=1` | 0 / 30 failed | not rerun |
| Exact filter with `SBATCH_NODELIST=node001` set | fails by construction | 0 / 20 failed |

It was the only test that failed across those 100 pre-fix runs, so nothing else was masked.

Also green: `cargo fmt --all -- --check`, `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` with no warnings, and `cargo test --locked` across the workspace.