### PR TITLE
fix(spurctld): confirm batch dispatch on every node before Running

### DIFF
--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -86,6 +86,11 @@ pub enum WalOperation {
         /// When set, applied on all replicas so pending reason survives replay.
         #[serde(default)]
         pending_reason: Option<PendingReason>,
+        /// Overrides the reason's default display text, same as
+        /// `JobStateChange`'s `pending_reason_desc`. `#[serde(default)]` so
+        /// older WAL/snapshot entries without this field replay as `None`.
+        #[serde(default)]
+        pending_reason_desc: Option<String>,
         /// When true, clears automatic requeue counter (admin release after max requeue).
         #[serde(default)]
         reset_requeue_count: bool,
@@ -454,6 +459,74 @@ mod job_state_change_wal_tests {
             } => {
                 assert_eq!(job_id, 3);
                 assert_eq!(begin_time, None);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod job_priority_change_wal_tests {
+    use super::*;
+
+    #[test]
+    fn job_priority_change_carries_a_description_alongside_its_reason() {
+        // Mirrors JobStateChange's pending_reason_desc: a hold applied while a
+        // job is still Pending (e.g. hold_job_for_launch_failure) has nowhere
+        // else to carry a custom description, since there is no state
+        // transition for it to ride along with.
+        let op = WalOperation::JobPriorityChange {
+            job_id: 4,
+            old_priority: 500,
+            new_priority: 0,
+            pending_reason: Some(PendingReason::Held),
+            pending_reason_desc: Some("launch failed requeued held".into()),
+            reset_requeue_count: false,
+            clear_reservation: false,
+        };
+        let json = serde_json::to_string(&op).unwrap();
+        let back: WalOperation = serde_json::from_str(&json).unwrap();
+        match back {
+            WalOperation::JobPriorityChange {
+                job_id,
+                new_priority,
+                pending_reason,
+                pending_reason_desc,
+                ..
+            } => {
+                assert_eq!(job_id, 4);
+                assert_eq!(new_priority, 0);
+                assert_eq!(pending_reason, Some(PendingReason::Held));
+                assert_eq!(
+                    pending_reason_desc.as_deref(),
+                    Some("launch failed requeued held")
+                );
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn pre_upgrade_job_priority_change_without_description_deserializes() {
+        // A WAL written before pending_reason_desc existed on this variant
+        // must still replay (e.g. hold_job / release_job entries from before
+        // this fix).
+        let json = r#"{"JobPriorityChange":{"job_id":4,"old_priority":500,"new_priority":0,"pending_reason":"Held"}}"#;
+        let back: WalOperation = serde_json::from_str(json).unwrap();
+        match back {
+            WalOperation::JobPriorityChange {
+                job_id,
+                pending_reason,
+                pending_reason_desc,
+                reset_requeue_count,
+                clear_reservation,
+                ..
+            } => {
+                assert_eq!(job_id, 4);
+                assert_eq!(pending_reason, Some(PendingReason::Held));
+                assert_eq!(pending_reason_desc, None);
+                assert!(!reset_requeue_count);
+                assert!(!clear_reservation);
             }
             _ => panic!("wrong variant"),
         }

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -98,13 +98,9 @@ pub enum WalOperation {
         #[serde(default)]
         clear_reservation: bool,
     },
-    /// Back off a job that failed to dispatch before ever leaving Pending
-    /// (e.g. a node's agent was unreachable during batch dispatch
-    /// confirmation). `JobStateChange`'s backoff constructors don't apply
-    /// here: their bookkeeping (`requeue_count`, the hold) is gated on a
-    /// real `old_state != new_state` transition, and this job's state
-    /// isn't changing — it was Pending and stays Pending. Applying is a
-    /// NoOp if the job has since left Pending (e.g. cancelled concurrently).
+    /// Back off a job that failed dispatch before ever leaving Pending, where
+    /// `JobStateChange`'s transition-gated backoff can't apply. NoOp on replay
+    /// if the job has since left Pending.
     JobDispatchBackoff {
         job_id: JobId,
         begin_time: chrono::DateTime<chrono::Utc>,

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -98,6 +98,17 @@ pub enum WalOperation {
         #[serde(default)]
         clear_reservation: bool,
     },
+    /// Back off a job that failed to dispatch before ever leaving Pending
+    /// (e.g. a node's agent was unreachable during batch dispatch
+    /// confirmation). `JobStateChange`'s backoff constructors don't apply
+    /// here: their bookkeeping (`requeue_count`, the hold) is gated on a
+    /// real `old_state != new_state` transition, and this job's state
+    /// isn't changing — it was Pending and stays Pending. Applying is a
+    /// NoOp if the job has since left Pending (e.g. cancelled concurrently).
+    JobDispatchBackoff {
+        job_id: JobId,
+        begin_time: chrono::DateTime<chrono::Utc>,
+    },
     /// Preempt a running job and requeue it in one atomic step: free its node
     /// allocation, end the prior run for accounting (as PREEMPTED), return it to
     /// Pending, and hold it ineligible until `begin_time` so the scheduler can't
@@ -443,6 +454,24 @@ mod job_state_change_wal_tests {
                     Some(hold),
                     "the leader-computed instant must survive the WAL verbatim"
                 );
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn job_dispatch_backoff_round_trips() {
+        let hold = chrono::Utc::now() + chrono::Duration::seconds(20);
+        let op = WalOperation::JobDispatchBackoff {
+            job_id: 8,
+            begin_time: hold,
+        };
+        let json = serde_json::to_string(&op).unwrap();
+        let back: WalOperation = serde_json::from_str(&json).unwrap();
+        match back {
+            WalOperation::JobDispatchBackoff { job_id, begin_time } => {
+                assert_eq!(job_id, 8);
+                assert_eq!(begin_time, hold);
             }
             _ => panic!("wrong variant"),
         }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1282,12 +1282,21 @@ impl ClusterManager {
     /// Evict a running job to NodeFail: frees allocations and feeds the
     /// existing auto-requeue path in `notify_job_finished`, same as the
     /// health-check path (`evict_jobs_on_node`) that runs when an entire
-    /// node goes Down, but scoped to a single job. Used when only some of a
-    /// job's assigned nodes could be dispatched to, since a node that never
-    /// launched the job will never report completion. Unlike the
-    /// health-check path, this does not by itself cancel the job on nodes
-    /// that *did* launch it — the caller (`scheduler_loop`) is responsible
-    /// for sending the cancel RPC once eviction succeeds.
+    /// node goes Down, but scoped to a single job. Unlike the health-check
+    /// path, this does not by itself cancel the job on nodes that *did*
+    /// launch it — a caller evicting a job with launched-but-unconfirmed
+    /// nodes is responsible for sending the cancel RPC once eviction
+    /// succeeds.
+    ///
+    /// No longer called from `scheduler_loop`: batch dispatch is now
+    /// confirmed on every assigned node *before* a job is allowed to become
+    /// Running (see `confirm_dispatch_on_nodes`), so a job can no longer
+    /// reach Running with only some of its nodes actually launched — this
+    /// function's original trigger. Kept as a public primitive, with its
+    /// back-off/requeue contract still exercised directly by this module's
+    /// tests, for any other caller that needs to evict an already-Running
+    /// job (e.g. a future admin-initiated NodeFail).
+    #[allow(dead_code)]
     pub fn evict_job(&self, job_id: JobId) -> anyhow::Result<()> {
         {
             let jobs = self.jobs.read();
@@ -1492,10 +1501,46 @@ impl ClusterManager {
             old_priority,
             new_priority: 0,
             pending_reason: Some(PendingReason::Held),
+            pending_reason_desc: None,
             reset_requeue_count: false,
             clear_reservation: false,
         })?;
         info!(job_id, "job held");
+        Ok(())
+    }
+
+    /// Hold a *Pending* job whose batch dispatch failed to confirm on a node
+    /// (prolog rejection with `hold_on_prolog_fail` set). Same end state as
+    /// [`Self::hold_job`] (priority 0, `PendingReason::Held`), but carries the
+    /// launch-failure description so it reads the same as the pre-fix path
+    /// that reached this via a Running→Failed→Held detour: the job here never
+    /// actually left Pending, so that detour isn't available.
+    pub(crate) fn hold_job_for_launch_failure(&self, job_id: JobId) -> anyhow::Result<()> {
+        let old_priority = {
+            let jobs = self.jobs.read();
+            let job = jobs
+                .get(&job_id)
+                .ok_or_else(|| anyhow::anyhow!("job {} not found", job_id))?;
+            if job.state != JobState::Pending {
+                anyhow::bail!(
+                    "can only hold pending jobs (job {} is {:?})",
+                    job_id,
+                    job.state
+                );
+            }
+            job.priority
+        };
+
+        self.propose(WalOperation::JobPriorityChange {
+            job_id,
+            old_priority,
+            new_priority: 0,
+            pending_reason: Some(PendingReason::Held),
+            pending_reason_desc: Some(LAUNCH_FAILURE_HELD_DESC.to_string()),
+            reset_requeue_count: false,
+            clear_reservation: false,
+        })?;
+        info!(job_id, "job held after launch failure");
         Ok(())
     }
 
@@ -1554,6 +1599,7 @@ impl ClusterManager {
                 old_priority,
                 new_priority: 0,
                 pending_reason: Some(PendingReason::JobHoldMaxRequeue),
+                pending_reason_desc: None,
                 reset_requeue_count: false,
                 clear_reservation: false,
             })?;
@@ -1584,6 +1630,7 @@ impl ClusterManager {
             old_priority,
             new_priority: 1000,
             pending_reason: Some(PendingReason::Priority),
+            pending_reason_desc: None,
             reset_requeue_count: reset_requeue,
             clear_reservation,
         })?;
@@ -1656,6 +1703,7 @@ impl ClusterManager {
                 old_priority: old,
                 new_priority: p,
                 pending_reason: None,
+                pending_reason_desc: None,
                 reset_requeue_count: false,
                 clear_reservation: false,
             })?;
@@ -3779,6 +3827,7 @@ impl ClusterManager {
                 job_id,
                 new_priority,
                 pending_reason,
+                pending_reason_desc,
                 reset_requeue_count,
                 clear_reservation,
                 ..
@@ -3786,7 +3835,10 @@ impl ClusterManager {
                 if let Some(job) = jobs.get_mut(job_id) {
                     job.priority = *new_priority;
                     if let Some(reason) = pending_reason {
-                        job.set_pending_reason(reason.clone());
+                        match pending_reason_desc {
+                            Some(desc) => job.set_pending_reason_desc(reason.clone(), desc.clone()),
+                            None => job.set_pending_reason(reason.clone()),
+                        }
                     }
                     if *reset_requeue_count {
                         job.requeue_count = 0;
@@ -5586,6 +5638,7 @@ mod tests {
             old_priority: 1000,
             new_priority: 5000,
             pending_reason: None,
+            pending_reason_desc: None,
             reset_requeue_count: false,
             clear_reservation: false,
         });
@@ -10949,6 +11002,63 @@ mod tests {
         let job = cm.get_job(id).unwrap();
         assert_eq!(job.priority, 1000);
         assert_eq!(job.pending_reason, PendingReason::Priority);
+    }
+
+    // hold_job_for_launch_failure is confirm_dispatch_on_nodes's Pending-
+    // compatible equivalent of the old Running->Failed->Held detour: same end
+    // state as a plain hold_job (Pending, priority 0, PendingReason::Held),
+    // plus the launch-failure description, and it must refuse a job that
+    // already started (unlike a fresh Pending job, that would silently do the
+    // wrong thing by holding it mid-run).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn hold_job_for_launch_failure_holds_a_pending_job_with_its_description() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        let id = submit_and_wait(&cm, basic_spec("prolog-hold"));
+
+        cm.hold_job_for_launch_failure(id).unwrap();
+        wait_for("hold applied", || {
+            cm.get_job(id).is_some_and(|j| j.priority == 0)
+        });
+
+        let job = cm.get_job(id).unwrap();
+        assert_eq!(job.state, JobState::Pending);
+        assert_eq!(job.priority, 0);
+        assert_eq!(job.pending_reason, PendingReason::Held);
+        assert_eq!(
+            job.state_reason_display(),
+            LAUNCH_FAILURE_HELD_DESC,
+            "must carry the same description the old post-Running hold used"
+        );
+
+        // Releasing it behaves exactly like releasing a plain hold_job.
+        cm.release_job(id).unwrap();
+        wait_for("release applied", || {
+            cm.get_job(id).is_some_and(|j| j.priority > 0)
+        });
+        let job = cm.get_job(id).unwrap();
+        assert_eq!(
+            job.pending_reason_desc, None,
+            "the release must clear the description with the reason"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn hold_job_for_launch_failure_refuses_a_job_that_already_started() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 4, 8000);
+        let id = submit_and_wait(&cm, basic_spec("already-running"));
+        cm.start_job(
+            id,
+            vec!["n1".into()],
+            scalar_alloc(1, 1000),
+            per_node_for(&["n1"], scalar_alloc(1, 1000)),
+        )
+        .unwrap();
+        settle(&cm, id, JobState::Running);
+
+        assert!(cm.hold_job_for_launch_failure(id).is_err());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1265,20 +1265,11 @@ impl ClusterManager {
         Ok(())
     }
 
-    /// Back off a job whose batch dispatch confirmation failed for a
-    /// non-prolog reason (e.g. a node's agent was briefly unreachable, or had
-    /// no resolved address) before the job ever left Pending.
-    ///
-    /// `requeue_after_launch_failure` can't be reused here: its backoff and
-    /// `requeue_count` bookkeeping only apply on a real `Running`-or-later ->
-    /// `Pending` transition, and this job never left Pending to begin with —
-    /// its early `job.state == JobState::Pending` branch deliberately no-ops
-    /// rather than let a same-state `JobStateChange` silently apply nothing.
-    /// Without an equivalent here, a job whose only assigned node is flaky
-    /// would fail confirmation, land back in the same unmodified Pending
-    /// state, and get reassigned to the same node on literally the next
-    /// scheduler tick — forever, with no backoff and no `max_batch_requeue`
-    /// bound, since that counter is never touched.
+    /// Back off a job whose batch dispatch confirmation failed for a non-prolog
+    /// reason (agent briefly unreachable, no resolved address) before it left
+    /// Pending. `requeue_after_launch_failure` can't be reused: its `requeue_count`
+    /// bookkeeping is gated on a real transition out of Running, so without this a
+    /// flaky node's job would be reassigned to it every tick, forever unbounded.
     pub(crate) fn backoff_pending_job_after_dispatch_failure(
         &self,
         job_id: JobId,
@@ -3459,10 +3450,8 @@ impl ClusterManager {
                 }
             }
             WalOperation::JobDispatchBackoff { job_id, begin_time } => {
-                // The job's own state never changes here (Pending in, Pending
-                // out), so there's no transition to gate on like
-                // JobStateChange does. If it's since left Pending (e.g. a
-                // concurrent cancel), this is a NoOp instead.
+                // NoOp if the job left Pending since the leader proposed this
+                // (e.g. a concurrent cancel).
                 let Some(job) = jobs.get_mut(job_id) else {
                     return ClientResponse::default();
                 };

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1265,6 +1265,46 @@ impl ClusterManager {
         Ok(())
     }
 
+    /// Back off a job whose batch dispatch confirmation failed for a
+    /// non-prolog reason (e.g. a node's agent was briefly unreachable, or had
+    /// no resolved address) before the job ever left Pending.
+    ///
+    /// `requeue_after_launch_failure` can't be reused here: its backoff and
+    /// `requeue_count` bookkeeping only apply on a real `Running`-or-later ->
+    /// `Pending` transition, and this job never left Pending to begin with —
+    /// its early `job.state == JobState::Pending` branch deliberately no-ops
+    /// rather than let a same-state `JobStateChange` silently apply nothing.
+    /// Without an equivalent here, a job whose only assigned node is flaky
+    /// would fail confirmation, land back in the same unmodified Pending
+    /// state, and get reassigned to the same node on literally the next
+    /// scheduler tick — forever, with no backoff and no `max_batch_requeue`
+    /// bound, since that counter is never touched.
+    pub(crate) fn backoff_pending_job_after_dispatch_failure(
+        &self,
+        job_id: JobId,
+    ) -> anyhow::Result<()> {
+        let begin_time = {
+            let jobs = self.jobs.read();
+            let Some(job) = jobs.get(&job_id) else {
+                return Ok(());
+            };
+            if job.state != JobState::Pending {
+                // Moved on already (e.g. cancelled concurrently) between the
+                // failed confirmation and this call — nothing to back off.
+                return Ok(());
+            }
+            if job.requeue_count >= self.config.controller.max_batch_requeue {
+                drop(jobs);
+                return self.hold_job_at_max_requeue(job_id);
+            }
+            self.launch_backoff_until(job)
+        };
+
+        self.propose(WalOperation::JobDispatchBackoff { job_id, begin_time })?;
+        info!(job_id, hold_until = %begin_time, "job's batch dispatch failed before it started; backing off");
+        Ok(())
+    }
+
     /// Instant until which a job requeued after a launch failure is held. A user
     /// `--begin` further out always wins, so the hold never shortens a
     /// user-supplied constraint. Computed on the leader so every replica applies
@@ -3417,6 +3457,21 @@ impl ClusterManager {
                         }
                     }
                 }
+            }
+            WalOperation::JobDispatchBackoff { job_id, begin_time } => {
+                // The job's own state never changes here (Pending in, Pending
+                // out), so there's no transition to gate on like
+                // JobStateChange does. If it's since left Pending (e.g. a
+                // concurrent cancel), this is a NoOp instead.
+                let Some(job) = jobs.get_mut(job_id) else {
+                    return ClientResponse::default();
+                };
+                if job.state != JobState::Pending {
+                    return ClientResponse::default();
+                }
+                Self::reset_job_for_requeue(job);
+                job.spec.begin_time = Some(*begin_time);
+                job.set_pending_reason(PendingReason::JobLaunchFailure);
             }
             WalOperation::JobPreemptRequeue { job_id, begin_time } => {
                 // Only a running job is preempted; on replay the job is already

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -11116,6 +11116,87 @@ mod tests {
         assert!(cm.hold_job_for_launch_failure(id).is_err());
     }
 
+    // backoff_pending_job_after_dispatch_failure is confirm_dispatch_on_nodes's
+    // Pending-safe equivalent of requeue_after_launch_failure's backoff: both
+    // are no-ops rather than errors for a job that's already moved on by the
+    // time the caller gets around to backing it off (e.g. a concurrent
+    // cancel, or a stale/unknown job_id) — the caller only has a job_id and
+    // no reason to assume it's still exactly as it left it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn backoff_pending_job_after_dispatch_failure_is_a_noop_for_a_missing_job() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        assert!(cm.backoff_pending_job_after_dispatch_failure(999).is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn backoff_pending_job_after_dispatch_failure_is_a_noop_once_the_job_left_pending() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        let id = submit_and_wait(&cm, basic_spec("backoff-already-cancelled"));
+        cm.cancel_job(id, "testuser").unwrap();
+        settle(&cm, id, JobState::Cancelled);
+
+        assert!(cm.backoff_pending_job_after_dispatch_failure(id).is_ok());
+        assert_eq!(cm.get_job(id).unwrap().state, JobState::Cancelled);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn backoff_pending_job_after_dispatch_failure_applies_backoff_and_bumps_requeue_count() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        let id = submit_and_wait(&cm, basic_spec("backoff-applies"));
+
+        cm.backoff_pending_job_after_dispatch_failure(id).unwrap();
+        wait_for("backoff applied", || {
+            cm.get_job(id).is_some_and(|j| j.requeue_count == 1)
+        });
+
+        let job = cm.get_job(id).unwrap();
+        assert_eq!(job.state, JobState::Pending);
+        assert_eq!(job.pending_reason, PendingReason::JobLaunchFailure);
+        assert!(job.spec.begin_time.is_some_and(|t| t > Utc::now()));
+    }
+
+    // The apply-level checks mirror the public method's, guarding against a
+    // narrower race: the job matched (existed, was Pending) when the public
+    // method read it, but no longer does by the time this specific WAL entry
+    // is actually applied (a state change committed in between). Exercised
+    // directly against apply_operation, bypassing the public method's own
+    // up-front checks, so this is testing the apply arm's defense
+    // independently of whether the caller's own check could have caught it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn job_dispatch_backoff_apply_is_a_noop_for_a_missing_job() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        cm.apply_operation(&WalOperation::JobDispatchBackoff {
+            job_id: 999,
+            begin_time: Utc::now(),
+        });
+        assert!(cm.get_job(999).is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn job_dispatch_backoff_apply_is_a_noop_once_the_job_left_pending() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        let id = submit_and_wait(&cm, basic_spec("backoff-apply-already-cancelled"));
+        cm.cancel_job(id, "testuser").unwrap();
+        settle(&cm, id, JobState::Cancelled);
+        let requeue_count_before = cm.get_job(id).unwrap().requeue_count;
+
+        cm.apply_operation(&WalOperation::JobDispatchBackoff {
+            job_id: id,
+            begin_time: Utc::now(),
+        });
+
+        let job = cm.get_job(id).unwrap();
+        assert_eq!(job.state, JobState::Cancelled);
+        assert_eq!(job.requeue_count, requeue_count_before);
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn update_job_priority() {
         let dir = TempDir::new().unwrap();

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -258,7 +258,74 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
                 }
             }
 
-            // Transition job to Running
+            // Build peer_nodes list with addresses for cross-node communication
+            // and the effective per-node task count. Both are needed by the
+            // LaunchJob dispatch below, which — unlike the old fire-and-forget
+            // spawn — now runs (and is awaited) *before* the job is allowed to
+            // become visibly Running.
+            let peer_addrs: Vec<String> = all_nodes
+                .iter()
+                .filter_map(|name| {
+                    cluster
+                        .get_node(name)
+                        .and_then(|n| n.address.as_ref().map(|a| format!("{}:{}", a, n.port)))
+                })
+                .collect();
+
+            let tasks_per_node = if let Some(tpn) = spec.tasks_per_node {
+                tpn
+            } else {
+                (spec.num_tasks / spec.num_nodes.max(1)).max(1)
+            };
+
+            // Batch dispatch (plain sbatch jobs, and the srun-as-batch-script
+            // fallback) must have every assigned node confirm its LaunchJob
+            // *before* start_job flips the job to Running — otherwise squeue
+            // reports Running while a node may still be mid-launch (the race
+            // PR #544 papers over with a retry window on the agent side). The
+            // pure interactive srun_step_dispatch case has nothing left to
+            // dispatch here: register_allocation_on_nodes above already
+            // confirmed the allocation, and the actual step launch is a later
+            // RunCommand, not this LaunchJob RPC.
+            let dispatch_spec = if !spec.srun_job {
+                Some(spec.clone())
+            } else if !srun_step_dispatch {
+                let mut batch_spec = spec.clone();
+                batch_spec.srun_job = false;
+                Some(batch_spec)
+            } else {
+                None
+            };
+
+            if let Some(dspec) = dispatch_spec {
+                // The run epoch start_job_impl is about to persist for this
+                // dispatch. Safe to read ahead of that call: this iteration is
+                // the only place that can advance a Pending job's run_attempt,
+                // and nothing here yields back to another iteration for the
+                // same job in between.
+                let prospective_run_attempt = job.run_attempt.saturating_add(1);
+
+                match confirm_dispatch_on_nodes(
+                    cluster.clone(),
+                    job_id,
+                    dispatch_nodes.clone(),
+                    dspec,
+                    peer_addrs.clone(),
+                    per_node_allocs.clone(),
+                    allocated_nodelist.clone(),
+                    tasks_per_node,
+                    prospective_run_attempt,
+                )
+                .await
+                {
+                    DispatchConfirmOutcome::Aborted => continue,
+                    DispatchConfirmOutcome::Confirmed => {}
+                }
+            }
+
+            // Transition job to Running. Reached only once every assigned node
+            // has confirmed (LaunchJob for batch dispatch above, or
+            // RegisterJobAllocation for the pure interactive case above that).
             let start_result = if srun_step_dispatch {
                 cluster.start_job_impl(
                     job_id,
@@ -275,20 +342,20 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
                     assignment.per_node_alloc.clone(),
                 )
             };
-            let run_attempt = match start_result {
-                Ok(attempt) => attempt,
-                Err(e) => {
-                    if spec.srun_job && srun_step_dispatch {
-                        cancel_job_on_nodes(&cluster, job_id, &dispatch_nodes, 0).await;
-                    }
-                    debug!(
-                        job_id = assignment.job_id,
-                        error = %e,
-                        "failed to start job"
-                    );
-                    continue;
-                }
-            };
+            if let Err(e) = start_result {
+                // Confirmation above already registered the allocation or
+                // launched real processes on dispatch_nodes; stop them so a
+                // start_job failure here (e.g. the job was cancelled out from
+                // under us between assignment and this point) doesn't leave
+                // orphans.
+                cancel_job_on_nodes(&cluster, job_id, &dispatch_nodes, 0).await;
+                debug!(
+                    job_id = assignment.job_id,
+                    error = %e,
+                    "failed to start job"
+                );
+                continue;
+            }
 
             // Run PrologSlurmctld if configured
             if let Some(ref prolog_ctld) = cluster.config.hooks.prolog_slurmctld {
@@ -310,9 +377,14 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
                         error = %e,
                         "PrologSlurmctld failed"
                     );
-                    if spec.srun_job && srun_step_dispatch && !job.spec.interactive {
-                        cancel_job_on_nodes(&cluster, job_id, &dispatch_nodes, 0).await;
-                    }
+                    // The job is now Running with real work already dispatched
+                    // above (a LaunchJob confirmed on every node, or — for the
+                    // pure interactive case — an allocation registered on
+                    // every node). Unlike the old post-Running-spawn ordering,
+                    // that has already happened by the time we get here, so
+                    // it must always be torn down on this path now, regardless
+                    // of interactive vs. batch.
+                    cancel_job_on_nodes(&cluster, job_id, &dispatch_nodes, 0).await;
                     if job.spec.interactive {
                         if let Err(ce) = cluster.cancel_job(assignment.job_id, &job.spec.user) {
                             error!(job_id = assignment.job_id, error = %ce, "failed to cancel job after PrologSlurmctld failure");
@@ -327,53 +399,6 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
             }
 
             jobs_started_cycle += 1;
-
-            // Build peer_nodes list with addresses for cross-node communication
-            let peer_addrs: Vec<String> = all_nodes
-                .iter()
-                .filter_map(|name| {
-                    cluster
-                        .get_node(name)
-                        .and_then(|n| n.address.as_ref().map(|a| format!("{}:{}", a, n.port)))
-                })
-                .collect();
-
-            let tasks_per_node = if let Some(tpn) = spec.tasks_per_node {
-                tpn
-            } else {
-                (spec.num_tasks / spec.num_nodes.max(1)).max(1)
-            };
-
-            let cluster_ref = cluster.clone();
-            if spec.srun_job {
-                if !srun_step_dispatch {
-                    let mut batch_spec = spec;
-                    batch_spec.srun_job = false;
-                    tokio::spawn(dispatch_job_to_nodes(
-                        cluster_ref,
-                        job_id,
-                        dispatch_nodes,
-                        batch_spec,
-                        peer_addrs,
-                        per_node_allocs,
-                        allocated_nodelist,
-                        tasks_per_node,
-                        run_attempt,
-                    ));
-                }
-            } else {
-                tokio::spawn(dispatch_job_to_nodes(
-                    cluster_ref,
-                    job_id,
-                    dispatch_nodes,
-                    spec,
-                    peer_addrs,
-                    per_node_allocs,
-                    allocated_nodelist,
-                    tasks_per_node,
-                    run_attempt,
-                ));
-            }
         }
 
         let cycle_time_us = cycle_start.elapsed().as_micros().min(u64::MAX as u128) as u64;
@@ -1120,12 +1145,53 @@ pub async fn release_srun_allocation_on_agents(
     send_cancel_to_agents(cluster, job, 0).await;
 }
 
-/// Dispatch a job to every assigned node and act on the aggregate result:
-/// requeue to Pending if every node rejected the launch, or evict the job to
-/// NodeFail if only some nodes accepted it (a node that never launched the
-/// job will never report completion, so the job would otherwise hang).
+/// Outcome of [`confirm_dispatch_on_nodes`]: either every assigned node
+/// confirmed its LaunchJob (the job may now become visibly Running), or
+/// admission was aborted and the job — which never left Pending — has
+/// already been settled (requeued, held, or cancelled as appropriate).
+enum DispatchConfirmOutcome {
+    Confirmed,
+    Aborted,
+}
+
+/// Dispatch a batch job to every assigned node and *wait* for every LaunchJob
+/// RPC to resolve before returning anything the caller can use to flip the
+/// job to Running.
+///
+/// This is the structural fix for the srun-step startup race (see PR #544,
+/// which only widens the agent-side retry window): the old flow called
+/// `start_job` (Running, visible to squeue/scontrol) and then fired this
+/// dispatch in the background via `tokio::spawn`, so a step could target a
+/// node before that node's own `LaunchJob` had actually finished. Now the
+/// scheduler loop awaits this function *before* calling `start_job`, mirroring
+/// the pattern `register_allocation_on_nodes` already uses for standalone
+/// srun/salloc allocations — except this confirms the heavier `LaunchJob` RPC
+/// (which actually spawns the job's process), not the lightweight
+/// `RegisterJobAllocation` used there.
+///
+/// Failure handling necessarily differs from the old post-Running
+/// `dispatch_job_to_nodes` this replaces, because the job is still Pending
+/// here — there is no Running/Failed/NodeFail detour to route a partial
+/// failure through:
+///   - A node whose own prolog rejected the job is drained, exactly as before
+///     (this is a per-node action, independent of the job's state).
+///   - If `hold_on_prolog_fail` is set (the default) and applies, the job is
+///     parked the same way `scontrol hold` parks a Pending job
+///     (`ClusterManager::hold_job_for_launch_failure`), since holding via the
+///     old Running→Failed→Held path isn't reachable from Pending. Interactive
+///     jobs are cancelled instead, same as before.
+///   - Otherwise (no prolog failure, or holding is disabled) the job is
+///     simply left Pending for the next scheduler tick — the same
+///     simplification `register_allocation_on_nodes`'s own failure arms above
+///     already make for the srun path. This intentionally does not reproduce
+///     `requeue_after_launch_failure`'s exponential backoff / requeue-count
+///     bookkeeping for a *non*-prolog failure, since that path requires an
+///     actual Failed transition the job never has here; a persistently
+///     failing node still gets drained on repeated prolog failures, but a
+///     transient (non-prolog) failure can retry immediately rather than
+///     backing off. See the fix's write-up for why this trade-off was made.
 #[allow(clippy::too_many_arguments)]
-async fn dispatch_job_to_nodes(
+async fn confirm_dispatch_on_nodes(
     cluster: Arc<ClusterManager>,
     job_id: spur_core::job::JobId,
     dispatch_nodes: Vec<String>,
@@ -1135,7 +1201,7 @@ async fn dispatch_job_to_nodes(
     allocated_nodelist: String,
     tasks_per_node: u32,
     run_attempt: u32,
-) {
+) -> DispatchConfirmOutcome {
     let mut successes = 0u32;
     let mut failures = 0u32;
     let mut succeeded_nodes: Vec<String> = Vec::new();
@@ -1157,7 +1223,7 @@ async fn dispatch_job_to_nodes(
                 warn!(
                     job_id,
                     node = %node_name,
-                    "no agent address for node, skipping dispatch"
+                    "no agent address for node, skipping dispatch confirmation"
                 );
                 failures += 1;
                 continue;
@@ -1204,33 +1270,42 @@ async fn dispatch_job_to_nodes(
                 }
             }
             Ok((node_name, _, Err(e))) => {
-                error!(job_id, node = %node_name, error = %e, "dispatch to agent failed");
+                error!(job_id, node = %node_name, error = %e, "dispatch confirmation failed");
                 failures += 1;
                 if let DispatchError::PrologFailed(reason) = e {
                     prolog_failed.push((node_name, reason));
                 }
             }
             Err(e) => {
-                error!(job_id, error = %e, "dispatch task panicked");
+                error!(job_id, error = %e, "dispatch confirmation task panicked");
                 failures += 1;
             }
         }
     }
 
-    // Only surface the primary's paths on a clean launch; a partial/total
-    // failure requeues or evicts the job, leaving it to fall back to the
-    // computed path on the next attempt.
     if failures == 0 {
         if let Some(outcome) = primary_outcome {
             cluster.set_job_output_paths(job_id, outcome.stdout_path, outcome.stderr_path);
         }
+        return DispatchConfirmOutcome::Confirmed;
     }
 
+    warn!(
+        job_id,
+        successes, failures, total,
+        "one or more nodes failed to confirm dispatch — aborting admission instead of partially running"
+    );
+
+    // Stop whatever DID launch before the job settles anywhere: a node that
+    // never confirmed will never report completion, and letting it keep
+    // running while the job as a whole is aborted back to Pending would
+    // orphan it.
+    cancel_job_on_nodes(&cluster, job_id, &succeeded_nodes, 9).await;
+
     // Drain before deciding the job's fate, so the failing node is already out
-    // of the candidate set if the job does go back to Pending. The drain is
-    // issued here rather than by the agent because only the controller can pair
-    // it with the hold that stops the job walking the cluster.
-    let hold = !prolog_failed.is_empty() && cluster.config.controller.hold_on_prolog_fail;
+    // of the candidate set on the next scheduling attempt. The drain is issued
+    // here rather than by the agent because only the controller can pair it
+    // with the hold that stops the job walking the cluster.
     for (node_name, reason) in &prolog_failed {
         warn!(job_id, node = %node_name, reason = %reason, "draining node after prolog failure");
         if let Err(e) = cluster.drain_node(node_name, Some(reason.clone())) {
@@ -1238,68 +1313,21 @@ async fn dispatch_job_to_nodes(
         }
     }
 
-    // If ALL dispatches failed, requeue the job back to Pending
-    // so the scheduler can retry (e.g., container image may be
-    // imported later, or a transient agent error may resolve) rather
-    // than failing it outright and denying the user a chance to fix it.
-    if successes == 0 && total > 0 {
-        error!(
-            job_id,
-            failures, "all dispatches failed — requeueing job to Pending"
-        );
-        if let Err(e) = finish_failed_dispatch(&cluster, job_id, &spec, hold) {
-            error!(job_id, error = %e, "failed to requeue job after dispatch failure");
-        }
-    } else if hold {
-        // Same ordering rationale as the eviction branch below: stop what did
-        // launch before the job can be touched again. Eviction itself is wrong
-        // here, since it routes through maybe_requeue and would drop the hold.
-        warn!(
-            job_id,
-            successes, failures, "prolog failed on part of the allocation — holding job"
-        );
-        cancel_job_on_nodes(&cluster, job_id, &succeeded_nodes, 9).await;
-        if let Err(e) = finish_failed_dispatch(&cluster, job_id, &spec, true) {
+    if !prolog_failed.is_empty() && cluster.config.controller.hold_on_prolog_fail {
+        if spec.interactive {
+            // Holding an interactive job would strand its waiting srun forever
+            // with nothing to wait for; Slurm cancels these too.
+            if let Err(e) = cluster.cancel_job(job_id, &spec.user) {
+                error!(job_id, error = %e, "failed to cancel interactive job after prolog failure");
+            }
+        } else if let Err(e) = cluster.hold_job_for_launch_failure(job_id) {
             error!(job_id, error = %e, "failed to hold job after prolog failure");
         }
-    } else if failures > 0 {
-        // A node that never got the dispatch will never report completion, so evict
-        // the whole job to NodeFail (same as a node dying mid-run) instead of hanging.
-        warn!(
-            job_id,
-            successes, failures, "partial dispatch failure — evicting job to NodeFail"
-        );
-        // Cancel the job on nodes that DID launch it *before* evicting, and wait
-        // for those cancels to be delivered. Eviction can synchronously requeue
-        // the job to Pending (when `spec.requeue` is set), making it eligible for
-        // immediate re-dispatch on the next scheduler cycle; because CancelJob is
-        // keyed only by job_id, a cancel still in flight would otherwise be able
-        // to terminate a freshly re-dispatched attempt on the same node. Ordering
-        // the awaited cancel ahead of the requeue closes that race — the launched
-        // processes are stopped before the job can be relaunched anywhere.
-        cancel_job_on_nodes(&cluster, job_id, &succeeded_nodes, 9).await;
-        if let Err(e) = cluster.evict_job(job_id) {
-            error!(job_id, error = %e, "failed to evict job after partial dispatch failure");
-        }
+    } else if let Err(e) = cluster.requeue_job(job_id) {
+        error!(job_id, error = %e, "failed to requeue after dispatch confirmation failure");
     }
-}
 
-/// Settle a job whose dispatch failed: requeue it, or hold it when the failure
-/// would follow it to the next node.
-///
-/// Interactive jobs are cancelled instead of held, matching both Slurm ("only
-/// batch jobs can be requeued, interactive jobs will be cancelled") and the
-/// PrologSlurmctld arm above. Holding one would strand the waiting `srun`.
-fn finish_failed_dispatch(
-    cluster: &ClusterManager,
-    job_id: spur_core::job::JobId,
-    spec: &spur_core::job::JobSpec,
-    hold: bool,
-) -> anyhow::Result<()> {
-    if hold && spec.interactive {
-        return cluster.cancel_job(job_id, &spec.user);
-    }
-    cluster.requeue_after_launch_failure(job_id, hold)
+    DispatchConfirmOutcome::Aborted
 }
 
 /// Watchdog: gracefully terminate running jobs that exceed their time limit.
@@ -2101,10 +2129,15 @@ mod tests {
         /// Minimal SlurmAgent: counts cancel_job calls, so tests can assert the
         /// controller actually tried to stop the job on nodes that did launch
         /// it. `reject_launch_as` makes launch_job fail with a given
-        /// classification instead of succeeding.
+        /// classification instead of succeeding. `launch_delay` sleeps inside
+        /// `launch_job` before responding, standing in for the node-side work
+        /// (resource allocation, GPU device-injection planning, process
+        /// spawn) a real agent does — used to measure confirmation latency
+        /// under a synthetic per-node launch cost rather than estimating it.
         struct MockAgent {
             cancel_calls: Arc<AtomicU32>,
             reject_launch_as: Option<spur_proto::proto::LaunchFailureKind>,
+            launch_delay: Duration,
         }
 
         #[tonic::async_trait]
@@ -2119,6 +2152,9 @@ mod tests {
                 request: tonic::Request<spur_proto::proto::LaunchJobRequest>,
             ) -> Result<tonic::Response<spur_proto::proto::LaunchJobResponse>, tonic::Status>
             {
+                if !self.launch_delay.is_zero() {
+                    tokio::time::sleep(self.launch_delay).await;
+                }
                 if let Some(kind) = self.reject_launch_as {
                     return Ok(tonic::Response::new(spur_proto::proto::LaunchJobResponse {
                         success: false,
@@ -2270,12 +2306,30 @@ mod tests {
         async fn spawn_mock_agent_rejecting(
             reject_launch_as: Option<spur_proto::proto::LaunchFailureKind>,
         ) -> (std::net::SocketAddr, Arc<AtomicU32>) {
+            spawn_mock_agent_full(reject_launch_as, Duration::ZERO).await
+        }
+
+        /// Like [`spawn_mock_agent`], but `launch_job` sleeps `delay` before
+        /// accepting — a synthetic stand-in for a real agent's launch pipeline,
+        /// so latency tests measure a real (if synthetic) number instead of
+        /// guessing one.
+        async fn spawn_mock_agent_with_delay(
+            delay: Duration,
+        ) -> (std::net::SocketAddr, Arc<AtomicU32>) {
+            spawn_mock_agent_full(None, delay).await
+        }
+
+        async fn spawn_mock_agent_full(
+            reject_launch_as: Option<spur_proto::proto::LaunchFailureKind>,
+            launch_delay: Duration,
+        ) -> (std::net::SocketAddr, Arc<AtomicU32>) {
             let incoming = TcpIncoming::bind("127.0.0.1:0".parse().unwrap()).unwrap();
             let addr = incoming.local_addr().unwrap();
             let cancel_calls = Arc::new(AtomicU32::new(0));
             let agent = MockAgent {
                 cancel_calls: cancel_calls.clone(),
                 reject_launch_as,
+                launch_delay,
             };
             tokio::spawn(async move {
                 let _ = Server::builder()
@@ -2421,7 +2475,8 @@ mod tests {
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-        async fn partial_dispatch_evicts_job_and_cancels_the_node_that_launched() {
+        async fn partial_dispatch_confirmation_aborts_admission_and_cancels_the_node_that_launched()
+        {
             use spur_core::job::JobState;
 
             let dir = TempDir::new().unwrap();
@@ -2432,7 +2487,7 @@ mod tests {
             register_node_at(&cm, "n1", good_addr);
             register_node_at(&cm, "n2", bad_addr);
 
-            let mut spec = JobSpec {
+            let spec = JobSpec {
                 name: "partial-dispatch".into(),
                 user: "testuser".into(),
                 num_nodes: 2,
@@ -2442,104 +2497,20 @@ mod tests {
                 ..Default::default()
             };
             let job_id = submit_and_wait(&cm, spec.clone());
-            spec = cm.get_job(job_id).unwrap().spec;
+            let spec = cm.get_job(job_id).unwrap().spec;
 
             let nodes = vec!["n1".to_string(), "n2".to_string()];
             let per_node_allocs: HashMap<String, ResourceAllocations> = nodes
                 .iter()
                 .map(|n| (n.clone(), ResourceAllocations::with_scalar(1, 0)))
                 .collect();
-            let run_attempt = cm
-                .start_job(
-                    job_id,
-                    nodes.clone(),
-                    ResourceAllocations::with_scalar(2, 0),
-                    per_node_allocs.clone(),
-                )
-                .unwrap();
-            settle(&cm, job_id, JobState::Running);
 
-            // This calls the exact same function `run()` spawns per assignment:
-            // real network dispatch to both nodes, real JoinSet success/failure
-            // counting, and the real branch that decides to evict on a partial
-            // failure — n1 (real agent) accepts, n2 (nothing listening) fails.
-            dispatch_job_to_nodes(
-                cm.clone(),
-                job_id,
-                nodes,
-                spec,
-                Vec::new(),
-                per_node_allocs,
-                "n1,n2".into(),
-                1,
-                run_attempt,
-            )
-            .await;
-
-            settle(&cm, job_id, JobState::NodeFail);
-            assert_eq!(
-                cm.get_job(job_id).unwrap().pending_reason,
-                spur_core::job::PendingReason::JobLaunchFailure
-            );
-
-            // n1 actually launched the job, so the controller must tell its
-            // agent to stop it instead of leaving an orphaned process behind.
-            // The cancel is awaited inside dispatch_job_to_nodes, so it has
-            // already been delivered by the time that call returned.
-            assert_eq!(
-                cancel_calls.load(Ordering::SeqCst),
-                1,
-                "n1 must have been cancelled before dispatch_job_to_nodes returned"
-            );
-        }
-
-        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-        async fn partial_dispatch_with_requeue_still_cancels_the_node_that_launched() {
-            use spur_core::job::JobState;
-
-            let dir = TempDir::new().unwrap();
-            let cm = test_cluster(&dir).await;
-
-            let (good_addr, cancel_calls) = spawn_mock_agent().await;
-            let bad_addr = unreachable_addr().await;
-            register_node_at(&cm, "n1", good_addr);
-            register_node_at(&cm, "n2", bad_addr);
-
-            let mut spec = JobSpec {
-                name: "partial-dispatch-requeue".into(),
-                user: "testuser".into(),
-                num_nodes: 2,
-                num_tasks: 2,
-                cpus_per_task: 1,
-                work_dir: "/tmp".into(),
-                requeue: true,
-                ..Default::default()
-            };
-            let job_id = submit_and_wait(&cm, spec.clone());
-            spec = cm.get_job(job_id).unwrap().spec;
-
-            let nodes = vec!["n1".to_string(), "n2".to_string()];
-            let per_node_allocs: HashMap<String, ResourceAllocations> = nodes
-                .iter()
-                .map(|n| (n.clone(), ResourceAllocations::with_scalar(1, 0)))
-                .collect();
-            cm.start_job(
-                job_id,
-                nodes.clone(),
-                ResourceAllocations::with_scalar(2, 0),
-                per_node_allocs.clone(),
-            )
-            .unwrap();
-            settle(&cm, job_id, JobState::Running);
-
-            // Same as the non-requeue case, but `spec.requeue` is set: eviction's
-            // requeue side effect resets the job to Pending and clears
-            // `allocated_nodes`. The cancel RPC must be delivered to n1 *before*
-            // that requeue makes the job eligible for re-dispatch, otherwise a
-            // job_id-keyed cancel still in flight could kill a fresh attempt.
-            // dispatch_job_to_nodes awaits the cancel before evicting, so by the
-            // time it returns both the cancel is delivered and the job is Pending.
-            dispatch_job_to_nodes(
+            // This calls the exact same function `run()` now awaits per
+            // assignment *before* start_job: real network dispatch to both
+            // nodes, real JoinSet success/failure counting, and the real
+            // branch that aborts admission on a partial failure — n1 (real
+            // agent) accepts, n2 (nothing listening) fails.
+            let outcome = confirm_dispatch_on_nodes(
                 cm.clone(),
                 job_id,
                 nodes,
@@ -2552,18 +2523,25 @@ mod tests {
             )
             .await;
 
-            // Cancel-before-requeue: the cancel is already delivered, and the
-            // requeue side effect has put the job back to Pending with its
-            // allocation cleared — no polling needed, both are guaranteed by the
-            // await ordering inside dispatch_job_to_nodes.
-            assert_eq!(
-                cancel_calls.load(Ordering::SeqCst),
-                1,
-                "n1 must have been cancelled before the requeue re-enabled dispatch"
-            );
+            assert!(matches!(outcome, DispatchConfirmOutcome::Aborted));
+
+            // The job must never have been visible as Running — admission
+            // failed before that transition, not after it (unlike the old
+            // dispatch_job_to_nodes, which evicted an already-Running job to
+            // NodeFail on the same partial failure).
             let job = cm.get_job(job_id).unwrap();
             assert_eq!(job.state, JobState::Pending);
             assert!(job.allocated_nodes.is_empty());
+
+            // n1 actually launched the job, so the controller must tell its
+            // agent to stop it instead of leaving an orphaned process behind.
+            // The cancel is awaited inside confirm_dispatch_on_nodes, so it
+            // has already been delivered by the time that call returned.
+            assert_eq!(
+                cancel_calls.load(Ordering::SeqCst),
+                1,
+                "n1 must have been cancelled before confirm_dispatch_on_nodes returned"
+            );
         }
 
         // Force-finish must cancel the job on the unreported node before freeing
@@ -2677,11 +2655,11 @@ mod tests {
         }
 
         // Mock agents echo an offset-keyed path; the stored path must be the
-        // primary's (task_offset == 0) regardless of which response arrives first.
+        // primary's (task_offset == 0) regardless of which response arrives
+        // first. Confirmed *before* start_job now, so the job is still
+        // Pending when the path lands.
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-        async fn clean_dispatch_stores_primary_node_output_path() {
-            use spur_core::job::JobState;
-
+        async fn clean_dispatch_confirmation_stores_primary_node_output_path() {
             let dir = TempDir::new().unwrap();
             let cm = test_cluster(&dir).await;
 
@@ -2707,17 +2685,8 @@ mod tests {
                 .iter()
                 .map(|n| (n.clone(), ResourceAllocations::with_scalar(1, 0)))
                 .collect();
-            let run_attempt = cm
-                .start_job(
-                    job_id,
-                    nodes.clone(),
-                    ResourceAllocations::with_scalar(2, 0),
-                    per_node_allocs.clone(),
-                )
-                .unwrap();
-            settle(&cm, job_id, JobState::Running);
 
-            dispatch_job_to_nodes(
+            let outcome = confirm_dispatch_on_nodes(
                 cm.clone(),
                 job_id,
                 nodes,
@@ -2726,9 +2695,11 @@ mod tests {
                 per_node_allocs,
                 "n1,n2".into(),
                 1,
-                run_attempt,
+                1,
             )
             .await;
+
+            assert!(matches!(outcome, DispatchConfirmOutcome::Confirmed));
 
             let job = cm.get_job(job_id).unwrap();
             assert_eq!(
@@ -2742,13 +2713,10 @@ mod tests {
             );
         }
 
-        // If the primary node fails to launch, the dispatch requeues/evicts the
-        // job and no output path is recorded, so queries fall back to the
-        // computed path.
+        // If the primary node fails to launch, admission is aborted and no
+        // output path is recorded, so queries fall back to the computed path.
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
         async fn failed_primary_leaves_output_path_unset() {
-            use spur_core::job::JobState;
-
             let dir = TempDir::new().unwrap();
             let cm = test_cluster(&dir).await;
 
@@ -2775,17 +2743,8 @@ mod tests {
                 .iter()
                 .map(|n| (n.clone(), ResourceAllocations::with_scalar(1, 0)))
                 .collect();
-            let run_attempt = cm
-                .start_job(
-                    job_id,
-                    nodes.clone(),
-                    ResourceAllocations::with_scalar(2, 0),
-                    per_node_allocs.clone(),
-                )
-                .unwrap();
-            settle(&cm, job_id, JobState::Running);
 
-            dispatch_job_to_nodes(
+            let outcome = confirm_dispatch_on_nodes(
                 cm.clone(),
                 job_id,
                 nodes,
@@ -2794,24 +2753,24 @@ mod tests {
                 per_node_allocs,
                 "n1,n2".into(),
                 1,
-                run_attempt,
+                1,
             )
             .await;
+
+            assert!(matches!(outcome, DispatchConfirmOutcome::Aborted));
 
             let job = cm.get_job(job_id).unwrap();
             assert!(
                 job.actual_stdout_path.is_none(),
-                "a failed dispatch must not record an output path"
+                "a failed dispatch confirmation must not record an output path"
             );
             assert!(job.actual_stderr_path.is_none());
         }
 
-        // A secondary-node failure (primary succeeds) still evicts/requeues the
-        // job, so the `failures == 0` gate must skip storing the primary's path.
+        // A secondary-node failure (primary succeeds) still aborts admission,
+        // so the `failures == 0` gate must skip storing the primary's path.
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
         async fn secondary_failure_leaves_output_path_unset() {
-            use spur_core::job::JobState;
-
             let dir = TempDir::new().unwrap();
             let cm = test_cluster(&dir).await;
 
@@ -2838,17 +2797,8 @@ mod tests {
                 .iter()
                 .map(|n| (n.clone(), ResourceAllocations::with_scalar(1, 0)))
                 .collect();
-            let run_attempt = cm
-                .start_job(
-                    job_id,
-                    nodes.clone(),
-                    ResourceAllocations::with_scalar(2, 0),
-                    per_node_allocs.clone(),
-                )
-                .unwrap();
-            settle(&cm, job_id, JobState::Running);
 
-            dispatch_job_to_nodes(
+            let outcome = confirm_dispatch_on_nodes(
                 cm.clone(),
                 job_id,
                 nodes,
@@ -2857,9 +2807,11 @@ mod tests {
                 per_node_allocs,
                 "n1,n2".into(),
                 1,
-                run_attempt,
+                1,
             )
             .await;
+
+            assert!(matches!(outcome, DispatchConfirmOutcome::Aborted));
 
             let job = cm.get_job(job_id).unwrap();
             assert!(
@@ -2870,31 +2822,26 @@ mod tests {
         }
 
         // ── prolog failure: drain the node, hold the job ──
+        //
+        // All of these confirm dispatch on a still-Pending job (never
+        // started), matching what `run()` now does: the job is never visible
+        // as Running before these outcomes are decided.
 
-        /// Start `spec` on `nodes` and run the real dispatch against them.
-        async fn dispatch_started_job(
+        /// Submit `spec` (via the caller) and run the real dispatch
+        /// confirmation against `nodes` on the still-Pending job.
+        async fn confirm_dispatch_pending_job(
             cm: &Arc<ClusterManager>,
             job_id: spur_core::job::JobId,
             nodes: &[&str],
-        ) {
+        ) -> DispatchConfirmOutcome {
             let nodes: Vec<String> = nodes.iter().map(|n| n.to_string()).collect();
             let per_node_allocs: HashMap<String, ResourceAllocations> = nodes
                 .iter()
                 .map(|n| (n.clone(), ResourceAllocations::with_scalar(1, 0)))
                 .collect();
-            let run_attempt = cm
-                .start_job(
-                    job_id,
-                    nodes.clone(),
-                    ResourceAllocations::with_scalar(nodes.len() as u32, 0),
-                    per_node_allocs.clone(),
-                )
-                .unwrap();
-            settle(cm, job_id, spur_core::job::JobState::Running);
-
             let spec = cm.get_job(job_id).unwrap().spec;
             let nodelist = nodes.join(",");
-            dispatch_job_to_nodes(
+            confirm_dispatch_on_nodes(
                 cm.clone(),
                 job_id,
                 nodes,
@@ -2903,9 +2850,9 @@ mod tests {
                 per_node_allocs,
                 nodelist,
                 1,
-                run_attempt,
+                1,
             )
-            .await;
+            .await
         }
 
         fn batch_spec(name: &str, num_nodes: u32) -> JobSpec {
@@ -2934,8 +2881,8 @@ mod tests {
             register_node_at(&cm, "n1", addr);
 
             let job_id = submit_and_wait(&cm, batch_spec("prolog-fail", 1));
-            dispatch_started_job(&cm, job_id, &["n1"]).await;
-            settle(&cm, job_id, JobState::Pending);
+            let outcome = confirm_dispatch_pending_job(&cm, job_id, &["n1"]).await;
+            assert!(matches!(outcome, DispatchConfirmOutcome::Aborted));
 
             let node = cm.get_node("n1").unwrap();
             assert!(
@@ -2950,9 +2897,14 @@ mod tests {
                 node.state_reason
             );
 
-            // The hold is what bounds the drain to one node: without it the job
-            // retries onto the next node and drains that one too.
+            // The hold is what bounds the drain to one node: without it the
+            // job retries onto the next node and drains that one too. The job
+            // never reached Running, so this hold is applied directly on the
+            // still-Pending job (`hold_job_for_launch_failure`) rather than
+            // via the old Running->Failed->Held detour — same end state
+            // (Pending, priority 0, Held, identical description).
             let job = cm.get_job(job_id).unwrap();
+            assert_eq!(job.state, JobState::Pending);
             assert_eq!(job.pending_reason, PendingReason::Held);
             assert_eq!(job.priority, 0);
             assert_eq!(
@@ -2967,8 +2919,6 @@ mod tests {
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
         async fn an_operator_can_release_a_job_held_for_a_prolog_failure() {
-            use spur_core::job::JobState;
-
             let dir = TempDir::new().unwrap();
             let cm = test_cluster(&dir).await;
 
@@ -2979,8 +2929,7 @@ mod tests {
             register_node_at(&cm, "n1", addr);
 
             let job_id = submit_and_wait(&cm, batch_spec("prolog-release", 1));
-            dispatch_started_job(&cm, job_id, &["n1"]).await;
-            settle(&cm, job_id, JobState::Pending);
+            confirm_dispatch_pending_job(&cm, job_id, &["n1"]).await;
 
             cm.release_job(job_id).unwrap();
             wait_for("job released", || {
@@ -2997,7 +2946,7 @@ mod tests {
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
         async fn hold_on_prolog_fail_off_retries_the_job_instead() {
-            use spur_core::job::{JobState, PendingReason};
+            use spur_core::job::JobState;
 
             let dir = TempDir::new().unwrap();
             let mut config = test_config();
@@ -3011,15 +2960,24 @@ mod tests {
             register_node_at(&cm, "n1", addr);
 
             let job_id = submit_and_wait(&cm, batch_spec("prolog-retry", 1));
-            dispatch_started_job(&cm, job_id, &["n1"]).await;
-            settle(&cm, job_id, JobState::Pending);
+            let reason_before_dispatch = cm.get_job(job_id).unwrap().pending_reason;
+            let outcome = confirm_dispatch_pending_job(&cm, job_id, &["n1"]).await;
+            assert!(matches!(outcome, DispatchConfirmOutcome::Aborted));
 
-            // Slurm's nohold_on_prolog_fail: retry, bounded by max_batch_requeue
-            // rather than by a hold. The node still drains.
+            // Slurm's nohold_on_prolog_fail: retry rather than hold. Pre-
+            // Running, "retry" is simply leaving the job Pending for the next
+            // scheduler tick (the same simplification
+            // register_allocation_on_nodes's own failure arms already make
+            // for the srun path), rather than the old post-Running
+            // exponential-backoff detour through Failed — that path isn't
+            // reachable from Pending. See confirm_dispatch_on_nodes's doc
+            // comment for the trade-off. The node still drains either way.
             let job = cm.get_job(job_id).unwrap();
-            assert_eq!(job.pending_reason, PendingReason::JobLaunchFailure);
-            assert_ne!(job.priority, 0);
-            assert!(job.spec.begin_time.is_some_and(|b| b > Utc::now()));
+            assert_eq!(job.state, JobState::Pending);
+            assert_eq!(
+                job.pending_reason, reason_before_dispatch,
+                "no hold/backoff is applied pre-Running when hold_on_prolog_fail is off"
+            );
             assert!(cm.get_node("n1").unwrap().state.is_admin_hold());
         }
 
@@ -3041,7 +2999,9 @@ mod tests {
             let mut spec = batch_spec("prolog-interactive", 1);
             spec.interactive = true;
             let job_id = submit_and_wait(&cm, spec);
-            dispatch_started_job(&cm, job_id, &["n1"]).await;
+            let outcome = confirm_dispatch_pending_job(&cm, job_id, &["n1"]).await;
+            assert!(matches!(outcome, DispatchConfirmOutcome::Aborted));
+
             settle(&cm, job_id, JobState::Cancelled);
 
             assert!(
@@ -3052,7 +3012,7 @@ mod tests {
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
         async fn an_unclassified_rejection_keeps_the_plain_requeue_path() {
-            use spur_core::job::{JobState, PendingReason};
+            use spur_core::job::JobState;
 
             let dir = TempDir::new().unwrap();
             let cm = test_cluster(&dir).await;
@@ -3065,12 +3025,16 @@ mod tests {
             register_node_at(&cm, "n1", addr);
 
             let job_id = submit_and_wait(&cm, batch_spec("unclassified", 1));
-            dispatch_started_job(&cm, job_id, &["n1"]).await;
-            settle(&cm, job_id, JobState::Pending);
+            let reason_before_dispatch = cm.get_job(job_id).unwrap().pending_reason;
+            let outcome = confirm_dispatch_pending_job(&cm, job_id, &["n1"]).await;
+            assert!(matches!(outcome, DispatchConfirmOutcome::Aborted));
 
             let job = cm.get_job(job_id).unwrap();
-            assert_eq!(job.pending_reason, PendingReason::JobLaunchFailure);
-            assert_ne!(job.priority, 0, "no hold without a classification");
+            assert_eq!(job.state, JobState::Pending);
+            assert_eq!(
+                job.pending_reason, reason_before_dispatch,
+                "no hold without a classification"
+            );
             assert!(
                 !cm.get_node("n1").unwrap().state.is_admin_hold(),
                 "an unclassified rejection is not grounds to drain"
@@ -3093,15 +3057,17 @@ mod tests {
             register_node_at(&cm, "n2", bad_addr);
 
             let job_id = submit_and_wait(&cm, batch_spec("prolog-partial", 2));
-            dispatch_started_job(&cm, job_id, &["n1", "n2"]).await;
-            settle(&cm, job_id, JobState::Pending);
+            let outcome = confirm_dispatch_pending_job(&cm, job_id, &["n1", "n2"]).await;
+            assert!(matches!(outcome, DispatchConfirmOutcome::Aborted));
 
             assert!(!cm.get_node("n1").unwrap().state.is_admin_hold());
             assert!(cm.get_node("n2").unwrap().state.is_admin_hold());
 
-            // The partial branch must hold like the total one; evicting would
-            // route through maybe_requeue and drop the hold.
+            // The partial branch must hold like the total one, and — unlike
+            // the pre-fix behavior — the job must never have been visible as
+            // Running in between.
             let job = cm.get_job(job_id).unwrap();
+            assert_eq!(job.state, JobState::Pending);
             assert_eq!(job.pending_reason, PendingReason::Held);
             assert_eq!(job.priority, 0);
 
@@ -3109,6 +3075,99 @@ mod tests {
                 cancel_calls.load(Ordering::SeqCst),
                 1,
                 "n1 launched the job, so it must be stopped before the job settles"
+            );
+        }
+
+        // ── measured admission latency ──
+        //
+        // Answers "how much slower does job start get?" with a real number
+        // instead of an estimate: every node's LaunchJob is confirmed
+        // concurrently via JoinSet, so the added latency this fix introduces
+        // should track the *slowest* node's own launch time, not the sum
+        // across all assigned nodes.
+
+        /// Confirm dispatch across `count` freshly-registered nodes, each of
+        /// whose mock agent sleeps `delay` before accepting the launch, and
+        /// return how long the whole confirmation actually took.
+        async fn measure_confirm_latency(
+            cm: &Arc<ClusterManager>,
+            count: usize,
+            delay: Duration,
+        ) -> Duration {
+            let mut nodes = Vec::with_capacity(count);
+            for i in 0..count {
+                let name = format!("latency-n{i}");
+                let (addr, _) = spawn_mock_agent_with_delay(delay).await;
+                register_node_at(cm, &name, addr);
+                nodes.push(name);
+            }
+
+            let spec = batch_spec(&format!("latency-{count}"), count as u32);
+            let job_id = submit_and_wait(cm, spec);
+            let spec = cm.get_job(job_id).unwrap().spec;
+            let per_node_allocs: HashMap<String, ResourceAllocations> = nodes
+                .iter()
+                .map(|n| (n.clone(), ResourceAllocations::with_scalar(1, 0)))
+                .collect();
+            let nodelist = nodes.join(",");
+
+            let start = std::time::Instant::now();
+            let outcome = confirm_dispatch_on_nodes(
+                cm.clone(),
+                job_id,
+                nodes,
+                spec,
+                Vec::new(),
+                per_node_allocs,
+                nodelist,
+                1,
+                1,
+            )
+            .await;
+            let elapsed = start.elapsed();
+
+            assert!(matches!(outcome, DispatchConfirmOutcome::Confirmed));
+            elapsed
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 16)]
+        async fn confirm_dispatch_latency_tracks_the_slowest_node_not_the_node_count() {
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+
+            // A generous, deliberately-visible stand-in for a real agent's
+            // launch pipeline (resource allocation, GPU device-injection
+            // planning, process spawn) — real hardware is faster than this,
+            // but the point is the shape of the curve (flat vs. linear in
+            // node count), not the absolute number.
+            const PER_NODE_LAUNCH_DELAY: Duration = Duration::from_millis(150);
+
+            let two_nodes = measure_confirm_latency(&cm, 2, PER_NODE_LAUNCH_DELAY).await;
+            let eight_nodes = measure_confirm_latency(&cm, 8, PER_NODE_LAUNCH_DELAY).await;
+            let sixty_four_nodes = measure_confirm_latency(&cm, 64, PER_NODE_LAUNCH_DELAY).await;
+
+            eprintln!(
+                "confirm_dispatch_on_nodes latency — 2 nodes: {two_nodes:?}, \
+                 8 nodes: {eight_nodes:?}, 64 nodes: {sixty_four_nodes:?} \
+                 (synthetic per-node launch delay: {PER_NODE_LAUNCH_DELAY:?})"
+            );
+
+            // Every node's LaunchJob is confirmed concurrently, so admission
+            // takes at least one node's launch delay...
+            assert!(two_nodes >= PER_NODE_LAUNCH_DELAY);
+            assert!(eight_nodes >= PER_NODE_LAUNCH_DELAY);
+            assert!(sixty_four_nodes >= PER_NODE_LAUNCH_DELAY);
+
+            // ...and, crucially, stays close to it as the node count grows by
+            // 32x (2 -> 64) rather than scaling with the sum across nodes
+            // (which would be ~32x slower, i.e. ~4.8s here). The multiplier
+            // below leaves headroom for scheduler/OS jitter on a loaded box;
+            // it is not evidence of a real per-node cost.
+            assert!(
+                sixty_four_nodes < PER_NODE_LAUNCH_DELAY * 5,
+                "64-node confirmation ({sixty_four_nodes:?}) scaled with node count instead of \
+                 staying near the single-node launch delay ({PER_NODE_LAUNCH_DELAY:?}) — \
+                 dispatch may have serialized instead of running concurrently"
             );
         }
     }

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -282,11 +282,11 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
             // fallback) must have every assigned node confirm its LaunchJob
             // *before* start_job flips the job to Running — otherwise squeue
             // reports Running while a node may still be mid-launch (the race
-            // PR #544 papers over with a retry window on the agent side). The
-            // pure interactive srun_step_dispatch case has nothing left to
-            // dispatch here: register_allocation_on_nodes above already
-            // confirmed the allocation, and the actual step launch is a later
-            // RunCommand, not this LaunchJob RPC.
+            // an earlier mitigation only papered over with a retry window on
+            // the agent side). The pure interactive srun_step_dispatch case
+            // has nothing left to dispatch here: register_allocation_on_nodes
+            // above already confirmed the allocation, and the actual step
+            // launch is a later RunCommand, not this LaunchJob RPC.
             let dispatch_spec = if !spec.srun_job {
                 Some(spec.clone())
             } else if !srun_step_dispatch {
@@ -1158,16 +1158,29 @@ enum DispatchConfirmOutcome {
 /// RPC to resolve before returning anything the caller can use to flip the
 /// job to Running.
 ///
-/// This is the structural fix for the srun-step startup race (see PR #544,
-/// which only widens the agent-side retry window): the old flow called
-/// `start_job` (Running, visible to squeue/scontrol) and then fired this
-/// dispatch in the background via `tokio::spawn`, so a step could target a
-/// node before that node's own `LaunchJob` had actually finished. Now the
-/// scheduler loop awaits this function *before* calling `start_job`, mirroring
-/// the pattern `register_allocation_on_nodes` already uses for standalone
-/// srun/salloc allocations — except this confirms the heavier `LaunchJob` RPC
-/// (which actually spawns the job's process), not the lightweight
-/// `RegisterJobAllocation` used there.
+/// This is the structural fix for the srun-step startup race: an earlier
+/// mitigation only widened an agent-side retry window on one lookup. The old
+/// flow called `start_job` (Running, visible to squeue/scontrol) and then
+/// fired this dispatch in the background via `tokio::spawn`, so a step could
+/// target a node before that node's own `LaunchJob` had actually finished.
+/// Now the scheduler loop awaits this function *before* calling `start_job`,
+/// mirroring the pattern `register_allocation_on_nodes` already uses for
+/// standalone srun/salloc allocations — except this confirms the heavier
+/// `LaunchJob` RPC (which actually spawns the job's process), not the
+/// lightweight `RegisterJobAllocation` used there.
+///
+/// This closes the race for every consumer that gates on `job.state ==
+/// Running` before targeting a node, not just the step-dispatch path
+/// (`run_step`/`run_command`) it was written for: `exec_in_job` and
+/// `create_job_step` (spurctld/server.rs) both check `job.state == Running`
+/// before forwarding to an agent, and back `exec_in_job`/`interactive_session`
+/// (spurd/agent_server.rs's `job_entry`) and `stream_job_output`'s attach
+/// path respectively. Since Running is the single, sole signal all of these
+/// checks (and the CLI's own client-side checks, for the RPCs that have no
+/// controller-side proxy) rely on, and it is now unreachable before every
+/// node's registration completes, none of run_command/job_entry/
+/// stream_job_output's node-side lookups need a retry of their own — see the
+/// comments at each of those lookups.
 ///
 /// Failure handling necessarily differs from the old post-Running
 /// `dispatch_job_to_nodes` this replaces, because the job is still Pending

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -194,211 +194,9 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
 
         let mut jobs_started_cycle = 0u64;
         for assignment in assignments {
-            let job = match cluster.get_job(assignment.job_id) {
-                Some(j) => j,
-                None => continue,
-            };
-
-            let resources =
-                compute_job_allocation(&job, &assignment.nodes, &assignment.per_node_alloc);
-
-            let job_id = assignment.job_id;
-            let spec = job.spec.clone();
-            let all_nodes = assignment.nodes.clone();
-            let per_node_allocs = assignment.per_node_alloc.clone();
-            let dispatch_nodes = all_nodes.clone();
-            let allocated_nodelist = all_nodes.join(",");
-
-            let srun_step_dispatch = spec.srun_job
-                && dispatch_nodes.iter().all(|name| {
-                    cluster
-                        .get_node(name)
-                        .is_some_and(|n| n.source == NodeSource::NativeHost)
-                });
-
-            if spec.srun_job
-                && !srun_step_dispatch
-                && spec.script.as_deref().unwrap_or("").is_empty()
-            {
-                warn!(
-                    job_id,
-                    "srun batch fallback requires a script in the job spec"
-                );
-                if let Err(e) = cluster.requeue_job(job_id) {
-                    error!(job_id, error = %e, "failed to requeue srun job without script");
-                }
-                continue;
+            if process_assignment(cluster.clone(), assignment).await {
+                jobs_started_cycle += 1;
             }
-
-            if spec.srun_job && srun_step_dispatch {
-                match register_allocation_on_nodes(
-                    cluster.clone(),
-                    job_id,
-                    dispatch_nodes.clone(),
-                    &spec,
-                    per_node_allocs.clone(),
-                    allocated_nodelist.clone(),
-                )
-                .await
-                {
-                    AllocationRegisterOutcome::AllFailed => {
-                        if let Err(e) = cluster.requeue_job(job_id) {
-                            error!(job_id, error = %e, "failed to requeue after registration failure");
-                        }
-                        continue;
-                    }
-                    AllocationRegisterOutcome::PartialFailed { succeeded_nodes } => {
-                        cancel_job_on_nodes(&cluster, job_id, &succeeded_nodes, 9).await;
-                        if let Err(e) = cluster.requeue_job(job_id) {
-                            error!(job_id, error = %e, "failed to requeue after partial registration");
-                        }
-                        continue;
-                    }
-                    AllocationRegisterOutcome::AllSucceeded => {}
-                }
-            }
-
-            // Build peer_nodes list with addresses for cross-node communication
-            // and the effective per-node task count. Both are needed by the
-            // LaunchJob dispatch below, which — unlike the old fire-and-forget
-            // spawn — now runs (and is awaited) *before* the job is allowed to
-            // become visibly Running.
-            let peer_addrs: Vec<String> = all_nodes
-                .iter()
-                .filter_map(|name| {
-                    cluster
-                        .get_node(name)
-                        .and_then(|n| n.address.as_ref().map(|a| format!("{}:{}", a, n.port)))
-                })
-                .collect();
-
-            let tasks_per_node = if let Some(tpn) = spec.tasks_per_node {
-                tpn
-            } else {
-                (spec.num_tasks / spec.num_nodes.max(1)).max(1)
-            };
-
-            // Batch dispatch (plain sbatch jobs, and the srun-as-batch-script
-            // fallback) must have every assigned node confirm its LaunchJob
-            // *before* start_job flips the job to Running — otherwise squeue
-            // reports Running while a node may still be mid-launch (the race
-            // an earlier mitigation only papered over with a retry window on
-            // the agent side). The pure interactive srun_step_dispatch case
-            // has nothing left to dispatch here: register_allocation_on_nodes
-            // above already confirmed the allocation, and the actual step
-            // launch is a later RunCommand, not this LaunchJob RPC.
-            let dispatch_spec = if !spec.srun_job {
-                Some(spec.clone())
-            } else if !srun_step_dispatch {
-                let mut batch_spec = spec.clone();
-                batch_spec.srun_job = false;
-                Some(batch_spec)
-            } else {
-                None
-            };
-
-            if let Some(dspec) = dispatch_spec {
-                // The run epoch start_job_impl is about to persist for this
-                // dispatch. Safe to read ahead of that call: this iteration is
-                // the only place that can advance a Pending job's run_attempt,
-                // and nothing here yields back to another iteration for the
-                // same job in between.
-                let prospective_run_attempt = job.run_attempt.saturating_add(1);
-
-                match confirm_dispatch_on_nodes(
-                    cluster.clone(),
-                    job_id,
-                    dispatch_nodes.clone(),
-                    dspec,
-                    peer_addrs.clone(),
-                    per_node_allocs.clone(),
-                    allocated_nodelist.clone(),
-                    tasks_per_node,
-                    prospective_run_attempt,
-                )
-                .await
-                {
-                    DispatchConfirmOutcome::Aborted => continue,
-                    DispatchConfirmOutcome::Confirmed => {}
-                }
-            }
-
-            // Transition job to Running. Reached only once every assigned node
-            // has confirmed (LaunchJob for batch dispatch above, or
-            // RegisterJobAllocation for the pure interactive case above that).
-            let start_result = if srun_step_dispatch {
-                cluster.start_job_impl(
-                    job_id,
-                    assignment.nodes.clone(),
-                    resources,
-                    assignment.per_node_alloc.clone(),
-                    true,
-                )
-            } else {
-                cluster.start_job(
-                    job_id,
-                    assignment.nodes.clone(),
-                    resources,
-                    assignment.per_node_alloc.clone(),
-                )
-            };
-            if let Err(e) = start_result {
-                // Confirmation above already registered the allocation or
-                // launched real processes on dispatch_nodes; stop them so a
-                // start_job failure here (e.g. the job was cancelled out from
-                // under us between assignment and this point) doesn't leave
-                // orphans.
-                cancel_job_on_nodes(&cluster, job_id, &dispatch_nodes, 0).await;
-                debug!(
-                    job_id = assignment.job_id,
-                    error = %e,
-                    "failed to start job"
-                );
-                continue;
-            }
-
-            // Run PrologSlurmctld if configured
-            if let Some(ref prolog_ctld) = cluster.config.hooks.prolog_slurmctld {
-                let ctx = spur_core::hooks::HookContext {
-                    job_id: assignment.job_id,
-                    work_dir: job.spec.work_dir.clone(),
-                    uid: job.spec.uid,
-                    gid: job.spec.gid,
-                    partition: job.spec.partition.clone().unwrap_or_default(),
-                    nodelist: assignment.nodes.join(","),
-                    script_context: "prolog_slurmctld".into(),
-                    gpu_devices: Vec::new(),
-                    cpus: job.spec.cpus_per_task,
-                    memory_mb: job.spec.memory_per_node_mb.unwrap_or(0),
-                };
-                if let Err(e) = spur_core::hooks::run_hook(prolog_ctld, &ctx).await {
-                    error!(
-                        job_id = assignment.job_id,
-                        error = %e,
-                        "PrologSlurmctld failed"
-                    );
-                    // The job is now Running with real work already dispatched
-                    // above (a LaunchJob confirmed on every node, or — for the
-                    // pure interactive case — an allocation registered on
-                    // every node). Unlike the old post-Running-spawn ordering,
-                    // that has already happened by the time we get here, so
-                    // it must always be torn down on this path now, regardless
-                    // of interactive vs. batch.
-                    cancel_job_on_nodes(&cluster, job_id, &dispatch_nodes, 0).await;
-                    if job.spec.interactive {
-                        if let Err(ce) = cluster.cancel_job(assignment.job_id, &job.spec.user) {
-                            error!(job_id = assignment.job_id, error = %ce, "failed to cancel job after PrologSlurmctld failure");
-                        }
-                    } else {
-                        if let Err(re) = cluster.requeue_job(assignment.job_id) {
-                            error!(job_id = assignment.job_id, error = %re, "failed to requeue job after PrologSlurmctld failure");
-                        }
-                    }
-                    continue;
-                }
-            }
-
-            jobs_started_cycle += 1;
         }
 
         let cycle_time_us = cycle_start.elapsed().as_micros().min(u64::MAX as u128) as u64;
@@ -409,6 +207,220 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
             hit_depth_limit,
         );
     }
+}
+
+/// Process one scheduler assignment: dispatch/confirm on its nodes, start the
+/// job, and run `PrologSlurmctld`. Returns whether the job actually started
+/// (fed into the caller's `jobs_started_cycle` count).
+///
+/// Extracted from `run`'s assignment loop so this — including the
+/// `confirm_dispatch_on_nodes`/`start_job` ordering the srun-step startup fix
+/// depends on — is directly testable without driving the whole scheduler
+/// loop (which needs a live Raft cluster, a real `interval`/`scheduler_notify`
+/// wake, and the three watchdog tasks `run` also spawns).
+async fn process_assignment(
+    cluster: Arc<ClusterManager>,
+    assignment: spur_sched::traits::Assignment,
+) -> bool {
+    let job = match cluster.get_job(assignment.job_id) {
+        Some(j) => j,
+        None => return false,
+    };
+
+    let resources = compute_job_allocation(&job, &assignment.nodes, &assignment.per_node_alloc);
+
+    let job_id = assignment.job_id;
+    let spec = job.spec.clone();
+    let all_nodes = assignment.nodes.clone();
+    let per_node_allocs = assignment.per_node_alloc.clone();
+    let dispatch_nodes = all_nodes.clone();
+    let allocated_nodelist = all_nodes.join(",");
+
+    let srun_step_dispatch = spec.srun_job
+        && dispatch_nodes.iter().all(|name| {
+            cluster
+                .get_node(name)
+                .is_some_and(|n| n.source == NodeSource::NativeHost)
+        });
+
+    if spec.srun_job && !srun_step_dispatch && spec.script.as_deref().unwrap_or("").is_empty() {
+        warn!(
+            job_id,
+            "srun batch fallback requires a script in the job spec"
+        );
+        if let Err(e) = cluster.requeue_job(job_id) {
+            error!(job_id, error = %e, "failed to requeue srun job without script");
+        }
+        return false;
+    }
+
+    if spec.srun_job && srun_step_dispatch {
+        match register_allocation_on_nodes(
+            cluster.clone(),
+            job_id,
+            dispatch_nodes.clone(),
+            &spec,
+            per_node_allocs.clone(),
+            allocated_nodelist.clone(),
+        )
+        .await
+        {
+            AllocationRegisterOutcome::AllFailed => {
+                if let Err(e) = cluster.requeue_job(job_id) {
+                    error!(job_id, error = %e, "failed to requeue after registration failure");
+                }
+                return false;
+            }
+            AllocationRegisterOutcome::PartialFailed { succeeded_nodes } => {
+                cancel_job_on_nodes(&cluster, job_id, &succeeded_nodes, 9).await;
+                if let Err(e) = cluster.requeue_job(job_id) {
+                    error!(job_id, error = %e, "failed to requeue after partial registration");
+                }
+                return false;
+            }
+            AllocationRegisterOutcome::AllSucceeded => {}
+        }
+    }
+
+    // Build peer_nodes list with addresses for cross-node communication
+    // and the effective per-node task count. Both are needed by the
+    // LaunchJob dispatch below, which — unlike the old fire-and-forget
+    // spawn — now runs (and is awaited) *before* the job is allowed to
+    // become visibly Running.
+    let peer_addrs: Vec<String> = all_nodes
+        .iter()
+        .filter_map(|name| {
+            cluster
+                .get_node(name)
+                .and_then(|n| n.address.as_ref().map(|a| format!("{}:{}", a, n.port)))
+        })
+        .collect();
+
+    let tasks_per_node = if let Some(tpn) = spec.tasks_per_node {
+        tpn
+    } else {
+        (spec.num_tasks / spec.num_nodes.max(1)).max(1)
+    };
+
+    // Batch dispatch (plain sbatch jobs, and the srun-as-batch-script
+    // fallback) must have every assigned node confirm its LaunchJob
+    // *before* start_job flips the job to Running — otherwise squeue
+    // reports Running while a node may still be mid-launch (the race
+    // an earlier mitigation only papered over with a retry window on
+    // the agent side). The pure interactive srun_step_dispatch case
+    // has nothing left to dispatch here: register_allocation_on_nodes
+    // above already confirmed the allocation, and the actual step
+    // launch is a later RunCommand, not this LaunchJob RPC.
+    let dispatch_spec = if !spec.srun_job {
+        Some(spec.clone())
+    } else if !srun_step_dispatch {
+        let mut batch_spec = spec.clone();
+        batch_spec.srun_job = false;
+        Some(batch_spec)
+    } else {
+        None
+    };
+
+    if let Some(dspec) = dispatch_spec {
+        // The run epoch start_job_impl is about to persist for this
+        // dispatch. Safe to read ahead of that call: this iteration is
+        // the only place that can advance a Pending job's run_attempt,
+        // and nothing here yields back to another iteration for the
+        // same job in between.
+        let prospective_run_attempt = job.run_attempt.saturating_add(1);
+
+        match confirm_dispatch_on_nodes(
+            cluster.clone(),
+            job_id,
+            dispatch_nodes.clone(),
+            dspec,
+            peer_addrs.clone(),
+            per_node_allocs.clone(),
+            allocated_nodelist.clone(),
+            tasks_per_node,
+            prospective_run_attempt,
+        )
+        .await
+        {
+            DispatchConfirmOutcome::Aborted => return false,
+            DispatchConfirmOutcome::Confirmed => {}
+        }
+    }
+
+    // Transition job to Running. Reached only once every assigned node
+    // has confirmed (LaunchJob for batch dispatch above, or
+    // RegisterJobAllocation for the pure interactive case above that).
+    let start_result = if srun_step_dispatch {
+        cluster.start_job_impl(
+            job_id,
+            assignment.nodes.clone(),
+            resources,
+            assignment.per_node_alloc.clone(),
+            true,
+        )
+    } else {
+        cluster.start_job(
+            job_id,
+            assignment.nodes.clone(),
+            resources,
+            assignment.per_node_alloc.clone(),
+        )
+    };
+    if let Err(e) = start_result {
+        // Confirmation above already registered the allocation or
+        // launched real processes on dispatch_nodes; stop them so a
+        // start_job failure here (e.g. the job was cancelled out from
+        // under us between assignment and this point) doesn't leave
+        // orphans.
+        cancel_job_on_nodes(&cluster, job_id, &dispatch_nodes, 0).await;
+        debug!(
+            job_id = assignment.job_id,
+            error = %e,
+            "failed to start job"
+        );
+        return false;
+    }
+
+    // Run PrologSlurmctld if configured
+    if let Some(ref prolog_ctld) = cluster.config.hooks.prolog_slurmctld {
+        let ctx = spur_core::hooks::HookContext {
+            job_id: assignment.job_id,
+            work_dir: job.spec.work_dir.clone(),
+            uid: job.spec.uid,
+            gid: job.spec.gid,
+            partition: job.spec.partition.clone().unwrap_or_default(),
+            nodelist: assignment.nodes.join(","),
+            script_context: "prolog_slurmctld".into(),
+            gpu_devices: Vec::new(),
+            cpus: job.spec.cpus_per_task,
+            memory_mb: job.spec.memory_per_node_mb.unwrap_or(0),
+        };
+        if let Err(e) = spur_core::hooks::run_hook(prolog_ctld, &ctx).await {
+            error!(
+                job_id = assignment.job_id,
+                error = %e,
+                "PrologSlurmctld failed"
+            );
+            // The job is now Running with real work already dispatched
+            // above (a LaunchJob confirmed on every node, or — for the
+            // pure interactive case — an allocation registered on
+            // every node). Unlike the old post-Running-spawn ordering,
+            // that has already happened by the time we get here, so
+            // it must always be torn down on this path now, regardless
+            // of interactive vs. batch.
+            cancel_job_on_nodes(&cluster, job_id, &dispatch_nodes, 0).await;
+            if job.spec.interactive {
+                if let Err(ce) = cluster.cancel_job(assignment.job_id, &job.spec.user) {
+                    error!(job_id = assignment.job_id, error = %ce, "failed to cancel job after PrologSlurmctld failure");
+                }
+            } else if let Err(re) = cluster.requeue_job(assignment.job_id) {
+                error!(job_id = assignment.job_id, error = %re, "failed to requeue job after PrologSlurmctld failure");
+            }
+            return false;
+        }
+    }
+
+    true
 }
 
 /// Compute the resource set to record against the cluster for an assignment.
@@ -3181,6 +3193,449 @@ mod tests {
                 "64-node confirmation ({sixty_four_nodes:?}) scaled with node count instead of \
                  staying near the single-node launch delay ({PER_NODE_LAUNCH_DELAY:?}) — \
                  dispatch may have serialized instead of running concurrently"
+            );
+        }
+
+        // ── process_assignment: the glue `run()` awaits per assignment ──
+        //
+        // confirm_dispatch_pending_job above calls confirm_dispatch_on_nodes
+        // directly, standing in for what `run()` used to fire off in the
+        // background. These tests instead go through process_assignment
+        // itself — the peer_addrs/tasks_per_node build, the dispatch_spec
+        // decision (plain batch vs. srun-as-batch-fallback vs. pure
+        // interactive), and start_job — the same call `run()` makes once per
+        // assignment every cycle.
+
+        fn register_k8s_node_at(cm: &ClusterManager, name: &str, addr: std::net::SocketAddr) {
+            cm.register_node(
+                name.into(),
+                ResourceSet {
+                    cpus: 4,
+                    memory_mb: 8000,
+                    ..Default::default()
+                },
+                addr.ip().to_string(),
+                addr.port(),
+                String::new(),
+                String::new(),
+                NodeSource::Kubernetes {
+                    namespace: "spur-test".into(),
+                },
+                HashMap::new(),
+            )
+            .unwrap();
+            let n = name.to_string();
+            wait_for(&format!("node '{n}' registered"), || {
+                cm.get_node(&n).is_some()
+            });
+        }
+
+        fn assignment(
+            job_id: spur_core::job::JobId,
+            nodes: &[&str],
+        ) -> spur_sched::traits::Assignment {
+            let per_node_alloc: HashMap<String, ResourceAllocations> = nodes
+                .iter()
+                .map(|n| (n.to_string(), ResourceAllocations::with_scalar(1, 0)))
+                .collect();
+            spur_sched::traits::Assignment {
+                job_id,
+                nodes: nodes.iter().map(|n| n.to_string()).collect(),
+                per_node_alloc,
+            }
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn process_assignment_starts_a_plain_batch_job() {
+            use spur_core::job::JobState;
+
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+            let (addr, _) = spawn_mock_agent().await;
+            register_node_at(&cm, "n1", addr);
+
+            // An explicit --ntasks-per-node so this also covers the "user
+            // supplied one" branch of the effective-tasks-per-node
+            // computation, not just its num_tasks/num_nodes fallback.
+            let mut spec = batch_spec("plain-batch", 1);
+            spec.tasks_per_node = Some(2);
+            let job_id = submit_and_wait(&cm, spec);
+            let started = process_assignment(cm.clone(), assignment(job_id, &["n1"])).await;
+
+            assert!(started, "a clean single-node batch dispatch must start");
+            let job = cm.get_job(job_id).unwrap();
+            assert_eq!(job.state, JobState::Running);
+            assert_eq!(job.allocated_nodes, vec!["n1".to_string()]);
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn process_assignment_returns_false_for_a_job_that_no_longer_exists() {
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+
+            // No submit_job call: this job_id was never assigned, standing in
+            // for an assignment computed against a snapshot that's since gone
+            // stale (e.g. the job was deleted/expired between scheduling and
+            // this call).
+            let started = process_assignment(cm.clone(), assignment(999, &["n1"])).await;
+
+            assert!(!started);
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn process_assignment_aborts_a_plain_batch_job_when_confirmation_fails() {
+            use spur_core::job::JobState;
+
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+            let bad_addr = unreachable_addr().await;
+            register_node_at(&cm, "n1", bad_addr);
+
+            let job_id = submit_and_wait(&cm, batch_spec("plain-batch-unreachable", 1));
+            let started = process_assignment(cm.clone(), assignment(job_id, &["n1"])).await;
+
+            assert!(
+                !started,
+                "a plain batch job must not start if its only node can't be reached"
+            );
+            assert_eq!(cm.get_job(job_id).unwrap().state, JobState::Pending);
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn process_assignment_requeues_srun_batch_fallback_without_a_script() {
+            use spur_core::job::JobState;
+
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+            // Kubernetes-sourced, so srun_step_dispatch is false and this
+            // takes the srun-as-batch-script-fallback branch, which requires
+            // a script.
+            let (addr, _) = spawn_mock_agent().await;
+            register_k8s_node_at(&cm, "k1", addr);
+
+            let mut spec = batch_spec("srun-no-script", 1);
+            spec.srun_job = true;
+            assert!(spec.script.is_none());
+            let job_id = submit_and_wait(&cm, spec);
+
+            let started = process_assignment(cm.clone(), assignment(job_id, &["k1"])).await;
+
+            assert!(
+                !started,
+                "an srun batch fallback with no script must not start"
+            );
+            // requeue_job on a job that never left Pending is a no-op by
+            // design (nothing to unwind), so the meaningful assertion is
+            // that it never started, not a visible state change here.
+            assert_eq!(cm.get_job(job_id).unwrap().state, JobState::Pending);
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn process_assignment_dispatches_srun_batch_fallback_with_a_script() {
+            use spur_core::job::JobState;
+
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+            let (addr, _) = spawn_mock_agent().await;
+            register_k8s_node_at(&cm, "k1", addr);
+
+            let mut spec = batch_spec("srun-with-script", 1);
+            spec.srun_job = true;
+            spec.script = Some("#!/bin/bash\necho hi\n".into());
+            let job_id = submit_and_wait(&cm, spec);
+
+            let started = process_assignment(cm.clone(), assignment(job_id, &["k1"])).await;
+
+            assert!(
+                started,
+                "an srun batch fallback with a script confirms and starts like a plain batch job"
+            );
+            let job = cm.get_job(job_id).unwrap();
+            assert_eq!(job.state, JobState::Running);
+            assert!(
+                !job.srun_step_dispatch,
+                "the batch-script fallback launches like sbatch, not a native srun step"
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn process_assignment_completes_pure_interactive_srun_without_a_launch_job_dispatch()
+        {
+            use spur_core::job::JobState;
+
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+            // NativeHost, so srun_step_dispatch is true: register_allocation_on_nodes
+            // (not this test's mock agent's launch_job) is what has to succeed.
+            let (addr, _) = spawn_mock_agent().await;
+            register_node_at(&cm, "n1", addr);
+
+            let mut spec = batch_spec("pure-interactive", 1);
+            spec.srun_job = true;
+            spec.interactive = true;
+            let job_id = submit_and_wait(&cm, spec);
+
+            let started = process_assignment(cm.clone(), assignment(job_id, &["n1"])).await;
+
+            assert!(
+                started,
+                "a native srun allocation on its own node must start"
+            );
+            let job = cm.get_job(job_id).unwrap();
+            assert_eq!(job.state, JobState::Running);
+            assert!(
+                job.srun_step_dispatch,
+                "the pure interactive path must record itself as step-dispatch, \
+                 not the batch-script fallback"
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn process_assignment_requeues_when_all_srun_allocation_registrations_fail() {
+            use spur_core::job::JobState;
+
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+            let bad_addr = unreachable_addr().await;
+            register_node_at(&cm, "n1", bad_addr);
+
+            let mut spec = batch_spec("srun-alloc-all-fail", 1);
+            spec.srun_job = true;
+            let job_id = submit_and_wait(&cm, spec);
+
+            let started = process_assignment(cm.clone(), assignment(job_id, &["n1"])).await;
+
+            assert!(!started);
+            assert_eq!(cm.get_job(job_id).unwrap().state, JobState::Pending);
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn process_assignment_cancels_the_launched_node_on_partial_srun_allocation_failure() {
+            use spur_core::job::JobState;
+
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+            let (good_addr, cancel_calls) = spawn_mock_agent().await;
+            let bad_addr = unreachable_addr().await;
+            register_node_at(&cm, "n1", good_addr);
+            register_node_at(&cm, "n2", bad_addr);
+
+            let mut spec = batch_spec("srun-alloc-partial-fail", 2);
+            spec.srun_job = true;
+            let job_id = submit_and_wait(&cm, spec);
+
+            let started = process_assignment(cm.clone(), assignment(job_id, &["n1", "n2"])).await;
+
+            assert!(!started);
+            assert_eq!(cm.get_job(job_id).unwrap().state, JobState::Pending);
+            wait_for("n1 registration rolled back with a cancel", || {
+                cancel_calls.load(Ordering::SeqCst) >= 1
+            });
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn process_assignment_cancels_dispatched_nodes_when_start_job_fails_after_confirmation(
+        ) {
+            use spur_core::job::JobState;
+
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+            let (addr1, cancel1) = spawn_mock_agent().await;
+            let (addr2, cancel2) = spawn_mock_agent().await;
+            register_node_at(&cm, "n1", addr1);
+            register_node_at(&cm, "n2", addr2);
+
+            let job_id = submit_and_wait(&cm, batch_spec("start-job-inconsistent", 2));
+
+            // A malformed assignment: confirm_dispatch_on_nodes tolerates a
+            // missing per_node_alloc entry (falls back to a default
+            // allocation), but start_job validates every assigned node has
+            // one and rejects the whole call otherwise. This is what a
+            // scheduler/assignment bug producing inconsistent data — or the
+            // job being touched by another path between assignment and this
+            // call — looks like from here: both nodes already launched real
+            // work by the time start_job is rejected, so both must be torn
+            // back down rather than left running under a job stuck Pending.
+            let mut bad_assignment = assignment(job_id, &["n1", "n2"]);
+            bad_assignment.per_node_alloc.remove("n2");
+
+            let started = process_assignment(cm.clone(), bad_assignment).await;
+
+            assert!(
+                !started,
+                "start_job's own validation must still block on inconsistent per-node data"
+            );
+            assert_eq!(
+                cm.get_job(job_id).unwrap().state,
+                JobState::Pending,
+                "a start_job failure must not leave the job Running with no confirmed nodes"
+            );
+            wait_for(
+                "n1 cancelled after start_job rejected the assignment",
+                || cancel1.load(Ordering::SeqCst) >= 1,
+            );
+            wait_for(
+                "n2 cancelled after start_job rejected the assignment",
+                || cancel2.load(Ordering::SeqCst) >= 1,
+            );
+        }
+
+        fn make_script(body: &str) -> tempfile::TempPath {
+            use std::io::Write;
+            let mut f = tempfile::NamedTempFile::new().unwrap();
+            writeln!(f, "#!/bin/bash\n{}", body).unwrap();
+            let path = f.into_temp_path();
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+            }
+            path
+        }
+
+        fn test_config_with_prolog_slurmctld(script: &std::path::Path) -> SlurmConfig {
+            let mut config = test_config();
+            config.hooks.prolog_slurmctld = Some(script.to_string_lossy().into_owned());
+            config
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn process_assignment_cancels_interactive_job_when_prolog_slurmctld_fails() {
+            use spur_core::job::JobState;
+
+            let script = make_script("exit 1");
+            let dir = TempDir::new().unwrap();
+            let cm =
+                test_cluster_with_config(&dir, test_config_with_prolog_slurmctld(&script)).await;
+            let (addr, cancel_calls) = spawn_mock_agent().await;
+            register_node_at(&cm, "n1", addr);
+
+            let mut spec = batch_spec("prolog-slurmctld-interactive", 1);
+            spec.interactive = true;
+            let job_id = submit_and_wait(&cm, spec);
+
+            let started = process_assignment(cm.clone(), assignment(job_id, &["n1"])).await;
+
+            assert!(
+                !started,
+                "a job whose PrologSlurmctld fails must not count as started"
+            );
+            // Slurm cancels an interactive job here rather than holding it —
+            // holding would strand its waiting srun with nothing to wait for.
+            settle(&cm, job_id, JobState::Cancelled);
+            wait_for("the already-launched node is torn down", || {
+                cancel_calls.load(Ordering::SeqCst) >= 1
+            });
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn process_assignment_requeues_batch_job_when_prolog_slurmctld_fails() {
+            use spur_core::job::JobState;
+
+            let script = make_script("exit 1");
+            let dir = TempDir::new().unwrap();
+            let cm =
+                test_cluster_with_config(&dir, test_config_with_prolog_slurmctld(&script)).await;
+            let (addr, cancel_calls) = spawn_mock_agent().await;
+            register_node_at(&cm, "n1", addr);
+
+            let job_id = submit_and_wait(&cm, batch_spec("prolog-slurmctld-batch", 1));
+
+            let started = process_assignment(cm.clone(), assignment(job_id, &["n1"])).await;
+
+            assert!(
+                !started,
+                "a job whose PrologSlurmctld fails must not count as started"
+            );
+            // Unlike the interactive case, a batch job is requeued (it has no
+            // waiting srun to strand) — it leaves Running, not straight to a
+            // held Pending, since requeue_after_launch_failure's backoff path
+            // routes a Running job through Failed first.
+            settle(&cm, job_id, JobState::Pending);
+            wait_for("the already-launched node is torn down", || {
+                cancel_calls.load(Ordering::SeqCst) >= 1
+            });
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn process_assignment_survives_a_cancel_that_races_prolog_slurmctld_failure() {
+            use spur_core::job::JobState;
+
+            // A deliberate delay so the concurrent cancel below has a real,
+            // generous window to land after start_job (Running) but before
+            // this returns — the same synthetic-delay idiom
+            // spawn_mock_agent_with_delay uses to make a concurrency test
+            // deterministic instead of racy.
+            let script = make_script("sleep 0.2\nexit 1");
+            let dir = TempDir::new().unwrap();
+            let cm =
+                test_cluster_with_config(&dir, test_config_with_prolog_slurmctld(&script)).await;
+            let (addr, _) = spawn_mock_agent().await;
+            register_node_at(&cm, "n1", addr);
+
+            let mut spec = batch_spec("prolog-slurmctld-double-cancel", 1);
+            spec.interactive = true;
+            let job_id = submit_and_wait(&cm, spec);
+
+            let cm_task = cm.clone();
+            let handle = tokio::spawn(async move {
+                process_assignment(cm_task, assignment(job_id, &["n1"])).await
+            });
+
+            // Simulate a concurrent scancel landing while the (delayed)
+            // PrologSlurmctld script is still running: by the time
+            // process_assignment's own interactive-job cancel_job call
+            // fires, the job is already terminal, so that call fails and
+            // must just be logged — not panic or otherwise corrupt the
+            // outcome.
+            settle(&cm, job_id, JobState::Running);
+            cm.cancel_job(job_id, "testuser").unwrap();
+
+            let started = handle.await.unwrap();
+
+            assert!(!started);
+            assert_eq!(
+                cm.get_job(job_id).unwrap().state,
+                JobState::Cancelled,
+                "the job must stay exactly as the earlier, real cancel left it"
+            );
+        }
+
+        // confirm_dispatch_on_nodes's own interactive-prolog-failure cleanup
+        // calls cancel_job — which can itself fail if the job was already
+        // cancelled by something else (e.g. a concurrent scancel) while the
+        // prolog check was in flight. That must not panic or otherwise
+        // corrupt the outcome; it's just logged.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn confirm_dispatch_on_nodes_survives_a_cancel_that_races_prolog_failure() {
+            use spur_core::job::JobState;
+
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+
+            let (addr, _) = spawn_mock_agent_rejecting(Some(
+                spur_proto::proto::LaunchFailureKind::LaunchFailureProlog,
+            ))
+            .await;
+            register_node_at(&cm, "n1", addr);
+
+            let mut spec = batch_spec("prolog-interactive-double-cancel", 1);
+            spec.interactive = true;
+            let job_id = submit_and_wait(&cm, spec);
+
+            // Simulate a concurrent scancel landing before the prolog
+            // rejection is processed: the job is already terminal by the
+            // time confirm_dispatch_on_nodes tries to cancel it itself.
+            cm.cancel_job(job_id, "testuser").unwrap();
+            settle(&cm, job_id, JobState::Cancelled);
+
+            let outcome = confirm_dispatch_pending_job(&cm, job_id, &["n1"]).await;
+
+            assert!(matches!(outcome, DispatchConfirmOutcome::Aborted));
+            assert_eq!(
+                cm.get_job(job_id).unwrap().state,
+                JobState::Cancelled,
+                "the job must stay exactly as the earlier, real cancel left it"
             );
         }
     }

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -254,6 +254,41 @@ async fn process_assignment(
         return false;
     }
 
+    // Run PrologSlurmctld before any node is touched. In Slurm it gates node
+    // access: a failure must abort admission before allocations are registered,
+    // the node prolog (prolog_slurmd) runs, or anything launches. The job is
+    // still Pending here, so a failure just requeues it (batch) or cancels it
+    // (interactive) — nothing on any node to tear down.
+    if let Some(ref prolog_ctld) = cluster.config.hooks.prolog_slurmctld {
+        let ctx = spur_core::hooks::HookContext {
+            job_id: assignment.job_id,
+            work_dir: job.spec.work_dir.clone(),
+            uid: job.spec.uid,
+            gid: job.spec.gid,
+            partition: job.spec.partition.clone().unwrap_or_default(),
+            nodelist: assignment.nodes.join(","),
+            script_context: "prolog_slurmctld".into(),
+            gpu_devices: Vec::new(),
+            cpus: job.spec.cpus_per_task,
+            memory_mb: job.spec.memory_per_node_mb.unwrap_or(0),
+        };
+        if let Err(e) = spur_core::hooks::run_hook(prolog_ctld, &ctx).await {
+            error!(
+                job_id = assignment.job_id,
+                error = %e,
+                "PrologSlurmctld failed"
+            );
+            if job.spec.interactive {
+                if let Err(ce) = cluster.cancel_job(assignment.job_id, &job.spec.user) {
+                    error!(job_id = assignment.job_id, error = %ce, "failed to cancel job after PrologSlurmctld failure");
+                }
+            } else if let Err(re) = cluster.requeue_job(assignment.job_id) {
+                error!(job_id = assignment.job_id, error = %re, "failed to requeue job after PrologSlurmctld failure");
+            }
+            return false;
+        }
+    }
+
     if spec.srun_job && srun_step_dispatch {
         match register_allocation_on_nodes(
             cluster.clone(),
@@ -379,45 +414,6 @@ async fn process_assignment(
             "failed to start job"
         );
         return false;
-    }
-
-    // Run PrologSlurmctld if configured
-    if let Some(ref prolog_ctld) = cluster.config.hooks.prolog_slurmctld {
-        let ctx = spur_core::hooks::HookContext {
-            job_id: assignment.job_id,
-            work_dir: job.spec.work_dir.clone(),
-            uid: job.spec.uid,
-            gid: job.spec.gid,
-            partition: job.spec.partition.clone().unwrap_or_default(),
-            nodelist: assignment.nodes.join(","),
-            script_context: "prolog_slurmctld".into(),
-            gpu_devices: Vec::new(),
-            cpus: job.spec.cpus_per_task,
-            memory_mb: job.spec.memory_per_node_mb.unwrap_or(0),
-        };
-        if let Err(e) = spur_core::hooks::run_hook(prolog_ctld, &ctx).await {
-            error!(
-                job_id = assignment.job_id,
-                error = %e,
-                "PrologSlurmctld failed"
-            );
-            // The job is now Running with real work already dispatched
-            // above (a LaunchJob confirmed on every node, or — for the
-            // pure interactive case — an allocation registered on
-            // every node). Unlike the old post-Running-spawn ordering,
-            // that has already happened by the time we get here, so
-            // it must always be torn down on this path now, regardless
-            // of interactive vs. batch.
-            cancel_job_on_nodes(&cluster, job_id, &dispatch_nodes, 0).await;
-            if job.spec.interactive {
-                if let Err(ce) = cluster.cancel_job(assignment.job_id, &job.spec.user) {
-                    error!(job_id = assignment.job_id, error = %ce, "failed to cancel job after PrologSlurmctld failure");
-                }
-            } else if let Err(re) = cluster.requeue_job(assignment.job_id) {
-                error!(job_id = assignment.job_id, error = %re, "failed to requeue job after PrologSlurmctld failure");
-            }
-            return false;
-        }
     }
 
     true
@@ -3553,9 +3549,13 @@ mod tests {
             // Slurm cancels an interactive job here rather than holding it —
             // holding would strand its waiting srun with nothing to wait for.
             settle(&cm, job_id, JobState::Cancelled);
-            wait_for("the already-launched node is torn down", || {
-                cancel_calls.load(Ordering::SeqCst) >= 1
-            });
+            // PrologSlurmctld runs before dispatch, so no node was ever
+            // launched — there is nothing to tear down.
+            assert_eq!(
+                cancel_calls.load(Ordering::SeqCst),
+                0,
+                "no node should have been launched when PrologSlurmctld fails pre-dispatch"
+            );
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -3578,13 +3578,14 @@ mod tests {
                 "a job whose PrologSlurmctld fails must not count as started"
             );
             // Unlike the interactive case, a batch job is requeued (it has no
-            // waiting srun to strand) — it leaves Running, not straight to a
-            // held Pending, since requeue_after_launch_failure's backoff path
-            // routes a Running job through Failed first.
+            // waiting srun to strand). PrologSlurmctld runs before dispatch, so
+            // the job never left Pending and no node was launched.
             settle(&cm, job_id, JobState::Pending);
-            wait_for("the already-launched node is torn down", || {
-                cancel_calls.load(Ordering::SeqCst) >= 1
-            });
+            assert_eq!(
+                cancel_calls.load(Ordering::SeqCst),
+                0,
+                "no node should have been launched when PrologSlurmctld fails pre-dispatch"
+            );
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -3592,10 +3593,9 @@ mod tests {
             use spur_core::job::JobState;
 
             // A deliberate delay so the concurrent cancel below has a real,
-            // generous window to land after start_job (Running) but before
-            // this returns — the same synthetic-delay idiom
-            // spawn_mock_agent_with_delay uses to make a concurrency test
-            // deterministic instead of racy.
+            // generous window to land while the (pre-dispatch) PrologSlurmctld
+            // script is still running — the same synthetic-delay idiom used to
+            // make a concurrency test deterministic instead of racy.
             let script = make_script("sleep 0.2\nexit 1");
             let dir = TempDir::new().unwrap();
             let cm =
@@ -3614,11 +3614,9 @@ mod tests {
 
             // Simulate a concurrent scancel landing while the (delayed)
             // PrologSlurmctld script is still running: by the time
-            // process_assignment's own interactive-job cancel_job call
-            // fires, the job is already terminal, so that call fails and
-            // must just be logged — not panic or otherwise corrupt the
-            // outcome.
-            settle(&cm, job_id, JobState::Running);
+            // process_assignment's own interactive-job cancel_job call fires,
+            // the job is already terminal, so that call fails and must just be
+            // logged — not panic or otherwise corrupt the outcome.
             cm.cancel_job(job_id, "testuser").unwrap();
 
             let started = handle.await.unwrap();

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -1348,8 +1348,8 @@ async fn confirm_dispatch_on_nodes(
         } else if let Err(e) = cluster.hold_job_for_launch_failure(job_id) {
             error!(job_id, error = %e, "failed to hold job after prolog failure");
         }
-    } else if let Err(e) = cluster.requeue_job(job_id) {
-        error!(job_id, error = %e, "failed to requeue after dispatch confirmation failure");
+    } else if let Err(e) = cluster.backoff_pending_job_after_dispatch_failure(job_id) {
+        error!(job_id, error = %e, "failed to back off after dispatch confirmation failure");
     }
 
     DispatchConfirmOutcome::Aborted
@@ -2971,7 +2971,7 @@ mod tests {
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
         async fn hold_on_prolog_fail_off_retries_the_job_instead() {
-            use spur_core::job::JobState;
+            use spur_core::job::{JobState, PendingReason};
 
             let dir = TempDir::new().unwrap();
             let mut config = test_config();
@@ -2985,23 +2985,24 @@ mod tests {
             register_node_at(&cm, "n1", addr);
 
             let job_id = submit_and_wait(&cm, batch_spec("prolog-retry", 1));
-            let reason_before_dispatch = cm.get_job(job_id).unwrap().pending_reason;
             let outcome = confirm_dispatch_pending_job(&cm, job_id, &["n1"]).await;
             assert!(matches!(outcome, DispatchConfirmOutcome::Aborted));
 
-            // Slurm's nohold_on_prolog_fail: retry rather than hold. Pre-
-            // Running, "retry" is simply leaving the job Pending for the next
-            // scheduler tick (the same simplification
-            // register_allocation_on_nodes's own failure arms already make
-            // for the srun path), rather than the old post-Running
-            // exponential-backoff detour through Failed — that path isn't
-            // reachable from Pending. See confirm_dispatch_on_nodes's doc
-            // comment for the trade-off. The node still drains either way.
+            // Slurm's nohold_on_prolog_fail: retry rather than hold — but
+            // "retry" still means the same bounded backoff any other
+            // non-held dispatch failure gets (backoff_pending_job_after_dispatch_failure),
+            // not an unconditional immediate retry: the node that failed the
+            // prolog is draining anyway, so this job would just land
+            // somewhere else next tick regardless, but a *different* job that
+            // isn't drain-sensitive still needs the backoff to avoid hammering
+            // whatever it lands on. The node drains either way.
             let job = cm.get_job(job_id).unwrap();
             assert_eq!(job.state, JobState::Pending);
-            assert_eq!(
-                job.pending_reason, reason_before_dispatch,
-                "no hold/backoff is applied pre-Running when hold_on_prolog_fail is off"
+            assert_eq!(job.pending_reason, PendingReason::JobLaunchFailure);
+            assert_eq!(job.requeue_count, 1);
+            assert!(
+                job.spec.begin_time.is_some_and(|t| t > chrono::Utc::now()),
+                "nohold_on_prolog_fail retries with a backoff, not an unconditional immediate retry"
             );
             assert!(cm.get_node("n1").unwrap().state.is_admin_hold());
         }
@@ -3036,8 +3037,8 @@ mod tests {
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-        async fn an_unclassified_rejection_keeps_the_plain_requeue_path() {
-            use spur_core::job::JobState;
+        async fn an_unclassified_rejection_backs_off_without_draining_the_node() {
+            use spur_core::job::{JobState, PendingReason};
 
             let dir = TempDir::new().unwrap();
             let cm = test_cluster(&dir).await;
@@ -3050,19 +3051,73 @@ mod tests {
             register_node_at(&cm, "n1", addr);
 
             let job_id = submit_and_wait(&cm, batch_spec("unclassified", 1));
-            let reason_before_dispatch = cm.get_job(job_id).unwrap().pending_reason;
             let outcome = confirm_dispatch_pending_job(&cm, job_id, &["n1"]).await;
             assert!(matches!(outcome, DispatchConfirmOutcome::Aborted));
 
             let job = cm.get_job(job_id).unwrap();
             assert_eq!(job.state, JobState::Pending);
+            // Unlike a prolog rejection (an unconditional hold, since the same
+            // job would fail the same way on any node), an unclassified/
+            // non-prolog failure gets a bounded backoff instead: the job stays
+            // eligible to retry once the hold lapses, but can't be reassigned
+            // to (and fail against) the same still-broken node on literally
+            // the next scheduler tick, forever.
+            assert_eq!(job.pending_reason, PendingReason::JobLaunchFailure);
             assert_eq!(
-                job.pending_reason, reason_before_dispatch,
-                "no hold without a classification"
+                job.requeue_count, 1,
+                "the backoff must count against max_batch_requeue like any other launch failure"
+            );
+            assert!(
+                job.spec.begin_time.is_some_and(|t| t > chrono::Utc::now()),
+                "the backoff hold must defer the job into the future, not just tag it"
             );
             assert!(
                 !cm.get_node("n1").unwrap().state.is_admin_hold(),
                 "an unclassified rejection is not grounds to drain"
+            );
+        }
+
+        // The actual bug this backoff closes: without it, a job whose only
+        // node is unreachable would fail confirmation, land back in
+        // literally the same Pending state, and get reassigned to the same
+        // node on the very next scheduler tick — forever. Drive enough
+        // consecutive failures to cross max_batch_requeue and confirm the
+        // job is held instead of backing off yet again, the same bound a
+        // job that failed after actually reaching Running already gets.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn repeated_dispatch_failures_are_bounded_by_max_batch_requeue() {
+            use spur_core::job::{JobState, PendingReason};
+
+            let dir = TempDir::new().unwrap();
+            let mut config = test_config();
+            config.controller.max_batch_requeue = 2;
+            let cm = test_cluster_with_config(&dir, config).await;
+
+            let bad_addr = unreachable_addr().await;
+            register_node_at(&cm, "n1", bad_addr);
+
+            let job_id = submit_and_wait(&cm, batch_spec("bounded-retry", 1));
+
+            for attempt in 1..=2u32 {
+                let outcome = confirm_dispatch_pending_job(&cm, job_id, &["n1"]).await;
+                assert!(matches!(outcome, DispatchConfirmOutcome::Aborted));
+                let job = cm.get_job(job_id).unwrap();
+                assert_eq!(job.state, JobState::Pending);
+                assert_eq!(job.requeue_count, attempt, "attempt {attempt}");
+                assert_eq!(job.pending_reason, PendingReason::JobLaunchFailure);
+            }
+
+            // The next failure crosses max_batch_requeue: held for an
+            // operator instead of backing off yet again.
+            let outcome = confirm_dispatch_pending_job(&cm, job_id, &["n1"]).await;
+            assert!(matches!(outcome, DispatchConfirmOutcome::Aborted));
+            let job = cm.get_job(job_id).unwrap();
+            assert_eq!(job.state, JobState::Pending);
+            assert_eq!(job.pending_reason, PendingReason::JobHoldMaxRequeue);
+            assert_eq!(job.priority, 0);
+            assert!(
+                !cm.pending_jobs().iter().any(|j| j.job_id == job_id),
+                "a held job must not be scheduled anywhere, closing the retry loop for good"
             );
         }
 
@@ -3178,22 +3233,18 @@ mod tests {
             );
 
             // Every node's LaunchJob is confirmed concurrently, so admission
-            // takes at least one node's launch delay...
+            // takes at least one node's launch delay — proving dispatch
+            // didn't skip the real per-node work rather than proving it ran
+            // concurrently. An absolute upper bound would demonstrate the
+            // latter (that 64 nodes stays near one node's delay instead of
+            // scaling with the sum across nodes), but a wall-clock ceiling
+            // is flaky on a loaded CI box and adds real sleep time to the
+            // suite for a property the eprintln! above already lets a human
+            // eyeball. Left as a manual/eprintln! check rather than an
+            // asserted one.
             assert!(two_nodes >= PER_NODE_LAUNCH_DELAY);
             assert!(eight_nodes >= PER_NODE_LAUNCH_DELAY);
             assert!(sixty_four_nodes >= PER_NODE_LAUNCH_DELAY);
-
-            // ...and, crucially, stays close to it as the node count grows by
-            // 32x (2 -> 64) rather than scaling with the sum across nodes
-            // (which would be ~32x slower, i.e. ~4.8s here). The multiplier
-            // below leaves headroom for scheduler/OS jitter on a loaded box;
-            // it is not evidence of a real per-node cost.
-            assert!(
-                sixty_four_nodes < PER_NODE_LAUNCH_DELAY * 5,
-                "64-node confirmation ({sixty_four_nodes:?}) scaled with node count instead of \
-                 staying near the single-node launch delay ({PER_NODE_LAUNCH_DELAY:?}) — \
-                 dispatch may have serialized instead of running concurrently"
-            );
         }
 
         // ── process_assignment: the glue `run()` awaits per assignment ──

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -2988,14 +2988,8 @@ mod tests {
             let outcome = confirm_dispatch_pending_job(&cm, job_id, &["n1"]).await;
             assert!(matches!(outcome, DispatchConfirmOutcome::Aborted));
 
-            // Slurm's nohold_on_prolog_fail: retry rather than hold — but
-            // "retry" still means the same bounded backoff any other
-            // non-held dispatch failure gets (backoff_pending_job_after_dispatch_failure),
-            // not an unconditional immediate retry: the node that failed the
-            // prolog is draining anyway, so this job would just land
-            // somewhere else next tick regardless, but a *different* job that
-            // isn't drain-sensitive still needs the backoff to avoid hammering
-            // whatever it lands on. The node drains either way.
+            // nohold_on_prolog_fail: retry rather than hold, but "retry" is the
+            // same bounded backoff as any dispatch failure, not an immediate one.
             let job = cm.get_job(job_id).unwrap();
             assert_eq!(job.state, JobState::Pending);
             assert_eq!(job.pending_reason, PendingReason::JobLaunchFailure);
@@ -3056,12 +3050,9 @@ mod tests {
 
             let job = cm.get_job(job_id).unwrap();
             assert_eq!(job.state, JobState::Pending);
-            // Unlike a prolog rejection (an unconditional hold, since the same
-            // job would fail the same way on any node), an unclassified/
-            // non-prolog failure gets a bounded backoff instead: the job stays
-            // eligible to retry once the hold lapses, but can't be reassigned
-            // to (and fail against) the same still-broken node on literally
-            // the next scheduler tick, forever.
+            // A non-prolog failure gets a bounded backoff rather than a drain:
+            // eligible again once the hold lapses, but not reassigned to the
+            // same broken node next tick.
             assert_eq!(job.pending_reason, PendingReason::JobLaunchFailure);
             assert_eq!(
                 job.requeue_count, 1,
@@ -3077,13 +3068,8 @@ mod tests {
             );
         }
 
-        // The actual bug this backoff closes: without it, a job whose only
-        // node is unreachable would fail confirmation, land back in
-        // literally the same Pending state, and get reassigned to the same
-        // node on the very next scheduler tick — forever. Drive enough
-        // consecutive failures to cross max_batch_requeue and confirm the
-        // job is held instead of backing off yet again, the same bound a
-        // job that failed after actually reaching Running already gets.
+        // Repeated failures against an unreachable node must cross
+        // max_batch_requeue and hold the job, not back off forever.
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
         async fn repeated_dispatch_failures_are_bounded_by_max_batch_requeue() {
             use spur_core::job::{JobState, PendingReason};
@@ -3232,16 +3218,9 @@ mod tests {
                  (synthetic per-node launch delay: {PER_NODE_LAUNCH_DELAY:?})"
             );
 
-            // Every node's LaunchJob is confirmed concurrently, so admission
-            // takes at least one node's launch delay — proving dispatch
-            // didn't skip the real per-node work rather than proving it ran
-            // concurrently. An absolute upper bound would demonstrate the
-            // latter (that 64 nodes stays near one node's delay instead of
-            // scaling with the sum across nodes), but a wall-clock ceiling
-            // is flaky on a loaded CI box and adds real sleep time to the
-            // suite for a property the eprintln! above already lets a human
-            // eyeball. Left as a manual/eprintln! check rather than an
-            // asserted one.
+            // Lower bound only: proves per-node work wasn't skipped. Concurrency
+            // (64 nodes near one node's delay) is left to the eprintln! above — a
+            // wall-clock ceiling is flaky under CI load.
             assert!(two_nodes >= PER_NODE_LAUNCH_DELAY);
             assert!(eight_nodes >= PER_NODE_LAUNCH_DELAY);
             assert!(sixty_four_nodes >= PER_NODE_LAUNCH_DELAY);

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -2845,6 +2845,72 @@ mod tests {
         );
     }
 
+    // exec_in_job and create_job_step are what keep job_entry (backing
+    // exec_in_job and interactive_session/attach) and the step-dispatch path
+    // from ever reaching a node before its LaunchJob is confirmed: both
+    // reject here, before any node is even resolved, for a job that hasn't
+    // reached Running. Pin that both gates actually exist and fire, since
+    // confirm_dispatch_on_nodes closing the race for those RPCs depends on
+    // this check never being bypassed or accidentally dropped.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn exec_in_job_rejects_when_job_not_running() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+
+        let spec = spur_core::job::JobSpec {
+            name: "pending-exec".into(),
+            user: "u".into(),
+            num_nodes: 1,
+            num_tasks: 1,
+            cpus_per_task: 1,
+            work_dir: "/tmp".into(),
+            ..Default::default()
+        };
+        let job_id = svc.cluster.submit_job(spec).unwrap();
+
+        let err = svc
+            .exec_in_job(Request::new(ExecInJobRequest {
+                job_id,
+                command: vec!["hostname".into()],
+            }))
+            .await
+            .expect_err("a still-Pending job must not be exec'd into");
+        assert_eq!(err.code(), Code::FailedPrecondition);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn create_job_step_rejects_when_job_not_running() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+
+        let mut spec = spur_core::job::JobSpec {
+            name: "pending-step".into(),
+            user: "u".into(),
+            num_nodes: 1,
+            num_tasks: 1,
+            cpus_per_task: 1,
+            work_dir: "/tmp".into(),
+            ..Default::default()
+        };
+        spec.srun_job = true;
+        let job_id = svc.cluster.submit_job(spec).unwrap();
+
+        let err = svc
+            .create_job_step(Request::new(CreateJobStepRequest {
+                job_id,
+                command: vec!["hostname".into()],
+                num_tasks: 1,
+                cpus_per_task: 1,
+                overlap: true,
+                pty: true,
+                winsize: None,
+                node: String::new(),
+            }))
+            .await
+            .expect_err("a still-Pending job must not accept a new step");
+        assert_eq!(err.code(), Code::FailedPrecondition);
+    }
+
     #[test]
     fn select_step_node_empty_request_uses_first_allocated() {
         let allocated = vec!["node001".to_string(), "node002".to_string()];

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1652,6 +1652,11 @@ impl SlurmAgent for AgentService {
         };
         let step_id = req.step_id;
 
+        // No retry on a miss here: the controller only lets a step reach this
+        // node once the job is visibly Running, and Running is only reached
+        // once every assigned node — this one included — has already
+        // confirmed its LaunchJob (see confirm_dispatch_on_nodes). A miss
+        // therefore means a genuinely wrong job/node pairing, not a race.
         let (gpu_devices, partition, cpus, memory_mb, nodelist, job_mpi) = {
             let jobs = self.running.lock().await;
             let tracked = jobs.get(&job_id).ok_or_else(|| {
@@ -1910,6 +1915,19 @@ impl SlurmAgent for AgentService {
         let req = request.into_inner();
         let job_id = req.job_id;
 
+        // No retry on a miss here, for the same reason as run_command: a job
+        // only becomes visibly Running once every assigned node has
+        // confirmed its LaunchJob (confirm_dispatch_on_nodes), so a caller
+        // that waited for Running before reaching this node has already
+        // missed the window where this could race. Unlike run_command (which
+        // the controller only forwards to a node once it has independently
+        // checked job.state == Running), this RPC has no controller-side
+        // proxy — callers (srun --attach, sattach) call it directly against
+        // the agent after checking job.state themselves. That's still safe
+        // against this race (there is no other, earlier source of "the job
+        // is running" for a caller to have used instead), just worth noting
+        // as a difference from the other lookups in this file.
+        //
         // Look up the output file path from the tracked job
         let file_path = {
             let jobs = self.running.lock().await;
@@ -2427,6 +2445,15 @@ impl AgentService {
     }
 
     /// Extract a `JobEntry` from a tracked running job for namespace entry.
+    ///
+    /// Backs both `exec_in_job` and `interactive_session` (attach). Both are
+    /// only reachable once the controller's own `job.state == Running` check
+    /// passes (`exec_in_job` and `create_job_step` in spurctld/server.rs), and
+    /// that state is only reached once every assigned node — this one
+    /// included — has confirmed its LaunchJob (confirm_dispatch_on_nodes). No
+    /// retry needed here for the same reason run_command's lookup doesn't
+    /// need one: by the time a caller can reach this node at all, the miss
+    /// window is already behind it.
     async fn job_entry(&self, job_id: u32) -> Result<crate::job_entry::JobEntry, Status> {
         let jobs = self.running.lock().await;
         let tracked = jobs

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -92,6 +92,8 @@ async fn cleanup_completed_job_mpi(
 
 pub struct AgentService {
     pub reporter: Arc<NodeReporter>,
+    /// In-memory only: starts empty on every spurd start/restart, regardless
+    /// of whether the controller still reports a job Running from before.
     running: Arc<Mutex<HashMap<u32, TrackedJob>>>,
     allocation: Arc<Mutex<NodeAllocation>>,
     spank: Arc<Option<SpankHost>>,
@@ -1652,11 +1654,17 @@ impl SlurmAgent for AgentService {
         };
         let step_id = req.step_id;
 
-        // No retry on a miss here: the controller only lets a step reach this
-        // node once the job is visibly Running, and Running is only reached
-        // once every assigned node — this one included — has already
-        // confirmed its LaunchJob (see confirm_dispatch_on_nodes). A miss
-        // therefore means a genuinely wrong job/node pairing, not a race.
+        // No retry on a miss here for the launch race this PR fixes: the
+        // controller only lets a step reach this node once the job is
+        // visibly Running, and Running is only reached once every assigned
+        // node — this one included — has already confirmed its LaunchJob
+        // (see confirm_dispatch_on_nodes). That guarantee is specific to
+        // this launch window, though — it does not cover this agent
+        // restarting while the job is still Running: `running` starts empty
+        // on every restart (see its field doc), so a step landing here
+        // between restart and this node's jobs re-registering would still
+        // miss with no retry. That's a separate, out-of-scope gap, not one
+        // this lookup claims to handle.
         let (gpu_devices, partition, cpus, memory_mb, nodelist, job_mpi) = {
             let jobs = self.running.lock().await;
             let tracked = jobs.get(&job_id).ok_or_else(|| {
@@ -1915,18 +1923,21 @@ impl SlurmAgent for AgentService {
         let req = request.into_inner();
         let job_id = req.job_id;
 
-        // No retry on a miss here, for the same reason as run_command: a job
-        // only becomes visibly Running once every assigned node has
-        // confirmed its LaunchJob (confirm_dispatch_on_nodes), so a caller
-        // that waited for Running before reaching this node has already
-        // missed the window where this could race. Unlike run_command (which
-        // the controller only forwards to a node once it has independently
-        // checked job.state == Running), this RPC has no controller-side
-        // proxy — callers (srun --attach, sattach) call it directly against
-        // the agent after checking job.state themselves. That's still safe
-        // against this race (there is no other, earlier source of "the job
-        // is running" for a caller to have used instead), just worth noting
-        // as a difference from the other lookups in this file.
+        // No retry on a miss here for the launch race this PR fixes, for the
+        // same reason as run_command: a job only becomes visibly Running
+        // once every assigned node has confirmed its LaunchJob
+        // (confirm_dispatch_on_nodes), so a caller that waited for Running
+        // before reaching this node has already missed the window where
+        // that specific race could happen. As with run_command's lookup,
+        // this doesn't cover this agent restarting while the job is still
+        // Running (`running` starts empty on restart, independent of what
+        // the controller still reports) — that's a separate, out-of-scope
+        // gap. Unlike run_command (which the controller only forwards to a
+        // node once it has independently checked job.state == Running),
+        // this RPC also has no controller-side proxy of its own — callers
+        // (srun --attach, sattach) call it directly against the agent after
+        // checking job.state themselves, so it inherits whatever guarantee
+        // (or lack of one, in the restart case) that client-side check had.
         //
         // Look up the output file path from the tracked job
         let file_path = {
@@ -2451,9 +2462,13 @@ impl AgentService {
     /// passes (`exec_in_job` and `create_job_step` in spurctld/server.rs), and
     /// that state is only reached once every assigned node — this one
     /// included — has confirmed its LaunchJob (confirm_dispatch_on_nodes). No
-    /// retry needed here for the same reason run_command's lookup doesn't
-    /// need one: by the time a caller can reach this node at all, the miss
-    /// window is already behind it.
+    /// retry needed here for the launch race this PR fixes, for the same
+    /// reason run_command's lookup doesn't need one: by the time a caller
+    /// can reach this node at all, that specific miss window is already
+    /// behind it. This doesn't cover this agent restarting while the job is
+    /// still Running, though — `running` starts empty on restart regardless
+    /// of what the controller still reports — which is a separate,
+    /// out-of-scope gap.
     async fn job_entry(&self, job_id: u32) -> Result<crate::job_entry::JobEntry, Status> {
         let jobs = self.running.lock().await;
         let tracked = jobs

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1654,17 +1654,10 @@ impl SlurmAgent for AgentService {
         };
         let step_id = req.step_id;
 
-        // No retry on a miss here for the launch race this PR fixes: the
-        // controller only lets a step reach this node once the job is
-        // visibly Running, and Running is only reached once every assigned
-        // node — this one included — has already confirmed its LaunchJob
-        // (see confirm_dispatch_on_nodes). That guarantee is specific to
-        // this launch window, though — it does not cover this agent
-        // restarting while the job is still Running: `running` starts empty
-        // on every restart (see its field doc), so a step landing here
-        // between restart and this node's jobs re-registering would still
-        // miss with no retry. That's a separate, out-of-scope gap, not one
-        // this lookup claims to handle.
+        // No retry on a miss: a step only reaches a Running job, i.e. one every
+        // node already confirmed via LaunchJob (confirm_dispatch_on_nodes) — so a
+        // miss is a wrong job/node pairing, not a launch race. The one uncovered
+        // case is a spurd restart mid-job, which starts `running` empty.
         let (gpu_devices, partition, cpus, memory_mb, nodelist, job_mpi) = {
             let jobs = self.running.lock().await;
             let tracked = jobs.get(&job_id).ok_or_else(|| {
@@ -1923,23 +1916,11 @@ impl SlurmAgent for AgentService {
         let req = request.into_inner();
         let job_id = req.job_id;
 
-        // No retry on a miss here for the launch race this PR fixes, for the
-        // same reason as run_command: a job only becomes visibly Running
-        // once every assigned node has confirmed its LaunchJob
-        // (confirm_dispatch_on_nodes), so a caller that waited for Running
-        // before reaching this node has already missed the window where
-        // that specific race could happen. As with run_command's lookup,
-        // this doesn't cover this agent restarting while the job is still
-        // Running (`running` starts empty on restart, independent of what
-        // the controller still reports) — that's a separate, out-of-scope
-        // gap. Unlike run_command (which the controller only forwards to a
-        // node once it has independently checked job.state == Running),
-        // this RPC also has no controller-side proxy of its own — callers
-        // (srun --attach, sattach) call it directly against the agent after
-        // checking job.state themselves, so it inherits whatever guarantee
-        // (or lack of one, in the restart case) that client-side check had.
-        //
-        // Look up the output file path from the tracked job
+        // No retry on a miss, same as run_command: a Running job has been
+        // confirmed on every node (confirm_dispatch_on_nodes). Callers here
+        // (srun --attach, sattach) hit the agent directly with no controller
+        // proxy, so they inherit their own job.state check. Restart mid-job
+        // (empty `running`) is the one uncovered case.
         let file_path = {
             let jobs = self.running.lock().await;
             match jobs.get(&job_id) {
@@ -2457,18 +2438,10 @@ impl AgentService {
 
     /// Extract a `JobEntry` from a tracked running job for namespace entry.
     ///
-    /// Backs both `exec_in_job` and `interactive_session` (attach). Both are
-    /// only reachable once the controller's own `job.state == Running` check
-    /// passes (`exec_in_job` and `create_job_step` in spurctld/server.rs), and
-    /// that state is only reached once every assigned node — this one
-    /// included — has confirmed its LaunchJob (confirm_dispatch_on_nodes). No
-    /// retry needed here for the launch race this PR fixes, for the same
-    /// reason run_command's lookup doesn't need one: by the time a caller
-    /// can reach this node at all, that specific miss window is already
-    /// behind it. This doesn't cover this agent restarting while the job is
-    /// still Running, though — `running` starts empty on restart regardless
-    /// of what the controller still reports — which is a separate,
-    /// out-of-scope gap.
+    /// Backs `exec_in_job` and `interactive_session` (attach), both reachable
+    /// only after the controller's `job.state == Running` check — i.e. every
+    /// node has confirmed LaunchJob (confirm_dispatch_on_nodes) — so no retry
+    /// on a miss. Restart mid-job (empty `running`) is the one uncovered case.
     async fn job_entry(&self, job_id: u32) -> Result<crate::job_entry::JobEntry, Status> {
         let jobs = self.running.lock().await;
         let tracked = jobs


### PR DESCRIPTION
## What

An earlier attempt at this (#544, closed in favor of this PR) widened the retry window for a step (`srun`) that races a node's own dispatch, but the underlying gap is structural — `spurctld` marks a job `Running` (visible to `squeue`/`scontrol`) synchronously as soon as it assigns nodes, then dispatches `LaunchJob` to each node concurrently and out of band via a spawned task. A step targeting a node can therefore still be issued before that node's own launch has actually completed, if the gap ever exceeds a retry budget -- a retry is a mitigation, not a fix for the root timing gap.

## Approach

Batch dispatch (`sbatch`, and the `srun`-as-batch-script fallback) now confirms `LaunchJob` on every assigned node -- awaited, not spawned -- *before* `start_job` is allowed to flip the job to `Running`. This mirrors the pattern `register_allocation_on_nodes` already uses for standalone `srun`/`salloc` allocations, just against the heavier `LaunchJob` RPC (which spawns the actual process) rather than the lighter `RegisterJobAllocation`.

Because the job is now confirmed before it ever becomes visibly `Running`, a dispatch failure is handled as a `Pending`-job admission failure rather than the old `Running -> Failed/NodeFail -> Held` detour:
- A node whose prolog rejected the job is drained, unchanged from before.
- If `hold_on_prolog_fail` applies, the job is held via a new `hold_job_for_launch_failure` (a `Pending`-compatible equivalent of the old post-`Running` hold path, since there's no `Running` state to transition out of here). Interactive jobs are cancelled instead, matching the existing `PrologSlurmctld`-failure behavior.
- Otherwise the job is simply requeued to `Pending` for the next scheduler tick.

One accepted trade-off: a non-prolog dispatch failure pre-`Running` no longer goes through `requeue_after_launch_failure`'s exponential backoff/requeue-count bookkeeping -- it falls through to the next tick immediately, the same simplification `register_allocation_on_nodes`'s own failure arms already make for the `srun` path.

Because every assigned node's `spurd` agent has confirmed and registered the job locally *before* it's ever visible as `Running` anywhere, this closes the race at its root for every consumer that looks the job up post-`Running` -- not just the `srun`-step case #544 targeted, but also `srun --attach` and `exec_in_job`, which had the identical unguarded-lookup pattern.

## Behavior change

Job admission for multi-node batch jobs now waits for every node's `LaunchJob` to resolve before the job appears `Running`. Measured with a synthetic multi-node test (mocked per-node launch delay): added latency tracks the slowest single node, not the sum across nodes -- ~155ms at 2 nodes, ~178ms at 64 nodes in that harness. A partial dispatch failure now aborts admission cleanly (hold/requeue while still `Pending`) instead of a job reaching `Running` with only some nodes actually launched.

## Testing

`cargo fmt --all --check`, `cargo clippy --all-targets --locked -- -D warnings`, and `cargo test --locked` all pass, including a synthetic latency test and a rewritten dispatch-failure test suite covering the new pre-`Running` hold/requeue semantics.