### PR TITLE
refactor(spurd)!: drop --comm-address alias and SPUR_COMM_ADDRESS

### DIFF
--- a/crates/spur-net/src/comm_addr.rs
+++ b/crates/spur-net/src/comm_addr.rs
@@ -33,7 +33,7 @@ pub fn normalized_comm_addr_is_unusable(normalized: &str) -> bool {
     normalized.parse::<IpAddr>().is_ok_and(is_unusable_comm_ip)
 }
 
-/// Whether a comm-address string resolves to an address unsuitable for
+/// Whether a comm address string resolves to an address unsuitable for
 /// inter-node reachability (loopback, unspecified, or link-local).
 pub fn comm_addr_is_unusable(input: &str) -> bool {
     normalize_comm_address(input)

--- a/crates/spur-net/src/detect.rs
+++ b/crates/spur-net/src/detect.rs
@@ -78,7 +78,7 @@ fn resolve_hostname(hostname: &str) -> String {
                 warn!(
                     hostname,
                     comm_addr = %addr,
-                    "hostname resolved to a non-routable address; set --address/--comm-address to a routable IP"
+                    "hostname resolved to a non-routable address; set --address to a routable IP"
                 );
             }
             addr

--- a/crates/spur-net/src/detect.rs
+++ b/crates/spur-net/src/detect.rs
@@ -78,7 +78,7 @@ fn resolve_hostname(hostname: &str) -> String {
                 warn!(
                     hostname,
                     comm_addr = %addr,
-                    "hostname resolved to a non-routable address; set --address to a routable IP"
+                    "hostname resolved to a non-routable address; set --address to a routable IP or FQDN"
                 );
             }
             addr

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -89,7 +89,7 @@ struct Args {
 
     /// Advertised comm address (IP or routable hostname) for inter-node reachability.
     /// If not set, auto-detected from WireGuard interface or hostname resolution.
-    #[arg(long, alias = "comm-address", env = "SPUR_NODE_ADDRESS")]
+    #[arg(long, env = "SPUR_NODE_ADDRESS")]
     address: Option<String>,
 
     /// Node labels for partition routing (key=value pairs).
@@ -179,11 +179,8 @@ async fn main() -> anyhow::Result<()> {
         spur_update::SPUR_BINARIES,
     );
 
-    // Detect node address (explicit --address/--comm-address > WireGuard > hostname)
-    let explicit_addr = args
-        .address
-        .clone()
-        .or_else(|| std::env::var("SPUR_COMM_ADDRESS").ok());
+    // Detect node address (explicit --address > WireGuard > hostname)
+    let explicit_addr = args.address.clone();
     let node_address = if let Some(ref addr) = explicit_addr {
         let addr_input = addr.clone();
         match tokio::task::spawn_blocking(move || spur_net::normalize_comm_address(&addr_input))

--- a/docs/deployment/native-host.rst
+++ b/docs/deployment/native-host.rst
@@ -132,7 +132,8 @@ Start the agent:
        --address 10.44.0.2 \
        --listen [::]:6818
 
-Or set the ``SPUR_NODE_ADDRESS`` environment variable. Pass a routable IP or FQDN,
+``--address`` sets the advertised comm address. Alternatively, set the
+``SPUR_NODE_ADDRESS`` environment variable. Pass a routable IP or FQDN,
 not the short hostname alone when ``/etc/hosts`` maps it to loopback.
 
 The agent auto-detects CPUs, memory, and GPUs, then registers with the controller over the mesh.

--- a/docs/deployment/native-host.rst
+++ b/docs/deployment/native-host.rst
@@ -132,8 +132,7 @@ Start the agent:
        --address 10.44.0.2 \
        --listen [::]:6818
 
-``--address`` and ``--comm-address`` are equivalent. You can also set
-``SPUR_NODE_ADDRESS`` or ``SPUR_COMM_ADDRESS``. Pass a routable IP or FQDN,
+Or set the ``SPUR_NODE_ADDRESS`` environment variable. Pass a routable IP or FQDN,
 not the short hostname alone when ``/etc/hosts`` maps it to loopback.
 
 The agent auto-detects CPUs, memory, and GPUs, then registers with the controller over the mesh.


### PR DESCRIPTION
## Summary

#557 added `--comm-address` and `SPUR_COMM_ADDRESS` as Spur-only aliases for the existing `--address` / `SPUR_NODE_ADDRESS` pair. Slurm has no `slurmd` counterpart: `NodeAddr` is set in `slurm.conf`, not via a daemon CLI flag. This PR removes the extra surface and documents `--address` only.

Internal NodeAddr handling from #557 (normalization, peer-IP fallback, controller-side `comm_addr()`) is unchanged.

## Breaking change

Anyone who adopted `--comm-address` or `SPUR_COMM_ADDRESS` from the #557 docs should switch to `--address` or `SPUR_NODE_ADDRESS`.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --exclude spur-ffi --all-targets --locked`
- [x] `cargo test --locked`