### PR TITLE
fix(auth): enforce job ownership on exec, attach, and output streaming

### DIFF
--- a/crates/spur-cli/src/exec.rs
+++ b/crates/spur-cli/src/exec.rs
@@ -46,6 +46,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         .exec_in_job(ExecInJobRequest {
             job_id: args.job_id,
             command: args.command.clone(),
+            user: crate::interactive::current_user(),
         })
         .await
         .context("exec failed")?;

--- a/crates/spur-cli/src/interactive.rs
+++ b/crates/spur-cli/src/interactive.rs
@@ -19,10 +19,10 @@ pub async fn connect_agent(addr: &str) -> Result<SlurmAgentClient<tonic::transpo
 }
 
 /// Local username sent with exec/attach requests so the server can enforce job
-/// ownership. Falls back to a non-matching placeholder so lookup failure denies
-/// access rather than granting it.
+/// ownership. The fallback is deliberately not a legal UNIX username, so a
+/// lookup failure cannot collide with a real account and grant access.
 pub fn current_user() -> String {
-    whoami::username().unwrap_or_else(|_| "unknown".into())
+    whoami::username().unwrap_or_else(|_| "<lookup-failed>".into())
 }
 
 pub fn get_terminal_size() -> spur_proto::proto::WindowSize {

--- a/crates/spur-cli/src/interactive.rs
+++ b/crates/spur-cli/src/interactive.rs
@@ -18,6 +18,13 @@ pub async fn connect_agent(addr: &str) -> Result<SlurmAgentClient<tonic::transpo
         .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE))
 }
 
+/// Local username sent with exec/attach requests so the server can enforce job
+/// ownership. Falls back to a non-matching placeholder so lookup failure denies
+/// access rather than granting it.
+pub fn current_user() -> String {
+    whoami::username().unwrap_or_else(|_| "unknown".into())
+}
+
 pub fn get_terminal_size() -> spur_proto::proto::WindowSize {
     let (cols, rows) = crossterm::terminal::size().unwrap_or((80, 24));
     spur_proto::proto::WindowSize {
@@ -54,6 +61,7 @@ pub async fn open_interactive_session(
             winsize: Some(winsize),
             argv,
             env: HashMap::new(),
+            user: current_user(),
         })),
     };
 

--- a/crates/spur-cli/src/sattach.rs
+++ b/crates/spur-cli/src/sattach.rs
@@ -95,6 +95,7 @@ async fn stream_output_only(
         .stream_job_output(StreamJobOutputRequest {
             job_id,
             stream: stream_name.to_string(),
+            user: crate::interactive::current_user(),
         })
         .await
         .context("failed to start output stream")?

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -726,6 +726,7 @@ async fn dispatch_step(
             pty: false,
             winsize: None,
             node: String::new(),
+            user: crate::interactive::current_user(),
         })
         .await
         .context("failed to create job step")?
@@ -1007,6 +1008,7 @@ async fn try_stream_output(
         .stream_job_output(StreamJobOutputRequest {
             job_id,
             stream: "stdout".into(),
+            user: crate::interactive::current_user(),
         })
         .await
     {
@@ -1219,6 +1221,7 @@ async fn run_interactive_pty(
                     pty: true,
                     winsize: Some(winsize),
                     node: node.clone(),
+                    user: crate::interactive::current_user(),
                 })
                 .await
             {

--- a/crates/spur-core/src/auth.rs
+++ b/crates/spur-core/src/auth.rs
@@ -88,13 +88,12 @@ impl Identity {
 
 /// Check that `user` is allowed to perform `action` on a job owned by `owner`.
 ///
-/// Allows the owner, root, an empty `user` (daemon calls and clients predating
-/// the identity field), and an empty `owner` (an unattributed job matches no
-/// caller, so denying would lock out its real owner rather than an intruder).
-/// A non-empty placeholder owner is not covered by that last rule and so stays
-/// restricted to root.
+/// Allows the owner, root, or an empty `user` (daemon calls and clients
+/// predating the identity field). Jobs with an empty owner are restricted to
+/// root only, since they run as root and granting access to any caller would
+/// be a privilege escalation.
 pub fn check_job_owner(user: &str, owner: &str, action: &str) -> Result<(), AuthError> {
-    if user.is_empty() || owner.is_empty() || user == "root" || user == owner {
+    if user.is_empty() || user == "root" || user == owner {
         return Ok(());
     }
     Err(AuthError::NotJobOwner {
@@ -249,14 +248,16 @@ mod tests {
         );
     }
 
-    /// A job with no recorded submitter must stay reachable by its real owner.
-    /// Reachable via REST submission without `user`, and via an allocation
-    /// registered by a controller predating the identity field.
+    /// Jobs with an empty owner run as root, so only root and daemon (empty
+    /// user) are allowed. A regular user must be denied.
     #[test]
-    fn test_check_job_owner_allows_any_user_when_owner_unrecorded() {
-        assert!(check_job_owner("alice", "", "exec").is_ok());
-        assert!(check_job_owner("bob", "", "attach to").is_ok());
+    fn test_check_job_owner_empty_owner_restricts_to_root() {
+        assert!(check_job_owner("root", "", "exec").is_ok());
         assert!(check_job_owner("", "", "exec").is_ok());
+        assert!(
+            check_job_owner("alice", "", "exec").is_err(),
+            "empty-owner jobs run as root; granting access is a privilege escalation"
+        );
     }
 
     /// A non-empty placeholder owner matches no caller, so it restricts the job

--- a/crates/spur-core/src/auth.rs
+++ b/crates/spur-core/src/auth.rs
@@ -92,8 +92,15 @@ impl Identity {
 /// before the identity field existed send nothing; root is an admin override.
 /// Callers that reach this from a self-reported client field get only as much
 /// assurance as that field carries.
+///
+/// An empty `owner` is also accepted: a job whose submitter was never recorded
+/// (REST submission without `user`, or an allocation registered by a controller
+/// predating the field) is unattributable, so it cannot be matched against any
+/// caller. Denying it would lock the real owner out of their own job instead of
+/// stopping an intruder. Note this reasoning does not extend to a non-empty
+/// placeholder owner, which matches nobody and so restricts the job to root.
 pub fn check_job_owner(user: &str, owner: &str, action: &str) -> Result<(), AuthError> {
-    if user.is_empty() || user == "root" || user == owner {
+    if user.is_empty() || owner.is_empty() || user == "root" || user == owner {
         return Ok(());
     }
     Err(AuthError::NotJobOwner {
@@ -245,6 +252,29 @@ mod tests {
             err.to_string(),
             "user bob cannot exec job owned by alice",
             "message names the requester, action, and owner"
+        );
+    }
+
+    /// A job with no recorded submitter must stay reachable by its real owner.
+    /// Reachable via REST submission without `user`, and via an allocation
+    /// registered by a controller predating the identity field.
+    #[test]
+    fn test_check_job_owner_allows_any_user_when_owner_unrecorded() {
+        assert!(check_job_owner("alice", "", "exec").is_ok());
+        assert!(check_job_owner("bob", "", "attach to").is_ok());
+        assert!(check_job_owner("", "", "exec").is_ok());
+    }
+
+    /// A non-empty placeholder owner matches no caller, so it restricts the job
+    /// to root. Asserted so that introducing such a placeholder cannot silently
+    /// lock users out of their own jobs.
+    #[test]
+    fn test_check_job_owner_placeholder_owner_restricts_to_root() {
+        assert!(check_job_owner("root", "k8s", "exec").is_ok());
+        assert!(
+            check_job_owner("alice", "k8s", "exec").is_err(),
+            "a placeholder owner denies every named user; record the real \
+             submitter or leave the owner empty instead"
         );
     }
 

--- a/crates/spur-core/src/auth.rs
+++ b/crates/spur-core/src/auth.rs
@@ -86,6 +86,23 @@ impl Identity {
     }
 }
 
+/// Check that `user` is allowed to perform `action` on a job owned by `owner`.
+///
+/// An empty `user` is accepted because daemon-to-daemon calls and clients from
+/// before the identity field existed send nothing; root is an admin override.
+/// Callers that reach this from a self-reported client field get only as much
+/// assurance as that field carries.
+pub fn check_job_owner(user: &str, owner: &str, action: &str) -> Result<(), AuthError> {
+    if user.is_empty() || user == "root" || user == owner {
+        return Ok(());
+    }
+    Err(AuthError::NotJobOwner {
+        user: user.into(),
+        owner: owner.into(),
+        action: action.into(),
+    })
+}
+
 /// JWT token claims.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TokenClaims {
@@ -211,6 +228,24 @@ mod tests {
         let id = Identity::admin();
         assert!(id.can_cancel_job("alice").is_ok());
         assert!(id.can_cancel_job("bob").is_ok());
+    }
+
+    #[test]
+    fn test_check_job_owner_allows_owner_root_and_daemon() {
+        assert!(check_job_owner("alice", "alice", "exec").is_ok());
+        assert!(check_job_owner("root", "alice", "exec").is_ok());
+        assert!(check_job_owner("", "alice", "exec").is_ok());
+    }
+
+    #[test]
+    fn test_check_job_owner_rejects_other_user() {
+        let err = check_job_owner("bob", "alice", "exec").expect_err("bob must be denied");
+        assert!(matches!(err, AuthError::NotJobOwner { .. }));
+        assert_eq!(
+            err.to_string(),
+            "user bob cannot exec job owned by alice",
+            "message names the requester, action, and owner"
+        );
     }
 
     #[test]

--- a/crates/spur-core/src/auth.rs
+++ b/crates/spur-core/src/auth.rs
@@ -88,17 +88,11 @@ impl Identity {
 
 /// Check that `user` is allowed to perform `action` on a job owned by `owner`.
 ///
-/// An empty `user` is accepted because daemon-to-daemon calls and clients from
-/// before the identity field existed send nothing; root is an admin override.
-/// Callers that reach this from a self-reported client field get only as much
-/// assurance as that field carries.
-///
-/// An empty `owner` is also accepted: a job whose submitter was never recorded
-/// (REST submission without `user`, or an allocation registered by a controller
-/// predating the field) is unattributable, so it cannot be matched against any
-/// caller. Denying it would lock the real owner out of their own job instead of
-/// stopping an intruder. Note this reasoning does not extend to a non-empty
-/// placeholder owner, which matches nobody and so restricts the job to root.
+/// Allows the owner, root, an empty `user` (daemon calls and clients predating
+/// the identity field), and an empty `owner` (an unattributed job matches no
+/// caller, so denying would lock out its real owner rather than an intruder).
+/// A non-empty placeholder owner is not covered by that last rule and so stays
+/// restricted to root.
 pub fn check_job_owner(user: &str, owner: &str, action: &str) -> Result<(), AuthError> {
     if user.is_empty() || owner.is_empty() || user == "root" || user == owner {
         return Ok(());

--- a/crates/spur-tests/src/t50_core.rs
+++ b/crates/spur-tests/src/t50_core.rs
@@ -963,6 +963,7 @@ address = "http://peer-a:6817"
         let req = spur_proto::proto::ExecInJobRequest {
             job_id: 42,
             command: vec!["ls".into(), "-la".into()],
+            user: "alice".into(),
         };
         assert_eq!(req.job_id, 42);
         assert_eq!(req.command.len(), 2);
@@ -988,6 +989,7 @@ address = "http://peer-a:6817"
                     }),
                     argv: vec!["/bin/bash".into()],
                     env: HashMap::new(),
+                    user: "alice".into(),
                 },
             )),
         };

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -647,7 +647,7 @@ impl ClusterManager {
     }
 
     /// Check that `user` is allowed to perform `action` on a job owned by `owner`.
-    /// Empty user (internal/daemon calls) and root are always allowed.
+    /// Delegates to [`spur_core::auth::check_job_owner`]; see there for the bypass rules.
     fn check_job_owner(user: &str, owner: &str, action: &str) -> anyhow::Result<()> {
         spur_core::auth::check_job_owner(user, owner, action).map_err(Into::into)
     }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -13,7 +13,6 @@ use tracing::{debug, info, warn};
 
 use spur_core::account_limits::{check_account_limits, AccountCheckResult};
 use spur_core::accounting::{Qos, TresRecord, TresType};
-use spur_core::auth::AuthError;
 use spur_core::burst_buffer::BbStageState;
 use spur_core::config::SlurmConfig;
 use spur_core::job::{
@@ -650,15 +649,7 @@ impl ClusterManager {
     /// Check that `user` is allowed to perform `action` on a job owned by `owner`.
     /// Empty user (internal/daemon calls) and root are always allowed.
     fn check_job_owner(user: &str, owner: &str, action: &str) -> anyhow::Result<()> {
-        if user.is_empty() || user == "root" || user == owner {
-            return Ok(());
-        }
-        Err(AuthError::NotJobOwner {
-            user: user.into(),
-            owner: owner.into(),
-            action: action.into(),
-        }
-        .into())
+        spur_core::auth::check_job_owner(user, owner, action).map_err(Into::into)
     }
 
     /// Cancel a job. The requesting `user` must be the job owner, root, or

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -1053,6 +1053,7 @@ struct AllocationRegisterParams {
     partition: String,
     uid: u32,
     gid: u32,
+    user: String,
     mpi: String,
     allocated_nodelist: String,
     allocated: spur_core::resource::ResourceAllocations,
@@ -1087,6 +1088,7 @@ async fn register_allocation_to_agent(
             allocated: Some(crate::server::allocations_to_proto(&params.allocated)),
             mpi: params.mpi.clone(),
             work_dir: params.work_dir.clone(),
+            user: params.user.clone(),
         })
         .await?;
 
@@ -1147,6 +1149,7 @@ async fn register_allocation_on_nodes(
             partition: spec.partition.clone().unwrap_or_default(),
             uid: spec.uid,
             gid: spec.gid,
+            user: spec.user.clone(),
             mpi: spec.mpi.clone().unwrap_or_default(),
             allocated_nodelist: allocated_nodelist.clone(),
             allocated,

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1380,6 +1380,9 @@ impl SlurmController for ControllerService {
             .get_job(job_id)
             .ok_or_else(|| Status::not_found(format!("job {} not found", job_id)))?;
 
+        spur_core::auth::check_job_owner(&req.user, &job.spec.user, "attach to")
+            .map_err(|e| Status::permission_denied(e.to_string()))?;
+
         if job.state != spur_core::job::JobState::Running {
             return Err(Status::failed_precondition(format!(
                 "job {} is not running (state: {:?})",
@@ -1601,6 +1604,9 @@ impl SlurmController for ControllerService {
             .get_job(job_id)
             .ok_or_else(|| Status::not_found(format!("job {} not found", job_id)))?;
 
+        spur_core::auth::check_job_owner(&req.user, &job.spec.user, "exec into")
+            .map_err(|e| Status::permission_denied(e.to_string()))?;
+
         if job.state != spur_core::job::JobState::Running {
             return Err(Status::failed_precondition(format!(
                 "job {} is not running (state: {})",
@@ -1632,6 +1638,7 @@ impl SlurmController for ControllerService {
             .exec_in_job(ExecInJobRequest {
                 job_id,
                 command: req.command,
+                user: req.user,
             })
             .await
             .map_err(|e| Status::internal(format!("exec failed: {}", e)))?;
@@ -2995,6 +3002,7 @@ mod tests {
                     pty: true,
                     winsize: None,
                     node: "ghost".into(),
+                    user: "u".into(),
                 }))
                 .await
                 .expect_err("unregistered target must fail");
@@ -3034,6 +3042,7 @@ mod tests {
             .exec_in_job(Request::new(ExecInJobRequest {
                 job_id,
                 command: vec!["hostname".into()],
+                user: "u".into(),
             }))
             .await
             .expect_err("a still-Pending job must not be exec'd into");
@@ -3061,16 +3070,166 @@ mod tests {
             .create_job_step(Request::new(CreateJobStepRequest {
                 job_id,
                 command: vec!["hostname".into()],
+                user: "u".into(),
                 num_tasks: 1,
                 cpus_per_task: 1,
                 overlap: true,
-                pty: true,
+                pty: false,
                 winsize: None,
                 node: String::new(),
             }))
             .await
             .expect_err("a still-Pending job must not accept a new step");
         assert_eq!(err.code(), Code::FailedPrecondition);
+    }
+
+    /// Submit and start a single-node job owned by `owner`, returning its id.
+    async fn running_job_owned_by(svc: &ControllerService, owner: &str) -> u32 {
+        use spur_core::resource::{ResourceAllocations, ResourceSet};
+
+        svc.cluster
+            .register_node(
+                "n1".into(),
+                "n1".into(),
+                ResourceSet {
+                    cpus: 8,
+                    memory_mb: 16000,
+                    ..Default::default()
+                },
+                "127.0.0.1".into(),
+                6818,
+                String::new(),
+                String::new(),
+                spur_core::node::NodeSource::NativeHost,
+                std::collections::HashMap::new(),
+            )
+            .unwrap();
+        for _ in 0..200 {
+            if svc.cluster.get_node("n1").is_some() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+
+        let spec = spur_core::job::JobSpec {
+            name: "owned".into(),
+            user: owner.into(),
+            num_nodes: 1,
+            num_tasks: 1,
+            cpus_per_task: 1,
+            work_dir: "/tmp".into(),
+            ..Default::default()
+        };
+        let job_id = svc.cluster.submit_job(spec).unwrap();
+
+        let res = ResourceAllocations::with_scalar(1, 1000);
+        let per_node: std::collections::HashMap<_, _> =
+            [("n1".to_string(), res.clone())].into_iter().collect();
+        svc.cluster
+            .start_job(job_id, vec!["n1".into()], res, per_node)
+            .unwrap();
+        for _ in 0..200 {
+            if svc.cluster.get_job(job_id).map(|j| j.state) == Some(JobState::Running) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+
+        job_id
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn exec_in_job_denies_non_owner() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let job_id = running_job_owned_by(&svc, "ubuntu").await;
+
+        let err = svc
+            .exec_in_job(Request::new(ExecInJobRequest {
+                job_id,
+                command: vec!["whoami".into()],
+                user: "rsikande".into(),
+            }))
+            .await
+            .expect_err("a non-owner must not exec inside another user's job");
+
+        assert_eq!(err.code(), Code::PermissionDenied);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn create_job_step_denies_non_owner() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let job_id = running_job_owned_by(&svc, "ubuntu").await;
+
+        let steps_before = svc.cluster.get_steps(job_id).len();
+        let err = svc
+            .create_job_step(Request::new(CreateJobStepRequest {
+                job_id,
+                command: vec!["bash".into()],
+                num_tasks: 1,
+                cpus_per_task: 1,
+                overlap: true,
+                pty: true,
+                winsize: None,
+                node: String::new(),
+                user: "rsikande".into(),
+            }))
+            .await
+            .expect_err("a non-owner must not attach to another user's job");
+
+        assert_eq!(err.code(), Code::PermissionDenied);
+        assert_eq!(
+            svc.cluster.get_steps(job_id).len(),
+            steps_before,
+            "a denied attach must not leave a step behind"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn create_job_step_allows_owner() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let job_id = running_job_owned_by(&svc, "ubuntu").await;
+
+        let resp = svc
+            .create_job_step(Request::new(CreateJobStepRequest {
+                job_id,
+                command: vec!["bash".into()],
+                num_tasks: 1,
+                cpus_per_task: 1,
+                overlap: true,
+                pty: true,
+                winsize: None,
+                node: String::new(),
+                user: "ubuntu".into(),
+            }))
+            .await
+            .expect("the owner must be allowed to attach");
+
+        assert_eq!(resp.into_inner().node_addr, "127.0.0.1:6818");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn exec_in_job_allows_caller_when_owner_unrecorded() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let job_id = running_job_owned_by(&svc, "").await;
+
+        let err = svc
+            .exec_in_job(Request::new(ExecInJobRequest {
+                job_id,
+                command: vec!["whoami".into()],
+                user: "anybody".into(),
+            }))
+            .await
+            .expect_err("job is running but no agent is listening");
+
+        assert_ne!(
+            err.code(),
+            Code::PermissionDenied,
+            "empty owner must not trigger auth denial"
+        );
     }
 
     async fn assign_ha_control_plane(svc: &ControllerService) {

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -3156,6 +3156,28 @@ mod tests {
         assert_eq!(err.code(), Code::PermissionDenied);
     }
 
+    /// A REST submission omitting `user` records no owner. Such a job must stay
+    /// reachable rather than becoming root-only.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn exec_in_job_allows_caller_when_owner_unrecorded() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let job_id = running_job_owned_by(&svc, "").await;
+
+        // The ownership gate must pass; dispatch to the fake agent still fails.
+        let code = svc
+            .exec_in_job(Request::new(ExecInJobRequest {
+                job_id,
+                command: vec!["whoami".into()],
+                user: "alice".into(),
+            }))
+            .await
+            .err()
+            .map(|e| e.code());
+
+        assert_ne!(code, Some(Code::PermissionDenied));
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn create_job_step_denies_non_owner() {
         let dir = tempfile::TempDir::new().unwrap();
@@ -3208,28 +3230,6 @@ mod tests {
             .expect("the owner must be allowed to attach");
 
         assert_eq!(resp.into_inner().node_addr, "127.0.0.1:6818");
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn exec_in_job_allows_caller_when_owner_unrecorded() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let svc = test_service(&dir).await;
-        let job_id = running_job_owned_by(&svc, "").await;
-
-        let err = svc
-            .exec_in_job(Request::new(ExecInJobRequest {
-                job_id,
-                command: vec!["whoami".into()],
-                user: "anybody".into(),
-            }))
-            .await
-            .expect_err("job is running but no agent is listening");
-
-        assert_ne!(
-            err.code(),
-            Code::PermissionDenied,
-            "empty owner must not trigger auth denial"
-        );
     }
 
     async fn assign_ha_control_plane(svc: &ControllerService) {

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -3156,26 +3156,24 @@ mod tests {
         assert_eq!(err.code(), Code::PermissionDenied);
     }
 
-    /// A REST submission omitting `user` records no owner. Such a job must stay
-    /// reachable rather than becoming root-only.
+    /// A REST submission omitting `user` records no owner. Such a job runs as
+    /// root, so non-root users must be denied to prevent privilege escalation.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn exec_in_job_allows_caller_when_owner_unrecorded() {
+    async fn exec_in_job_denies_non_root_on_empty_owner_job() {
         let dir = tempfile::TempDir::new().unwrap();
         let svc = test_service(&dir).await;
         let job_id = running_job_owned_by(&svc, "").await;
 
-        // The ownership gate must pass; dispatch to the fake agent still fails.
-        let code = svc
+        let err = svc
             .exec_in_job(Request::new(ExecInJobRequest {
                 job_id,
                 command: vec!["whoami".into()],
                 user: "alice".into(),
             }))
             .await
-            .err()
-            .map(|e| e.code());
+            .expect_err("empty-owner jobs run as root; non-root must be denied");
 
-        assert_ne!(code, Some(Code::PermissionDenied));
+        assert_eq!(err.code(), Code::PermissionDenied);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -43,6 +43,9 @@ struct TrackedJob {
     work_dir: String,
     uid: u32,
     gid: u32,
+    /// Owning username, used to gate exec/attach requests that arrive straight
+    /// at the agent without passing through the controller.
+    user: String,
     partition: String,
     gpu_devices: Vec<u32>,
     cpus: u32,
@@ -1364,6 +1367,7 @@ impl SlurmAgent for AgentService {
                         work_dir: launch_cfg.work_dir,
                         uid: launch_cfg.uid,
                         gid: launch_cfg.gid,
+                        user: launch_cfg.user,
                         partition: launch_cfg.partition,
                         gpu_devices: launch_cfg.gpu_devices,
                         cpus: launch_cfg.cpus,
@@ -1476,6 +1480,9 @@ impl SlurmAgent for AgentService {
         request: Request<ExecInJobRequest>,
     ) -> Result<Response<ExecInJobResponse>, Status> {
         let req = request.into_inner();
+
+        self.check_job_access(req.job_id, &req.user, "exec into")
+            .await?;
 
         let entry = self.job_entry(req.job_id).await?;
 
@@ -1614,6 +1621,7 @@ impl SlurmAgent for AgentService {
                 work_dir: req.work_dir.clone(),
                 uid: req.uid,
                 gid: req.gid,
+                user: req.user,
                 partition: req.partition,
                 gpu_devices: controller_gpu_ids,
                 cpus,
@@ -1923,6 +1931,9 @@ impl SlurmAgent for AgentService {
         let req = request.into_inner();
         let job_id = req.job_id;
 
+        self.check_job_access(job_id, &req.user, "read output of")
+            .await?;
+
         // No retry on a miss, same as run_command: a Running job has been
         // confirmed on every node (confirm_dispatch_on_nodes). Callers here
         // (srun --attach, sattach) hit the agent directly with no controller
@@ -2030,6 +2041,9 @@ impl SlurmAgent for AgentService {
                 ));
             }
         };
+
+        self.check_job_access(init.job_id, &init.user, "attach to")
+            .await?;
 
         let entry = self.job_entry(init.job_id).await?;
 
@@ -2443,6 +2457,20 @@ impl AgentService {
         });
     }
 
+    /// Reject `user` unless they own job `job_id`.
+    ///
+    /// Enforced here as well as on the controller because `sattach` and the
+    /// output stream dial the agent's port directly.
+    async fn check_job_access(&self, job_id: u32, user: &str, action: &str) -> Result<(), Status> {
+        let jobs = self.running.lock().await;
+        let tracked = jobs
+            .get(&job_id)
+            .ok_or_else(|| Status::not_found(format!("job {} not running on this node", job_id)))?;
+
+        spur_core::auth::check_job_owner(user, &tracked.user, action)
+            .map_err(|e| Status::permission_denied(e.to_string()))
+    }
+
     /// Extract a `JobEntry` from a tracked running job for namespace entry.
     ///
     /// Backs `exec_in_job` and `interactive_session` (attach), both reachable
@@ -2781,9 +2809,11 @@ impl TrackedJob {
     fn dummy(_pid: u32) -> Self {
         // Spawn in its own process group, matching how real managed jobs are
         // launched, so group-targeted signals (kill_signal) land correctly.
+        // kill_on_drop keeps the long sleep from outliving the test that owns it.
         let child = tokio::process::Command::new("sleep")
             .arg("3600")
             .process_group(0)
+            .kill_on_drop(true)
             .spawn()
             .expect("failed to spawn dummy process");
         Self {
@@ -2801,6 +2831,7 @@ impl TrackedJob {
             work_dir: "/tmp".into(),
             uid: 0,
             gid: 0,
+            user: "testuser".into(),
             partition: String::new(),
             gpu_devices: Vec::new(),
             cpus: 1,
@@ -3067,6 +3098,7 @@ mod tests {
         let req = Request::new(ExecInJobRequest {
             job_id: 42,
             command: vec!["echo".into(), "hello".into()],
+            user: "testuser".into(),
         });
 
         let result = svc.exec_in_job(req).await;
@@ -3085,10 +3117,83 @@ mod tests {
         let req = Request::new(ExecInJobRequest {
             job_id: 999,
             command: vec!["echo".into()],
+            user: "testuser".into(),
         });
 
         let err = svc.exec_in_job(req).await.unwrap_err();
         assert_eq!(err.code(), tonic::Code::NotFound);
+    }
+
+    #[tokio::test]
+    async fn exec_in_job_rejects_non_owner() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        svc.insert_test_job(43, TrackedJob::dummy(std::process::id()))
+            .await;
+
+        let err = svc
+            .exec_in_job(Request::new(ExecInJobRequest {
+                job_id: 43,
+                command: vec!["whoami".into()],
+                user: "intruder".into(),
+            }))
+            .await
+            .expect_err("a non-owner must not exec inside another user's job");
+
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    #[tokio::test]
+    async fn stream_job_output_rejects_non_owner() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        svc.insert_test_job(44, TrackedJob::dummy(std::process::id()))
+            .await;
+
+        let err = svc
+            .stream_job_output(Request::new(StreamJobOutputRequest {
+                job_id: 44,
+                stream: "stdout".into(),
+                user: "intruder".into(),
+            }))
+            .await
+            .expect_err("a non-owner must not read another user's job output");
+
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+    }
+
+    #[tokio::test]
+    async fn exec_in_job_allows_owner() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        svc.insert_test_job(45, TrackedJob::dummy(std::process::id()))
+            .await;
+
+        // The owner clears the gate; the exec itself may still fail in a test
+        // sandbox, so only the absence of PermissionDenied is asserted.
+        let code = svc
+            .exec_in_job(Request::new(ExecInJobRequest {
+                job_id: 45,
+                command: vec!["echo".into(), "hello".into()],
+                user: "testuser".into(),
+            }))
+            .await
+            .err()
+            .map(|e| e.code());
+
+        assert_ne!(code, Some(tonic::Code::PermissionDenied));
     }
 
     // --- srun step dispatch via RunCommand ---
@@ -4247,6 +4352,7 @@ mod tests {
             work_dir: "/tmp".into(),
             uid: 0,
             gid: 0,
+            user: "testuser".into(),
             partition: String::new(),
             gpu_devices: Vec::new(),
             cpus: 1,
@@ -4279,8 +4385,8 @@ mod tests {
         // No monitor: this test asserts the grace timer's epoch guard directly,
         // so nothing should reap the job out from under it.
 
-        // SIGTERM-trapping process so epoch 1 survives its cancel; built inline
-        // (not via dummy(), which would leak its own sleep child).
+        // SIGTERM-trapping process so epoch 1 survives its cancel; dummy()'s
+        // plain sleep would die on the first SIGTERM.
         fn spawn_trap(run_attempt: u32) -> (TrackedJob, i32) {
             let child = tokio::process::Command::new("/bin/sh")
                 .args(["-c", "trap '' TERM; while true; do sleep 1; done"])
@@ -4306,6 +4412,7 @@ mod tests {
                 work_dir: "/tmp".into(),
                 uid: 0,
                 gid: 0,
+                user: "testuser".into(),
                 partition: String::new(),
                 gpu_devices: Vec::new(),
                 cpus: 1,

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -3196,6 +3196,59 @@ mod tests {
         assert_ne!(code, Some(tonic::Code::PermissionDenied));
     }
 
+    /// `interactive_session` (the `sattach` and `srun --pty` path) gates on
+    /// `check_job_access`, but its handler consumes a gRPC stream that cannot be
+    /// built in-process, so the gate is exercised directly here.
+    #[tokio::test]
+    async fn check_job_access_gates_attach_by_owner() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        svc.insert_test_job(46, TrackedJob::dummy(std::process::id()))
+            .await;
+
+        svc.check_job_access(46, "testuser", "attach to")
+            .await
+            .expect("the owner must be allowed to attach");
+        svc.check_job_access(46, "root", "attach to")
+            .await
+            .expect("root is an admin override");
+
+        let err = svc
+            .check_job_access(46, "intruder", "attach to")
+            .await
+            .expect_err("a non-owner must not attach to another user's job");
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        let missing = svc
+            .check_job_access(999, "testuser", "attach to")
+            .await
+            .expect_err("an untracked job must report not-found");
+        assert_eq!(missing.code(), tonic::Code::NotFound);
+    }
+
+    /// An allocation registered by a controller predating the identity field
+    /// leaves the owner blank; the real owner must not be locked out of it.
+    #[tokio::test]
+    async fn check_job_access_allows_attach_when_owner_unrecorded() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        let mut job = TrackedJob::dummy(std::process::id());
+        job.user = String::new();
+        svc.insert_test_job(47, job).await;
+
+        svc.check_job_access(47, "alice", "attach to")
+            .await
+            .expect("an unattributed job stays reachable by its owner");
+    }
+
     // --- srun step dispatch via RunCommand ---
     //
     // Regression: srun's run_as_step previously called

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -3231,10 +3231,9 @@ mod tests {
         assert_eq!(missing.code(), tonic::Code::NotFound);
     }
 
-    /// An allocation registered by a controller predating the identity field
-    /// leaves the owner blank; the real owner must not be locked out of it.
+    /// An empty-owner job runs as root, so non-root callers must be denied.
     #[tokio::test]
-    async fn check_job_access_allows_attach_when_owner_unrecorded() {
+    async fn check_job_access_denies_non_root_on_empty_owner() {
         let svc = AgentService::new(
             test_reporter(),
             HooksConfig::default(),
@@ -3245,9 +3244,19 @@ mod tests {
         job.user = String::new();
         svc.insert_test_job(47, job).await;
 
-        svc.check_job_access(47, "alice", "attach to")
+        let err = svc
+            .check_job_access(47, "alice", "attach to")
             .await
-            .expect("an unattributed job stays reachable by its owner");
+            .expect_err("empty-owner jobs run as root; non-root must be denied");
+        assert_eq!(err.code(), tonic::Code::PermissionDenied);
+
+        svc.check_job_access(47, "root", "attach to")
+            .await
+            .expect("root must always be allowed");
+
+        svc.check_job_access(47, "", "attach to")
+            .await
+            .expect("daemon (empty user) must always be allowed");
     }
 
     // --- srun step dispatch via RunCommand ---

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -2457,7 +2457,8 @@ impl AgentService {
         });
     }
 
-    /// Reject `user` unless they own job `job_id`.
+    /// Gate `user` for `action` on job `job_id`, per
+    /// [`spur_core::auth::check_job_owner`].
     ///
     /// Enforced here as well as on the controller because `sattach` and the
     /// output stream dial the agent's port directly.

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -754,6 +754,7 @@ message NodeResourcesResponse {
 message ExecInJobRequest {
   uint32 job_id = 1;
   repeated string command = 2;  // Command to exec inside the container
+  string user = 3;              // Requesting user; must own the job (empty/root bypasses)
 }
 
 message ExecInJobResponse {
@@ -947,6 +948,7 @@ message RegisterJobAllocationRequest {
   ResourceAllocations allocated = 9;
   string mpi = 10;
   string work_dir = 11;
+  string user = 12;  // Job owner; the agent gates exec/attach on it
 }
 
 message RegisterJobAllocationResponse {}
@@ -960,6 +962,7 @@ message RunCommandResponse {
 message StreamJobOutputRequest {
   uint32 job_id = 1;
   string stream = 2;  // "stdout" or "stderr"
+  string user = 3;    // Requesting user; must own the job (empty/root bypasses)
 }
 
 message StreamJobOutputChunk {
@@ -984,6 +987,7 @@ message InitSession {
   WindowSize winsize = 5;    // Initial terminal dimensions
   repeated string argv = 6;  // Command to run (empty = default shell)
   map<string, string> env = 7;
+  string user = 8;           // Requesting user; must own the job (empty/root bypasses)
 }
 
 message InteractiveInput {
@@ -1252,6 +1256,7 @@ message CreateJobStepRequest {
   bool pty = 6;               // Allocate a PTY for the step
   WindowSize winsize = 7;     // Initial terminal dimensions
   string node = 8;            // Target node (-w); empty = first allocated node
+  string user = 9;            // Requesting user; must own the job (empty/root bypasses)
 }
 
 message CreateJobStepResponse {


### PR DESCRIPTION
## Summary

Users could `spur exec` or `sattach` into jobs they do not own, executing commands or attaching interactive shells as the job owner. This closes two privilege-escalation vulnerabilities:

- **SPUR-108**: `spur exec <jobid> <cmd>` allowed any user to run commands inside another user's job.
- **SPUR-109**: `srun --jobid=N --overlap --pty` / `sattach` allowed any user to attach an interactive PTY to another user's job.

## Approach

Dual-layer ownership enforcement at both controller and agent:

- **Controller** gates `ExecInJob` and `CreateJobStep` RPCs before dispatching to the agent.
- **Agent** gates `ExecInJob`, `InteractiveSession`, and `StreamJobOutput` RPCs directly (defense-in-depth for direct-to-agent connections like `sattach`).
- Shared `spur_core::auth::check_job_owner()` implements the allow rule: empty requester (daemon/internal), root, or matching owner passes; all else denied with `PermissionDenied`.
- CLI sends the local username in each relevant proto message (`ExecInJobRequest`, `CreateJobStepRequest`, `StreamJobOutputRequest`, `InitSession`, `RegisterJobAllocationRequest`).

## Design choices

- **Empty-owner jobs are root-only**: Jobs submitted via REST without a `user` field, or allocations registered by older controllers during rolling upgrades, have no recorded owner. These jobs run as root (the executor never drops privileges for uid 0), so granting access to any caller would be a privilege escalation. Only root and daemon (empty user) can exec/attach/stream/cancel them. During a rolling upgrade this means the real submitter temporarily needs root to interact with their job; this is acceptable since the alternative is handing root shells to any local user.

- **Self-reported username**: The `user` field is trust-on-first-use from the CLI, matching what `scancel` already did. It raises the bar from "no check at all" to "must lie deliberately", and is not a substitute for authenticated identity. Real enforcement requires the mTLS/JWT layer. On lookup failure the CLI sends a value that cannot be a UNIX username, so a `whoami` failure denies rather than colliding with a real account.

- **`RunStep`/`RunCommand` remain ungated**: These carry no owner and are not gated here. `srun` dispatches `RunStep` directly with a caller-supplied `job_id`, so this is a real gap, but a pre-existing one that this PR neither introduces nor widens. Closing it properly means giving `JobStep` an owner and threading identity through both handlers, which belongs with the ownership framework rather than bolted onto this fix. Tracked separately.

## Test plan

- [x] Unit tests in `spur-core` covering owner, root, daemon (empty user), empty owner denial, and denial cases
- [x] Controller integration tests for `exec_in_job` and `create_job_step` authorization, including empty-owner denial
- [x] Agent integration tests for `check_job_access` on the attach and stream paths, including empty-owner denial
- [x] Full 38-point authorization matrix on the bare-metal testbed, with `spurd` running as root so the privilege drop is real: owner allowed, cross-user denied, root allowed, `scancel` ownership, empty-owner escalation blocked, edge cases (non-existent job, cancelled job), standalone `srun` allocation propagation
- [x] Pre-fix binaries confirmed to reproduce both tickets, so the post-fix denials are not vacuous
- [x] `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` clean
- [x] `cargo test --locked` all pass