### PR TITLE
fix(spurd): run sbatch batch script once per node, not once per task

### DIFF
--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -346,14 +346,21 @@ async fn process_assignment(
     // has nothing left to dispatch here: register_allocation_on_nodes
     // above already confirmed the allocation, and the actual step
     // launch is a later RunCommand, not this LaunchJob RPC.
-    let dispatch_spec = if !spec.srun_job {
-        Some(spec.clone())
+    //
+    // `task_fanout` distinguishes the two dispatched cases for the agent:
+    // true only for the srun-as-batch-script fallback, where the dispatched
+    // "script" is the literal command srun was asked to run tasks_per_node
+    // times on this node (real srun semantics). False for a genuine sbatch
+    // batch script, which runs exactly once per node regardless of
+    // tasks_per_node, matching Slurm.
+    let (dispatch_spec, task_fanout) = if !spec.srun_job {
+        (Some(spec.clone()), false)
     } else if !srun_step_dispatch {
         let mut batch_spec = spec.clone();
         batch_spec.srun_job = false;
-        Some(batch_spec)
+        (Some(batch_spec), true)
     } else {
-        None
+        (None, false)
     };
 
     if let Some(dspec) = dispatch_spec {
@@ -374,6 +381,7 @@ async fn process_assignment(
             allocated_nodelist.clone(),
             tasks_per_node,
             prospective_run_attempt,
+            task_fanout,
         )
         .await
         {
@@ -792,6 +800,11 @@ struct AgentDispatchParams<'a> {
     allocated_nodelist: &'a str,
     run_attempt: u32,
     pmix_tmpdir: &'a str,
+    /// See `LaunchJobRequest.task_fanout` in slurm.proto: true only for a
+    /// standalone `srun` request routed through this batch dispatch path
+    /// (e.g. a Kubernetes-inclusive allocation), where the dispatched
+    /// "script" is the literal command `srun` was asked to fan out.
+    task_fanout: bool,
 }
 
 /// Resolved output paths reported by an agent after a successful launch.
@@ -973,6 +986,7 @@ async fn dispatch_to_agent(
             array_task_id: spec.array_task_id.unwrap_or(0),
             run_attempt: params.run_attempt,
             pmix_plan,
+            task_fanout: params.task_fanout,
         })
         .await?;
 
@@ -1222,6 +1236,7 @@ async fn confirm_dispatch_on_nodes(
     allocated_nodelist: String,
     tasks_per_node: u32,
     run_attempt: u32,
+    task_fanout: bool,
 ) -> DispatchConfirmOutcome {
     let mut successes = 0u32;
     let mut failures = 0u32;
@@ -1274,6 +1289,7 @@ async fn confirm_dispatch_on_nodes(
                     allocated_nodelist: &allocated_nodelist,
                     run_attempt,
                     pmix_tmpdir: &pmix_tmpdir,
+                    task_fanout,
                 },
             )
             .await;
@@ -2159,6 +2175,9 @@ mod tests {
             cancel_calls: Arc<AtomicU32>,
             reject_launch_as: Option<spur_proto::proto::LaunchFailureKind>,
             launch_delay: Duration,
+            /// Records each `LaunchJobRequest.task_fanout` this agent receives,
+            /// so tests can assert on it without a real spurd behind the RPC.
+            fanout_calls: Option<Arc<std::sync::Mutex<Vec<bool>>>>,
         }
 
         #[tonic::async_trait]
@@ -2188,6 +2207,9 @@ mod tests {
                 // Echo a path keyed by task_offset so tests can assert the
                 // controller keeps the primary node's (task_offset == 0) path.
                 let req = request.into_inner();
+                if let Some(sink) = &self.fanout_calls {
+                    sink.lock().unwrap().push(req.task_fanout);
+                }
                 let path = format!("/spool/off{}/spur.out", req.task_offset);
                 Ok(tonic::Response::new(spur_proto::proto::LaunchJobResponse {
                     success: true,
@@ -2344,13 +2366,34 @@ mod tests {
             reject_launch_as: Option<spur_proto::proto::LaunchFailureKind>,
             launch_delay: Duration,
         ) -> (std::net::SocketAddr, Arc<AtomicU32>) {
+            let (addr, cancel_calls, _) =
+                spawn_mock_agent_capturing_fanout(reject_launch_as, launch_delay, false).await;
+            (addr, cancel_calls)
+        }
+
+        /// Like [`spawn_mock_agent`], but also records every
+        /// `LaunchJobRequest.task_fanout` this agent receives when `capture` is
+        /// true, so a test can assert on it — `spawn_mock_agent`/`_rejecting`/
+        /// `_with_delay` don't need this, so they pass `capture: false` and
+        /// discard the (empty) sink.
+        async fn spawn_mock_agent_capturing_fanout(
+            reject_launch_as: Option<spur_proto::proto::LaunchFailureKind>,
+            launch_delay: Duration,
+            capture: bool,
+        ) -> (
+            std::net::SocketAddr,
+            Arc<AtomicU32>,
+            Arc<std::sync::Mutex<Vec<bool>>>,
+        ) {
             let incoming = TcpIncoming::bind("127.0.0.1:0".parse().unwrap()).unwrap();
             let addr = incoming.local_addr().unwrap();
             let cancel_calls = Arc::new(AtomicU32::new(0));
+            let fanout_calls = Arc::new(std::sync::Mutex::new(Vec::new()));
             let agent = MockAgent {
                 cancel_calls: cancel_calls.clone(),
                 reject_launch_as,
                 launch_delay,
+                fanout_calls: capture.then(|| fanout_calls.clone()),
             };
             tokio::spawn(async move {
                 let _ = Server::builder()
@@ -2360,7 +2403,7 @@ mod tests {
                     .serve_with_incoming(incoming)
                     .await;
             });
-            (addr, cancel_calls)
+            (addr, cancel_calls, fanout_calls)
         }
 
         /// Reserve a localhost port with nothing listening on it, so a
@@ -2541,6 +2584,7 @@ mod tests {
                 "n1,n2".into(),
                 1,
                 1,
+                false,
             )
             .await;
 
@@ -2717,6 +2761,7 @@ mod tests {
                 "n1,n2".into(),
                 1,
                 1,
+                false,
             )
             .await;
 
@@ -2775,6 +2820,7 @@ mod tests {
                 "n1,n2".into(),
                 1,
                 1,
+                false,
             )
             .await;
 
@@ -2829,6 +2875,7 @@ mod tests {
                 "n1,n2".into(),
                 1,
                 1,
+                false,
             )
             .await;
 
@@ -2872,6 +2919,7 @@ mod tests {
                 nodelist,
                 1,
                 1,
+                false,
             )
             .await
         }
@@ -3184,6 +3232,7 @@ mod tests {
                 nodelist,
                 1,
                 1,
+                false,
             )
             .await;
             let elapsed = start.elapsed();
@@ -3381,6 +3430,59 @@ mod tests {
             assert!(
                 !job.srun_step_dispatch,
                 "the batch-script fallback launches like sbatch, not a native srun step"
+            );
+        }
+
+        // task_fanout: the agent-facing signal distinguishing a genuine sbatch
+        // batch script (runs once per node, regardless of tasks_per_node or
+        // mpi) from a standalone srun request routed through this same batch
+        // dispatch path (the dispatched "script" is the literal command srun
+        // was asked to run tasks_per_node times — real srun semantics).
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn process_assignment_dispatches_a_plain_batch_job_with_task_fanout_false() {
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+            let (addr, _, fanout_calls) =
+                spawn_mock_agent_capturing_fanout(None, Duration::ZERO, true).await;
+            register_node_at(&cm, "n1", addr);
+
+            let mut spec = batch_spec("plain-batch-fanout", 1);
+            spec.tasks_per_node = Some(4);
+            let job_id = submit_and_wait(&cm, spec);
+            let started = process_assignment(cm.clone(), assignment(job_id, &["n1"])).await;
+
+            assert!(started, "a clean single-node batch dispatch must start");
+            assert_eq!(
+                *fanout_calls.lock().unwrap(),
+                vec![false],
+                "a genuine sbatch job must dispatch with task_fanout=false"
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn process_assignment_dispatches_srun_batch_fallback_with_task_fanout_true() {
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+            let (addr, _, fanout_calls) =
+                spawn_mock_agent_capturing_fanout(None, Duration::ZERO, true).await;
+            register_k8s_node_at(&cm, "k1", addr);
+
+            let mut spec = batch_spec("srun-fanout-with-script", 1);
+            spec.srun_job = true;
+            spec.tasks_per_node = Some(4);
+            spec.script = Some("#!/bin/bash\necho hi\n".into());
+            let job_id = submit_and_wait(&cm, spec);
+            let started = process_assignment(cm.clone(), assignment(job_id, &["k1"])).await;
+
+            assert!(
+                started,
+                "an srun batch fallback with a script confirms and starts like a plain batch job"
+            );
+            assert_eq!(
+                *fanout_calls.lock().unwrap(),
+                vec![true],
+                "the srun-as-batch-fallback path must dispatch with task_fanout=true"
             );
         }
 

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1091,12 +1091,19 @@ impl SlurmAgent for AgentService {
             (script, crate::container::RootfsMode::Extracted)
         };
 
-        // Multi-task per-node: wrap the user script so it forks N processes,
-        // each with a distinct LOCAL_RANK. The wrapper backgrounds N copies and
-        // waits for all to finish, so TrackedJob only tracks a single PID (the
-        // wrapper shell). GPU devices are partitioned across tasks via
-        // ROCR_VISIBLE_DEVICES / CUDA_VISIBLE_DEVICES overrides in each fork.
-        let launch_script = if tasks_per_node > 1 {
+        // Under Slurm semantics a batch script runs exactly once per node,
+        // regardless of --ntasks-per-node or --mpi: task multiplicity is only
+        // advertised via environment variables (SPUR_TASKS_PER_NODE,
+        // LOCAL_WORLD_SIZE, NPROC_PER_NODE, ...) and any fan-out — including
+        // multi-rank MPI — is the script's own responsibility, typically via
+        // an internal `srun` call. The one exception is `task_fanout`: this
+        // dispatch is itself the fan-out mechanism for a standalone `srun`
+        // request routed through the batch dispatch path (e.g. an allocation
+        // spanning Kubernetes-backed nodes, which bypass the native-host
+        // per-task step path), where the dispatched "script" is the literal
+        // command `srun` was asked to run `tasks_per_node` times on this node
+        // — real srun semantics, not a batch script.
+        let launch_script = if tasks_per_node > 1 && req.task_fanout {
             // Write the user script to disk first so the wrapper can reference it
             let user_script_path = format!("{}/.spur_user_{}.sh", work_dir, job_id);
             std::fs::write(&user_script_path, &launch_script)
@@ -3366,6 +3373,240 @@ mod tests {
         let expected = format!("{}/spur-77.out", work_dir_str);
         assert_eq!(inner.stdout_path, expected);
         assert_eq!(inner.stderr_path, expected);
+    }
+
+    /// Poll `path` until its content stabilizes (unchanged across two
+    /// consecutive checks) or `timeout_ms` elapses, then return it. Used to
+    /// wait out a script's execution(s) without depending on job-completion
+    /// reporting to a controller (which these unit tests don't run).
+    async fn wait_for_stable_file(path: &std::path::Path, timeout_ms: u64) -> String {
+        let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(timeout_ms);
+        let mut last = String::new();
+        loop {
+            let current = std::fs::read_to_string(path).unwrap_or_default();
+            if current == last && !current.is_empty() {
+                return current;
+            }
+            last = current;
+            if tokio::time::Instant::now() >= deadline {
+                return last;
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        }
+    }
+
+    // A file that's still being actively rewritten never satisfies the
+    // "two consecutive identical reads" stability check above; the helper
+    // must give up after `timeout_ms` and return the last-seen value rather
+    // than hang forever (relevant if a launched script never converges or
+    // never completes). Exercises `wait_for_stable_file`'s timeout branch,
+    // which the tests above never reach since their scripts finish quickly.
+    #[tokio::test]
+    async fn wait_for_stable_file_gives_up_after_timeout() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("churn.txt");
+        let writer_path = path.clone();
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let stop_writer = stop.clone();
+        let writer = tokio::spawn(async move {
+            let mut n: u64 = 0;
+            while !stop_writer.load(std::sync::atomic::Ordering::Relaxed) {
+                std::fs::write(&writer_path, format!("v{n}")).unwrap();
+                n += 1;
+                tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+            }
+        });
+
+        let result = wait_for_stable_file(&path, 200).await;
+
+        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        let _ = writer.await;
+
+        assert!(
+            result.starts_with('v'),
+            "expected a churned placeholder value, got {result:?}"
+        );
+    }
+
+    // A plain (mpi=none) batch script must execute exactly once per node
+    // regardless of --ntasks-per-node, matching Slurm semantics (task
+    // multiplicity is only advertised via environment variables; further
+    // fan-out is the script's own responsibility, typically via `srun`).
+    // Without this, `launch_job` wraps every batch script in
+    // `build_multi_task_wrapper` whenever tasks_per_node > 1, forking that
+    // many concurrent copies of the ENTIRE script — corrupting any script
+    // with more than a single trivial command. Reproduces that failure mode
+    // directly: an unconditional counter step plus an `mkdir` step that
+    // collides when run more than once concurrently.
+    #[tokio::test]
+    async fn sbatch_script_runs_exactly_once_regardless_of_ntasks_per_node() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        let work_dir = tempfile::tempdir().unwrap();
+        let work_dir_str = work_dir.path().to_string_lossy().to_string();
+        let counter_path = work_dir.path().join("run_count.txt");
+        let collide_dir = work_dir.path().join("only_once_dir");
+
+        let script = format!(
+            "#!/bin/bash\necho ran >> \"{counter}\"\nmkdir \"{collide}\" 2>/dev/null || true\n",
+            counter = counter_path.display(),
+            collide = collide_dir.display(),
+        );
+
+        let req = Request::new(LaunchJobRequest {
+            job_id: 5350,
+            spec: Some(JobSpec {
+                script,
+                num_tasks: 4,
+                num_nodes: 1,
+                tasks_per_node: 4,
+                cpus_per_task: 1,
+                work_dir: work_dir_str,
+                ..Default::default()
+            }),
+            allocated: Some(ResourceAllocations {
+                cpus: 4,
+                memory_mb: 0,
+                devices: std::collections::HashMap::new(),
+            }),
+            // Default (false): a genuine sbatch batch script, not an
+            // explicit srun task fan-out.
+            ..Default::default()
+        });
+
+        let resp = svc.launch_job(req).await.expect("launch should succeed");
+        assert!(resp.into_inner().success, "launch should succeed");
+
+        let content = wait_for_stable_file(&counter_path, 2_000).await;
+        let runs = content.lines().filter(|l| *l == "ran").count();
+        assert_eq!(
+            runs, 1,
+            "batch script must run exactly once regardless of tasks_per_node=4, got {runs} run(s): {content:?}"
+        );
+    }
+
+    // Counterpart to the test above: a standalone `srun` request routed
+    // through the batch dispatch path (Kubernetes-inclusive allocations;
+    // see `dispatch_job_to_nodes` in scheduler_loop.rs) sets
+    // `task_fanout: true` because there the dispatched "script" is the
+    // literal command srun was asked to run `tasks_per_node` times — real
+    // srun semantics that must not regress into running only once.
+    #[tokio::test]
+    async fn task_fanout_dispatch_still_replicates_per_ntasks_per_node() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        let work_dir = tempfile::tempdir().unwrap();
+        let work_dir_str = work_dir.path().to_string_lossy().to_string();
+        let counter_path = work_dir.path().join("run_count.txt");
+
+        let script = format!(
+            "#!/bin/bash\necho ran >> \"{counter}\"\n",
+            counter = counter_path.display(),
+        );
+
+        let req = Request::new(LaunchJobRequest {
+            job_id: 5351,
+            spec: Some(JobSpec {
+                script,
+                num_tasks: 4,
+                num_nodes: 1,
+                tasks_per_node: 4,
+                cpus_per_task: 1,
+                work_dir: work_dir_str,
+                ..Default::default()
+            }),
+            allocated: Some(ResourceAllocations {
+                cpus: 4,
+                memory_mb: 0,
+                devices: std::collections::HashMap::new(),
+            }),
+            task_fanout: true,
+            ..Default::default()
+        });
+
+        let resp = svc.launch_job(req).await.expect("launch should succeed");
+        assert!(resp.into_inner().success, "launch should succeed");
+
+        let content = wait_for_stable_file(&counter_path, 2_000).await;
+        let runs = content.lines().filter(|l| *l == "ran").count();
+        assert_eq!(
+            runs, 4,
+            "task_fanout dispatch must still run tasks_per_node=4 copies, got {runs} run(s): {content:?}"
+        );
+    }
+
+    // A documented `--mpi=pmix` batch job is no longer a special case: with
+    // `task_fanout` false (a genuine sbatch job, not a routed srun request)
+    // it must run its script exactly once per node like any other batch
+    // script, the same as mpi=none. Multi-rank MPI is the script's own job
+    // via an internal `srun` call, not the launcher replicating the whole
+    // script.
+    //
+    // A real end-to-end run isn't possible here: `launch_job` unconditionally
+    // requires a PMIx launch plan (and the plugin/mpirun behind it, neither
+    // installed in this environment) whenever `spec.mpi == "pmix"`, so this
+    // launch always errors before the script would actually execute. The
+    // wrapper-selection decision under test runs earlier in `launch_job` than
+    // that PMIx requirement, though, and its outcome is directly observable:
+    // the multi-task wrapper path writes an intermediate `.spur_user_<id>.sh`
+    // copy of the script to disk before building the wrapper, so its absence
+    // proves the fan-out branch was skipped.
+    #[tokio::test]
+    async fn sbatch_mpi_pmix_without_task_fanout_does_not_fan_out() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        let work_dir = tempfile::tempdir().unwrap();
+        let work_dir_str = work_dir.path().to_string_lossy().to_string();
+
+        let req = Request::new(LaunchJobRequest {
+            job_id: 5352,
+            spec: Some(JobSpec {
+                script: "#!/bin/bash\ntrue\n".into(),
+                num_tasks: 4,
+                num_nodes: 1,
+                tasks_per_node: 4,
+                cpus_per_task: 1,
+                mpi: MPI_PMIX.into(),
+                work_dir: work_dir_str.clone(),
+                ..Default::default()
+            }),
+            allocated: Some(ResourceAllocations {
+                cpus: 4,
+                memory_mb: 0,
+                devices: std::collections::HashMap::new(),
+            }),
+            // Default (false): a genuine sbatch job, not a routed srun
+            // request — no pmix_plan is supplied either, so if this reached
+            // the multi-task wrapper it would need one regardless.
+            ..Default::default()
+        });
+
+        let result = svc.launch_job(req).await;
+        assert!(
+            result.is_err(),
+            "a missing PMIx launch plan must still fail the launch"
+        );
+
+        let wrapper_input_path = format!("{work_dir_str}/.spur_user_5352.sh");
+        assert!(
+            !std::path::Path::new(&wrapper_input_path).exists(),
+            "mpi=pmix without task_fanout must not take the multi-task-wrapper branch"
+        );
     }
 
     // The monitor loop's reconcile step must reclaim an

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -705,6 +705,16 @@ message LaunchJobRequest {
   // the controller can drop stale-run reports. 0 = unset (legacy), check off.
   uint32 run_attempt = 9;
   PmixLaunchPlan pmix_plan = 10;
+  // True when this dispatch is itself a per-task fan-out mechanism (a
+  // standalone `srun` request routed through the batch dispatch path, e.g.
+  // an allocation spanning Kubernetes-backed nodes) and `spec.script` is the
+  // literal command that should run `tasks_per_node` times on this node.
+  // False (default) for a genuine `sbatch` batch script: it runs exactly
+  // once per node regardless of tasks_per_node or mpi, matching Slurm
+  // semantics — task multiplicity (including multi-rank MPI) is only
+  // advertised via environment variables, and any fan-out is the script's
+  // own responsibility, typically via an internal `srun` call.
+  bool task_fanout = 11;
 }
 
 // Why a launch was rejected, when the controller's response depends on it.

--- a/tests/native_host/e2e/test_devices.py
+++ b/tests/native_host/e2e/test_devices.py
@@ -456,7 +456,15 @@ class TestContainerInjection:
 
 
 class TestMultiNodeSpread:
-    def test_multitask_per_node_gpu_partition(self, gpu_cluster):
+    def test_multitask_per_node_runs_batch_script_once(self, gpu_cluster):
+        # A plain (mpi=none) sbatch script must run exactly once per node,
+        # matching Slurm semantics, regardless of --ntasks-per-node. Without
+        # this, spurd forks one concurrent copy of the whole script per task,
+        # so this probe (a single, non-fan-out command) would print PROBE_OK
+        # 4 times with 4 distinct partitioned ROCR_VISIBLE_DEVICES subsets.
+        # Instead it prints once and sees every GPU allocated to the job —
+        # the script itself is responsible for any further per-task fan-out
+        # (typically via `srun`).
         cluster = gpu_cluster
         cluster.gpu_preflight(1)
         if _max_gpus_per_node(cluster) < 4:
@@ -481,14 +489,15 @@ class TestMultiNodeSpread:
         assert job_id is not None
         wait_job(cluster, job_id, timeout=180)
         content = cluster.wait_output(out_path, "PROBE_OK")
-        assert content.count("PROBE_OK") >= 4, content
+        assert content.count("PROBE_OK") == 1, content
         rocr_lines = [
             ln.split("=", 1)[1]
             for ln in content.splitlines()
             if ln.startswith("ROCR_VISIBLE_DEVICES=")
         ]
-        assert len(rocr_lines) >= 4, content
-        assert len(set(rocr_lines)) >= 4, f"expected distinct per-task ROCR values\n{content}"
+        assert len(rocr_lines) == 1, content
+        visible_count = _parse_probe(content).get("VISIBLE_COUNT")
+        assert visible_count == "4", f"expected all 4 allocated GPUs visible\n{content}"
 
     def test_two_node_gres_spread(self, gpu_cluster):
         cluster = gpu_cluster


### PR DESCRIPTION
## What

Closes #535. When a job requests multiple tasks per node (`--ntasks-per-node=K`), `AgentService::launch_job` unconditionally wrapped the batch script in a multi-copy launcher whenever `tasks_per_node > 1`, forking K concurrent copies of the *entire* script per node. Real Slurm runs a batch script exactly once per allocation; the script itself is responsible for any internal fan-out via `srun`. Any script with more than a single trivial command (setup, file writes, cleanup) silently races itself K times under the old behavior.

## Approach

Added a `task_fanout` field to `LaunchJobRequest` so the controller can tell the agent whether a dispatch is a genuine multi-task fan-out or a plain batch script:

- `task_fanout=true`: set only for standalone `srun` requests that fall back to the batch dispatch path (e.g. Kubernetes-inclusive allocations, where the dispatched "command" is literally what should repeat N times) -- unchanged multi-copy behavior.
- Everything else -- a plain `sbatch` script, regardless of `--mpi` value -- now runs exactly once per node. `SPUR_TASKS_PER_NODE`/`LOCAL_WORLD_SIZE`/`NPROC_PER_NODE` are still set so the script can fan out itself via `srun` if it needs to.

This is scoped to intra-node duplication only. Per-*node* dispatch (once per node, with `NODE_RANK`/`MASTER_ADDR`/`WORLD_SIZE` set, for multi-node distributed scripts) is untouched -- internal `srun` calls issued from within a running batch script require the job to already be tracked on every allocated node, so collapsing dispatch to a single head node would break multi-node internal `srun` fan-out. That's a separate, more invasive change and out of scope here.

**Scope note (per review):** an earlier version of this PR also kept the old multi-copy behavior for `--mpi=pmix`/`--mpi=pmi1` batch jobs, to preserve existing multi-rank PMIx launch behavior. That carve-out has been dropped at @sgopinath1's request, since it re-introduces the same "replicate the whole script per task" model this PR removes for plain `sbatch`, and would collide with upcoming multi-node PMIx work. Multi-rank direct PMIx batch launch is intentionally left to a follow-up MPI PR.

## Behavior change

A plain `sbatch` script requesting multiple tasks per node now executes once, not once per task -- this is an intentional breaking-behavior fix, not something gated behind a flag. The only legitimate prior use of the multi-copy path (the `srun`-fallback dispatch case) is explicitly preserved.

This now also includes `--mpi=pmix`/`--mpi=pmi1` batch jobs: `sbatch --mpi=pmix -n4 batch.sh` no longer forks the script 4x per node. Users who want multi-rank PMIx launched directly from a batch script should instead do the fan-out explicitly inside the script, e.g.:

```bash
#!/bin/bash
#SBATCH --mpi=pmix
srun --mpi=pmix -n4 ./hello_mpi
```

(or equivalent step dispatch). Direct multi-rank PMIx batch launch (without an internal `srun`) can land in the follow-up multi-node MPI PR.

## Testing

Regression tests in `agent_server.rs`, modeled on the reproducer from #535 (a counter plus a colliding `mkdir` to detect concurrent re-execution): one confirms a plain script now runs exactly once regardless of `--ntasks-per-node` (verified this fails on the old code, passes after the fix), one confirms `task_fanout` dispatch still replicates correctly, and one confirms a documented `--mpi=pmix` batch job is no longer a special case and also runs once. Also corrected a native-host e2e test (`test_devices.py`) that had encoded the old buggy behavior as its expected outcome, and added `scheduler_loop.rs` tests asserting `task_fanout` is set correctly for both the plain-batch and srun-fallback dispatch paths.

`cargo fmt --all --check`, `cargo clippy --all-targets --locked -- -D warnings`, and `cargo test --locked --workspace` all pass. Patch coverage on the changed Rust files is 100%.
