### PR TITLE
fix(spurctld): report wall-time expiry as TIMEOUT

### DIFF
--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -245,6 +245,9 @@ pub enum PendingReason {
     ReqNodeNotAvail,
     BeginTime,
     DeadLine,
+    /// Slurm's `FAIL_TIMEOUT`: the run ended because it exhausted its wall-clock
+    /// time limit. Sibling of `DeadLine`, which fires before the job ever starts.
+    TimeLimit,
     Licenses,
     NonZeroExitCode,
     RaisedSignal,
@@ -331,6 +334,7 @@ impl PendingReason {
             Self::ReqNodeNotAvail => "ReqNodeNotAvail",
             Self::BeginTime => "BeginTime",
             Self::DeadLine => "DeadLine",
+            Self::TimeLimit => "TimeLimit",
             Self::Licenses => "Licenses",
             Self::NonZeroExitCode => "NonZeroExitCode",
             Self::RaisedSignal => "RaisedSignal",
@@ -718,6 +722,15 @@ pub struct Job {
     #[serde(default)]
     pub srun_step_dispatch: bool,
 
+    /// Wall-clock instant the controller signalled this run for exceeding its
+    /// time limit, cleared on requeue. Replicated rather than kept in the
+    /// watchdog's memory for two reasons: the completion path runs inside the
+    /// Raft apply and must reach the same verdict on every replica, and a
+    /// leadership change mid-grace-period would otherwise restart the grace
+    /// period from scratch.
+    #[serde(default)]
+    pub time_limit_signaled_at: Option<DateTime<Utc>>,
+
     /// Wall-clock instant the job entered Suspended (None unless currently suspended).
     #[serde(default)]
     pub suspended_at: Option<DateTime<Utc>>,
@@ -780,6 +793,7 @@ impl Job {
             het_job_id: None,
             het_group: None,
             node_completions: HashMap::new(),
+            time_limit_signaled_at: None,
             suspended_at: None,
             suspended_secs: 0,
             bb_stage_state: BbStageState::None,
@@ -827,6 +841,39 @@ impl Job {
             }
             None => (JobState::Completed, 0, 0),
         }
+    }
+
+    /// Reconcile the per-node completion verdict with what the controller
+    /// already knows about the run, yielding its final `(state, reason)`.
+    ///
+    /// A run signalled for exceeding its time limit reports `Timeout` however
+    /// the process itself ended: the exit signal records how it was stopped,
+    /// not why. An OOM kill outranks even that, being direct kernel evidence of
+    /// a distinct failure the user has to act on.
+    pub fn completion_verdict(
+        &self,
+        derived_state: JobState,
+        exit_code: i32,
+        signal: i32,
+        oom: bool,
+    ) -> (JobState, PendingReason) {
+        let state = if oom {
+            JobState::OutOfMemory
+        } else if self.time_limit_signaled_at.is_some() {
+            JobState::Timeout
+        } else {
+            derived_state
+        };
+
+        let reason = match state {
+            JobState::OutOfMemory => PendingReason::OutOfMemory,
+            JobState::Timeout => PendingReason::TimeLimit,
+            _ if signal != 0 => PendingReason::RaisedSignal,
+            _ if exit_code != 0 => PendingReason::NonZeroExitCode,
+            _ => PendingReason::None,
+        };
+
+        (state, reason)
     }
 
     pub fn all_nodes_completed(&self) -> bool {
@@ -1096,6 +1143,10 @@ impl Job {
             (JobState::Completing, JobState::Completed) => true,
             (JobState::Completing, JobState::Failed) => true,
             (JobState::Completing, JobState::Cancelled) => true,
+            // A job signalled for exceeding its time limit routes through
+            // Completing like any other, so the final verdict lands from there
+            // (Slurm's JOB_TIMEOUT | JOB_COMPLETING).
+            (JobState::Completing, JobState::Timeout) => true,
             (JobState::Completing, JobState::NodeFail) => true,
             (JobState::Completing, JobState::OutOfMemory) => true,
             (JobState::Suspended, JobState::Running) => true,
@@ -1519,6 +1570,68 @@ mod tests {
         assert_eq!(signal, 11);
     }
 
+    /// A job whose run the watchdog signalled for exhausting its time limit.
+    fn timed_out_job() -> Job {
+        let mut job = make_job();
+        job.time_limit_signaled_at = Some(Utc::now());
+        job
+    }
+
+    #[test]
+    fn completion_verdict_reports_timeout_for_a_job_killed_by_its_time_limit() {
+        // The regression: SIGTERM from the watchdog looks exactly like any other
+        // signal death to derived_completion, which reports Failed.
+        let (state, reason) = timed_out_job().completion_verdict(JobState::Failed, 0, 15, false);
+        assert_eq!(state, JobState::Timeout);
+        assert_eq!(reason, PendingReason::TimeLimit);
+    }
+
+    #[test]
+    fn completion_verdict_reports_timeout_when_the_job_exits_cleanly_on_sigterm() {
+        // A script that traps SIGTERM, checkpoints, and exits 0 still ran out of
+        // time; the run's outcome is not the handler's exit status.
+        let (state, reason) = timed_out_job().completion_verdict(JobState::Completed, 0, 0, false);
+        assert_eq!(state, JobState::Timeout);
+        assert_eq!(reason, PendingReason::TimeLimit);
+    }
+
+    #[test]
+    fn completion_verdict_leaves_an_unsignalled_death_alone() {
+        // Nothing to do with the time limit: a job killed by an external SIGKILL
+        // must keep reporting Failed / RaisedSignal.
+        let (state, reason) = make_job().completion_verdict(JobState::Failed, 0, 9, false);
+        assert_eq!(state, JobState::Failed);
+        assert_eq!(reason, PendingReason::RaisedSignal);
+
+        let (state, reason) = make_job().completion_verdict(JobState::Failed, 42, 0, false);
+        assert_eq!(state, JobState::Failed);
+        assert_eq!(reason, PendingReason::NonZeroExitCode);
+
+        let (state, reason) = make_job().completion_verdict(JobState::Completed, 0, 0, false);
+        assert_eq!(state, JobState::Completed);
+        assert_eq!(reason, PendingReason::None);
+    }
+
+    #[test]
+    fn completion_verdict_lets_an_oom_kill_outrank_the_time_limit() {
+        // Kernel evidence of a specific failure the user must act on beats the
+        // controller's own reason for signalling the job.
+        let (state, reason) = timed_out_job().completion_verdict(JobState::Failed, 0, 9, true);
+        assert_eq!(state, JobState::OutOfMemory);
+        assert_eq!(reason, PendingReason::OutOfMemory);
+    }
+
+    #[test]
+    fn a_timed_out_job_finalizes_from_completing() {
+        // The completion path routes every job through Completing, so without
+        // this transition a timed-out job could not reach its verdict.
+        let mut job = make_job();
+        job.transition(JobState::Running).unwrap();
+        job.transition(JobState::Completing).unwrap();
+        job.transition(JobState::Timeout).unwrap();
+        assert_eq!(job.state, JobState::Timeout);
+    }
+
     #[test]
     fn completion_state_for_exit_code_maps_expected_states() {
         assert_eq!(
@@ -1810,6 +1923,7 @@ mod tests {
         (PendingReason::BurstBufferResources, "BurstBufferResources"),
         (PendingReason::BurstBufferStageIn, "BurstBufferStageIn"),
         (PendingReason::JobHoldMaxRequeue, "JobHoldMaxRequeue"),
+        (PendingReason::TimeLimit, "TimeLimit"),
         (PendingReason::AssocMaxJobsLimit, "AssocMaxJobsLimit"),
         (
             PendingReason::AssocMaxSubmitJobLimit,

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -68,6 +68,15 @@ pub enum WalOperation {
         exit_code: i32,
         signal: i32,
     },
+    /// The time-limit watchdog signalled a running job for exhausting its wall
+    /// clock. Durable so the grace period survives a leadership change and so
+    /// every replica finalizes the run as `Timeout` rather than reading the
+    /// terminating signal as an ordinary failure. `at` is stamped on the leader
+    /// so replicas share one instant instead of consulting their own clocks.
+    JobTimeLimitSignaled {
+        job_id: JobId,
+        at: chrono::DateTime<chrono::Utc>,
+    },
     /// An srun job step finished. Records the step's exit code durably so the
     /// job's DerivedExitCode (running max over steps) survives restart/replay.
     JobStepComplete {

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -721,6 +721,24 @@ mod suspend_wal_tests {
             }
         }
     }
+
+    #[test]
+    fn job_time_limit_signaled_op_round_trips() {
+        let at = chrono::Utc::now();
+        let op = WalOperation::JobTimeLimitSignaled { job_id: 13, at };
+        let json = serde_json::to_string(&op).unwrap();
+        let back: WalOperation = serde_json::from_str(&json).unwrap();
+        match back {
+            WalOperation::JobTimeLimitSignaled {
+                job_id,
+                at: at_back,
+            } => {
+                assert_eq!(job_id, 13);
+                assert_eq!(at_back, at);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/spur-tests/src/t55_format.rs
+++ b/crates/spur-tests/src/t55_format.rs
@@ -127,6 +127,7 @@ mod tests {
             ),
             (PendingReason::ReservationDeleted, "ReservationDeleted"),
             (PendingReason::JobHoldMaxRequeue, "JobHoldMaxRequeue"),
+            (PendingReason::TimeLimit, "TimeLimit"),
             (PendingReason::QosMaxCpuPerJobLimit, "QOSMaxCpuPerJobLimit"),
             (
                 PendingReason::QosMaxWallDurationPerJobLimit,

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -991,6 +991,16 @@ impl ClusterManager {
         Ok(())
     }
 
+    /// Record that a running job has exhausted its time limit, before the
+    /// caller sends SIGTERM. Durably marking the run first is what lets the
+    /// completion path report `Timeout` instead of reading the terminating
+    /// signal as an ordinary failure — a job that exits promptly on SIGTERM
+    /// reports back long before the grace period is up.
+    pub fn signal_time_limit(&self, job_id: JobId, at: DateTime<Utc>) -> anyhow::Result<()> {
+        self.propose(WalOperation::JobTimeLimitSignaled { job_id, at })?;
+        Ok(())
+    }
+
     /// Preempt a running job per its partition's PreemptMode. Does the
     /// controller-side state change; the caller dispatches the signal named by
     /// the returned `PreemptOutcome`. `Off` is rejected.
@@ -3187,6 +3197,7 @@ impl ClusterManager {
         job.allocated_nodes.clear();
         job.allocated_resources = None;
         job.per_node_alloc.clear();
+        job.time_limit_signaled_at = None;
         job.set_pending_reason(PendingReason::None);
         // Stale after requeue (points at nodes the job left); next dispatch resets it.
         job.actual_stdout_path = None;
@@ -3589,11 +3600,8 @@ impl ClusterManager {
                         let (derived_state, final_exit, raw_signal) =
                             Job::derived_completion(&job.node_completions, &primary);
                         let final_signal = raw_signal & !spur_core::job::OOM_SIGNAL_FLAG;
-                        let final_state = if oom {
-                            JobState::OutOfMemory
-                        } else {
-                            derived_state
-                        };
+                        let (final_state, final_reason) =
+                            job.completion_verdict(derived_state, final_exit, final_signal, oom);
                         match job.transition(final_state) {
                             Ok(()) => {
                                 job.exit_code = Some(final_exit);
@@ -3602,15 +3610,7 @@ impl ClusterManager {
                                 // steps, accumulated live by JobStepComplete; a
                                 // job with no srun steps keeps 0 (Slurm parity),
                                 // not the batch exit. Left as-is here.
-                                job.set_pending_reason(if oom {
-                                    PendingReason::OutOfMemory
-                                } else if final_signal != 0 {
-                                    PendingReason::RaisedSignal
-                                } else if final_exit != 0 {
-                                    PendingReason::NonZeroExitCode
-                                } else {
-                                    PendingReason::None
-                                });
+                                job.set_pending_reason(final_reason);
                                 job.end_time = Some(timestamp);
                                 job.node_completions.clear();
                                 Some((final_state, final_exit))
@@ -3642,6 +3642,15 @@ impl ClusterManager {
                         }],
                         ..Default::default()
                     };
+                }
+            }
+            WalOperation::JobTimeLimitSignaled { job_id, at } => {
+                if let Some(job) = jobs.get_mut(job_id) {
+                    // A run that already ended keeps the verdict it finalized
+                    // with: the watchdog raced the job's own exit and lost.
+                    if job.state.is_active() && job.time_limit_signaled_at.is_none() {
+                        job.time_limit_signaled_at = Some(*at);
+                    }
                 }
             }
             WalOperation::JobComplete {
@@ -3678,6 +3687,11 @@ impl ClusterManager {
                     }
                     job.exit_code = Some(*exit_code);
                     job.end_time = Some(timestamp);
+                    // Derived from the replicated entry, so every replica reports
+                    // the same reason for a job the watchdog had to force-kill.
+                    if *state == JobState::Timeout {
+                        job.set_pending_reason(PendingReason::TimeLimit);
+                    }
                     // Suspended -> terminal: fold the final suspended interval in
                     // and clear suspended_at so it never lingers on a terminal job.
                     if let Some(since) = job.suspended_at.take() {
@@ -6140,6 +6154,103 @@ mod tests {
         assert_eq!(job.exit_signal, 9);
         assert_eq!(job.derived_exit_code, 0);
         assert_eq!(job.pending_reason, PendingReason::RaisedSignal);
+    }
+
+    // A job that exits promptly on the watchdog's SIGTERM used to report FAILED:
+    // its completion reached the controller well before the grace period was up,
+    // and nothing durable recorded why it had been signalled.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn node_complete_after_a_time_limit_signal_reports_timeout() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let job_id = run_job_on(&cm, "time-limit-job", "worker1");
+        cm.signal_time_limit(job_id, Utc::now()).unwrap();
+        wait_for("time limit expiry recorded", || {
+            cm.get_job(job_id)
+                .is_some_and(|j| j.time_limit_signaled_at.is_some())
+        });
+
+        // What spurd reports for a script that dies on SIGTERM.
+        cm.node_complete(job_id, "worker1", 0, 15, 0).unwrap();
+
+        let job = cm.get_job(job_id).unwrap();
+        assert_eq!(job.state, JobState::Timeout);
+        assert_eq!(job.pending_reason, PendingReason::TimeLimit);
+        // The terminating signal is still reported, so ExitCode stays 0:15.
+        assert_eq!(job.exit_code, Some(0));
+        assert_eq!(job.exit_signal, 15);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn a_time_limit_signal_after_the_run_ended_is_a_noop() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        // The watchdog can lose the race: the job finished on its own just as
+        // the deadline passed, so its verdict is already final.
+        let job_id = run_job_on(&cm, "raced-job", "worker1");
+        cm.node_complete(job_id, "worker1", 0, 0, 0).unwrap();
+        settle(&cm, job_id, JobState::Completed);
+
+        cm.signal_time_limit(job_id, Utc::now()).unwrap();
+
+        let job = cm.get_job(job_id).unwrap();
+        assert_eq!(job.state, JobState::Completed);
+        assert_eq!(job.pending_reason, PendingReason::None);
+        assert!(job.time_limit_signaled_at.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn force_kill_after_the_grace_period_reports_the_time_limit_reason() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        // A job that outlives the grace period is finalized by the watchdog
+        // itself rather than by an agent report.
+        let job_id = run_job_on(&cm, "grace-expired", "worker1");
+        cm.signal_time_limit(job_id, Utc::now()).unwrap();
+        cm.complete_job(job_id, -1, JobState::Timeout).unwrap();
+        settle(&cm, job_id, JobState::Timeout);
+
+        let job = cm.get_job(job_id).unwrap();
+        assert_eq!(job.pending_reason, PendingReason::TimeLimit);
+        assert_eq!(job.exit_code, Some(-1));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn requeue_after_a_time_limit_kill_clears_the_marker() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let mut spec = basic_spec("requeue-after-timeout");
+        spec.requeue = true;
+        let job_id = submit_and_wait(&cm, spec);
+        let alloc = scalar_alloc(2, 4000);
+        cm.start_job(
+            job_id,
+            vec!["worker1".into()],
+            alloc.clone(),
+            per_node_for(&["worker1"], alloc),
+        )
+        .unwrap();
+        settle(&cm, job_id, JobState::Running);
+
+        cm.signal_time_limit(job_id, Utc::now()).unwrap();
+        cm.node_complete(job_id, "worker1", 0, 15, 0).unwrap();
+
+        // Attributing the kill to the time limit is what routes a well-behaved
+        // job into the requeue path at all.
+        settle(&cm, job_id, JobState::Pending);
+        let job = cm.get_job(job_id).unwrap();
+        assert_eq!(job.requeue_count, 1);
+        // A marker left behind would make the next run report TIMEOUT the
+        // moment it ended, whatever its outcome.
+        assert!(job.time_limit_signaled_at.is_none());
     }
 
     // Reproduces the two steps report_job_status performs (validate the wire

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -967,8 +967,15 @@ impl ClusterManager {
         exit_code: i32,
         state: JobState,
     ) -> anyhow::Result<()> {
-        // Validate
-        {
+        // A time-limit expiry has to win over the caller's outcome here, not
+        // just in the per-node completion path. The marker is only ever set on
+        // a run the watchdog signalled, so any completion routed through this
+        // method — the completing-timeout force-finish and the srun path, both
+        // of which finalize without seeing node_completions — is a wall-time
+        // expiry that would otherwise be reported as an ordinary failure and
+        // skip the Timeout requeue. Cancelled (user cancel, preemption) and an
+        // already-correct Timeout pass through untouched.
+        let state = {
             let jobs = self.jobs.read();
             let job = jobs
                 .get(&job_id)
@@ -976,7 +983,14 @@ impl ClusterManager {
             if job.state.is_terminal() {
                 anyhow::bail!("invalid transition from {:?} to {:?}", job.state, state);
             }
-        }
+            if job.time_limit_signaled_at.is_some()
+                && matches!(state, JobState::Failed | JobState::Completed)
+            {
+                JobState::Timeout
+            } else {
+                state
+            }
+        };
 
         // propose() handles: state transition, exit_code, end_time,
         // resource deallocation, step completion, license return
@@ -6219,6 +6233,53 @@ mod tests {
         let job = cm.get_job(job_id).unwrap();
         assert_eq!(job.pending_reason, PendingReason::TimeLimit);
         assert_eq!(job.exit_code, Some(-1));
+    }
+
+    // The completing-timeout force-finish and srun completion paths finalize
+    // through complete_job with a state derived from exit status alone, never
+    // consulting the marker. A run the watchdog already signalled must still
+    // report TIMEOUT through those paths, or a well-behaved job skips requeue.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn complete_job_promotes_a_signaled_run_to_timeout() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "worker1", 8, 16000);
+
+        let record_marker = |job_id: JobId| {
+            cm.signal_time_limit(job_id, Utc::now()).unwrap();
+            wait_for("time limit expiry recorded", || {
+                cm.get_job(job_id)
+                    .is_some_and(|j| j.time_limit_signaled_at.is_some())
+            });
+        };
+
+        // force_finish_completing_job passes Failed (e.g. a node never reported)
+        // and its exit_code must survive the promotion.
+        let failed = run_job_on(&cm, "completing-timeout", "worker1");
+        record_marker(failed);
+        cm.complete_job(failed, 1, JobState::Failed).unwrap();
+        settle(&cm, failed, JobState::Timeout);
+        let job = cm.get_job(failed).unwrap();
+        assert_eq!(job.pending_reason, PendingReason::TimeLimit);
+        assert_eq!(job.exit_code, Some(1));
+
+        // finish_srun_job passes Completed for a handler that trapped SIGTERM
+        // and exited 0; the run still expired, matching Job::completion_verdict.
+        let clean = run_job_on(&cm, "srun-timeout", "worker1");
+        record_marker(clean);
+        cm.complete_job(clean, 0, JobState::Completed).unwrap();
+        settle(&cm, clean, JobState::Timeout);
+        assert_eq!(
+            cm.get_job(clean).unwrap().pending_reason,
+            PendingReason::TimeLimit
+        );
+
+        // The promotion is narrow: a cancel on a signalled run stays Cancelled,
+        // since the user's intent is not a time-limit expiry.
+        let cancelled = run_job_on(&cm, "cancel-wins", "worker1");
+        record_marker(cancelled);
+        cm.complete_job(cancelled, -1, JobState::Cancelled).unwrap();
+        settle(&cm, cancelled, JobState::Cancelled);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -1305,19 +1305,21 @@ fn finish_failed_dispatch(
 /// Watchdog: gracefully terminate running jobs that exceed their time limit.
 ///
 /// Two-phase shutdown:
-///   1. **Warning phase**: When `start_time + time_limit < now`, send SIGTERM
-///      (signal 15) to all agents and record the job as "warned".
-///   2. **Kill phase**: 30 seconds after warning, if the job is still running,
-///      mark it as Timeout and send SIGKILL (signal 9).
+///   1. **Warning phase**: When `start_time + time_limit < now`, durably mark
+///      the run as timed out and send SIGTERM (signal 15) to all agents.
+///   2. **Kill phase**: 30 seconds after the warning, if the job is still
+///      running, mark it as Timeout and send SIGKILL (signal 9).
+///
+/// Both phases key off the job's replicated `time_limit_signaled_at`, so the
+/// grace period is measured from one agreed instant even across a leadership
+/// change, and a job that exits during the grace period still finalizes as
+/// `Timeout` rather than as a plain signal death.
 ///
 /// Runs every 10 seconds.
 async fn enforce_time_limits(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
     const GRACE_PERIOD_SECS: i64 = 30;
 
     let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(10));
-    let mut warned_jobs: HashSet<spur_core::job::JobId> = HashSet::new();
-    let mut warn_times: std::collections::HashMap<spur_core::job::JobId, chrono::DateTime<Utc>> =
-        std::collections::HashMap::new();
 
     loop {
         interval.tick().await;
@@ -1374,34 +1376,7 @@ async fn enforce_time_limits(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>
                 continue;
             }
 
-            if warned_jobs.contains(&job.job_id) {
-                // Already warned — check if grace period has elapsed
-                let warn_time = warn_times
-                    .get(&job.job_id)
-                    .copied()
-                    .unwrap_or(now - chrono::Duration::seconds(GRACE_PERIOD_SECS + 1));
-                if (now - warn_time).num_seconds() < GRACE_PERIOD_SECS {
-                    continue; // Still in grace period
-                }
-
-                // Grace period expired — force kill
-                info!(
-                    job_id = job.job_id,
-                    "grace period expired — force-killing job"
-                );
-
-                if let Err(e) =
-                    cluster.complete_job(job.job_id, -1, spur_core::job::JobState::Timeout)
-                {
-                    warn!(job_id = job.job_id, error = %e, "failed to mark job as timed out");
-                    continue;
-                }
-
-                send_cancel_to_agents(&cluster, job, 9).await; // SIGKILL
-                warned_jobs.remove(&job.job_id);
-                warn_times.remove(&job.job_id);
-            } else {
-                // First time past deadline — send SIGTERM (graceful warning)
+            let Some(signaled_at) = job.time_limit_signaled_at else {
                 info!(
                     job_id = job.job_id,
                     elapsed_secs = (now - start_time).num_seconds(),
@@ -1410,17 +1385,34 @@ async fn enforce_time_limits(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>
                     "time limit exceeded — sending SIGTERM, grace period starts"
                 );
 
-                send_cancel_to_agents(&cluster, job, 15).await; // SIGTERM
-                warned_jobs.insert(job.job_id);
-                warn_times.insert(job.job_id, now);
-            }
-        }
+                // Record before signalling: if the job exits on the SIGTERM, its
+                // completion must find the run already marked as timed out.
+                if let Err(e) = cluster.signal_time_limit(job.job_id, now) {
+                    warn!(job_id = job.job_id, error = %e, "failed to record time limit expiry");
+                    continue;
+                }
 
-        // Clean up warned_jobs for jobs that are no longer running
-        // (e.g., they exited cleanly during grace period)
-        let running_ids: HashSet<_> = running.iter().map(|j| j.job_id).collect();
-        warned_jobs.retain(|id| running_ids.contains(id));
-        warn_times.retain(|id, _| running_ids.contains(id));
+                send_cancel_to_agents(&cluster, job, 15).await; // SIGTERM
+                continue;
+            };
+
+            if (now - signaled_at).num_seconds() < GRACE_PERIOD_SECS {
+                continue;
+            }
+
+            info!(
+                job_id = job.job_id,
+                "grace period expired — force-killing job"
+            );
+
+            if let Err(e) = cluster.complete_job(job.job_id, -1, spur_core::job::JobState::Timeout)
+            {
+                warn!(job_id = job.job_id, error = %e, "failed to mark job as timed out");
+                continue;
+            }
+
+            send_cancel_to_agents(&cluster, job, 9).await; // SIGKILL
+        }
     }
 }
 

--- a/tests/native_host/e2e/test_time_limit.py
+++ b/tests/native_host/e2e/test_time_limit.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for wall-time expiry attribution.
+
+The time-limit watchdog terminates an over-running job in two phases: SIGTERM
+once the deadline passes, then SIGKILL after a grace period. Both outcomes are
+a wall-time expiry and must report TIMEOUT, but the two paths finalize the job
+through different code: a job that dies on the SIGTERM is finalized from its
+agent's completion report, while one that ignores SIGTERM is finalized by the
+watchdog itself. Only the second used to report TIMEOUT — the well-behaved job
+reported FAILED, indistinguishable from a crash.
+
+Each test submits with a short ``--time`` and waits out the watchdog, so the
+timeouts below allow for the 10s watchdog tick plus the 30s grace period.
+"""
+
+from cluster import parse_job_id, wait_job
+
+TIME_LIMIT = "00:00:20"
+# Deadline + watchdog tick + grace period + SIGKILL reap, with slack.
+FINISH_TIMEOUT = 180
+
+
+def _show_job(cluster, job_id: int) -> str:
+    return cluster.scontrol("show", "job", str(job_id))
+
+
+class TestTimeLimitExpiry:
+    def test_job_exiting_on_sigterm_reports_timeout(self, cluster):
+        script = cluster.write_file(
+            "timelimit-plain.sh",
+            "#!/bin/bash\nsleep 300\n",
+        )
+        job_id = parse_job_id(cluster.sbatch(["-J", "tl-plain", f"--time={TIME_LIMIT}", script]))
+        assert job_id is not None
+
+        state = wait_job(cluster, job_id, timeout=FINISH_TIMEOUT)
+        assert state == "TO", (
+            f"a job killed by its wall-time limit must report TIMEOUT, got {state}. "
+            f"FAILED here means the completion report was read as an ordinary "
+            f"signal death:\n{cluster.debug_job(job_id)}"
+        )
+
+        show = _show_job(cluster, job_id)
+        assert "JobState=TIMEOUT" in show, show
+        assert "Reason=TimeLimit" in show, show
+        # The agent's real exit status survives the timeout verdict rather than
+        # being replaced by the watchdog's synthetic -1. Its exact value depends
+        # on whether the shell dies from SIGTERM or exits 128+15, so only the
+        # synthetic value is ruled out here.
+        assert "ExitCode=-1:" not in show, show
+
+    def test_job_ignoring_sigterm_reports_timeout(self, cluster):
+        script = cluster.write_file(
+            "timelimit-trap.sh",
+            '#!/bin/bash\ntrap "" TERM\nsleep 300\n',
+        )
+        job_id = parse_job_id(cluster.sbatch(["-J", "tl-trap", f"--time={TIME_LIMIT}", script]))
+        assert job_id is not None
+
+        state = wait_job(cluster, job_id, timeout=FINISH_TIMEOUT)
+        assert state == "TO", (
+            f"a job that outlives the grace period must report TIMEOUT, got "
+            f"{state}:\n{cluster.debug_job(job_id)}"
+        )
+
+        show = _show_job(cluster, job_id)
+        assert "JobState=TIMEOUT" in show, show
+        assert "Reason=TimeLimit" in show, show
+
+    def test_job_finishing_inside_its_limit_is_untouched(self, cluster):
+        # Guards against over-applying the timeout verdict: a job that ends on
+        # its own must keep reporting its real outcome.
+        script = cluster.write_file(
+            "timelimit-fast-fail.sh",
+            "#!/bin/bash\nexit 3\n",
+        )
+        job_id = parse_job_id(cluster.sbatch(["-J", "tl-fast", f"--time={TIME_LIMIT}", script]))
+        assert job_id is not None
+
+        state = wait_job(cluster, job_id, timeout=FINISH_TIMEOUT)
+        assert state == "F", f"expected FAILED for a genuine non-zero exit, got {state}"
+
+        show = _show_job(cluster, job_id)
+        assert "JobState=FAILED" in show, show
+        assert "ExitCode=3:0" in show, show
+        assert "TimeLimit" not in show, show


### PR DESCRIPTION
## Motivation

A job killed by its wall-time limit landed in `FAILED` with `ExitCode=0:15`, and whether it ever reached `TIMEOUT` depended on how it reacted to SIGTERM — the well-behaved job was the one misreported.

The time-limit watchdog tracked which jobs it had signalled in two in-memory maps (`warned_jobs`, `warn_times`) owned by the scheduler task, so the SIGTERM decision was invisible to the completion path. A job that exits promptly on that SIGTERM is finalized from its agent's completion report, where `Job::derived_completion` sees only "signaled" and returns `Failed`. Only a job that ignored SIGTERM survived to the kill phase, which sets `Timeout` explicitly.

Fixes #546.

## Technical Details

The expiry is now recorded on the job itself as `time_limit_signaled_at`, written through a new `JobTimeLimitSignaled` WAL entry before the SIGTERM goes out.

Replicating it is not optional: completions are finalized inside the Raft apply, so a non-replicated flag could not be consulted there without replicas disagreeing on the outcome. Deriving the grace period from the same field then falls out for free — it removes both in-memory maps and makes the window survive a leadership change, which previously restarted it from scratch.

Two smaller pieces follow from that:

- `Job::completion_verdict` decides the final state and reason together, so they cannot drift. `Completing -> Timeout` was missing from the state machine, since every completion routes through `Completing` (Slurm's `JOB_TIMEOUT | JOB_COMPLETING`).
- `PendingReason::TimeLimit` mirrors Slurm's `FAIL_TIMEOUT`, replacing the `RaisedSignal:15(Terminated)` that would otherwise sit incongruously next to `JobState=TIMEOUT`.

Design choices worth flagging:

[1] The agent's real exit status survives the verdict rather than being normalized, so a job that ended on SIGTERM stays distinguishable from one the watchdog had to SIGKILL. The forced kill-phase path keeps its synthetic `-1`, because it is the backstop that guarantees finalization when no agent report is coming.

[2] An OOM kill still outranks the time limit. It is direct kernel evidence of a distinct failure the user has to act on, whereas the timeout is the controller's own reason for signalling.

[3] Correct attribution routes these jobs into the existing `Timeout` requeue path, which `--requeue` jobs dying on SIGTERM previously skipped. The issue names this as affected behaviour. `time_limit_signaled_at` is cleared in `clear_run_state_for_requeue`, so a requeued run starts with a fresh budget instead of being marked timed out the moment it ends.

## Test Plan

- Unit tests in `spur-core` for the verdict itself: SIGTERM death, a trapped-SIGTERM clean exit, an unrelated signal death, OOM precedence, and the `Completing -> Timeout` transition.
- Unit tests in `spurctld` driving the real WAL apply: completion after a signal reports `Timeout`/`TimeLimit`, a signal arriving after the run ended is a no-op, the forced kill path carries the reason, and requeue clears the marker.
- New `tests/native_host/e2e/test_time_limit.py` covering the issue's two scripts plus a control job that fails inside its limit.
- Clippy and the full workspace suite.
- Live two-node LXD cluster (Ubuntu 24.04), `--time=00:00:20`.

## Test Result

Clippy clean; full workspace suite passes.

On the LXD cluster:

| job | script | result |
| --- | --- | --- |
| `tl-plain` | `sleep 300` | `JobState=TIMEOUT Reason=TimeLimit ExitCode=143:0` |
| `tl-trap` | `trap "" TERM; sleep 300` | `JobState=TIMEOUT Reason=TimeLimit ExitCode=-1:0` |
| `tl-fastfail` | `exit 3` | `JobState=FAILED Reason=NonZeroExitCode ExitCode=3:0` |

The controller log shows `tl-plain` reaching `TIMEOUT` with no `grace period expired` line, confirming it was finalized from the agent's completion report — the exact path that used to yield `FAILED`. `tl-trap` was force-killed 30s after its SIGTERM, as before.

`ExitCode` for `tl-plain` is `143:0` rather than the issue's `0:15` because this environment's bash exits `128+15` instead of dying from the signal. That is a property of the shell, not of the fix, so the e2e test only rules out the synthetic `-1` rather than asserting an exact status.

A `--requeue` job at the same limit was requeued repeatedly with `from=TIMEOUT`, each run logging a full `elapsed_secs=27` against `limit_secs=20`, which confirms both the new requeue routing and that the marker is cleared between runs.

## Submission Checklist

- Look over the contributing guidelines at <https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests>.

Made with [Cursor](https://cursor.com)