### PR TITLE
feat(spur-net): normalize node comm addresses for agent reachability

### DIFF
--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -556,7 +556,8 @@ pub struct NodeConfig {
     pub gres: Vec<String>,
     #[serde(default)]
     pub features: Vec<String>,
-    /// Override address (if different from hostname).
+    /// Default comm address when the agent has not registered one yet. Does not
+    /// override an agent-registered address.
     pub address: Option<String>,
     /// Scheduling weight. Higher weight = preferred for scheduling.
     #[serde(default = "default_one")]
@@ -581,6 +582,9 @@ pub struct NetworkConfig {
     /// Agent gRPC listen port (default: 6818).
     #[serde(default = "default_agent_port")]
     pub agent_port: u16,
+    /// Reject agent registrations whose comm address resolves to loopback.
+    #[serde(default)]
+    pub reject_loopback_comm_addr: bool,
 }
 
 fn default_wg_cidr() -> String {
@@ -604,6 +608,7 @@ impl Default for NetworkConfig {
             wg_interface: "spur0".into(),
             wg_port: 51820,
             agent_port: 6818,
+            reject_loopback_comm_addr: false,
         }
     }
 }

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -582,7 +582,8 @@ pub struct NetworkConfig {
     /// Agent gRPC listen port (default: 6818).
     #[serde(default = "default_agent_port")]
     pub agent_port: u16,
-    /// Reject agent registrations whose comm address resolves to loopback.
+    /// Reject agent registrations whose comm address is not routable (loopback,
+    /// unspecified, or link-local).
     #[serde(default)]
     pub reject_loopback_comm_addr: bool,
 }

--- a/crates/spur-core/src/node.rs
+++ b/crates/spur-core/src/node.rs
@@ -355,20 +355,6 @@ impl Node {
         self.address.as_deref()
     }
 
-    /// Host used to reach this agent; prefers comm address over node name.
-    pub fn agent_host(&self) -> &str {
-        self.comm_addr().unwrap_or(&self.name)
-    }
-
-    /// OS hostname reported at registration; falls back to node name.
-    pub fn node_hostname(&self) -> &str {
-        if self.hostname.is_empty() {
-            &self.name
-        } else {
-            &self.hostname
-        }
-    }
-
     /// Update state based on allocation level.
     pub fn update_state_from_alloc(&mut self) {
         if self.state.is_admin_hold() {
@@ -627,23 +613,5 @@ mod tests {
     fn node_state_from_short_or_name_rejects_unknown() {
         assert_eq!(NodeState::from_short_or_name("bogus"), None);
         assert_eq!(NodeState::from_short_or_name(""), None);
-    }
-
-    #[test]
-    fn agent_host_prefers_comm_addr() {
-        let mut node = Node::new("node1".into(), ResourceSet::default());
-        assert_eq!(node.agent_host(), "node1");
-        node.address = Some("10.0.0.5".into());
-        assert_eq!(node.agent_host(), "10.0.0.5");
-    }
-
-    #[test]
-    fn node_hostname_falls_back_to_name() {
-        let node = Node::new("node1".into(), ResourceSet::default());
-        assert_eq!(node.node_hostname(), "node1");
-
-        let mut node = Node::new("node1".into(), ResourceSet::default());
-        node.hostname = "host1.example.com".into();
-        assert_eq!(node.node_hostname(), "host1.example.com");
     }
 }

--- a/crates/spur-core/src/node.rs
+++ b/crates/spur-core/src/node.rs
@@ -226,7 +226,11 @@ pub enum NodeSource {
 /// A compute node in the cluster.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Node {
+    /// Cluster node name (NodeName): used by `-w`, partitions, and display.
     pub name: String,
+    /// OS hostname reported at agent registration (NodeHostname).
+    #[serde(default)]
+    pub hostname: String,
     pub state: NodeState,
     pub state_reason: Option<String>,
     /// When true, the current state was set by an operator (admin API, drain,
@@ -261,7 +265,7 @@ pub struct Node {
     pub agent_start_time: Option<DateTime<Utc>>,
     pub last_heartbeat: Option<DateTime<Utc>>,
 
-    /// Agent address for gRPC communication.
+    /// Routable comm address for agent gRPC and inter-node TCP (NodeAddr).
     pub address: Option<String>,
     /// Agent gRPC listen port.
     pub port: u16,
@@ -297,6 +301,7 @@ impl Node {
     pub fn new(name: String, resources: ResourceSet) -> Self {
         Self {
             name,
+            hostname: String::new(),
             state: NodeState::Unknown,
             state_reason: None,
             admin_locked: false,
@@ -343,6 +348,25 @@ impl Node {
     /// Whether this node can accept new work.
     pub fn is_schedulable(&self) -> bool {
         self.state.is_available()
+    }
+
+    /// Routable comm address (NodeAddr), when registered.
+    pub fn comm_addr(&self) -> Option<&str> {
+        self.address.as_deref()
+    }
+
+    /// Host used to reach this agent; prefers comm address over node name.
+    pub fn agent_host(&self) -> &str {
+        self.comm_addr().unwrap_or(&self.name)
+    }
+
+    /// OS hostname reported at registration; falls back to node name.
+    pub fn node_hostname(&self) -> &str {
+        if self.hostname.is_empty() {
+            &self.name
+        } else {
+            &self.hostname
+        }
     }
 
     /// Update state based on allocation level.
@@ -603,5 +627,23 @@ mod tests {
     fn node_state_from_short_or_name_rejects_unknown() {
         assert_eq!(NodeState::from_short_or_name("bogus"), None);
         assert_eq!(NodeState::from_short_or_name(""), None);
+    }
+
+    #[test]
+    fn agent_host_prefers_comm_addr() {
+        let mut node = Node::new("node1".into(), ResourceSet::default());
+        assert_eq!(node.agent_host(), "node1");
+        node.address = Some("10.0.0.5".into());
+        assert_eq!(node.agent_host(), "10.0.0.5");
+    }
+
+    #[test]
+    fn node_hostname_falls_back_to_name() {
+        let node = Node::new("node1".into(), ResourceSet::default());
+        assert_eq!(node.node_hostname(), "node1");
+
+        let mut node = Node::new("node1".into(), ResourceSet::default());
+        node.hostname = "host1.example.com".into();
+        assert_eq!(node.node_hostname(), "host1.example.com");
     }
 }

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -138,6 +138,8 @@ pub enum WalOperation {
     // Node operations
     NodeRegister {
         name: String,
+        #[serde(default)]
+        hostname: String,
         resources: ResourceSet,
         address: String,
         #[serde(default = "default_port")]
@@ -151,6 +153,8 @@ pub enum WalOperation {
     },
     NodeUpdate {
         name: String,
+        #[serde(default)]
+        hostname: String,
         resources: ResourceSet,
         address: String,
         port: u16,

--- a/crates/spur-net/src/comm_addr.rs
+++ b/crates/spur-net/src/comm_addr.rs
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Validate and normalize node comm addresses (NodeAddr) used for agent gRPC
+//! and inter-node TCP reachability.
+
+use std::net::{IpAddr, ToSocketAddrs};
+
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum CommAddressError {
+    #[error("comm address is empty")]
+    Empty,
+    #[error("comm address {0:?} is not resolvable: {1}")]
+    Unresolvable(String, String),
+    #[error("comm address {0} is not routable ({1})")]
+    Unusable(String, String),
+}
+
+/// True when `addr` is loopback or an unspecified address.
+pub fn is_loopback_ip(addr: IpAddr) -> bool {
+    match addr {
+        IpAddr::V4(v4) => v4.is_loopback() || v4.is_unspecified(),
+        IpAddr::V6(v6) => v6.is_loopback() || v6.is_unspecified(),
+    }
+}
+
+/// True when `addr` is unsuitable for inter-node reachability (loopback,
+/// unspecified, or link-local).
+pub fn is_unusable_comm_ip(addr: IpAddr) -> bool {
+    match addr {
+        IpAddr::V4(v4) => v4.is_loopback() || v4.is_unspecified() || v4.is_link_local(),
+        IpAddr::V6(v6) => v6.is_loopback() || v6.is_unspecified() || v6.is_unicast_link_local(),
+    }
+}
+
+/// Whether a comm-address string resolves to an address unsuitable for
+/// inter-node reachability (loopback, unspecified, or link-local).
+pub fn comm_addr_is_unusable(input: &str) -> bool {
+    normalize_comm_address(input)
+        .map(|resolved| resolved.parse::<IpAddr>().is_ok_and(is_unusable_comm_ip))
+        .unwrap_or(false)
+}
+
+/// Resolve `input` to a canonical comm address string (IP literal preferred).
+pub fn normalize_comm_address(input: &str) -> Result<String, CommAddressError> {
+    let input = input.trim();
+    if input.is_empty() {
+        return Err(CommAddressError::Empty);
+    }
+
+    if let Ok(ip) = input.parse::<IpAddr>() {
+        return Ok(ip.to_string());
+    }
+
+    let addrs: Vec<_> = format!("{input}:0")
+        .to_socket_addrs()
+        .map_err(|e| CommAddressError::Unresolvable(input.to_string(), e.to_string()))?
+        .map(|sa| sa.ip())
+        .collect();
+
+    if addrs.is_empty() {
+        return Err(CommAddressError::Unresolvable(
+            input.to_string(),
+            "no addresses returned".into(),
+        ));
+    }
+
+    if let Some(ip) = addrs.iter().copied().find(|ip| !is_unusable_comm_ip(*ip)) {
+        return Ok(ip.to_string());
+    }
+
+    Ok(addrs[0].to_string())
+}
+
+/// Normalize and optionally reject loopback comm addresses.
+pub fn validate_comm_address(
+    input: &str,
+    reject_loopback: bool,
+) -> Result<String, CommAddressError> {
+    let normalized = normalize_comm_address(input)?;
+    if reject_loopback {
+        if let Ok(ip) = normalized.parse::<IpAddr>() {
+            if is_unusable_comm_ip(ip) {
+                return Err(CommAddressError::Unusable(input.to_string(), normalized));
+            }
+        }
+    }
+    Ok(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_ip_literal() {
+        assert_eq!(normalize_comm_address("10.0.0.1").unwrap(), "10.0.0.1");
+    }
+
+    #[test]
+    fn normalize_localhost_is_loopback() {
+        let addr = normalize_comm_address("127.0.0.1").unwrap();
+        assert_eq!(addr, "127.0.0.1");
+        assert!(comm_addr_is_unusable("127.0.0.1"));
+    }
+
+    #[test]
+    fn normalize_localhost_hostname() {
+        let addr = normalize_comm_address("localhost").unwrap();
+        assert!(addr == "127.0.0.1" || addr == "::1");
+    }
+
+    #[test]
+    fn reject_loopback_when_configured() {
+        assert!(matches!(
+            validate_comm_address("127.0.0.1", true),
+            Err(CommAddressError::Unusable(_, _))
+        ));
+        assert_eq!(validate_comm_address("10.0.0.2", true).unwrap(), "10.0.0.2");
+    }
+
+    #[test]
+    fn allow_loopback_when_not_rejecting() {
+        assert_eq!(
+            validate_comm_address("127.0.0.1", false).unwrap(),
+            "127.0.0.1"
+        );
+    }
+
+    #[test]
+    fn reject_link_local_when_configured() {
+        assert!(matches!(
+            validate_comm_address("169.254.1.1", true),
+            Err(CommAddressError::Unusable(_, _))
+        ));
+    }
+
+    #[test]
+    fn empty_is_rejected() {
+        assert!(matches!(
+            normalize_comm_address(""),
+            Err(CommAddressError::Empty)
+        ));
+    }
+}

--- a/crates/spur-net/src/comm_addr.rs
+++ b/crates/spur-net/src/comm_addr.rs
@@ -44,6 +44,9 @@ pub fn comm_addr_is_unusable(input: &str) -> bool {
 }
 
 /// Resolve `input` to a canonical comm address string (IP literal preferred).
+///
+/// Hostname inputs perform blocking DNS via [`ToSocketAddrs`]. Call from async
+/// contexts through [`tokio::task::spawn_blocking`].
 pub fn normalize_comm_address(input: &str) -> Result<String, CommAddressError> {
     let input = input.trim();
     if input.is_empty() {
@@ -74,7 +77,8 @@ pub fn normalize_comm_address(input: &str) -> Result<String, CommAddressError> {
     Ok(addrs[0].to_string())
 }
 
-/// Normalize and optionally reject loopback comm addresses.
+/// Normalize and optionally reject non-routable comm addresses (loopback,
+/// unspecified, or link-local).
 pub fn validate_comm_address(
     input: &str,
     reject_loopback: bool,
@@ -88,6 +92,25 @@ pub fn validate_comm_address(
         }
     }
     Ok(normalized)
+}
+
+/// Host portion for `host:port` strings; bracket IPv6 literals.
+pub fn comm_host_for_socket(host: &str) -> String {
+    if host.parse::<IpAddr>().is_ok_and(|ip| ip.is_ipv6()) {
+        format!("[{host}]")
+    } else {
+        host.to_string()
+    }
+}
+
+/// Format a comm address and port for TCP/gRPC socket connection strings.
+pub fn format_comm_socket(host: &str, port: u16) -> String {
+    format!("{}:{port}", comm_host_for_socket(host))
+}
+
+/// Format a comm address and port for HTTP agent RPC URLs.
+pub fn format_comm_http_url(host: &str, port: u16) -> String {
+    format!("http://{}:{port}", comm_host_for_socket(host))
 }
 
 #[cfg(test)]
@@ -143,5 +166,15 @@ mod tests {
             normalize_comm_address(""),
             Err(CommAddressError::Empty)
         ));
+    }
+
+    #[test]
+    fn format_comm_socket_brackets_ipv6() {
+        assert_eq!(format_comm_socket("::1", 6818), "[::1]:6818");
+        assert_eq!(
+            format_comm_http_url("2001:db8::1", 6818),
+            "http://[2001:db8::1]:6818"
+        );
+        assert_eq!(format_comm_socket("10.0.0.1", 6818), "10.0.0.1:6818");
     }
 }

--- a/crates/spur-net/src/comm_addr.rs
+++ b/crates/spur-net/src/comm_addr.rs
@@ -18,21 +18,19 @@ pub enum CommAddressError {
     Unusable(String, String),
 }
 
-/// True when `addr` is loopback or an unspecified address.
-pub fn is_loopback_ip(addr: IpAddr) -> bool {
-    match addr {
-        IpAddr::V4(v4) => v4.is_loopback() || v4.is_unspecified(),
-        IpAddr::V6(v6) => v6.is_loopback() || v6.is_unspecified(),
-    }
-}
-
 /// True when `addr` is unsuitable for inter-node reachability (loopback,
 /// unspecified, or link-local).
-pub fn is_unusable_comm_ip(addr: IpAddr) -> bool {
+fn is_unusable_comm_ip(addr: IpAddr) -> bool {
     match addr {
         IpAddr::V4(v4) => v4.is_loopback() || v4.is_unspecified() || v4.is_link_local(),
         IpAddr::V6(v6) => v6.is_loopback() || v6.is_unspecified() || v6.is_unicast_link_local(),
     }
+}
+
+/// Whether an already-normalized comm address is unsuitable for inter-node
+/// reachability (loopback, unspecified, or link-local).
+pub fn normalized_comm_addr_is_unusable(normalized: &str) -> bool {
+    normalized.parse::<IpAddr>().is_ok_and(is_unusable_comm_ip)
 }
 
 /// Whether a comm-address string resolves to an address unsuitable for
@@ -166,6 +164,12 @@ mod tests {
             normalize_comm_address(""),
             Err(CommAddressError::Empty)
         ));
+    }
+
+    #[test]
+    fn normalized_comm_addr_is_unusable_detects_loopback() {
+        assert!(normalized_comm_addr_is_unusable("127.0.0.1"));
+        assert!(!normalized_comm_addr_is_unusable("10.0.0.1"));
     }
 
     #[test]

--- a/crates/spur-net/src/detect.rs
+++ b/crates/spur-net/src/detect.rs
@@ -70,21 +70,18 @@ fn get_wg_address(interface: &str) -> Option<String> {
     None
 }
 
-/// Resolve hostname to IP address.
+/// Resolve hostname to IP address, preferring non-loopback results.
 fn resolve_hostname(hostname: &str) -> String {
-    use std::net::ToSocketAddrs;
-    let addr_str = format!("{}:0", hostname);
-    match addr_str.to_socket_addrs() {
-        Ok(mut addrs) => {
-            if let Some(addr) = addrs.next() {
-                addr.ip().to_string()
-            } else {
+    match crate::comm_addr::normalize_comm_address(hostname) {
+        Ok(addr) => {
+            if crate::comm_addr::comm_addr_is_unusable(&addr) {
                 warn!(
                     hostname,
-                    "hostname resolved to no addresses, using 127.0.0.1"
+                    comm_addr = %addr,
+                    "hostname resolved to loopback; set --address/--comm-address to a routable IP"
                 );
-                "127.0.0.1".to_string()
             }
+            addr
         }
         Err(e) => {
             warn!(hostname, error = %e, "failed to resolve hostname, using 127.0.0.1");

--- a/crates/spur-net/src/detect.rs
+++ b/crates/spur-net/src/detect.rs
@@ -74,7 +74,7 @@ fn get_wg_address(interface: &str) -> Option<String> {
 fn resolve_hostname(hostname: &str) -> String {
     match crate::comm_addr::normalize_comm_address(hostname) {
         Ok(addr) => {
-            if crate::comm_addr::comm_addr_is_unusable(&addr) {
+            if crate::comm_addr::normalized_comm_addr_is_unusable(&addr) {
                 warn!(
                     hostname,
                     comm_addr = %addr,

--- a/crates/spur-net/src/detect.rs
+++ b/crates/spur-net/src/detect.rs
@@ -78,7 +78,7 @@ fn resolve_hostname(hostname: &str) -> String {
                 warn!(
                     hostname,
                     comm_addr = %addr,
-                    "hostname resolved to loopback; set --address/--comm-address to a routable IP"
+                    "hostname resolved to a non-routable address; set --address/--comm-address to a routable IP"
                 );
             }
             addr

--- a/crates/spur-net/src/lib.rs
+++ b/crates/spur-net/src/lib.rs
@@ -10,9 +10,8 @@ pub mod wireguard;
 
 pub use address::{AddressPool, AddressSource, NodeAddress};
 pub use comm_addr::{
-    comm_addr_is_unusable, comm_host_for_socket, format_comm_http_url, format_comm_socket,
-    is_loopback_ip, is_unusable_comm_ip, normalize_comm_address, validate_comm_address,
-    CommAddressError,
+    comm_addr_is_unusable, format_comm_http_url, format_comm_socket, normalize_comm_address,
+    normalized_comm_addr_is_unusable, validate_comm_address, CommAddressError,
 };
 pub use detect::detect_node_address;
 pub use mesh::{MeshMembership, MeshNode};

--- a/crates/spur-net/src/lib.rs
+++ b/crates/spur-net/src/lib.rs
@@ -10,8 +10,9 @@ pub mod wireguard;
 
 pub use address::{AddressPool, AddressSource, NodeAddress};
 pub use comm_addr::{
-    comm_addr_is_unusable, is_loopback_ip, is_unusable_comm_ip, normalize_comm_address,
-    validate_comm_address, CommAddressError,
+    comm_addr_is_unusable, comm_host_for_socket, format_comm_http_url, format_comm_socket,
+    is_loopback_ip, is_unusable_comm_ip, normalize_comm_address, validate_comm_address,
+    CommAddressError,
 };
 pub use detect::detect_node_address;
 pub use mesh::{MeshMembership, MeshNode};

--- a/crates/spur-net/src/lib.rs
+++ b/crates/spur-net/src/lib.rs
@@ -2,12 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod address;
+pub mod comm_addr;
 pub mod detect;
 pub mod mesh;
 pub mod oci;
 pub mod wireguard;
 
 pub use address::{AddressPool, AddressSource, NodeAddress};
+pub use comm_addr::{
+    comm_addr_is_unusable, is_loopback_ip, is_unusable_comm_ip, normalize_comm_address,
+    validate_comm_address, CommAddressError,
+};
 pub use detect::detect_node_address;
 pub use mesh::{MeshMembership, MeshNode};
 pub use oci::{pull_image, ImageRef};

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -13394,6 +13394,43 @@ mod tests {
         );
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn node_config_address_fills_when_agent_address_empty() {
+        let dir = TempDir::new().unwrap();
+        let mut cfg = test_config();
+        cfg.nodes = vec![spur_core::config::NodeConfig {
+            names: "worker1".into(),
+            selector: HashMap::new(),
+            cpus: 0,
+            memory_mb: 0,
+            gres: Vec::new(),
+            features: Vec::new(),
+            address: Some("10.0.0.99".into()),
+            weight: 1,
+        }];
+        let cm = test_cluster_with_config(&dir, cfg).await;
+
+        cm.apply_operation(&WalOperation::NodeRegister {
+            name: "worker1".into(),
+            hostname: "worker1".into(),
+            resources: ResourceSet {
+                cpus: 4,
+                memory_mb: 8000,
+                ..Default::default()
+            },
+            address: String::new(),
+            port: 6818,
+            wg_pubkey: String::new(),
+            version: String::new(),
+            labels: HashMap::new(),
+        });
+
+        assert_eq!(
+            cm.get_node("worker1").unwrap().address,
+            Some("10.0.0.99".into())
+        );
+    }
+
     #[test]
     fn label_update_applies_nodeconfig_features() {
         let dir = TempDir::new().unwrap();

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1348,6 +1348,7 @@ impl ClusterManager {
     pub fn register_node(
         &self,
         name: String,
+        hostname: String,
         resources: ResourceSet,
         address: String,
         port: u16,
@@ -1356,6 +1357,11 @@ impl ClusterManager {
         source: NodeSource,
         labels: HashMap<String, String>,
     ) -> anyhow::Result<()> {
+        let hostname = if hostname.is_empty() {
+            name.clone()
+        } else {
+            hostname
+        };
         let action = {
             let nodes = self.nodes.read();
             evaluate_registration(nodes.get(&name), &resources)
@@ -1365,10 +1371,32 @@ impl ClusterManager {
             RegistrationAction::Skip => {
                 debug!(node = %name, "node unchanged, skipping");
                 self.sync_node_labels(&name, labels)?;
+                if let Some(existing) = self.get_node(&name) {
+                    let needs_update = existing.address.as_deref() != Some(address.as_str())
+                        || existing.hostname != hostname
+                        || existing.port != port
+                        || (!wg_pubkey.is_empty()
+                            && existing.wg_pubkey.as_deref() != Some(wg_pubkey.as_str()))
+                        || (!version.is_empty()
+                            && existing.version.as_deref() != Some(version.as_str()));
+                    if needs_update {
+                        self.propose(WalOperation::NodeUpdate {
+                            name: name.clone(),
+                            hostname: hostname.clone(),
+                            resources: existing.total_resources.clone(),
+                            address,
+                            port,
+                            wg_pubkey,
+                            version,
+                        })?;
+                        info!(node = %name, "node comm address or metadata updated");
+                    }
+                }
             }
             RegistrationAction::Update => {
                 self.propose(WalOperation::NodeUpdate {
                     name: name.clone(),
+                    hostname: hostname.clone(),
                     resources,
                     address,
                     port,
@@ -1384,6 +1412,7 @@ impl ClusterManager {
             RegistrationAction::Register => {
                 self.propose(WalOperation::NodeRegister {
                     name: name.clone(),
+                    hostname: hostname.clone(),
                     resources,
                     address,
                     port,
@@ -3897,6 +3926,7 @@ impl ClusterManager {
             }
             WalOperation::NodeRegister {
                 name,
+                hostname,
                 resources,
                 address,
                 port,
@@ -3905,9 +3935,17 @@ impl ClusterManager {
                 labels,
             } => {
                 let mut node = Node::new(name.clone(), resources.clone());
-                node.address = Some(address.clone());
-                node.port = *port;
+                node.hostname = if hostname.is_empty() {
+                    name.clone()
+                } else {
+                    hostname.clone()
+                };
                 node.labels = labels.clone();
+                self.apply_node_config_policy(&mut node);
+                if !address.is_empty() {
+                    node.address = Some(address.clone());
+                }
+                node.port = *port;
                 if !wg_pubkey.is_empty() {
                     node.wg_pubkey = Some(wg_pubkey.clone());
                 }
@@ -3937,8 +3975,6 @@ impl ClusterManager {
                 }
                 drop(partitions);
 
-                self.apply_node_config_policy(&mut node);
-
                 let mut nodes = self.nodes.write();
                 nodes.insert(name.clone(), node);
                 self.next_job_id.store(next_id, Ordering::Relaxed);
@@ -3946,6 +3982,7 @@ impl ClusterManager {
             }
             WalOperation::NodeUpdate {
                 name,
+                hostname,
                 resources,
                 address,
                 port,
@@ -3954,7 +3991,12 @@ impl ClusterManager {
             } => {
                 if let Some(node) = nodes.get_mut(name) {
                     node.total_resources = resources.clone();
-                    node.address = Some(address.clone());
+                    if !hostname.is_empty() {
+                        node.hostname = hostname.clone();
+                    }
+                    if !address.is_empty() {
+                        node.address = Some(address.clone());
+                    }
                     node.port = *port;
                     if !wg_pubkey.is_empty() {
                         node.wg_pubkey = Some(wg_pubkey.clone());
@@ -4161,6 +4203,11 @@ impl ClusterManager {
             if node_config_matches(nc, &node.name, &node.labels) {
                 node.features = nc.features.clone();
                 node.weight = nc.weight;
+                if node.address.is_none() {
+                    if let Some(ref cfg_addr) = nc.address {
+                        node.address = Some(cfg_addr.clone());
+                    }
+                }
                 return;
             }
         }
@@ -5196,6 +5243,7 @@ mod tests {
     fn register_node(cm: &ClusterManager, name: &str, cpus: u32, mem: u64) {
         cm.register_node(
             name.into(),
+            name.into(),
             ResourceSet {
                 cpus,
                 memory_mb: mem,
@@ -5632,6 +5680,7 @@ mod tests {
 
         cm.apply_operation(&WalOperation::NodeRegister {
             name: "gpu-node".into(),
+            hostname: String::new(),
             resources: ResourceSet {
                 cpus: 64,
                 memory_mb: 256000,
@@ -5648,6 +5697,7 @@ mod tests {
         assert_eq!(node.total_resources.cpus, 64);
         assert_eq!(node.state, NodeState::Idle);
         assert_eq!(node.address, Some("10.0.0.1".into()));
+        assert_eq!(node.hostname, "gpu-node");
         // Dynamically registered nodes get the default partition
         assert!(
             !node.partitions.is_empty(),
@@ -11608,6 +11658,7 @@ mod tests {
         // Agent reconnects — re-registration must NOT recover to Idle
         cm.register_node(
             "locked".into(),
+            "locked".into(),
             ResourceSet {
                 cpus: 4,
                 memory_mb: 8000,
@@ -13141,6 +13192,7 @@ mod tests {
 
         cm.register_node(
             "dyn-node".into(),
+            "dyn-node".into(),
             ResourceSet {
                 cpus: 8,
                 memory_mb: 16000,
@@ -13207,6 +13259,7 @@ mod tests {
         // First registration with labels
         cm.register_node(
             "worker1".into(),
+            "worker1".into(),
             ResourceSet {
                 cpus: 4,
                 memory_mb: 8000,
@@ -13228,6 +13281,7 @@ mod tests {
 
         // Re-register with same resources but different labels
         cm.register_node(
+            "worker1".into(),
             "worker1".into(),
             ResourceSet {
                 cpus: 4,
@@ -13253,6 +13307,93 @@ mod tests {
         assert_eq!(node.labels.get("tier"), Some(&"1".into()));
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reregistration_updates_comm_address_without_resource_change() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        let resources = ResourceSet {
+            cpus: 4,
+            memory_mb: 8000,
+            ..Default::default()
+        };
+
+        cm.register_node(
+            "worker1".into(),
+            "worker1".into(),
+            resources.clone(),
+            "10.0.0.1".into(),
+            6818,
+            String::new(),
+            String::new(),
+            spur_core::node::NodeSource::NativeHost,
+            HashMap::new(),
+        )
+        .unwrap();
+        wait_for("node registered", || cm.get_node("worker1").is_some());
+
+        cm.register_node(
+            "worker1".into(),
+            "worker1".into(),
+            resources,
+            "10.0.0.2".into(),
+            6818,
+            String::new(),
+            String::new(),
+            spur_core::node::NodeSource::NativeHost,
+            HashMap::new(),
+        )
+        .unwrap();
+        wait_for("comm address updated", || {
+            cm.get_node("worker1").and_then(|n| n.address).as_deref() == Some("10.0.0.2")
+        });
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn node_config_address_does_not_override_registered_comm_addr() {
+        let dir = TempDir::new().unwrap();
+        let mut cfg = test_config();
+        cfg.nodes = vec![spur_core::config::NodeConfig {
+            names: "worker1".into(),
+            selector: HashMap::new(),
+            cpus: 0,
+            memory_mb: 0,
+            gres: Vec::new(),
+            features: Vec::new(),
+            address: Some("10.0.0.99".into()),
+            weight: 1,
+        }];
+        let cm = test_cluster_with_config(&dir, cfg).await;
+
+        cm.register_node(
+            "worker1".into(),
+            "worker1".into(),
+            ResourceSet {
+                cpus: 4,
+                memory_mb: 8000,
+                ..Default::default()
+            },
+            "10.0.0.1".into(),
+            6818,
+            String::new(),
+            String::new(),
+            spur_core::node::NodeSource::NativeHost,
+            HashMap::from([("pool".into(), "train".into())]),
+        )
+        .unwrap();
+        wait_for("node registered", || cm.get_node("worker1").is_some());
+
+        cm.apply_operation(&WalOperation::NodeLabelsUpdate {
+            name: "worker1".into(),
+            set: HashMap::from([("pool".into(), "infer".into())]),
+            remove: Vec::new(),
+        });
+
+        assert_eq!(
+            cm.get_node("worker1").unwrap().address,
+            Some("10.0.0.1".into())
+        );
+    }
+
     #[test]
     fn label_update_applies_nodeconfig_features() {
         let dir = TempDir::new().unwrap();
@@ -13272,6 +13413,7 @@ mod tests {
         // Register a node directly via WAL apply
         cm.apply_operation(&WalOperation::NodeRegister {
             name: "gpu-node".into(),
+            hostname: String::new(),
             resources: ResourceSet {
                 cpus: 8,
                 memory_mb: 16000,
@@ -13317,6 +13459,7 @@ mod tests {
 
         cm.apply_operation(&WalOperation::NodeRegister {
             name: "gpu-node".into(),
+            hostname: String::new(),
             resources: ResourceSet {
                 cpus: 8,
                 memory_mb: 16000,
@@ -13362,6 +13505,7 @@ mod tests {
 
         cm.apply_operation(&WalOperation::NodeRegister {
             name: "cpu-node".into(),
+            hostname: String::new(),
             resources: ResourceSet {
                 cpus: 8,
                 memory_mb: 16000,

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -29,16 +29,12 @@ const CANCEL_RPC_TIMEOUT: Duration = Duration::from_secs(5);
 
 fn node_comm_socket(node: &Node) -> Option<String> {
     let host = node.comm_addr()?;
-    Some(format!("{host}:{}", node.port))
+    Some(spur_net::format_comm_socket(host, node.port))
 }
 
 fn node_comm_http_url(node: &Node) -> Option<String> {
     let host = node.comm_addr()?;
-    Some(format!("http://{host}:{}", node.port))
-}
-
-fn node_comm_endpoint(node: &Node) -> Option<(String, u16)> {
-    Some((node.comm_addr()?.to_string(), node.port))
+    Some(spur_net::format_comm_http_url(host, node.port))
 }
 
 /// Spawn the time-limit enforcement watchdog and power manager alongside the scheduler loop.
@@ -1110,9 +1106,9 @@ async fn register_allocation_on_nodes(
     let mut set = tokio::task::JoinSet::new();
     for node_name in &dispatch_nodes {
         let node_info = cluster.get_node(node_name);
-        let (addr, port) = match node_info {
-            Some(ref n) => match node_comm_endpoint(n) {
-                Some(ep) => ep,
+        let agent_addr = match node_info {
+            Some(ref n) => match node_comm_http_url(n) {
+                Some(url) => url,
                 None => {
                     warn!(
                         job_id,
@@ -1134,7 +1130,6 @@ async fn register_allocation_on_nodes(
             }
         };
 
-        let agent_addr = format!("http://{}:{}", addr, port);
         let result_node = node_name.clone();
         let allocated = per_node_allocs.get(node_name).cloned().unwrap_or_default();
         let params = AllocationRegisterParams {
@@ -1283,9 +1278,9 @@ async fn confirm_dispatch_on_nodes(
     let mut set = tokio::task::JoinSet::new();
     for (node_idx, node_name) in dispatch_nodes.iter().enumerate() {
         let node_info = cluster.get_node(node_name);
-        let (addr, port) = match node_info {
-            Some(ref n) => match node_comm_endpoint(n) {
-                Some(ep) => ep,
+        let agent_addr = match node_info {
+            Some(ref n) => match node_comm_http_url(n) {
+                Some(url) => url,
                 None => {
                     warn!(
                         job_id,
@@ -1307,7 +1302,6 @@ async fn confirm_dispatch_on_nodes(
             }
         };
 
-        let agent_addr = format!("http://{}:{}", addr, port);
         let spec = spec.clone();
         let peer_addrs = peer_addrs.clone();
         let task_offset = node_idx as u32 * tasks_per_node;
@@ -1831,9 +1825,9 @@ pub async fn send_suspend_to_agents(
 ) {
     for node_name in &job.allocated_nodes {
         let node_info = cluster.get_node(node_name);
-        let (addr, port) = match node_info {
-            Some(ref n) => match node_comm_endpoint(n) {
-                Some(ep) => ep,
+        let agent_addr = match node_info {
+            Some(ref n) => match node_comm_http_url(n) {
+                Some(url) => url,
                 None => {
                     warn!(job_id = job.job_id, node = %node_name,
                         "no comm address — cannot suspend/resume job on node");
@@ -1846,7 +1840,6 @@ pub async fn send_suspend_to_agents(
                 continue;
             }
         };
-        let agent_addr = format!("http://{}:{}", addr, port);
         let job_id = job.job_id;
         tokio::spawn(async move {
             match SlurmAgentClient::connect(agent_addr.clone())

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 use chrono::Utc;
 use tracing::{debug, error, info, warn};
 
-use spur_core::node::NodeSource;
+use spur_core::node::{Node, NodeSource};
 use spur_core::partition::requested_partition_names;
 use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
@@ -26,6 +26,20 @@ use crate::raft::RaftHandle;
 /// awaits delivery. Best-effort cleanup must not stall eviction on an
 /// unreachable agent.
 const CANCEL_RPC_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn node_comm_socket(node: &Node) -> Option<String> {
+    let host = node.comm_addr()?;
+    Some(format!("{host}:{}", node.port))
+}
+
+fn node_comm_http_url(node: &Node) -> Option<String> {
+    let host = node.comm_addr()?;
+    Some(format!("http://{host}:{}", node.port))
+}
+
+fn node_comm_endpoint(node: &Node) -> Option<(String, u16)> {
+    Some((node.comm_addr()?.to_string(), node.port))
+}
 
 /// Spawn the time-limit enforcement watchdog and power manager alongside the scheduler loop.
 pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
@@ -325,9 +339,14 @@ async fn process_assignment(
     let peer_addrs: Vec<String> = all_nodes
         .iter()
         .filter_map(|name| {
-            cluster
-                .get_node(name)
-                .and_then(|n| n.address.as_ref().map(|a| format!("{}:{}", a, n.port)))
+            let n = cluster.get_node(name)?;
+            if n.comm_addr().is_none() {
+                warn!(
+                    node = %name,
+                    "no comm address for peer list; node omitted from multi-node peers"
+                );
+            }
+            node_comm_socket(&n)
         })
         .collect();
 
@@ -1092,7 +1111,18 @@ async fn register_allocation_on_nodes(
     for node_name in &dispatch_nodes {
         let node_info = cluster.get_node(node_name);
         let (addr, port) = match node_info {
-            Some(ref n) if n.address.is_some() => (n.address.clone().unwrap(), n.port),
+            Some(ref n) => match node_comm_endpoint(n) {
+                Some(ep) => ep,
+                None => {
+                    warn!(
+                        job_id,
+                        node = %node_name,
+                        "no comm address for node, skipping allocation registration"
+                    );
+                    failures += 1;
+                    continue;
+                }
+            },
             _ => {
                 warn!(
                     job_id,
@@ -1254,7 +1284,18 @@ async fn confirm_dispatch_on_nodes(
     for (node_idx, node_name) in dispatch_nodes.iter().enumerate() {
         let node_info = cluster.get_node(node_name);
         let (addr, port) = match node_info {
-            Some(ref n) if n.address.is_some() => (n.address.clone().unwrap(), n.port),
+            Some(ref n) => match node_comm_endpoint(n) {
+                Some(ep) => ep,
+                None => {
+                    warn!(
+                        job_id,
+                        node = %node_name,
+                        "no comm address for node, skipping dispatch confirmation"
+                    );
+                    failures += 1;
+                    continue;
+                }
+            },
             _ => {
                 warn!(
                     job_id,
@@ -1710,8 +1751,16 @@ fn cancel_agent_addrs(
     let mut addrs = Vec::with_capacity(node_names.len());
     for node_name in node_names {
         match cluster.get_node(node_name) {
-            Some(ref n) if n.address.is_some() => {
-                addrs.push(format!("http://{}:{}", n.address.clone().unwrap(), n.port));
+            Some(ref n) => {
+                if let Some(url) = node_comm_http_url(n) {
+                    addrs.push(url);
+                } else {
+                    warn!(
+                        job_id,
+                        node = %node_name,
+                        "no comm address — cannot cancel job on node"
+                    );
+                }
             }
             _ => {
                 warn!(
@@ -1783,7 +1832,14 @@ pub async fn send_suspend_to_agents(
     for node_name in &job.allocated_nodes {
         let node_info = cluster.get_node(node_name);
         let (addr, port) = match node_info {
-            Some(ref n) if n.address.is_some() => (n.address.clone().unwrap(), n.port),
+            Some(ref n) => match node_comm_endpoint(n) {
+                Some(ep) => ep,
+                None => {
+                    warn!(job_id = job.job_id, node = %node_name,
+                        "no comm address — cannot suspend/resume job on node");
+                    continue;
+                }
+            },
             _ => {
                 warn!(job_id = job.job_id, node = %node_name,
                     "no agent address — cannot suspend/resume job on node");
@@ -2503,6 +2559,7 @@ mod tests {
         fn register_node_at(cm: &ClusterManager, name: &str, addr: std::net::SocketAddr) {
             cm.register_node(
                 name.into(),
+                name.into(),
                 ResourceSet {
                     cpus: 4,
                     memory_mb: 8000,
@@ -2520,6 +2577,34 @@ mod tests {
             wait_for(&format!("node '{n}' registered"), || {
                 cm.get_node(&n).is_some()
             });
+        }
+
+        fn register_node_without_comm_addr(cm: &ClusterManager, name: &str) {
+            use crate::raft::StateMachineApply;
+            use spur_core::wal::WalOperation;
+
+            cm.apply_operation(&WalOperation::NodeRegister {
+                name: name.into(),
+                hostname: name.into(),
+                resources: ResourceSet {
+                    cpus: 4,
+                    memory_mb: 8000,
+                    ..Default::default()
+                },
+                address: String::new(),
+                port: 6818,
+                wg_pubkey: String::new(),
+                version: String::new(),
+                labels: HashMap::new(),
+            });
+            let n = name.to_string();
+            wait_for(
+                &format!("node '{n}' registered without comm address"),
+                || {
+                    cm.get_node(&n)
+                        .is_some_and(|node| node.comm_addr().is_none())
+                },
+            );
         }
 
         fn submit_and_wait(cm: &ClusterManager, spec: JobSpec) -> spur_core::job::JobId {
@@ -2937,6 +3022,18 @@ mod tests {
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn dispatch_aborts_when_node_has_no_comm_address() {
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+
+            register_node_without_comm_addr(&cm, "n1");
+
+            let job_id = submit_and_wait(&cm, batch_spec("no-comm-addr", 1));
+            let outcome = confirm_dispatch_pending_job(&cm, job_id, &["n1"]).await;
+            assert!(matches!(outcome, DispatchConfirmOutcome::Aborted));
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
         async fn a_prolog_failure_drains_the_node_and_parks_the_job() {
             use spur_core::job::{JobState, PendingReason};
 
@@ -3283,6 +3380,7 @@ mod tests {
 
         fn register_k8s_node_at(cm: &ClusterManager, name: &str, addr: std::net::SocketAddr) {
             cm.register_node(
+                name.into(),
                 name.into(),
                 ResourceSet {
                     cpus: 4,

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -332,19 +332,29 @@ async fn process_assignment(
     // LaunchJob dispatch below, which — unlike the old fire-and-forget
     // spawn — now runs (and is awaited) *before* the job is allowed to
     // become visibly Running.
-    let peer_addrs: Vec<String> = all_nodes
-        .iter()
-        .filter_map(|name| {
-            let n = cluster.get_node(name)?;
-            if n.comm_addr().is_none() {
+    let peer_addrs: Vec<String> = {
+        let mut addrs = Vec::with_capacity(all_nodes.len());
+        for name in &all_nodes {
+            let Some(n) = cluster.get_node(name) else {
                 warn!(
+                    job_id,
                     node = %name,
-                    "no comm address for peer list; node omitted from multi-node peers"
+                    "node missing while building peer list"
                 );
-            }
-            node_comm_socket(&n)
-        })
-        .collect();
+                return false;
+            };
+            let Some(addr) = node_comm_socket(&n) else {
+                warn!(
+                    job_id,
+                    node = %name,
+                    "no comm address for peer list"
+                );
+                return false;
+            };
+            addrs.push(addr);
+        }
+        addrs
+    };
 
     let tasks_per_node = if let Some(tpn) = spec.tasks_per_node {
         tpn

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -27,6 +27,82 @@ use crate::sched_stats::SchedStatsCollector;
 const FORWARDED_HEADER: &str = "x-spur-forwarded";
 const LEADER_HEADER: &str = "x-spur-leader";
 
+/// Resolve the comm address for an agent registration.
+///
+/// Tries the advertised address first, then the gRPC peer IP (Slurm-style
+/// dynamic registration fallback). Loopback or link-local results are deferred
+/// when a routable candidate is also available.
+fn resolve_registration_comm_addr(
+    advertised: &str,
+    remote_addr: &str,
+    reject_loopback: bool,
+) -> Result<String, Status> {
+    let mut candidates = Vec::new();
+    if !advertised.is_empty() {
+        candidates.push(advertised);
+    }
+    if !remote_addr.is_empty() && remote_addr != advertised {
+        candidates.push(remote_addr);
+    }
+
+    if candidates.is_empty() {
+        return Err(Status::invalid_argument(
+            "no comm address available for registration",
+        ));
+    }
+
+    let mut last_err = None;
+    let mut unusable_result = None;
+    for candidate in candidates {
+        match spur_net::validate_comm_address(candidate, reject_loopback) {
+            Ok(addr) if spur_net::comm_addr_is_unusable(&addr) => {
+                if unusable_result.is_none() {
+                    unusable_result = Some((candidate.to_string(), addr));
+                }
+            }
+            Ok(addr) => {
+                if candidate != addr {
+                    info!(
+                        candidate = %candidate,
+                        comm_addr = %addr,
+                        "normalized comm address for registration"
+                    );
+                }
+                return Ok(addr);
+            }
+            Err(e) => last_err = Some(e),
+        }
+    }
+
+    if let Some((candidate, addr)) = unusable_result {
+        warn!(
+            comm_addr = %addr,
+            candidate = %candidate,
+            "node registered with loopback or link-local comm address"
+        );
+        return Ok(addr);
+    }
+
+    Err(Status::invalid_argument(format!(
+        "invalid comm address: {}",
+        last_err.unwrap()
+    )))
+}
+
+fn node_comm_http_url(node: &spur_core::node::Node, node_name: &str) -> Result<String, Status> {
+    let host = node
+        .comm_addr()
+        .ok_or_else(|| Status::unavailable(format!("node {node_name} has no comm address")))?;
+    Ok(format!("http://{host}:{}", node.port))
+}
+
+fn node_comm_socket(node: &spur_core::node::Node, node_name: &str) -> Result<String, Status> {
+    let host = node
+        .comm_addr()
+        .ok_or_else(|| Status::unavailable(format!("node {node_name} has no comm address")))?;
+    Ok(format!("{host}:{}", node.port))
+}
+
 /// Forwarding decision for read RPCs, split out so it's unit-testable.
 fn read_forwarding_policy(is_leader: bool, is_forwarded: bool) -> bool {
     !is_leader && !is_forwarded
@@ -977,17 +1053,9 @@ impl SlurmController for ControllerService {
         let req = request.into_inner();
         let resources = req.resources.map(proto_to_resource_set).unwrap_or_default();
 
-        let agent_addr = if !req.address.is_empty() {
-            req.address.clone()
-        } else {
-            let is_loopback =
-                remote_addr.is_empty() || remote_addr == "127.0.0.1" || remote_addr == "::1";
-            if is_loopback {
-                "127.0.0.1".to_string()
-            } else {
-                remote_addr
-            }
-        };
+        let reject_loopback = self.cluster.config.network.reject_loopback_comm_addr;
+        let agent_addr =
+            resolve_registration_comm_addr(&req.address, &remote_addr, reject_loopback)?;
 
         let agent_port = if req.port > 0 { req.port as u16 } else { 6818 };
 
@@ -995,6 +1063,8 @@ impl SlurmController for ControllerService {
 
         self.cluster
             .register_node(
+                // NodeName and NodeHostname are the same until agents can supply both.
+                req.hostname.clone(),
                 req.hostname.clone(),
                 resources,
                 agent_addr,
@@ -1322,8 +1392,7 @@ impl SlurmController for ControllerService {
         let node = self.cluster.get_node(target_node).ok_or_else(|| {
             Status::unavailable(format!("node {target_node} is not currently registered"))
         })?;
-        let host = node.address.as_deref().unwrap_or(&node.name);
-        let node_addr = format!("{}:{}", host, node.port);
+        let node_addr = node_comm_socket(&node, target_node)?;
 
         let existing_steps = self.cluster.get_steps(job_id);
         let step_id = existing_steps
@@ -1545,11 +1614,7 @@ impl SlurmController for ControllerService {
             .cluster
             .get_node(&node_name)
             .ok_or_else(|| Status::not_found(format!("node {} not found", node_name)))?;
-        let addr = node
-            .address
-            .as_ref()
-            .ok_or_else(|| Status::internal(format!("node {} has no agent address", node_name)))?;
-        let agent_addr = format!("http://{}:{}", addr, node.port);
+        let agent_addr = node_comm_http_url(&node, &node_name)?;
 
         let mut agent = SlurmAgentClient::connect(agent_addr.clone())
             .await
@@ -1660,13 +1725,16 @@ impl SlurmController for ControllerService {
                 dispatch_errors.push(format!("node {node_name} not found"));
                 continue;
             };
-            let Some(addr) = node.address.as_ref() else {
-                dispatch_errors.push(format!("node {node_name} has no agent address"));
-                continue;
+            let agent_addr = match node_comm_http_url(&node, &node_name) {
+                Ok(url) => url,
+                Err(e) => {
+                    dispatch_errors.push(format!("node {node_name}: {e}"));
+                    continue;
+                }
             };
             dispatches.push(NodeDispatch {
                 node_name,
-                agent_addr: format!("http://{}:{}", addr, node.port),
+                agent_addr,
                 node_tasks,
             });
         }
@@ -2608,6 +2676,35 @@ mod tests {
     use tonic::Code;
 
     #[test]
+    fn resolve_registration_comm_addr_normalizes_explicit_ip() {
+        assert_eq!(
+            resolve_registration_comm_addr("10.0.0.2", "", false).unwrap(),
+            "10.0.0.2"
+        );
+    }
+
+    #[test]
+    fn resolve_registration_comm_addr_falls_back_to_peer_ip() {
+        assert_eq!(
+            resolve_registration_comm_addr("", "10.0.0.9", false).unwrap(),
+            "10.0.0.9"
+        );
+    }
+
+    #[test]
+    fn resolve_registration_comm_addr_prefers_peer_over_loopback_advertised() {
+        assert_eq!(
+            resolve_registration_comm_addr("127.0.0.1", "10.245.159.30", false).unwrap(),
+            "10.245.159.30"
+        );
+    }
+
+    #[test]
+    fn resolve_registration_comm_addr_rejects_loopback_when_configured() {
+        assert!(resolve_registration_comm_addr("127.0.0.1", "", true).is_err());
+    }
+
+    #[test]
     fn resolve_user_namespace_sa_fails_closed_on_cold_cache() {
         // A not-yet-loaded cache resolves fail-open, so the scoped-kubeconfig path
         // must reject rather than mint an unscoped (cluster-wide) token.
@@ -2809,6 +2906,7 @@ mod tests {
 
         svc.cluster
             .register_node(
+                "n1".into(),
                 "n1".into(),
                 ResourceSet {
                     cpus: 8,

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -55,7 +55,7 @@ fn resolve_registration_comm_addr(
     let mut unusable_result = None;
     for candidate in candidates {
         match spur_net::validate_comm_address(candidate, reject_loopback) {
-            Ok(addr) if spur_net::comm_addr_is_unusable(&addr) => {
+            Ok(addr) if spur_net::normalized_comm_addr_is_unusable(&addr) => {
                 if unusable_result.is_none() {
                     unusable_result = Some((candidate.to_string(), addr));
                 }
@@ -83,10 +83,10 @@ fn resolve_registration_comm_addr(
         return Ok(addr);
     }
 
-    Err(Status::invalid_argument(format!(
-        "invalid comm address: {}",
-        last_err.unwrap()
-    )))
+    Err(Status::invalid_argument(match last_err {
+        Some(e) => format!("invalid comm address: {e}"),
+        None => "no comm address candidate resolved".into(),
+    }))
 }
 
 fn node_comm_http_url(node: &spur_core::node::Node, node_name: &str) -> Result<String, Status> {
@@ -2706,6 +2706,26 @@ mod tests {
     #[test]
     fn resolve_registration_comm_addr_rejects_loopback_when_configured() {
         assert!(resolve_registration_comm_addr("127.0.0.1", "", true).is_err());
+    }
+
+    #[test]
+    fn resolve_registration_comm_addr_prefers_peer_when_rejecting_loopback() {
+        assert_eq!(
+            resolve_registration_comm_addr("127.0.0.1", "10.245.159.30", true).unwrap(),
+            "10.245.159.30"
+        );
+    }
+
+    #[test]
+    fn node_comm_http_url_brackets_ipv6() {
+        let mut node =
+            spur_core::node::Node::new("n1".into(), spur_core::resource::ResourceSet::default());
+        node.address = Some("2001:db8::1".into());
+        node.port = 6818;
+        assert_eq!(
+            node_comm_http_url(&node, "n1").unwrap(),
+            "http://[2001:db8::1]:6818"
+        );
     }
 
     #[test]

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -3080,6 +3080,7 @@ mod tests {
             svc.cluster
                 .register_node(
                     (*name).into(),
+                    (*name).into(),
                     spur_core::resource::ResourceSet {
                         cpus: 4,
                         memory_mb: 8000,

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -93,14 +93,14 @@ fn node_comm_http_url(node: &spur_core::node::Node, node_name: &str) -> Result<S
     let host = node
         .comm_addr()
         .ok_or_else(|| Status::unavailable(format!("node {node_name} has no comm address")))?;
-    Ok(format!("http://{host}:{}", node.port))
+    Ok(spur_net::format_comm_http_url(host, node.port))
 }
 
 fn node_comm_socket(node: &spur_core::node::Node, node_name: &str) -> Result<String, Status> {
     let host = node
         .comm_addr()
         .ok_or_else(|| Status::unavailable(format!("node {node_name} has no comm address")))?;
-    Ok(format!("{host}:{}", node.port))
+    Ok(spur_net::format_comm_socket(host, node.port))
 }
 
 /// Forwarding decision for read RPCs, split out so it's unit-testable.
@@ -1054,8 +1054,12 @@ impl SlurmController for ControllerService {
         let resources = req.resources.map(proto_to_resource_set).unwrap_or_default();
 
         let reject_loopback = self.cluster.config.network.reject_loopback_comm_addr;
-        let agent_addr =
-            resolve_registration_comm_addr(&req.address, &remote_addr, reject_loopback)?;
+        let advertised = req.address.clone();
+        let agent_addr = tokio::task::spawn_blocking(move || {
+            resolve_registration_comm_addr(&advertised, &remote_addr, reject_loopback)
+        })
+        .await
+        .map_err(|e| Status::internal(format!("comm address resolution task failed: {e}")))??;
 
         let agent_port = if req.port > 0 { req.port as u16 } else { 6818 };
 

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -185,13 +185,17 @@ async fn main() -> anyhow::Result<()> {
         .clone()
         .or_else(|| std::env::var("SPUR_COMM_ADDRESS").ok());
     let node_address = if let Some(ref addr) = explicit_addr {
-        match spur_net::normalize_comm_address(addr) {
+        let addr_input = addr.clone();
+        match tokio::task::spawn_blocking(move || spur_net::normalize_comm_address(&addr_input))
+            .await
+            .map_err(|e| anyhow::anyhow!("comm address normalization task failed: {e}"))?
+        {
             Ok(normalized) => {
                 if spur_net::comm_addr_is_unusable(&normalized) {
                     warn!(
                         comm_addr = %normalized,
                         input = %addr,
-                        "explicit comm address resolves to loopback; inter-node jobs may fail"
+                        "explicit comm address is not routable; inter-node jobs may fail"
                     );
                 } else if normalized != *addr {
                     info!(
@@ -224,8 +228,13 @@ async fn main() -> anyhow::Result<()> {
             }
         }
     } else {
+        let detect_hostname = hostname.clone();
         let wg_interface = std::env::var("SPUR_WG_INTERFACE").unwrap_or_else(|_| "spur0".into());
-        spur_net::detect_node_address(&hostname, listen_port, &wg_interface)
+        tokio::task::spawn_blocking(move || {
+            spur_net::detect_node_address(&detect_hostname, listen_port, &wg_interface)
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("node address detection task failed: {e}"))?
     };
     info!(
         ip = %node_address.ip,

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -87,9 +87,9 @@ struct Args {
     #[arg(short = 'N', long)]
     hostname: Option<String>,
 
-    /// Advertised IP address for the controller to reach this agent.
+    /// Advertised comm address (IP or routable hostname) for inter-node reachability.
     /// If not set, auto-detected from WireGuard interface or hostname resolution.
-    #[arg(long, env = "SPUR_NODE_ADDRESS")]
+    #[arg(long, alias = "comm-address", env = "SPUR_NODE_ADDRESS")]
     address: Option<String>,
 
     /// Node labels for partition routing (key=value pairs).
@@ -179,14 +179,49 @@ async fn main() -> anyhow::Result<()> {
         spur_update::SPUR_BINARIES,
     );
 
-    // Detect node address (explicit --address > WireGuard > hostname)
-    let node_address = if let Some(ref addr) = args.address {
-        info!(ip = %addr, "using explicit node address");
-        spur_net::address::NodeAddress {
-            ip: addr.clone(),
-            hostname: hostname.clone(),
-            port: listen_port,
-            source: spur_net::address::AddressSource::Static,
+    // Detect node address (explicit --address/--comm-address > WireGuard > hostname)
+    let explicit_addr = args
+        .address
+        .clone()
+        .or_else(|| std::env::var("SPUR_COMM_ADDRESS").ok());
+    let node_address = if let Some(ref addr) = explicit_addr {
+        match spur_net::normalize_comm_address(addr) {
+            Ok(normalized) => {
+                if spur_net::comm_addr_is_unusable(&normalized) {
+                    warn!(
+                        comm_addr = %normalized,
+                        input = %addr,
+                        "explicit comm address resolves to loopback; inter-node jobs may fail"
+                    );
+                } else if normalized != *addr {
+                    info!(
+                        input = %addr,
+                        comm_addr = %normalized,
+                        "normalized explicit comm address"
+                    );
+                } else {
+                    info!(comm_addr = %normalized, "using explicit comm address");
+                }
+                spur_net::address::NodeAddress {
+                    ip: normalized,
+                    hostname: hostname.clone(),
+                    port: listen_port,
+                    source: spur_net::address::AddressSource::Static,
+                }
+            }
+            Err(e) => {
+                warn!(
+                    input = %addr,
+                    error = %e,
+                    "failed to normalize comm address; using raw value"
+                );
+                spur_net::address::NodeAddress {
+                    ip: addr.clone(),
+                    hostname: hostname.clone(),
+                    port: listen_port,
+                    source: spur_net::address::AddressSource::Static,
+                }
+            }
         }
     } else {
         let wg_interface = std::env::var("SPUR_WG_INTERFACE").unwrap_or_else(|_| "spur0".into());

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -191,7 +191,7 @@ async fn main() -> anyhow::Result<()> {
             .map_err(|e| anyhow::anyhow!("comm address normalization task failed: {e}"))?
         {
             Ok(normalized) => {
-                if spur_net::comm_addr_is_unusable(&normalized) {
+                if spur_net::normalized_comm_addr_is_unusable(&normalized) {
                     warn!(
                         comm_addr = %normalized,
                         input = %addr,

--- a/docs/deployment/native-host.rst
+++ b/docs/deployment/native-host.rst
@@ -45,6 +45,7 @@ Create ``/etc/spur/spur.conf``. The repository includes ``examples/spur.conf``. 
    wg_enabled = true
    wg_interface = "spur0"
    agent_port = 6818
+   # reject_loopback_comm_addr = true   # optional: refuse agent registrations whose comm address is loopback or link-local
 
    [[partitions]]
    name = "gpu"
@@ -57,6 +58,7 @@ Create ``/etc/spur/spur.conf``. The repository includes ``examples/spur.conf``. 
    cpus = 128
    memory_mb = 512000
    gres = ["gpu:mi300x:8"]
+   # address = "10.44.0.2"   # optional default comm address before the agent registers
 
 Start the controller:
 
@@ -127,7 +129,12 @@ Start the agent:
    spurd -D \
        --controller http://10.44.0.1:6817 \
        --hostname gpu-node-1 \
+       --address 10.44.0.2 \
        --listen [::]:6818
+
+``--address`` and ``--comm-address`` are equivalent. You can also set
+``SPUR_NODE_ADDRESS`` or ``SPUR_COMM_ADDRESS``. Pass a routable IP or FQDN,
+not the short hostname alone when ``/etc/hosts`` maps it to loopback.
 
 The agent auto-detects CPUs, memory, and GPUs, then registers with the controller over the mesh.
 

--- a/examples/spur.conf
+++ b/examples/spur.conf
@@ -74,12 +74,14 @@ names = "mi300"
 cpus = 256
 memory_mb = 2321924
 gres = ["gpu:mi300x:8"]
+# address = "10.44.0.2"   # optional default comm address before the agent registers
 
 [[nodes]]
 names = "mi300-2"
 cpus = 256
 memory_mb = 2321904
 gres = ["gpu:mi300x:8"]
+# address = "10.44.0.3"   # optional default comm address before the agent registers
 
 # Node configs can also match by label selector instead of hostname pattern.
 # Features and weight from matching configs are applied at registration.
@@ -92,6 +94,7 @@ gres = ["gpu:mi300x:8"]
 [network]
 wg_enabled = false
 agent_port = 6818
+# reject_loopback_comm_addr = true   # optional: refuse agent registrations whose comm address is loopback or link-local
 
 [logging]
 level = "info"


### PR DESCRIPTION
## Summary

Multi-node jobs and agent RPCs need a routable comm address (NodeAddr), not just the cluster node name. Agents on hosts where the short hostname resolves to loopback (common on cloud bare-metal) were registering unusable addresses and breaking inter-node TCP.

This PR separates node identity from reachability:

- **NodeName** — cluster name (`Node.name`, `-w`, partitions)
- **NodeHostname** — OS hostname at registration (`Node.hostname`, WAL-backed)
- **NodeAddr** — routable IP/FQDN for agent gRPC and inter-node TCP (`Node.address`)

Registration now normalizes comm addresses, prefers the gRPC peer IP when the advertised address is loopback or link-local, and updates comm metadata on re-register even when resources are unchanged. Dispatch and agent RPC paths require a registered comm address; they no longer fall back to the node name.

## Approach

- New `spur-net::comm_addr` module: normalize, validate, and detect unusable addresses (loopback, unspecified, link-local)
- `spurd`: keep `--address`, add `--comm-address` alias and `SPUR_COMM_ADDRESS`; normalize explicit addresses at startup
- `spurctld`: `resolve_registration_comm_addr()` at registration; Skip-path metadata updates; scheduler/gRPC dispatch via `comm_addr()`
- `NodeConfig.address` fills only when the agent has not registered an address yet (non-breaking for existing configs)
- Optional `[network] reject_loopback_comm_addr` to refuse non-routable registrations at the controller

Proto and wire format unchanged. WAL gains optional `hostname` on `NodeRegister`/`NodeUpdate` with `#[serde(default)]` for replay compatibility.

## Test plan

- [x] `cargo clippy --workspace --exclude spur-ffi --all-targets --locked`
- [x] `cargo test --locked`
- [x] `cargo fmt --all --check`
- [x] Unit tests: comm address normalization, registration peer-IP fallback, re-register comm update, NodeConfig non-override, dispatch abort without comm address