### PR TITLE
feat(spurctld): authorize k0s cluster ops and scope kubeconfigs per user

### DIFF
--- a/crates/spur-cli/src/k8s.rs
+++ b/crates/spur-cli/src/k8s.rs
@@ -51,12 +51,15 @@ pub enum K8sCommand {
     },
     /// Show cluster phase + per-node component status.
     Status,
-    /// Print a kubeconfig to stdout. Default: the cluster-admin kubeconfig. With `--user`, a
-    /// namespace-scoped kubeconfig (a ServiceAccount token in that user's account namespace).
+    /// Print a kubeconfig to stdout. Default: your own scope. `--admin`: cluster-admin (admins only).
+    /// `--user X`: another user's scope (admins only).
     Kubeconfig {
-        /// Mint a scoped kubeconfig for this SPUR user instead of the admin one.
+        /// Mint a scoped kubeconfig for this SPUR user instead of your own (requires cluster admin).
         #[arg(long)]
         user: Option<String>,
+        /// Fetch the cluster-admin kubeconfig instead of a scoped one (requires cluster admin).
+        #[arg(long, conflicts_with = "user")]
+        admin: bool,
     },
     /// Download + install the k0s binary on THIS node (local; no controller needed).
     /// Run as root for the default /usr/local/bin path.
@@ -96,13 +99,17 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         }
         K8sCommand::Down { reset } => cmd_down(&controller, reset).await,
         K8sCommand::Status => cmd_status(&controller).await,
-        K8sCommand::Kubeconfig { user } => cmd_kubeconfig(&controller, user).await,
+        K8sCommand::Kubeconfig { user, admin } => cmd_kubeconfig(&controller, user, admin).await,
         K8sCommand::InstallK0s {
             version,
             path,
             force,
         } => cmd_install_k0s(&version, &path, force).await,
     }
+}
+
+fn effective_user() -> String {
+    whoami::username().unwrap_or_else(|_| "unknown".into())
 }
 
 async fn cmd_install_k0s(version: &str, path: &str, force: bool) -> Result<()> {
@@ -135,6 +142,7 @@ async fn cmd_up(
             control_plane_node,
             control_plane_replicas: replicas,
             control_plane_nodes,
+            caller: effective_user(),
         })
         .await?
         .into_inner();
@@ -152,7 +160,10 @@ async fn cmd_up(
 async fn cmd_down(controller: &str, reset: bool) -> Result<()> {
     let mut client = SlurmControllerClient::new(spur_client::connect_channel(controller).await?);
     let resp = client
-        .cluster_down(ClusterDownRequest { reset })
+        .cluster_down(ClusterDownRequest {
+            reset,
+            caller: effective_user(),
+        })
         .await?
         .into_inner();
     if resp.accepted {
@@ -184,11 +195,13 @@ async fn cmd_status(controller: &str) -> Result<()> {
     Ok(())
 }
 
-async fn cmd_kubeconfig(controller: &str, user: Option<String>) -> Result<()> {
+async fn cmd_kubeconfig(controller: &str, user: Option<String>, admin: bool) -> Result<()> {
     let mut client = SlurmControllerClient::new(spur_client::connect_channel(controller).await?);
     let resp = client
         .cluster_kubeconfig(ClusterKubeconfigRequest {
             user: user.unwrap_or_default(),
+            caller: effective_user(),
+            admin,
         })
         .await?
         .into_inner();
@@ -250,5 +263,37 @@ mod tests {
     fn controller_defaults_and_env() {
         let args = K8sArgs::try_parse_from(["k8s", "status"]).unwrap();
         assert_eq!(args.controller, "http://localhost:6817");
+    }
+
+    #[test]
+    fn kubeconfig_bare_is_self_scoped() {
+        let args = K8sArgs::try_parse_from(["k8s", "kubeconfig"]).unwrap();
+        match args.command {
+            K8sCommand::Kubeconfig { user, admin } => {
+                assert_eq!(user, None);
+                assert!(!admin);
+            }
+            _ => panic!("wrong command"),
+        }
+    }
+
+    #[test]
+    fn kubeconfig_admin_flag_parses() {
+        let args = K8sArgs::try_parse_from(["k8s", "kubeconfig", "--admin"]).unwrap();
+        match args.command {
+            K8sCommand::Kubeconfig { admin, .. } => assert!(admin),
+            _ => panic!("wrong command"),
+        }
+    }
+
+    #[test]
+    fn kubeconfig_admin_and_user_conflict() {
+        let err =
+            K8sArgs::try_parse_from(["k8s", "kubeconfig", "--admin", "--user", "bob"]).unwrap_err();
+        assert_eq!(
+            err.kind(),
+            clap::error::ErrorKind::ArgumentConflict,
+            "--admin and --user must be mutually exclusive"
+        );
     }
 }

--- a/crates/spur-cli/src/k8s.rs
+++ b/crates/spur-cli/src/k8s.rs
@@ -54,7 +54,7 @@ pub enum K8sCommand {
     /// Print a kubeconfig to stdout. Default: your own scope. `--admin`: cluster-admin (admins only).
     /// `--user X`: another user's scope (admins only).
     Kubeconfig {
-        /// Mint a scoped kubeconfig for this SPUR user instead of your own (requires cluster admin).
+        /// Mint a scoped kubeconfig for this SPUR user; targeting anyone but yourself needs admin.
         #[arg(long)]
         user: Option<String>,
         /// Fetch the cluster-admin kubeconfig instead of a scoped one (requires cluster admin).

--- a/crates/spurctld/src/accounting/mod.rs
+++ b/crates/spurctld/src/accounting/mod.rs
@@ -49,6 +49,18 @@ pub async fn fairshare_factors(
     ))
 }
 
+/// Fold one user-row's admin_level into the per-user map, keeping the highest: `Admin` wins over
+/// any lower level so a later non-admin row for a multi-account user can't clobber it.
+fn merge_admin_level(map: &mut HashMap<String, String>, user: &str, level: &str) {
+    if level.is_empty() || level.eq_ignore_ascii_case("none") {
+        return;
+    }
+    let entry = map.entry(user.to_owned()).or_default();
+    if entry.is_empty() || level.eq_ignore_ascii_case("admin") {
+        *entry = level.to_owned();
+    }
+}
+
 /// Load association defaults, the full user→account membership set, and
 /// per-association resource limits backing the controller's `AssociationCache`.
 pub async fn association_maps(
@@ -59,6 +71,7 @@ pub async fn association_maps(
     HashSet<(String, String)>,
     HashMap<(String, String), AccountLimits>,
     HashMap<(String, String), HashSet<String>>,
+    HashMap<String, String>,
 )> {
     let users = db::list_users(pool, None, None).await?;
 
@@ -66,9 +79,11 @@ pub async fn association_maps(
     let mut default_account = HashMap::new();
     let mut memberships = HashSet::new();
     let mut allowed_qos = HashMap::new();
+    let mut admin_level = HashMap::new();
     for u in users {
         let key = (u.name.clone(), u.account.clone());
         memberships.insert(key.clone());
+        merge_admin_level(&mut admin_level, &u.name, &u.admin_level);
         if let Some(qos) = u.default_qos {
             default_qos.insert(key.clone(), qos);
         }
@@ -103,6 +118,7 @@ pub async fn association_maps(
         memberships,
         limits,
         allowed_qos,
+        admin_level,
     ))
 }
 
@@ -127,5 +143,34 @@ fn account_limits_from_record(r: db::AssociationRecord) -> AccountLimits {
         max_tres_per_job: opt_tres(r.max_tres_per_job),
         grp_tres: opt_tres(r.grp_tres),
         max_wall_minutes: opt_u32(r.max_wall_min),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::merge_admin_level;
+    use std::collections::HashMap;
+
+    #[test]
+    fn admin_wins_regardless_of_row_order() {
+        // Admin then Operator: Admin must survive the later non-admin row.
+        let mut m = HashMap::new();
+        merge_admin_level(&mut m, "carol", "Admin");
+        merge_admin_level(&mut m, "carol", "Operator");
+        assert_eq!(m.get("carol").map(String::as_str), Some("Admin"));
+
+        // Operator then Admin: Admin must still win.
+        let mut m = HashMap::new();
+        merge_admin_level(&mut m, "carol", "Operator");
+        merge_admin_level(&mut m, "carol", "Admin");
+        assert_eq!(m.get("carol").map(String::as_str), Some("Admin"));
+    }
+
+    #[test]
+    fn none_and_empty_levels_are_dropped() {
+        let mut m = HashMap::new();
+        merge_admin_level(&mut m, "dave", "none");
+        merge_admin_level(&mut m, "dave", "");
+        assert!(!m.contains_key("dave"));
     }
 }

--- a/crates/spurctld/src/association_cache.rs
+++ b/crates/spurctld/src/association_cache.rs
@@ -17,6 +17,7 @@ struct Snapshot {
     memberships: HashSet<(String, String)>,
     limits: HashMap<(String, String), AccountLimits>,
     allowed_qos: HashMap<(String, String), HashSet<String>>,
+    admin_level: HashMap<String, String>,
     loaded: bool,
 }
 
@@ -50,6 +51,7 @@ impl AssociationCache {
                 memberships: HashSet::new(),
                 limits: HashMap::new(),
                 allowed_qos: HashMap::new(),
+                admin_level: HashMap::new(),
                 loaded: false,
             }),
         }
@@ -58,6 +60,17 @@ impl AssociationCache {
     /// True after a successful load from the accounting database.
     pub fn is_loaded(&self) -> bool {
         self.snapshot.read().loaded
+    }
+
+    /// Whether `user` holds the `Admin` accounting admin-level. Fails closed: an unloaded cache
+    /// (accounting off or not yet fetched) reports no admins.
+    pub fn is_admin(&self, user: &str) -> bool {
+        let snapshot = self.snapshot.read();
+        snapshot.loaded
+            && snapshot
+                .admin_level
+                .get(user)
+                .is_some_and(|lvl| lvl.eq_ignore_ascii_case("admin"))
     }
 
     pub fn account_membership(&self, user: &str, account: &str) -> AccountMembership {
@@ -158,6 +171,7 @@ impl AssociationCache {
             .unwrap_or_default()
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn replace(
         &self,
         default_qos: HashMap<(String, String), String>,
@@ -165,6 +179,7 @@ impl AssociationCache {
         memberships: HashSet<(String, String)>,
         limits: HashMap<(String, String), AccountLimits>,
         allowed_qos: HashMap<(String, String), HashSet<String>>,
+        admin_level: HashMap<String, String>,
     ) {
         *self.snapshot.write() = Snapshot {
             default_qos,
@@ -172,6 +187,7 @@ impl AssociationCache {
             memberships,
             limits,
             allowed_qos,
+            admin_level,
             loaded: true,
         };
     }
@@ -182,6 +198,13 @@ impl AssociationCache {
         let mut snap = self.snapshot.write();
         snap.memberships
             .insert((user.to_owned(), account.to_owned()));
+        snap.loaded = true;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn insert_admin_level(&self, user: &str, level: &str) {
+        let mut snap = self.snapshot.write();
+        snap.admin_level.insert(user.to_owned(), level.to_owned());
         snap.loaded = true;
     }
 
@@ -243,16 +266,17 @@ impl AssociationCache {
             )
             .await
             {
-                Ok(Ok((qos, accounts, memberships, limits, allowed_qos))) => {
+                Ok(Ok((qos, accounts, memberships, limits, allowed_qos, admin_level))) => {
                     info!(
                         default_qos = qos.len(),
                         default_account = accounts.len(),
                         memberships = memberships.len(),
                         limits = limits.len(),
                         allowed_qos = allowed_qos.len(),
+                        admin_level = admin_level.len(),
                         "association cache initialized"
                     );
-                    cache.replace(qos, accounts, memberships, limits, allowed_qos);
+                    cache.replace(qos, accounts, memberships, limits, allowed_qos, admin_level);
                 }
                 Ok(Err(e)) => {
                     warn!(error = %e, "initial association fetch failed, will retry in background");
@@ -271,8 +295,8 @@ impl AssociationCache {
                 )
                 .await
                 {
-                    Ok(Ok((qos, accounts, memberships, limits, allowed_qos))) => {
-                        cache.replace(qos, accounts, memberships, limits, allowed_qos)
+                    Ok(Ok((qos, accounts, memberships, limits, allowed_qos, admin_level))) => {
+                        cache.replace(qos, accounts, memberships, limits, allowed_qos, admin_level)
                     }
                     Ok(Err(e)) => {
                         warn!(error = %e, "association refresh failed, retaining stale data")
@@ -295,6 +319,22 @@ mod tests {
             cache.resolve("alice", Some("research")),
             (Some("research".into()), None, HashSet::new())
         );
+    }
+
+    #[test]
+    fn is_admin_false_on_cold_cache() {
+        let cache = AssociationCache::new();
+        assert!(!cache.is_admin("carol"));
+    }
+
+    #[test]
+    fn is_admin_true_only_for_admin_level_case_insensitive() {
+        let cache = AssociationCache::new();
+        cache.insert_admin_level("carol", "admin");
+        cache.insert_admin_level("dave", "Operator");
+        assert!(cache.is_admin("carol"));
+        assert!(!cache.is_admin("dave"));
+        assert!(!cache.is_admin("erin"));
     }
 
     #[test]
@@ -340,6 +380,7 @@ mod tests {
             HashSet::from([("bob".to_string(), "eng".to_string())]),
             HashMap::new(),
             HashMap::new(),
+            HashMap::new(),
         );
         assert_eq!(
             cache.resolve("alice", Some("research")),
@@ -383,6 +424,7 @@ mod tests {
             HashMap::from([(("bob".to_string(), "eng".to_string()), "new".to_string())]),
             HashMap::new(),
             HashSet::from([("bob".to_string(), "eng".to_string())]),
+            HashMap::new(),
             HashMap::new(),
             HashMap::new(),
         );
@@ -525,6 +567,7 @@ mod tests {
                     ..Default::default()
                 },
             )]),
+            HashMap::new(),
             HashMap::new(),
         );
         assert_eq!(

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -320,6 +320,12 @@ fn resolve_user_namespace_sa(
     ))
 }
 
+/// Whether `caller` may perform k0s cluster-admin ops: empty/root always, else accounting `Admin`.
+/// Fails closed when accounting is off (cache reports no admins), leaving only root/internal.
+fn is_k0s_admin(cache: &crate::association_cache::AssociationCache, caller: &str) -> bool {
+    caller.is_empty() || caller == "root" || cache.is_admin(caller)
+}
+
 #[tonic::async_trait]
 impl SlurmController for ControllerService {
     async fn submit_job(
@@ -1872,6 +1878,11 @@ impl SlurmController for ControllerService {
             }
         }
         let req = request.into_inner();
+        if !is_k0s_admin(self.cluster.association_cache(), &req.caller) {
+            return Err(Status::permission_denied(
+                "k0s cluster up requires cluster admin",
+            ));
+        }
         let state = self.cluster.k0s_state();
         let nodes = self.cluster.get_nodes();
         let assigned = nodes.iter().any(|n| n.k0s_role.is_some());
@@ -1954,6 +1965,11 @@ impl SlurmController for ControllerService {
             }
         }
         let req = request.into_inner();
+        if !is_k0s_admin(self.cluster.association_cache(), &req.caller) {
+            return Err(Status::permission_denied(
+                "k0s cluster down requires cluster admin",
+            ));
+        }
         self.cluster
             .set_k0s_phase(spur_core::k0s::K0sPhase::Down, None, Vec::new(), req.reset)
             .map_err(|e| Status::internal(format!("set k0s phase: {e}")))?;
@@ -1994,7 +2010,14 @@ impl SlurmController for ControllerService {
             return client.cluster_kubeconfig(fwd).await;
         }
         let req = request.into_inner();
-        if req.user.is_empty() {
+        let is_admin = is_k0s_admin(self.cluster.association_cache(), &req.caller);
+
+        if req.admin {
+            if !is_admin {
+                return Err(Status::permission_denied(
+                    "the cluster-admin kubeconfig requires cluster admin",
+                ));
+            }
             // Cluster-admin kubeconfig (`k0s kubeconfig admin` on the control-plane agent).
             return match crate::cluster_k8s::fetch_admin_kubeconfig(&self.cluster).await {
                 Ok(kubeconfig) => Ok(Response::new(ClusterKubeconfigResponse { kubeconfig })),
@@ -2003,17 +2026,35 @@ impl SlurmController for ControllerService {
                 ))),
             };
         }
-        // Scoped kubeconfig: resolve the user's account -> its namespace + per-user ServiceAccount,
+
+        // A non-admin caller may only mint their own scope; an admin may target any user. An empty
+        // target means "the caller's own namespace" (an empty caller is internal/root).
+        let target = if req.user.is_empty() {
+            req.caller.clone()
+        } else {
+            req.user.clone()
+        };
+        if !is_admin && target != req.caller {
+            return Err(Status::permission_denied(format!(
+                "user '{}' may only request their own kubeconfig",
+                req.caller
+            )));
+        }
+        if target.is_empty() {
+            return Err(Status::invalid_argument(
+                "no target user for the scoped kubeconfig; pass --user or set a caller identity",
+            ));
+        }
+
+        // Scoped kubeconfig: resolve the target's account -> its namespace + per-user ServiceAccount,
         // then have the control-plane agent mint a bound token there.
-        let (namespace, sa) =
-            resolve_user_namespace_sa(self.cluster.association_cache(), &req.user)?;
-        match crate::cluster_k8s::fetch_user_kubeconfig(&self.cluster, &req.user, &namespace, &sa)
+        let (namespace, sa) = resolve_user_namespace_sa(self.cluster.association_cache(), &target)?;
+        match crate::cluster_k8s::fetch_user_kubeconfig(&self.cluster, &target, &namespace, &sa)
             .await
         {
             Ok(kubeconfig) => Ok(Response::new(ClusterKubeconfigResponse { kubeconfig })),
             Err(e) => Err(Status::unavailable(format!(
-                "could not mint a scoped kubeconfig for user '{}': {e}",
-                req.user
+                "could not mint a scoped kubeconfig for user '{target}': {e}"
             ))),
         }
     }
@@ -2755,6 +2796,31 @@ mod tests {
     }
 
     #[test]
+    fn is_k0s_admin_root_and_empty_always_admin_even_cold_cache() {
+        let cache = crate::association_cache::AssociationCache::new();
+        assert!(is_k0s_admin(&cache, ""));
+        assert!(is_k0s_admin(&cache, "root"));
+    }
+
+    #[test]
+    fn is_k0s_admin_named_user_denied_when_accounting_off() {
+        // Cold cache = accounting disabled/not loaded: only root/internal are admin.
+        let cache = crate::association_cache::AssociationCache::new();
+        assert!(!is_k0s_admin(&cache, "alice"));
+    }
+
+    #[test]
+    fn is_k0s_admin_honors_accounting_admin_level() {
+        let cache = crate::association_cache::AssociationCache::new();
+        cache.insert_admin_level("carol", "Admin");
+        cache.insert_admin_level("dave", "Operator");
+        assert!(is_k0s_admin(&cache, "carol"));
+        // Operator is not full admin; a plain member isn't either.
+        assert!(!is_k0s_admin(&cache, "dave"));
+        assert!(!is_k0s_admin(&cache, "erin"));
+    }
+
+    #[test]
     fn read_forwards_only_when_follower_and_not_already_forwarded() {
         // Leader serves reads locally; never forwards.
         assert!(!read_forwarding_policy(true, false));
@@ -3144,6 +3210,146 @@ mod tests {
             .await
             .expect_err("shrinking an assigned 3-CP cluster must be rejected");
         assert_eq!(err.code(), Code::FailedPrecondition);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cluster_up_denied_for_non_admin_caller() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        svc.cluster
+            .association_cache()
+            .insert_association("alice", "physics");
+        let err = svc
+            .cluster_up(Request::new(ClusterUpRequest {
+                caller: "alice".into(),
+                ..Default::default()
+            }))
+            .await
+            .expect_err("a non-admin caller must not bring the cluster up");
+        assert_eq!(err.code(), Code::PermissionDenied);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cluster_down_denied_for_non_admin_caller() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        svc.cluster
+            .association_cache()
+            .insert_association("alice", "physics");
+        let err = svc
+            .cluster_down(Request::new(ClusterDownRequest {
+                caller: "alice".into(),
+                ..Default::default()
+            }))
+            .await
+            .expect_err("a non-admin caller must not tear the cluster down");
+        assert_eq!(err.code(), Code::PermissionDenied);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cluster_up_allowed_for_admin_level_caller() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        svc.cluster
+            .register_node(
+                "cp-a".into(),
+                "cp-a".into(),
+                spur_core::resource::ResourceSet {
+                    cpus: 4,
+                    memory_mb: 8000,
+                    ..Default::default()
+                },
+                "127.0.0.1".into(),
+                6818,
+                String::new(),
+                String::new(),
+                spur_core::node::NodeSource::NativeHost,
+                std::collections::HashMap::new(),
+            )
+            .unwrap();
+        svc.cluster
+            .association_cache()
+            .insert_admin_level("carol", "Admin");
+        let resp = svc
+            .cluster_up(Request::new(ClusterUpRequest {
+                caller: "carol".into(),
+                control_plane_replicas: Some(1),
+                ..Default::default()
+            }))
+            .await
+            .expect("an Admin-level caller may bring the cluster up")
+            .into_inner();
+        assert!(resp.accepted);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cluster_kubeconfig_admin_flag_denied_for_non_admin() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        svc.cluster
+            .association_cache()
+            .insert_association("alice", "physics");
+        let err = svc
+            .cluster_kubeconfig(Request::new(ClusterKubeconfigRequest {
+                caller: "alice".into(),
+                admin: true,
+                ..Default::default()
+            }))
+            .await
+            .expect_err("a non-admin must not get the cluster-admin kubeconfig");
+        assert_eq!(err.code(), Code::PermissionDenied);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cluster_kubeconfig_other_user_denied_for_non_admin() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        svc.cluster
+            .association_cache()
+            .insert_default_account("alice", "physics");
+        let err = svc
+            .cluster_kubeconfig(Request::new(ClusterKubeconfigRequest {
+                caller: "alice".into(),
+                user: "bob".into(),
+                ..Default::default()
+            }))
+            .await
+            .expect_err("a non-admin must not mint another user's kubeconfig");
+        assert_eq!(err.code(), Code::PermissionDenied);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cluster_kubeconfig_bare_self_scope_clears_authz_for_non_admin() {
+        // A non-admin bare request (own scope) must pass authz and reach target resolution; the
+        // absent control-plane agent then yields Unavailable — never PermissionDenied/InvalidArgument.
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        svc.cluster
+            .association_cache()
+            .insert_default_account("alice", "physics");
+        let err = svc
+            .cluster_kubeconfig(Request::new(ClusterKubeconfigRequest {
+                caller: "alice".into(),
+                ..Default::default()
+            }))
+            .await
+            .expect_err("no control-plane agent is running in this test");
+        assert_eq!(err.code(), Code::Unavailable);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cluster_up_denied_for_named_caller_when_accounting_off() {
+        // Cold cache = accounting disabled: a named caller is not admin, so up fails closed.
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let err = svc
+            .cluster_up(Request::new(ClusterUpRequest {
+                caller: "alice".into(),
+                ..Default::default()
+            }))
+            .await
+            .expect_err("a named caller must be denied when accounting is off");
+        assert_eq!(err.code(), Code::PermissionDenied);
     }
 
     #[test]

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -3320,8 +3320,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn cluster_kubeconfig_bare_self_scope_clears_authz_for_non_admin() {
-        // A non-admin bare request (own scope) must pass authz and reach target resolution; the
-        // absent control-plane agent then yields Unavailable — never PermissionDenied/InvalidArgument.
+        // A non-admin bare request (own scope) clears authz; the absent control-plane agent then
+        // yields Unavailable, never PermissionDenied/InvalidArgument.
         let dir = tempfile::TempDir::new().unwrap();
         let svc = test_service(&dir).await;
         svc.cluster
@@ -3330,6 +3330,44 @@ mod tests {
         let err = svc
             .cluster_kubeconfig(Request::new(ClusterKubeconfigRequest {
                 caller: "alice".into(),
+                ..Default::default()
+            }))
+            .await
+            .expect_err("no control-plane agent is running in this test");
+        assert_eq!(err.code(), Code::Unavailable);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cluster_kubeconfig_admin_may_target_other_user() {
+        // An Admin caller clears authz for another user's scope; failure is the absent agent
+        // (Unavailable), not PermissionDenied.
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let cache = svc.cluster.association_cache();
+        cache.insert_admin_level("carol", "Admin");
+        cache.insert_default_account("bob", "chem");
+        let err = svc
+            .cluster_kubeconfig(Request::new(ClusterKubeconfigRequest {
+                caller: "carol".into(),
+                user: "bob".into(),
+                ..Default::default()
+            }))
+            .await
+            .expect_err("no control-plane agent is running in this test");
+        assert_eq!(err.code(), Code::Unavailable);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cluster_kubeconfig_admin_flag_allowed_for_admin_level_caller() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        svc.cluster
+            .association_cache()
+            .insert_admin_level("carol", "Admin");
+        let err = svc
+            .cluster_kubeconfig(Request::new(ClusterKubeconfigRequest {
+                caller: "carol".into(),
+                admin: true,
                 ..Default::default()
             }))
             .await

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -796,6 +796,7 @@ message ClusterUpRequest {
   optional uint32 control_plane_replicas = 3;
   // Explicit control-plane node names (1, 3, or 5). First is the etcd bootstrap node.
   repeated string control_plane_nodes = 4;
+  string caller = 5;   // For authorization (cluster admin required).
 }
 message ClusterUpResponse {
   bool accepted = 1;
@@ -806,6 +807,7 @@ message ClusterUpResponse {
 message ClusterDownRequest {
   // Also `k0s reset` each node (destructive: wipes cluster state).
   bool reset = 1;
+  string caller = 2;   // For authorization (cluster admin required).
 }
 message ClusterDownResponse {
   bool accepted = 1;
@@ -830,9 +832,11 @@ message ClusterNodeStatus {
 }
 
 message ClusterKubeconfigRequest {
-  // Empty -> the cluster-admin kubeconfig. Set -> a namespace-scoped kubeconfig for this SPUR user
-  // (a ServiceAccount + bound token in the user's account namespace).
+  // Target user for the scoped kubeconfig. Empty -> the caller's own namespace. A non-empty value
+  // other than the caller requires cluster admin.
   string user = 1;
+  string caller = 2;   // For authorization; empty is treated as root (internal).
+  bool admin = 3;      // Request the cluster-admin kubeconfig (cluster admin required).
 }
 message ClusterKubeconfigResponse {
   // Admin kubeconfig YAML (server rewritten to the control-plane's mesh IP), or the scoped kubeconfig

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -445,11 +445,12 @@ class SpurCluster:
     # --- Native k0s cluster (spur k8s) wrappers ---
 
     def k8s_up(self, args: list[str] | None = None) -> str:
-        return self.cli(["spur", "k8s", "up"] + (args or []))
+        # k0s up/down are admin-gated; run as root so they pass without accounting.
+        return self.cli_as_user("root", ["spur", "k8s", "up"] + (args or []))
 
     def k8s_down(self, reset: bool = True) -> str:
         extra = ["--reset"] if reset else []
-        return self.cli(["spur", "k8s", "down"] + extra)
+        return self.cli_as_user("root", ["spur", "k8s", "down"] + extra)
 
     def k8s_status(self) -> str:
         return self.cli(["spur", "k8s", "status"])

--- a/tests/native_host/e2e/test_k8s_auth.py
+++ b/tests/native_host/e2e/test_k8s_auth.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Authorization for native k0s cluster ops (SPUR-115).
+
+The admin gate rejects a non-admin caller before any k0s work, so these deny
+paths need no real control plane. Identity is whoami-derived, exercised via
+`cli_as_user` (same seam as the reservation owner tests)."""
+
+import pytest
+
+
+class TestK8sAuth:
+    def _require_sudo_second_identity(self, cluster):
+        submit_user = cluster.nodes[0].user
+        if submit_user == "root":
+            pytest.skip("need a non-root SSH user to test non-admin rejection")
+        probe = cluster.cli_as_user("root", ["spur", "k8s", "status"])
+        if "sudo" in probe.lower() and (
+            "password" in probe.lower() or "not allowed" in probe.lower()
+        ):
+            pytest.skip(f"sudo -u unavailable in this environment: {probe.strip()}")
+        return submit_user
+
+    def test_non_admin_cannot_up_or_down(self, cluster):
+        submit_user = self._require_sudo_second_identity(cluster)
+
+        up = cluster.cli_as_user(submit_user, ["spur", "k8s", "up"])
+        assert "permission" in up.lower(), f"non-admin up must be denied: {up}"
+
+        down = cluster.cli_as_user(submit_user, ["spur", "k8s", "down"])
+        assert "permission" in down.lower(), f"non-admin down must be denied: {down}"
+
+    def test_non_admin_cannot_fetch_admin_kubeconfig(self, cluster):
+        submit_user = self._require_sudo_second_identity(cluster)
+        out = cluster.cli_as_user(submit_user, ["spur", "k8s", "kubeconfig", "--admin"])
+        assert "permission" in out.lower(), f"non-admin --admin must be denied: {out}"
+
+    def test_non_admin_cannot_target_another_user(self, cluster):
+        submit_user = self._require_sudo_second_identity(cluster)
+        out = cluster.cli_as_user(
+            submit_user, ["spur", "k8s", "kubeconfig", "--user", "someone-else"]
+        )
+        assert "permission" in out.lower(), f"non-admin --user X must be denied: {out}"
+
+    def test_root_passes_the_admin_gate(self, cluster):
+        # Root clears the gate: up proceeds past authz to the k0s layer, so the
+        # failure (if any) is never PermissionDenied.
+        self._require_sudo_second_identity(cluster)
+        out = cluster.cli_as_user("root", ["spur", "k8s", "up"])
+        assert "permission" not in out.lower(), f"root must clear the admin gate: {out}"

--- a/tests/native_host/e2e/test_k8s_auth.py
+++ b/tests/native_host/e2e/test_k8s_auth.py
@@ -1,11 +1,8 @@
 # Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Authorization for native k0s cluster ops (SPUR-115).
-
-The admin gate rejects a non-admin caller before any k0s work, so these deny
-paths need no real control plane. Identity is whoami-derived, exercised via
-`cli_as_user` (same seam as the reservation owner tests)."""
+"""Authorization for native k0s cluster ops (SPUR-115); deny paths need no
+control plane. Identity is whoami-derived, exercised via `cli_as_user`."""
 
 import pytest
 
@@ -26,26 +23,25 @@ class TestK8sAuth:
         submit_user = self._require_sudo_second_identity(cluster)
 
         up = cluster.cli_as_user(submit_user, ["spur", "k8s", "up"])
-        assert "permission" in up.lower(), f"non-admin up must be denied: {up}"
+        assert "requires cluster admin" in up.lower(), f"non-admin up must be denied: {up}"
 
         down = cluster.cli_as_user(submit_user, ["spur", "k8s", "down"])
-        assert "permission" in down.lower(), f"non-admin down must be denied: {down}"
+        assert "requires cluster admin" in down.lower(), f"non-admin down must be denied: {down}"
 
     def test_non_admin_cannot_fetch_admin_kubeconfig(self, cluster):
         submit_user = self._require_sudo_second_identity(cluster)
         out = cluster.cli_as_user(submit_user, ["spur", "k8s", "kubeconfig", "--admin"])
-        assert "permission" in out.lower(), f"non-admin --admin must be denied: {out}"
+        assert "requires cluster admin" in out.lower(), f"non-admin --admin must be denied: {out}"
 
     def test_non_admin_cannot_target_another_user(self, cluster):
         submit_user = self._require_sudo_second_identity(cluster)
         out = cluster.cli_as_user(
             submit_user, ["spur", "k8s", "kubeconfig", "--user", "someone-else"]
         )
-        assert "permission" in out.lower(), f"non-admin --user X must be denied: {out}"
+        assert "may only request their own" in out.lower(), f"non-admin --user X must be denied: {out}"
 
     def test_root_passes_the_admin_gate(self, cluster):
-        # Root clears the gate: up proceeds past authz to the k0s layer, so the
-        # failure (if any) is never PermissionDenied.
+        # Root clears the gate; the specific admin-gate rejection must not appear.
         self._require_sudo_second_identity(cluster)
         out = cluster.cli_as_user("root", ["spur", "k8s", "up"])
-        assert "permission" not in out.lower(), f"root must clear the admin gate: {out}"
+        assert "requires cluster admin" not in out.lower(), f"root must clear the admin gate: {out}"

--- a/tests/native_host/e2e/test_k8s_multicp.py
+++ b/tests/native_host/e2e/test_k8s_multicp.py
@@ -32,5 +32,6 @@ class TestK8sMultiControlPlane:
 
     def test_even_replica_count_rejected(self, k8s_multicp_cluster):
         cluster = k8s_multicp_cluster
-        out = cluster.cli_allow_fail(["spur", "k8s", "up", "--replicas", "2"])
+        # k0s up is admin-gated; run as root to reach the replica-count validation.
+        out = cluster.cli_as_user("root", ["spur", "k8s", "up", "--replicas", "2"])
         assert "1, 3, or 5" in out, f"even replica count must be rejected: {out}"


### PR DESCRIPTION
## Summary

The native k0s cluster gRPC ops had only a Raft-leader check, so any authenticated caller could:

- provision or tear down the single global k0s cluster (`cluster_up` / `cluster_down`), and
- mint **another** user's namespace-scoped kubeconfig by naming them, or fetch the full **cluster-admin** kubeconfig (`cluster_kubeconfig`).

This adds an authorization boundary at the RPC layer (SPUR-115).

## Approach

A caller is a **cluster admin** when it is empty (internal/daemon), `root`, or holds accounting admin-level `Admin` (resolved via the association cache). The check **fails closed**: when accounting is disabled the cache reports no admins, so only `root`/internal qualify.

- `cluster_up` / `cluster_down` now require admin.
- `cluster_kubeconfig`:
  - bare (no flags) → the caller's **own** namespace-scoped kubeconfig,
  - `--admin` → the cluster-admin kubeconfig (**admin only**),
  - `--user X` → user X's scoped kubeconfig (**admin only**; a non-admin may only target itself).

The caller identity is threaded through new proto fields (`caller` on the three request messages, plus `admin` on `ClusterKubeconfigRequest`) — all append-only with fresh tags, so wire compatibility is preserved. The per-user scoped-kubeconfig machinery itself already existed (per-account namespace + per-user ServiceAccount + bound token); this change only adds the gate that decides *who may request which scope*.

A multi-account user carries one admin-level per association row; the cache now keeps the **highest** so a later non-admin row can't clobber an earlier `Admin`.

## Scope / known limitations

- **Authorization, not authentication.** Identity is still the self-asserted `caller` string (the CLI fills it from the invoking user). This closes the authorization gap — a caller can no longer request a scope it isn't entitled to — but not the authentication gap: a hand-crafted client can still assert an arbitrary `caller`. Wiring verified identity (token/peer-cred) into the controller RPC path is a separate, larger change and is intentionally out of scope here.
- **Bare `kubeconfig` is now always self-scoped.** Operators who previously ran `spur k8s kubeconfig` (no args) to get the cluster-admin config must now pass `--admin`. This is deliberate — the default should never hand out cluster-admin.
- True per-tenant isolation (individually addressable clusters, so a user's admin rights are scoped to *their* cluster) needs the multi-cluster work tracked separately; this PR gates the existing single global cluster.

## Testing

- Unit tests cover the admin-resolution matrix (root/empty always; `Admin` honored case-insensitively; `Operator`/member denied; cold-cache fails closed), the multi-account admin-wins merge in both row orderings, each gated RPC's deny path (asserting `PermissionDenied`), an admin-allowed path, and the non-admin bare self-scope path clearing authz. Each behavioral test was confirmed to fail against the unfixed code.
- CLI tests cover the new `--admin` flag and its mutual exclusion with `--user`.
- A native-host e2e (`test_k8s_auth.py`) exercises the deny paths and the root-clears-the-gate path end to end through the real CLI → gRPC boundary.
- Validated end-to-end on an isolated deployment with accounting both disabled and enabled: with accounting off, a non-root caller is denied and `root` passes; with accounting on, the *same* non-root caller passes once granted `admin_level=Admin`, confirming the admin level flows from the DB through the cache to the gate at runtime.