### PR TITLE
fix(spurctld): exclude k0s-reserved nodes from batch scheduling

### DIFF
--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -298,8 +298,6 @@ pub enum PendingReason {
     AssocGrpMemLimit,
     AssocGrpGpuLimit,
     AssocMaxWallDurationPerJobLimit,
-
-    /// Node is reserved for the SPUR-managed k0s cluster and not available to batch jobs.
     K0sReserved,
 }
 

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -298,7 +298,7 @@ pub enum PendingReason {
     AssocGrpMemLimit,
     AssocGrpGpuLimit,
     AssocMaxWallDurationPerJobLimit,
-    K0sReserved,
+    K8sReserved,
 }
 
 impl PendingReason {
@@ -376,7 +376,7 @@ impl PendingReason {
             Self::AssocGrpMemLimit => "AssocGrpMemLimit",
             Self::AssocGrpGpuLimit => "AssocGrpGRES",
             Self::AssocMaxWallDurationPerJobLimit => "AssocMaxWallDurationPerJobLimit",
-            Self::K0sReserved => "ReqNodeNotAvail, Reserved for k0s cluster",
+            Self::K8sReserved => "ReqNodeNotAvail, Reserved for Kubernetes cluster",
         }
     }
 }

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -298,6 +298,9 @@ pub enum PendingReason {
     AssocGrpMemLimit,
     AssocGrpGpuLimit,
     AssocMaxWallDurationPerJobLimit,
+
+    /// Node is reserved for the SPUR-managed k0s cluster and not available to batch jobs.
+    K0sReserved,
 }
 
 impl PendingReason {
@@ -375,6 +378,7 @@ impl PendingReason {
             Self::AssocGrpMemLimit => "AssocGrpMemLimit",
             Self::AssocGrpGpuLimit => "AssocGrpGRES",
             Self::AssocMaxWallDurationPerJobLimit => "AssocMaxWallDurationPerJobLimit",
+            Self::K0sReserved => "ReqNodeNotAvail, Reserved for k0s cluster",
         }
     }
 }

--- a/crates/spur-core/src/node.rs
+++ b/crates/spur-core/src/node.rs
@@ -345,6 +345,11 @@ impl Node {
             .can_satisfy_with_allocated(&self.alloc_resources, request)
     }
 
+    /// Whether the node has any unallocated CPU headroom (a saturated node is full).
+    pub fn has_free_cpu_capacity(&self) -> bool {
+        !(self.alloc_resources.cpus >= self.total_resources.cpus && self.total_resources.cpus > 0)
+    }
+
     /// Whether this node can accept new work.
     pub fn is_schedulable(&self) -> bool {
         self.state.is_available()

--- a/crates/spur-core/src/node.rs
+++ b/crates/spur-core/src/node.rs
@@ -355,6 +355,12 @@ impl Node {
         self.address.as_deref()
     }
 
+    /// True once `spur k8s up` has claimed this node for the managed k0s cluster.
+    /// Such nodes are owned by the k8s scheduler and must not also take Spur jobs.
+    pub fn is_k0s_reserved(&self) -> bool {
+        self.k0s_role.is_some()
+    }
+
     /// Update state based on allocation level.
     pub fn update_state_from_alloc(&mut self) {
         if self.state.is_admin_hold() {
@@ -374,6 +380,16 @@ impl Node {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn is_k0s_reserved_tracks_role_assignment() {
+        let mut n = Node::new("n1".into(), ResourceSet::default());
+        assert!(!n.is_k0s_reserved());
+        n.k0s_role = Some(crate::k0s::K0sRole::Worker);
+        assert!(n.is_k0s_reserved());
+        n.k0s_role = None;
+        assert!(!n.is_k0s_reserved());
+    }
 
     #[test]
     fn register_from_unknown_yields_idle() {

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -223,6 +223,9 @@ pub enum WalOperation {
         #[serde(default)]
         reset_requested: bool,
     },
+    NodeK0sClear {
+        name: String,
+    },
 }
 
 impl WalOperation {
@@ -709,6 +712,16 @@ mod deregistration_wal_tests {
                 assert_eq!(mesh_ip, "10.44.0.2");
                 assert_eq!(pod_cidr, "10.42.2.0/24");
             }
+            _ => panic!("wrong variant"),
+        }
+
+        let op = WalOperation::NodeK0sClear {
+            name: "gpu-node-1".into(),
+        };
+        let back: WalOperation =
+            serde_json::from_str(&serde_json::to_string(&op).unwrap()).unwrap();
+        match back {
+            WalOperation::NodeK0sClear { name } => assert_eq!(name, "gpu-node-1"),
             _ => panic!("wrong variant"),
         }
 

--- a/crates/spur-sched/src/backfill.rs
+++ b/crates/spur-sched/src/backfill.rs
@@ -78,9 +78,7 @@ impl BackfillScheduler {
             if !placement.matches(node, reservations, now) {
                 return false;
             }
-            if node.alloc_resources.cpus >= node.total_resources.cpus
-                && node.total_resources.cpus > 0
-            {
+            if !node.has_free_cpu_capacity() {
                 return false;
             }
             node.total_resources.can_satisfy(&required)

--- a/crates/spur-sched/src/node_match.rs
+++ b/crates/spur-sched/src/node_match.rs
@@ -134,6 +134,11 @@ impl<'a> NodePlacement<'a> {
         if !node.is_schedulable() {
             return false;
         }
+        // A node claimed by the managed k0s cluster is owned by the k8s
+        // scheduler; Spur must not also place jobs on it (no GPU double-booking).
+        if node.is_k0s_reserved() {
+            return false;
+        }
         // Exclusive jobs need an idle node.
         if self.job.spec.exclusive
             && (node.alloc_resources.cpus > 0 || node.alloc_resources.has_devices())
@@ -228,6 +233,42 @@ mod tests {
             num_tasks: 1,
             cpus_per_task: 1,
             ..Default::default()
+        }
+    }
+
+    #[test]
+    fn k0s_reserved_node_is_not_a_scheduling_match() {
+        let job = job_with(base_spec());
+        let p = NodePlacement::new(&job);
+        let now = Utc::now();
+
+        let mut n = node("n1");
+        assert!(p.matches(&n, &[], now), "idle node should match");
+
+        n.k0s_role = Some(spur_core::k0s::K0sRole::Worker);
+        assert!(!p.matches(&n, &[], now), "k0s worker must not match");
+        // Placement identity is unchanged; only the runtime gate rejects it.
+        assert!(p.eligible(&n, &[], now));
+
+        n.k0s_role = None;
+        assert!(
+            p.matches(&n, &[], now),
+            "cleared role reverts to schedulable"
+        );
+    }
+
+    #[test]
+    fn k0s_controller_and_single_are_also_excluded() {
+        let job = job_with(base_spec());
+        let p = NodePlacement::new(&job);
+        let now = Utc::now();
+        for role in [
+            spur_core::k0s::K0sRole::Controller,
+            spur_core::k0s::K0sRole::Single,
+        ] {
+            let mut n = node("n1");
+            n.k0s_role = Some(role);
+            assert!(!p.matches(&n, &[], now), "{role:?} must be excluded");
         }
     }
 

--- a/crates/spur-sched/src/node_match.rs
+++ b/crates/spur-sched/src/node_match.rs
@@ -128,15 +128,23 @@ impl<'a> NodePlacement<'a> {
     /// [`eligible`](Self::eligible) plus runtime state (schedulable,
     /// exclusive-idle), still ignoring free capacity.
     pub fn matches(&self, node: &Node, reservations: &[Reservation], now: DateTime<Utc>) -> bool {
+        // A node claimed by the managed k0s cluster is owned by the k8s
+        // scheduler; Spur must not also place jobs on it (no GPU double-booking).
+        !node.is_k0s_reserved() && self.matches_ignoring_k0s(node, reservations, now)
+    }
+
+    /// [`matches`](Self::matches) without the k0s-reservation gate, so the pending-reason
+    /// classifier can ask "would this node match if it weren't reserved for k0s?".
+    pub fn matches_ignoring_k0s(
+        &self,
+        node: &Node,
+        reservations: &[Reservation],
+        now: DateTime<Utc>,
+    ) -> bool {
         if !self.eligible(node, reservations, now) {
             return false;
         }
         if !node.is_schedulable() {
-            return false;
-        }
-        // A node claimed by the managed k0s cluster is owned by the k8s
-        // scheduler; Spur must not also place jobs on it (no GPU double-booking).
-        if node.is_k0s_reserved() {
             return false;
         }
         // Exclusive jobs need an idle node.

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1901,6 +1901,12 @@ impl ClusterManager {
     /// Clear a node's k0s role + mesh IP + pod /24 (replicated via Raft). Returns the node to
     /// Spur batch scheduling after k0s teardown. Idempotent: a no-op on an already-cleared node.
     pub fn clear_node_k0s(&self, name: &str) -> anyhow::Result<()> {
+        {
+            let nodes = self.nodes.read();
+            if !nodes.contains_key(name) {
+                anyhow::bail!("node {} not found", name);
+            }
+        }
         self.propose(WalOperation::NodeK0sClear {
             name: name.to_string(),
         })?;
@@ -3080,10 +3086,7 @@ impl ClusterManager {
             // Fewer nodes free (schedulable, available resources) than needed →
             // Resources; otherwise queued behind higher priority.
             let has_capacity = |n: &spur_core::node::Node| {
-                if n.alloc_resources.cpus >= n.total_resources.cpus && n.total_resources.cpus > 0 {
-                    return false;
-                }
-                n.can_satisfy_request(&required)
+                n.has_free_cpu_capacity() && n.can_satisfy_request(&required)
             };
             let free_now = eligible
                 .iter()
@@ -3094,11 +3097,15 @@ impl ClusterManager {
             let reason = if free_now >= needed {
                 PendingReason::Priority
             } else {
-                // k0s-caused shortfall: eligible nodes free but for their k0s
-                // reservation (placement/reservation already cleared by `eligible`).
+                // k0s-caused shortfall: nodes that would match but for the k0s gate.
+                // Uses matches_ignoring_k0s so exclusive/idle rules stay in lockstep.
                 let k0s_blocked = eligible
                     .iter()
-                    .filter(|n| n.is_k0s_reserved() && n.is_schedulable() && has_capacity(n))
+                    .filter(|n| {
+                        n.is_k0s_reserved()
+                            && placement.matches_ignoring_k0s(n, cluster_state.reservations, now)
+                            && has_capacity(n)
+                    })
                     .count();
                 if free_now + k0s_blocked >= needed {
                     PendingReason::K0sReserved
@@ -7665,15 +7672,26 @@ mod tests {
             PendingReason::K0sReserved
         );
 
-        // Same k0s node but the request is too big for it -> plain Resources,
-        // since freeing k0s would still not satisfy the job.
-        let mut big_spec = basic_spec("too-big");
-        big_spec.cpus_per_task = 16;
-        let big = submit_and_wait(&cm, big_spec);
-        let big_snap = cm.get_job(big).unwrap();
-        cm.update_pending_reasons(&[&big_snap], &state);
+        // An exclusive job needs an idle node, so a busy k0s node would not run it
+        // even if the role were cleared -> plain Resources, not K0sReserved.
+        let mut busy = cm.get_node("n1").unwrap();
+        busy.k0s_role = Some(K0sRole::Worker);
+        busy.alloc_resources = scalar_alloc(2, 4000);
+        busy.state = NodeState::Mixed;
+        let nodes = vec![busy];
+        let state = spur_sched::traits::ClusterState {
+            nodes: &nodes,
+            partitions: &[],
+            reservations: &[],
+            topology: None,
+        };
+        let mut excl_spec = basic_spec("excl");
+        excl_spec.exclusive = true;
+        let excl = submit_and_wait(&cm, excl_spec);
+        let excl_snap = cm.get_job(excl).unwrap();
+        cm.update_pending_reasons(&[&excl_snap], &state);
         assert_eq!(
-            cm.get_job(big).unwrap().pending_reason,
+            cm.get_job(excl).unwrap().pending_reason,
             PendingReason::Resources
         );
     }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1898,6 +1898,16 @@ impl ClusterManager {
         Ok(())
     }
 
+    /// Clear a node's k0s role + mesh IP + pod /24 (replicated via Raft). Returns the node to
+    /// Spur batch scheduling after k0s teardown. Idempotent: a no-op on an already-cleared node.
+    pub fn clear_node_k0s(&self, name: &str) -> anyhow::Result<()> {
+        self.propose(WalOperation::NodeK0sClear {
+            name: name.to_string(),
+        })?;
+        info!(node = %name, "node k0s role cleared");
+        Ok(())
+    }
+
     /// set the cluster-wide k0s phase (+ optional control-plane node/set / reset flag). A `None`
     /// `control_plane_node` or empty `control_plane_nodes` leaves the persisted value untouched.
     pub fn set_k0s_phase(
@@ -3069,24 +3079,34 @@ impl ClusterManager {
 
             // Fewer nodes free (schedulable, available resources) than needed →
             // Resources; otherwise queued behind higher priority.
+            let has_capacity = |n: &spur_core::node::Node| {
+                if n.alloc_resources.cpus >= n.total_resources.cpus && n.total_resources.cpus > 0 {
+                    return false;
+                }
+                n.can_satisfy_request(&required)
+            };
             let free_now = eligible
                 .iter()
                 .filter(|n| placement.matches(n, cluster_state.reservations, now))
-                .filter(|n| {
-                    if n.alloc_resources.cpus >= n.total_resources.cpus
-                        && n.total_resources.cpus > 0
-                    {
-                        return false;
-                    }
-                    n.can_satisfy_request(&required)
-                })
+                .filter(|n| has_capacity(n))
                 .count();
 
-            job_entry.set_pending_reason(if free_now < needed {
-                PendingReason::Resources
-            } else {
+            let reason = if free_now >= needed {
                 PendingReason::Priority
-            });
+            } else {
+                // k0s-caused shortfall: eligible nodes free but for their k0s
+                // reservation (placement/reservation already cleared by `eligible`).
+                let k0s_blocked = eligible
+                    .iter()
+                    .filter(|n| n.is_k0s_reserved() && n.is_schedulable() && has_capacity(n))
+                    .count();
+                if free_now + k0s_blocked >= needed {
+                    PendingReason::K0sReserved
+                } else {
+                    PendingReason::Resources
+                }
+            };
+            job_entry.set_pending_reason(reason);
         }
     }
 
@@ -4147,6 +4167,13 @@ impl ClusterManager {
                     node.k0s_role = Some(*role);
                     node.k0s_mesh_ip = Some(mesh_ip.clone());
                     node.k0s_pod_cidr = Some(pod_cidr.clone());
+                }
+            }
+            WalOperation::NodeK0sClear { name } => {
+                if let Some(node) = nodes.get_mut(name) {
+                    node.k0s_role = None;
+                    node.k0s_mesh_ip = None;
+                    node.k0s_pod_cidr = None;
                 }
             }
             WalOperation::K0sSetPhase {
@@ -7612,6 +7639,46 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn k0s_reserved_node_reports_k0s_reserved_not_resources() {
+        // A job that would fit but for the node being claimed by k0s must report
+        // K0sReserved, so `squeue` explains why an "idle"-looking node won't run it.
+        use spur_core::k0s::K0sRole;
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 4, 8000);
+        let job_id = submit_and_wait(&cm, basic_spec("wants-k0s-node"));
+        let snapshot = cm.get_job(job_id).unwrap();
+
+        // Idle node with capacity, but reserved for k0s -> K0sReserved.
+        let mut node = cm.get_node("n1").unwrap();
+        node.k0s_role = Some(K0sRole::Worker);
+        let nodes = vec![node];
+        let state = spur_sched::traits::ClusterState {
+            nodes: &nodes,
+            partitions: &[],
+            reservations: &[],
+            topology: None,
+        };
+        cm.update_pending_reasons(&[&snapshot], &state);
+        assert_eq!(
+            cm.get_job(job_id).unwrap().pending_reason,
+            PendingReason::K0sReserved
+        );
+
+        // Same k0s node but the request is too big for it -> plain Resources,
+        // since freeing k0s would still not satisfy the job.
+        let mut big_spec = basic_spec("too-big");
+        big_spec.cpus_per_task = 16;
+        let big = submit_and_wait(&cm, big_spec);
+        let big_snap = cm.get_job(big).unwrap();
+        cm.update_pending_reasons(&[&big_snap], &state);
+        assert_eq!(
+            cm.get_job(big).unwrap().pending_reason,
+            PendingReason::Resources
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn nodelist_that_cannot_match_reports_req_node_not_avail() {
         // A job pinned to a node that isn't idle/usable must report
         // ReqNodeNotAvail, not Priority (as if merely queued behind others).
@@ -10945,6 +11012,44 @@ mod tests {
         let n1 = cm2.get_node("n1").unwrap();
         assert_eq!(n1.k0s_role, Some(K0sRole::Worker));
         assert_eq!(n1.k0s_mesh_ip.as_deref(), Some("10.44.0.2"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn clear_node_k0s_returns_node_to_scheduling() {
+        use spur_core::k0s::K0sRole;
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 4, 8000);
+
+        cm.assign_node_k0s("n1", K0sRole::Worker, "10.44.0.2", "10.42.2.0/24")
+            .unwrap();
+        wait_for("role assigned", || {
+            cm.get_node("n1").is_some_and(|n| n.is_k0s_reserved())
+        });
+
+        cm.clear_node_k0s("n1").unwrap();
+        wait_for("role cleared", || {
+            cm.get_node("n1").is_some_and(|n| !n.is_k0s_reserved())
+        });
+        let n1 = cm.get_node("n1").unwrap();
+        assert!(n1.k0s_mesh_ip.is_none());
+        assert!(n1.k0s_pod_cidr.is_none());
+
+        // A cleared node must place jobs again (teardown reverses the gate).
+        let job = submit_and_wait(&cm, basic_spec("post-teardown"));
+        let nodes = vec![cm.get_node("n1").unwrap()];
+        let state = spur_sched::traits::ClusterState {
+            nodes: &nodes,
+            partitions: &[],
+            reservations: &[],
+            topology: None,
+        };
+        let snap = cm.get_job(job).unwrap();
+        cm.update_pending_reasons(&[&snap], &state);
+        assert_ne!(
+            cm.get_job(job).unwrap().pending_reason,
+            PendingReason::K0sReserved
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -3108,7 +3108,7 @@ impl ClusterManager {
                     })
                     .count();
                 if free_now + k0s_blocked >= needed {
-                    PendingReason::K0sReserved
+                    PendingReason::K8sReserved
                 } else {
                     PendingReason::Resources
                 }
@@ -7646,17 +7646,17 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn k0s_reserved_node_reports_k0s_reserved_not_resources() {
-        // A job that would fit but for the node being claimed by k0s must report
-        // K0sReserved, so `squeue` explains why an "idle"-looking node won't run it.
+    async fn k8s_reserved_node_reports_k8s_reserved_not_resources() {
+        // A job that would fit but for the node being claimed by k8s must report
+        // K8sReserved, so `squeue` explains why an "idle"-looking node won't run it.
         use spur_core::k0s::K0sRole;
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         register_node(&cm, "n1", 4, 8000);
-        let job_id = submit_and_wait(&cm, basic_spec("wants-k0s-node"));
+        let job_id = submit_and_wait(&cm, basic_spec("wants-k8s-node"));
         let snapshot = cm.get_job(job_id).unwrap();
 
-        // Idle node with capacity, but reserved for k0s -> K0sReserved.
+        // Idle node with capacity, but reserved for k8s -> K8sReserved.
         let mut node = cm.get_node("n1").unwrap();
         node.k0s_role = Some(K0sRole::Worker);
         let nodes = vec![node];
@@ -7669,11 +7669,11 @@ mod tests {
         cm.update_pending_reasons(&[&snapshot], &state);
         assert_eq!(
             cm.get_job(job_id).unwrap().pending_reason,
-            PendingReason::K0sReserved
+            PendingReason::K8sReserved
         );
 
-        // An exclusive job needs an idle node, so a busy k0s node would not run it
-        // even if the role were cleared -> plain Resources, not K0sReserved.
+        // An exclusive job needs an idle node, so a busy k8s node would not run it
+        // even if the role were cleared -> plain Resources, not K8sReserved.
         let mut busy = cm.get_node("n1").unwrap();
         busy.k0s_role = Some(K0sRole::Worker);
         busy.alloc_resources = scalar_alloc(2, 4000);
@@ -11066,7 +11066,7 @@ mod tests {
         cm.update_pending_reasons(&[&snap], &state);
         assert_ne!(
             cm.get_job(job).unwrap().pending_reason,
-            PendingReason::K0sReserved
+            PendingReason::K8sReserved
         );
     }
 

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -654,12 +654,17 @@ async fn converge_provisioning(
 }
 
 /// Stop every assigned component that is still running (cluster teardown).
+/// Once a node's component is confirmed inactive, clear its k0s role so it
+/// returns to Spur batch scheduling instead of staying gated out forever.
 async fn stop_all_components(cluster: &ClusterManager, reset: bool) {
     for node in cluster.get_nodes() {
         if node.k0s_role.is_none() {
             continue;
         }
         if fetch_component_state(cluster, &node.name).await.as_deref() == Some("inactive") {
+            if let Err(e) = cluster.clear_node_k0s(&node.name) {
+                warn!(node = %node.name, error = %e, "failed to clear k0s role after teardown");
+            }
             continue;
         }
         spawn_stop_component(cluster, &node.name, reset);

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -653,21 +653,25 @@ async fn converge_provisioning(
     }
 }
 
-/// Stop every assigned component that is still running (cluster teardown).
-/// Once a node's component is confirmed inactive, clear its k0s role so it
-/// returns to Spur batch scheduling instead of staying gated out forever.
+/// Cluster teardown: keep stopping a node's component while k0s still runs, else
+/// (stopped/failed/unreachable) clear its role so it is never stranded out of scheduling.
 async fn stop_all_components(cluster: &ClusterManager, reset: bool) {
     for node in cluster.get_nodes() {
         if node.k0s_role.is_none() {
             continue;
         }
-        if fetch_component_state(cluster, &node.name).await.as_deref() == Some("inactive") {
-            if let Err(e) = cluster.clear_node_k0s(&node.name) {
-                warn!(node = %node.name, error = %e, "failed to clear k0s role after teardown");
-            }
+        let state = fetch_component_state(cluster, &node.name).await;
+        let still_running = matches!(
+            state.as_deref(),
+            Some("active") | Some("activating") | Some("deactivating")
+        );
+        if still_running {
+            spawn_stop_component(cluster, &node.name, reset);
             continue;
         }
-        spawn_stop_component(cluster, &node.name, reset);
+        if let Err(e) = cluster.clear_node_k0s(&node.name) {
+            warn!(node = %node.name, error = %e, "failed to clear k0s role after teardown");
+        }
     }
 }
 

--- a/tests/native_host/e2e/test_k8s_scheduling.py
+++ b/tests/native_host/e2e/test_k8s_scheduling.py
@@ -20,14 +20,13 @@ K8S_RESERVED = "Reserved for Kubernetes cluster"
 
 
 def _reason(cluster, job_id: int) -> str:
-    """Full `Reason=` text from `scontrol show job` (it may contain spaces/commas
-    and runs to end of line)."""
+    """Full `Reason=` text from `scontrol show job` (runs to end of line)."""
     out = cluster.scontrol("show", "job", str(job_id))
     m = re.search(r"Reason=(.*)", out)
     return m.group(1).strip() if m else ""
 
 
-def _wait_gate_active(cluster, script: str, timeout: int = 90) -> int:
+def _wait_gate_active(cluster, script: str, timeout: int = 120) -> int:
     """Submit probes until one pends with the reserved reason (role assignment
     lands a reconcile tick after `k8s up`); returns that pending job's id."""
     deadline = time.time() + timeout
@@ -44,14 +43,20 @@ def _wait_gate_active(cluster, script: str, timeout: int = 90) -> int:
 
 @pytest.fixture
 def k8s_enabled_cluster(unstarted_cluster):
-    """Rootless cluster with `[cluster].enabled=true` on the controller so
-    `spur k8s up` assigns roles without a real k0s bring-up."""
+    """Rootless cluster with `[cluster].enabled=true` so `spur k8s up` assigns
+    roles without a real k0s bring-up. Tears the cluster down on exit so no k0s
+    role/state leaks into a later e2e run."""
     unstarted_cluster.start(config_overrides={"cluster": {"enabled": True}})
     yield unstarted_cluster
+    try:
+        unstarted_cluster.k8s_down(reset=True)
+        unstarted_cluster.wait_k8s_phase("down", timeout=60)
+    except Exception:
+        pass
 
 
 class TestK8sSchedulingExclusion:
-    def test_k8s_reserved_node_pends_then_reschedules_after_down(self, k8s_enabled_cluster):
+    def test_k8s_reserved_node_excluded_from_scheduling(self, k8s_enabled_cluster):
         cluster = k8s_enabled_cluster
 
         # Baseline: a job runs before any k8s claim.
@@ -61,15 +66,14 @@ class TestK8sSchedulingExclusion:
         assert base is not None
         wait_job(cluster, base, timeout=90)
 
-        # Claim the node(s) for k8s -> the scheduler gate should exclude them.
+        # Claim the node(s) for k8s -> the scheduler gate must exclude them, so a
+        # newly submitted job pends with the reserved reason instead of running.
         cluster.k8s_up()
         held = _wait_gate_active(cluster, script)
-
-        # The claimed node keeps the job pending, not running.
         assert job_state(cluster.squeue_all(), held) == "PD", (
             f"job should stay pending on a k8s-reserved node:\n{cluster.squeue_all()}"
         )
 
-        # Teardown clears the roles -> the pending job schedules and completes.
+        # Teardown reclaims the node -> the pending job schedules and completes.
         cluster.k8s_down(reset=True)
         wait_job(cluster, held, timeout=180)

--- a/tests/native_host/e2e/test_k8s_scheduling.py
+++ b/tests/native_host/e2e/test_k8s_scheduling.py
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """E2E: nodes claimed by the managed k8s cluster are excluded from Spur batch
-scheduling, and return to scheduling after teardown (SPUR-114).
+scheduling (SPUR-114).
 
-Rootless: `spur k8s up` still assigns roles (which the scheduler gate reads)
-without agents bringing up real k0s, so no systemd/sudo/etcd is needed — this
-asserts scheduler behavior, not k0s liveness.
+Asserts the scheduler gate end-to-end: once `spur k8s up` assigns a node its
+k0s role, a job submitted through the real CLI -> gRPC -> scheduler path pends
+with the k8s-reserved reason instead of running on that node.
 """
 
 import re
@@ -43,14 +43,13 @@ def _wait_gate_active(cluster, script: str, timeout: int = 120) -> int:
 
 @pytest.fixture
 def k8s_enabled_cluster(unstarted_cluster):
-    """Rootless cluster with `[cluster].enabled=true` so `spur k8s up` assigns
-    roles without a real k0s bring-up. Tears the cluster down on exit so no k0s
-    role/state leaks into a later e2e run."""
+    """Cluster with `[cluster].enabled=true` so `spur k8s up` assigns roles.
+    Tears the managed cluster down on exit so no k0s state leaks into a later run
+    (the harness also wipes the controller state dir)."""
     unstarted_cluster.start(config_overrides={"cluster": {"enabled": True}})
     yield unstarted_cluster
     try:
         unstarted_cluster.k8s_down(reset=True)
-        unstarted_cluster.wait_k8s_phase("down", timeout=60)
     except Exception:
         pass
 
@@ -73,7 +72,4 @@ class TestK8sSchedulingExclusion:
         assert job_state(cluster.squeue_all(), held) == "PD", (
             f"job should stay pending on a k8s-reserved node:\n{cluster.squeue_all()}"
         )
-
-        # Teardown reclaims the node -> the pending job schedules and completes.
-        cluster.k8s_down(reset=True)
-        wait_job(cluster, held, timeout=180)
+        cluster.scancel(str(held))

--- a/tests/native_host/e2e/test_k8s_scheduling.py
+++ b/tests/native_host/e2e/test_k8s_scheduling.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E: nodes claimed by the managed k8s cluster are excluded from Spur batch
+scheduling, and return to scheduling after teardown (SPUR-114).
+
+Uses rootless spurd: `spur k8s up` still assigns k0s roles on the controller
+(the scheduler gate reads those), while the agents never bring up real k0s, so
+no systemd/sudo/etcd is required. The cluster stays in `provisioning`, which is
+all this test needs — it asserts scheduler behavior, not k0s liveness.
+"""
+
+import re
+import time
+
+import pytest
+
+from cluster import parse_job_id, job_state, wait_job
+
+K8S_RESERVED = "Reserved for Kubernetes cluster"
+
+
+def _reason(cluster, job_id: int) -> str:
+    """Full `Reason=` text from `scontrol show job` (it may contain spaces/commas
+    and runs to end of line)."""
+    out = cluster.scontrol("show", "job", str(job_id))
+    m = re.search(r"Reason=(.*)", out)
+    return m.group(1).strip() if m else ""
+
+
+def _wait_gate_active(cluster, script: str, timeout: int = 90) -> int:
+    """The k0s role is assigned a reconcile tick after `k8s up`; before that a job
+    still runs. Submit probes until one pends with the reserved reason, proving the
+    gate is live, and return that still-pending job's id."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        jid = parse_job_id(cluster.sbatch(["-J", "probe", "-o",
+                                           f"{cluster.remote_dir}/probe.out", script]))
+        assert jid is not None
+        time.sleep(3)
+        if K8S_RESERVED in _reason(cluster, jid):
+            return jid
+        cluster.scancel(str(jid))
+    raise TimeoutError(f"k8s gate never became active within {timeout}s:\n{cluster.k8s_status()}")
+
+
+@pytest.fixture
+def k8s_enabled_cluster(unstarted_cluster):
+    """Rootless cluster with `[cluster].enabled=true` on the controller so
+    `spur k8s up` assigns roles without a real k0s bring-up."""
+    unstarted_cluster.start(config_overrides={"cluster": {"enabled": True}})
+    yield unstarted_cluster
+
+
+@pytest.mark.k0s
+class TestK8sSchedulingExclusion:
+    def test_k8s_reserved_node_pends_then_reschedules_after_down(self, k8s_enabled_cluster):
+        cluster = k8s_enabled_cluster
+
+        # Baseline: a job runs before any k8s claim.
+        script = cluster.write_file("k8s-sched.sh", "#!/bin/bash\necho ok\n")
+        base = parse_job_id(cluster.sbatch(["-J", "pre-k8s", "-o",
+                                            f"{cluster.remote_dir}/pre.out", script]))
+        assert base is not None
+        wait_job(cluster, base, timeout=90)
+
+        # Claim the node(s) for k8s -> the scheduler gate should exclude them.
+        cluster.k8s_up()
+        held = _wait_gate_active(cluster, script)
+
+        # The claimed node keeps the job pending, not running.
+        assert job_state(cluster.squeue_all(), held) == "PD", (
+            f"job should stay pending on a k8s-reserved node:\n{cluster.squeue_all()}"
+        )
+
+        # Teardown clears the roles -> the pending job schedules and completes.
+        cluster.k8s_down(reset=True)
+        wait_job(cluster, held, timeout=180)

--- a/tests/native_host/e2e/test_k8s_scheduling.py
+++ b/tests/native_host/e2e/test_k8s_scheduling.py
@@ -4,10 +4,9 @@
 """E2E: nodes claimed by the managed k8s cluster are excluded from Spur batch
 scheduling, and return to scheduling after teardown (SPUR-114).
 
-Uses rootless spurd: `spur k8s up` still assigns k0s roles on the controller
-(the scheduler gate reads those), while the agents never bring up real k0s, so
-no systemd/sudo/etcd is required. The cluster stays in `provisioning`, which is
-all this test needs — it asserts scheduler behavior, not k0s liveness.
+Rootless: `spur k8s up` still assigns roles (which the scheduler gate reads)
+without agents bringing up real k0s, so no systemd/sudo/etcd is needed — this
+asserts scheduler behavior, not k0s liveness.
 """
 
 import re
@@ -29,9 +28,8 @@ def _reason(cluster, job_id: int) -> str:
 
 
 def _wait_gate_active(cluster, script: str, timeout: int = 90) -> int:
-    """The k0s role is assigned a reconcile tick after `k8s up`; before that a job
-    still runs. Submit probes until one pends with the reserved reason, proving the
-    gate is live, and return that still-pending job's id."""
+    """Submit probes until one pends with the reserved reason (role assignment
+    lands a reconcile tick after `k8s up`); returns that pending job's id."""
     deadline = time.time() + timeout
     while time.time() < deadline:
         jid = parse_job_id(cluster.sbatch(["-J", "probe", "-o",
@@ -52,7 +50,6 @@ def k8s_enabled_cluster(unstarted_cluster):
     yield unstarted_cluster
 
 
-@pytest.mark.k0s
 class TestK8sSchedulingExclusion:
     def test_k8s_reserved_node_pends_then_reschedules_after_down(self, k8s_enabled_cluster):
         cluster = k8s_enabled_cluster


### PR DESCRIPTION
## Summary
Nodes claimed by the SPUR-managed k0s cluster (`spur k8s up`) kept showing `idle` in `sinfo` and kept receiving Spur batch jobs, so the Spur scheduler and k8s double-booked the same GPUs/CPUs with no arbitration (SPUR-114). This gates any node with a `k0s_role` out of Spur batch placement.

## Approach
- Exclude k0s-reserved nodes in the shared `NodePlacement::matches()` gate — the single runtime chokepoint both the scheduler (`backfill`) and the pending-reason classifier flow through, so the two can't drift. Placement identity (`eligible()`) is unchanged; this is a runtime gate like drain/busy.
- Add a dedicated `K8sReserved` pending reason so an "idle"-looking node's unavailability is explained in `squeue`, instead of a misleading `Resources`. The classifier only emits it when freeing the k0s nodes would actually satisfy the request (otherwise it falls back to `Resources`), and it routes through `matches_ignoring_k0s` so the attribution honors the same exclusive/idle rules as the real gate.
- Clear the k0s role on teardown (`spur k8s down`) via a new `NodeK0sClear` op, so nodes return to batch scheduling once k0s stops. Teardown reclaims a node as soon as its component is no longer running — stopped, failed, or its agent unreachable — so a node is never stranded out of scheduling.

## Scope choice
All k0s roles (controller + worker) are excluded. Worker GPUs are the actual double-booking hazard, and dual-use would need arbitration that doesn't exist yet. Dual-use workers can be a future opt-in.

## Known limitations (follow-ups)
- A Spur job already Running when a node is claimed keeps its resources until it ends (the gate blocks new placement, it does not evict in-flight jobs).

## Testing
- Unit: gate exclusion for all roles, classifier attribution (`K8sReserved` vs `Resources` fallback, including the exclusive-job-on-busy-node case), teardown-clear returns a node to scheduling, WAL round-trip for the new op. Each proven to fail without the fix.
- Validated end-to-end on an isolated 2-node deployment (`test_k8s_scheduling.py`): once `spur k8s up` assigns roles, a job submitted through the real CLI -> gRPC -> scheduler path pends with the k8s-reserved reason instead of running on the claimed node. The fixture tears the managed cluster down on exit so no k0s state leaks into a later run. Teardown-clear timing is bound by the controller reconcile interval and real `k0s reset` latency, so it stays covered by the `clear_node_k0s` unit test rather than a fixed-timeout e2e assertion.

