### PR TITLE
fix(spur-sched): allocate CPUs and cap nodes when tasks fewer than nodes

### DIFF
--- a/crates/spur-cli/src/salloc.rs
+++ b/crates/spur-cli/src/salloc.rs
@@ -132,7 +132,11 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         .await
         .context("job submission failed")?;
 
-    let job_id = response.into_inner().job_id;
+    let response = response.into_inner();
+    for warning in &response.warnings {
+        eprintln!("salloc: warning: {warning}");
+    }
+    let job_id = response.job_id;
     let user = whoami::username().unwrap_or_else(|_| "unknown".into());
     eprintln!("salloc: Pending job allocation {}...", job_id);
 

--- a/crates/spur-cli/src/sbatch.rs
+++ b/crates/spur-cli/src/sbatch.rs
@@ -1033,7 +1033,11 @@ pub async fn main_with_args(cli_args: Vec<String>) -> Result<()> {
         .await
         .context("job submission failed")?;
 
-    let job_id = response.into_inner().job_id;
+    let response = response.into_inner();
+    for warning in &response.warnings {
+        eprintln!("sbatch: warning: {warning}");
+    }
+    let job_id = response.job_id;
     if args.parsable {
         println!("{}", job_id);
     } else {

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -837,14 +837,17 @@ async fn run_standalone_srun(
     let user = whoami::username().unwrap_or_else(|_| "unknown".into());
 
     let job_spec = build_srun_job_spec(args, work_dir, &io, mpi)?;
-    let job_id = client
+    let submit_resp = client
         .submit_job(SubmitJobRequest {
             spec: Some(job_spec),
         })
         .await
         .context("job submission failed")?
-        .into_inner()
-        .job_id;
+        .into_inner();
+    for warning in &submit_resp.warnings {
+        eprintln!("srun: warning: {warning}");
+    }
+    let job_id = submit_resp.job_id;
 
     eprintln!("srun: Pending job allocation {}...", job_id);
 

--- a/crates/spur-core/src/gpu_request.rs
+++ b/crates/spur-core/src/gpu_request.rs
@@ -149,8 +149,9 @@ pub enum GpuRequestError {
 /// Number of tasks placed on each of `num_nodes` nodes.
 ///
 /// Prefers an explicit `tasks_per_node` (uniform); otherwise derives the
-/// per-node counts from the task distribution policy.
-fn tasks_per_node_counts(spec: &JobSpec, num_nodes: u32) -> Vec<u32> {
+/// per-node counts from the task distribution policy. Shared with the scheduler
+/// so per-node CPU reservations follow the same block/cyclic split as GPUs.
+pub fn tasks_per_node_counts(spec: &JobSpec, num_nodes: u32) -> Vec<u32> {
     if let Some(tpn) = spec.tasks_per_node {
         return vec![tpn; num_nodes as usize];
     }

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -600,13 +600,9 @@ impl Default for JobSpec {
 }
 
 impl JobSpec {
-    /// Node count to actually allocate for this job.
-    ///
-    /// A task never spans nodes, so like Slurm's cons_tres we cap at
-    /// `min(num_nodes, num_tasks)` unless a per-node layout is pinned.
-    /// `submit_job` applies this at intake so the stored `num_nodes` matches
-    /// what is allocated and what all reporting shows. An explicit
-    /// `--ntasks-per-node` pins the layout, so the request stands.
+    /// Node count to actually allocate: `min(num_nodes, num_tasks)`, since a
+    /// task never spans nodes. An explicit `--ntasks-per-node` pins the layout
+    /// and skips the cap.
     pub fn effective_num_nodes(&self) -> u32 {
         let nodes = self.num_nodes.max(1);
         if self.tasks_per_node.is_some() {

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -599,6 +599,24 @@ impl Default for JobSpec {
     }
 }
 
+impl JobSpec {
+    /// Node count to actually allocate for this job.
+    ///
+    /// A task never spans nodes, so like Slurm's cons_tres we cap at
+    /// `min(num_nodes, num_tasks)` unless a per-node layout is pinned.
+    /// `submit_job` applies this at intake so the stored `num_nodes` matches
+    /// what is allocated and what all reporting shows. An explicit
+    /// `--ntasks-per-node` pins the layout, so the request stands.
+    pub fn effective_num_nodes(&self) -> u32 {
+        let nodes = self.num_nodes.max(1);
+        if self.tasks_per_node.is_some() {
+            nodes
+        } else {
+            nodes.min(self.num_tasks.max(1))
+        }
+    }
+}
+
 /// Total memory (MB) a job of `num_nodes` nodes requests, derived from
 /// either an explicit per-node request or a per-CPU request applied across
 /// the job's total CPU count. Falls back to 0 (unconstrained) if neither is
@@ -1334,6 +1352,72 @@ mod tests {
             },
         );
         assert_eq!(job.resolved_stdout(), "relwork/out.log");
+    }
+
+    #[test]
+    fn effective_num_nodes_caps_at_task_count() {
+        let spec = JobSpec {
+            num_nodes: 4,
+            num_tasks: 1,
+            tasks_per_node: None,
+            ..Default::default()
+        };
+        assert_eq!(spec.effective_num_nodes(), 1);
+    }
+
+    #[test]
+    fn effective_num_nodes_caps_at_partial_task_count() {
+        let spec = JobSpec {
+            num_nodes: 4,
+            num_tasks: 3,
+            tasks_per_node: None,
+            ..Default::default()
+        };
+        assert_eq!(spec.effective_num_nodes(), 3);
+    }
+
+    #[test]
+    fn effective_num_nodes_keeps_exact_fit() {
+        let spec = JobSpec {
+            num_nodes: 4,
+            num_tasks: 4,
+            tasks_per_node: None,
+            ..Default::default()
+        };
+        assert_eq!(spec.effective_num_nodes(), 4);
+    }
+
+    #[test]
+    fn effective_num_nodes_does_not_grow_beyond_request() {
+        let spec = JobSpec {
+            num_nodes: 4,
+            num_tasks: 8,
+            tasks_per_node: None,
+            ..Default::default()
+        };
+        assert_eq!(spec.effective_num_nodes(), 4);
+    }
+
+    #[test]
+    fn effective_num_nodes_honors_explicit_tasks_per_node() {
+        let spec = JobSpec {
+            num_nodes: 4,
+            num_tasks: 1,
+            tasks_per_node: Some(2),
+            ..Default::default()
+        };
+        assert_eq!(spec.effective_num_nodes(), 4);
+    }
+
+    #[test]
+    fn effective_num_nodes_floors_at_one() {
+        let spec = JobSpec {
+            num_nodes: 0,
+            num_tasks: 0,
+            tasks_per_node: None,
+            ..Default::default()
+        };
+        assert_eq!(spec.effective_num_nodes(), 1);
     }
 
     #[test]

--- a/crates/spur-ffi/src/lib.rs
+++ b/crates/spur-ffi/src/lib.rs
@@ -76,7 +76,7 @@ pub extern "C" fn slurm_submit_batch_job(
             script: c_str_to_string(desc.script),
             work_dir: c_str_to_string(desc.work_dir),
             num_nodes: desc.min_nodes,
-            num_tasks: desc.num_tasks,
+            num_tasks: desc_num_tasks(desc.num_tasks),
             cpus_per_task: desc.cpus_per_task,
             time_limit: if desc.time_limit > 0 {
                 Some(prost_types::Duration {
@@ -396,6 +396,16 @@ fn c_str_to_string(ptr: *const c_char) -> String {
     unsafe { CStr::from_ptr(ptr).to_string_lossy().into_owned() }
 }
 
+/// Map a descriptor's task count to the proto field. `NO_VAL` (the caller left
+/// it unset) becomes 0 so the controller defaults to one task per node instead
+/// of collapsing a multi-node request onto a single node.
+fn desc_num_tasks(raw: c_uint) -> u32 {
+    match raw {
+        crate::types::NO_VAL => 0,
+        n => n,
+    }
+}
+
 fn string_to_c_str(s: &str) -> *mut c_char {
     CString::new(s)
         .unwrap_or_else(|_| CString::new("").unwrap())
@@ -407,5 +417,27 @@ fn free_c_str(ptr: *mut c_char) {
         unsafe {
             let _ = CString::from_raw(ptr);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn desc_num_tasks_maps_no_val_to_unset() {
+        // C1 (FFI): NO_VAL (the init default) -> 0 so the controller defaults
+        // to one task per node; explicit values pass through unchanged.
+        assert_eq!(desc_num_tasks(crate::types::NO_VAL), 0);
+        assert_eq!(desc_num_tasks(1), 1);
+        assert_eq!(desc_num_tasks(8), 8);
+    }
+
+    #[test]
+    fn job_desc_default_leaves_tasks_unset() {
+        assert_eq!(
+            crate::types::SlurmJobDescMsg::default().num_tasks,
+            crate::types::NO_VAL
+        );
     }
 }

--- a/crates/spur-ffi/src/types.rs
+++ b/crates/spur-ffi/src/types.rs
@@ -5,6 +5,10 @@
 
 use std::os::raw::{c_char, c_uint};
 
+/// Slurm's "field not set" sentinel (`NO_VAL`). A descriptor left at this value
+/// means the caller did not specify it, so the controller applies its default.
+pub const NO_VAL: c_uint = u32::MAX;
+
 /// Job submission descriptor (simplified).
 #[repr(C)]
 pub struct SlurmJobDescMsg {
@@ -31,7 +35,9 @@ impl Default for SlurmJobDescMsg {
             work_dir: std::ptr::null(),
             min_nodes: 1,
             max_nodes: 1,
-            num_tasks: 1,
+            // NO_VAL, not 1: an unset task count must default to one task per
+            // node at the controller, matching slurm_init_job_desc_msg.
+            num_tasks: NO_VAL,
             cpus_per_task: 1,
             time_limit: 0,
             priority: 0,

--- a/crates/spur-sched/src/backfill.rs
+++ b/crates/spur-sched/src/backfill.rs
@@ -478,11 +478,13 @@ impl Scheduler for BackfillScheduler {
 /// are modeled separately (see [`resolve_gpu_demand`]) so total-vs-per-node
 /// semantics are preserved.
 pub fn base_node_request(job: &Job) -> ResourceSet {
-    let cpus = if job.spec.tasks_per_node.is_some() {
-        job.spec.tasks_per_node.unwrap_or(1) * job.spec.cpus_per_task
-    } else {
-        (job.spec.num_tasks / job.spec.num_nodes.max(1)) * job.spec.cpus_per_task
-    };
+    // Rounds up so the busiest node's share is never under-reserved, and floors
+    // at one CPU so an allocated node always consumes tracked capacity.
+    let cpus = match job.spec.tasks_per_node {
+        Some(tasks_per_node) => tasks_per_node * job.spec.cpus_per_task,
+        None => job.spec.num_tasks.div_ceil(job.spec.num_nodes.max(1)) * job.spec.cpus_per_task,
+    }
+    .max(1);
 
     let memory = job
         .spec
@@ -2020,5 +2022,88 @@ mod tests {
 
         let request = job_resource_request(&job);
         assert_eq!(request.generic.get("bandwidth:lustre"), Some(&100));
+    }
+
+    fn cpu_request(num_nodes: u32, num_tasks: u32, cpus_per_task: u32) -> u32 {
+        let job = Job::new(
+            1,
+            JobSpec {
+                name: "cpu-job".into(),
+                partition: Some("default".into()),
+                user: "test".into(),
+                num_nodes,
+                num_tasks,
+                cpus_per_task,
+                ..Default::default()
+            },
+        );
+        base_node_request(&job).cpus
+    }
+
+    // A per-node share that truncated to zero left the allocation invisible to
+    // resource tracking, so any number of such jobs could stack on one node.
+    #[test]
+    fn base_node_request_reserves_cpus_when_tasks_below_nodes() {
+        assert_eq!(cpu_request(4, 1, 1), 1);
+    }
+
+    #[test]
+    fn base_node_request_scales_cpus_per_task_when_tasks_below_nodes() {
+        assert_eq!(cpu_request(4, 1, 4), 4);
+    }
+
+    #[test]
+    fn base_node_request_rounds_partial_task_share_up() {
+        assert_eq!(cpu_request(4, 3, 2), 2);
+    }
+
+    #[test]
+    fn base_node_request_rounds_uneven_share_up() {
+        // 7 tasks over 2 nodes: the busiest node runs 4, so reserve for 4.
+        assert_eq!(cpu_request(2, 7, 1), 4);
+    }
+
+    #[test]
+    fn base_node_request_keeps_exact_fit_unchanged() {
+        assert_eq!(cpu_request(4, 4, 1), 1);
+        assert_eq!(cpu_request(4, 8, 2), 4);
+    }
+
+    #[test]
+    fn base_node_request_uses_explicit_tasks_per_node() {
+        let job = Job::new(
+            1,
+            JobSpec {
+                name: "cpu-job".into(),
+                partition: Some("default".into()),
+                user: "test".into(),
+                num_nodes: 4,
+                num_tasks: 1,
+                tasks_per_node: Some(2),
+                cpus_per_task: 3,
+                ..Default::default()
+            },
+        );
+        assert_eq!(base_node_request(&job).cpus, 6);
+    }
+
+    #[test]
+    fn base_node_request_derives_memory_from_corrected_cpu_count() {
+        let job = Job::new(
+            1,
+            JobSpec {
+                name: "cpu-job".into(),
+                partition: Some("default".into()),
+                user: "test".into(),
+                num_nodes: 4,
+                num_tasks: 1,
+                cpus_per_task: 2,
+                memory_per_cpu_mb: Some(512),
+                ..Default::default()
+            },
+        );
+        let request = base_node_request(&job);
+        assert_eq!(request.cpus, 2);
+        assert_eq!(request.memory_mb, 1024);
     }
 }

--- a/crates/spur-sched/src/backfill.rs
+++ b/crates/spur-sched/src/backfill.rs
@@ -118,23 +118,34 @@ impl BackfillScheduler {
             .len() as u32
     }
 
-    /// Resolve concrete per-node GPU allocations for a heterogeneous demand.
-    ///
-    /// Nodes are ordered by free-GPU capacity (descending); the target per-node
-    /// counts (greedy packing for `Total`, the fixed vector for uneven
-    /// per-task) are matched to that order. Returns `None` if no assignment
-    /// fits the current free capacity.
-    fn plan_heterogeneous_alloc(
+    /// Resolve concrete per-node CPU and GPU allocations for non-uniform demand.
+    /// CPU counts are positional (aligned to task launch order); a GPU total is
+    /// packed greedily onto the most-available nodes. `None` if it cannot fit now.
+    fn plan_per_node_alloc(
         &self,
+        job: &Job,
         demand: &GpuDemand,
         assigned_nodes: &[(usize, chrono::DateTime<Utc>)],
         nodes: &[Node],
-        base: &ResourceSet,
-        gpu_type: Option<&str>,
         now: chrono::DateTime<Utc>,
     ) -> Option<HashMap<String, ResourceAllocations>> {
-        debug_assert!(!demand.is_none());
-        match demand {
+        let base = base_node_request(job);
+        let cpu_counts = cpu_per_node_counts(job);
+        let gpu_type = demand.gpu_type();
+
+        // Per-node GPU target keyed by node index.
+        let gpu_targets: HashMap<usize, u32> = match demand {
+            GpuDemand::None => HashMap::new(),
+            GpuDemand::PerNode { counts, .. } => {
+                if counts.len() != assigned_nodes.len() {
+                    return None;
+                }
+                assigned_nodes
+                    .iter()
+                    .zip(counts.iter())
+                    .map(|((ni, _), &c)| (*ni, c))
+                    .collect()
+            }
             GpuDemand::Total { count, .. } => {
                 // Capacity-sorted greedy: pack GPUs onto most-available nodes.
                 let mut caps: Vec<(usize, u32)> = assigned_nodes
@@ -144,41 +155,42 @@ impl BackfillScheduler {
                 caps.sort_by_key(|(_, cap)| std::cmp::Reverse(*cap));
                 let cap_values: Vec<u32> = caps.iter().map(|(_, c)| *c).collect();
                 let targets = distribute_total(*count, &cap_values)?;
+                caps.iter()
+                    .zip(targets)
+                    .map(|((ni, _), give)| (*ni, give))
+                    .collect()
+            }
+        };
 
-                let mut per_node_alloc = HashMap::new();
-                for ((ni, _), give) in caps.iter().zip(targets) {
-                    let node = &nodes[*ni];
-                    let current = self.timelines[*ni].accumulated_at(now);
-                    let mut req = base.clone();
-                    req.gpus = placeholder_gpus(give, gpu_type);
-                    let alloc = build_node_allocation(&node.total_resources, &current, &req);
-                    per_node_alloc.insert(node.name.clone(), alloc);
-                }
-                Some(per_node_alloc)
+        let mut per_node_alloc = HashMap::new();
+        for (idx, (ni, _)) in assigned_nodes.iter().enumerate() {
+            let node = &nodes[*ni];
+            let current = self.timelines[*ni].accumulated_at(now);
+
+            let mut req = base.clone();
+            let cpus = cpu_counts.get(idx).copied().unwrap_or(base.cpus).max(1);
+            req.cpus = cpus;
+            // A per-CPU memory request scales with this node's CPU share.
+            if let Some(mem_per_cpu) = job.spec.memory_per_cpu_mb {
+                req.memory_mb = mem_per_cpu * cpus as u64;
             }
-            GpuDemand::PerNode { counts, .. } => {
-                // Positional: counts[i] maps to assigned_nodes[i], matching the
-                // task-distribution node order used at launch.
-                if counts.len() != assigned_nodes.len() {
-                    return None;
-                }
-                let mut per_node_alloc = HashMap::new();
-                for ((ni, _), &want) in assigned_nodes.iter().zip(counts.iter()) {
-                    let free = self.free_gpus_at(*ni, &nodes[*ni], gpu_type, now);
-                    if want > free {
-                        return None;
-                    }
-                    let node = &nodes[*ni];
-                    let current = self.timelines[*ni].accumulated_at(now);
-                    let mut req = base.clone();
-                    req.gpus = placeholder_gpus(want, gpu_type);
-                    let alloc = build_node_allocation(&node.total_resources, &current, &req);
-                    per_node_alloc.insert(node.name.clone(), alloc);
-                }
-                Some(per_node_alloc)
+            req.gpus = placeholder_gpus(gpu_targets.get(ni).copied().unwrap_or(0), gpu_type);
+
+            // Exact per-node feasibility against current free capacity; if a node
+            // cannot hold its share the whole placement is deferred.
+            if !node
+                .total_resources
+                .can_satisfy_with_allocated(&current, &req)
+            {
+                return None;
             }
-            GpuDemand::None => None,
+
+            per_node_alloc.insert(
+                node.name.clone(),
+                build_node_allocation(&node.total_resources, &current, &req),
+            );
         }
+        Some(per_node_alloc)
     }
 }
 
@@ -260,10 +272,12 @@ impl Scheduler for BackfillScheduler {
 
             let demand = resolve_gpu_demand(&job.spec).unwrap_or(GpuDemand::None);
             let gpu_type = demand.gpu_type().map(str::to_string);
-            // Heterogeneous demand (--gpus total, uneven --gpus-per-task) needs
-            // per-node counts resolved against actual free capacity; homogeneous
-            // demand rides the exact-per-node fast path.
-            let heterogeneous = !job.spec.exclusive && homogeneous_per_node(&demand).is_none();
+            // Per-node GPU counts (--gpus total, uneven --gpus-per-task) or an
+            // uneven per-node CPU split (e.g. -N2 -n7 -> [4,3]) need per-node
+            // counts resolved against actual free capacity; a fully uniform
+            // request rides the exact-per-node fast path.
+            let heterogeneous = !job.spec.exclusive
+                && (homogeneous_per_node(&demand).is_none() || cpu_is_heterogeneous(job));
 
             // Free GPUs of the requested type per candidate, used to pack the
             // job onto the most-available nodes.
@@ -398,24 +412,17 @@ impl Scheduler for BackfillScheduler {
 
             let mut per_node_alloc = HashMap::new();
             if heterogeneous {
-                // Total / uneven-per-task GPUs: resolve concrete per-node counts
-                // against current free capacity. We only place these when the
-                // job can start now (no heterogeneous future shadow reservation
-                // yet); otherwise leave it pending for a later cycle.
+                // Non-uniform per-node CPU or GPU counts: resolve concrete
+                // per-node allocations against current free capacity. We only
+                // place these when the job can start now (no heterogeneous
+                // future shadow reservation yet); otherwise leave it pending for
+                // a later cycle.
                 if earliest > now {
                     continue;
                 }
-                let base = base_node_request(job);
-                match self.plan_heterogeneous_alloc(
-                    &demand,
-                    &assigned_nodes,
-                    cluster.nodes,
-                    &base,
-                    gpu_type.as_deref(),
-                    now,
-                ) {
+                match self.plan_per_node_alloc(job, &demand, &assigned_nodes, cluster.nodes, now) {
                     Some(allocs) => per_node_alloc = allocs,
-                    None => continue, // not enough free GPUs right now
+                    None => continue, // not enough free capacity right now
                 }
             } else {
                 for (ni, _) in &assigned_nodes {
@@ -478,11 +485,11 @@ impl Scheduler for BackfillScheduler {
 /// are modeled separately (see [`resolve_gpu_demand`]) so total-vs-per-node
 /// semantics are preserved.
 pub fn base_node_request(job: &Job) -> ResourceSet {
-    // Rounds up so the busiest node's share is never under-reserved, and floors
-    // at one CPU so an allocated node always consumes tracked capacity.
+    // Minimum per-node CPU share for feasibility filtering; exact per-node
+    // counts are resolved at allocation. Floors at one CPU.
     let cpus = match job.spec.tasks_per_node {
         Some(tasks_per_node) => tasks_per_node * job.spec.cpus_per_task,
-        None => job.spec.num_tasks.div_ceil(job.spec.num_nodes.max(1)) * job.spec.cpus_per_task,
+        None => (job.spec.num_tasks / job.spec.num_nodes.max(1)) * job.spec.cpus_per_task,
     }
     .max(1);
 
@@ -548,6 +555,27 @@ fn homogeneous_per_node(demand: &GpuDemand) -> Option<u32> {
         }
         GpuDemand::Total { .. } => None,
     }
+}
+
+/// Per-node CPU counts honoring the task distribution (e.g. `-N2 -n7` ->
+/// `[4, 3]`), positionally aligned to the assigned nodes. Floors each node at
+/// one CPU.
+pub fn cpu_per_node_counts(job: &Job) -> Vec<u32> {
+    let cpt = job.spec.cpus_per_task.max(1);
+    spur_core::gpu_request::tasks_per_node_counts(&job.spec, job.spec.num_nodes.max(1))
+        .into_iter()
+        .map(|tasks| (tasks * cpt).max(1))
+        .collect()
+}
+
+/// Whether a job's per-node CPU demand is non-uniform, so it must take the
+/// heterogeneous allocation path rather than the uniform fast path.
+fn cpu_is_heterogeneous(job: &Job) -> bool {
+    if job.spec.exclusive {
+        return false;
+    }
+    let counts = cpu_per_node_counts(job);
+    counts.iter().min() != counts.iter().max()
 }
 
 /// The single-node resource request used for feasibility filtering and
@@ -650,6 +678,190 @@ mod tests {
 
         let assignments = sched.schedule(&pending, &cluster);
         assert_eq!(assignments.len(), 2);
+    }
+
+    // I3: an uneven task split reserves the exact per-node CPU counts (block
+    // distribution 7 tasks over 2 nodes -> [4,3]), summing to the total instead
+    // of over-reserving [4,4] on both nodes.
+    #[test]
+    fn schedule_uneven_cpu_reserves_exact_split() {
+        let mut sched = BackfillScheduler::new(100);
+        let nodes = make_nodes(2);
+        let partitions = vec![Partition {
+            name: "default".into(),
+            ..Default::default()
+        }];
+
+        let job = Job::new(
+            1,
+            JobSpec {
+                name: "uneven".into(),
+                partition: Some("default".into()),
+                user: "test".into(),
+                num_nodes: 2,
+                num_tasks: 7,
+                cpus_per_task: 1,
+                time_limit: Some(Duration::hours(1)),
+                ..Default::default()
+            },
+        );
+        let cluster = ClusterState {
+            nodes: &nodes,
+            partitions: &partitions,
+            reservations: &[],
+            topology: None,
+        };
+
+        let assignments = sched.schedule(&[job], &cluster);
+        assert_eq!(assignments.len(), 1);
+        let mut cpus: Vec<u32> = assignments[0]
+            .per_node_alloc
+            .values()
+            .map(|a| a.cpus)
+            .collect();
+        cpus.sort();
+        assert_eq!(cpus, vec![3, 4]);
+        assert_eq!(cpus.iter().sum::<u32>(), 7);
+    }
+
+    // I3 + C2: an uneven CPU split combined with a job-total GPU request places
+    // CPUs [4,3] and GPUs [4,4] on the same two nodes, staying positionally
+    // aligned (CPU vector and GPU vector are resolved independently).
+    #[test]
+    fn schedule_uneven_cpu_with_total_gpus() {
+        let mut sched = BackfillScheduler::new(100);
+        let mut nodes = vec![make_gpu_node(8), make_gpu_node(8)];
+        nodes[0].name = "gpu-node1".into();
+        nodes[1].name = "gpu-node2".into();
+        let partitions = vec![Partition {
+            name: "default".into(),
+            ..Default::default()
+        }];
+
+        let job = Job::new(
+            1,
+            JobSpec {
+                name: "combo".into(),
+                partition: Some("default".into()),
+                user: "test".into(),
+                num_nodes: 2,
+                num_tasks: 7,
+                cpus_per_task: 1,
+                gpus: Some(spur_core::gpu_request::GpuRequest::new(8, None)),
+                time_limit: Some(Duration::hours(1)),
+                ..Default::default()
+            },
+        );
+        let cluster = ClusterState {
+            nodes: &nodes,
+            partitions: &partitions,
+            reservations: &[],
+            topology: None,
+        };
+
+        let assignments = sched.schedule(&[job], &cluster);
+        assert_eq!(assignments.len(), 1);
+        // CPU vector is the exact block split, independent of GPU packing.
+        let mut cpus: Vec<u32> = assignments[0]
+            .per_node_alloc
+            .values()
+            .map(|a| a.cpus)
+            .collect();
+        cpus.sort();
+        assert_eq!(cpus, vec![3, 4]);
+
+        // GPUs follow the greedy job-total packing (see distribute_total); the
+        // invariant is that all 8 are placed across the two nodes.
+        let gpus: Vec<usize> = assignments[0]
+            .per_node_alloc
+            .values()
+            .map(|a| a.device_ids("gpu").len())
+            .collect();
+        assert_eq!(gpus.iter().sum::<usize>(), 8);
+        assert!(gpus.iter().all(|&g| g >= 1));
+    }
+
+    // C2: -N4 --gpus=8 (one task per node) keeps all four nodes and places the
+    // 8 GPUs across them (greedy packing), rather than collapsing onto one node.
+    #[test]
+    fn schedule_total_gpus_spread_across_nodes() {
+        let mut sched = BackfillScheduler::new(100);
+        let mut nodes: Vec<Node> = (0..4).map(|_| make_gpu_node(8)).collect();
+        for (i, node) in nodes.iter_mut().enumerate() {
+            node.name = format!("gpu-node{}", i + 1);
+        }
+        let partitions = vec![Partition {
+            name: "default".into(),
+            ..Default::default()
+        }];
+
+        let job = Job::new(
+            1,
+            JobSpec {
+                name: "spread".into(),
+                partition: Some("default".into()),
+                user: "test".into(),
+                num_nodes: 4,
+                num_tasks: 4,
+                cpus_per_task: 1,
+                gpus: Some(spur_core::gpu_request::GpuRequest::new(8, None)),
+                time_limit: Some(Duration::hours(1)),
+                ..Default::default()
+            },
+        );
+        let cluster = ClusterState {
+            nodes: &nodes,
+            partitions: &partitions,
+            reservations: &[],
+            topology: None,
+        };
+
+        let assignments = sched.schedule(&[job], &cluster);
+        assert_eq!(assignments.len(), 1);
+        assert_eq!(assignments[0].nodes.len(), 4);
+        let gpus: Vec<usize> = assignments[0]
+            .per_node_alloc
+            .values()
+            .map(|a| a.device_ids("gpu").len())
+            .collect();
+        assert_eq!(gpus.iter().sum::<usize>(), 8);
+        assert!(
+            gpus.iter().all(|&g| g >= 1),
+            "every node should get part of the total, got {gpus:?}"
+        );
+    }
+
+    // I6: after submit reduces -N4 -n1 to a single node, a 4-node --nodelist is
+    // restrictive (a candidate pool), not additive: the job lands on exactly one
+    // of the named nodes. Documents the additive->restrictive shift.
+    #[test]
+    fn nodelist_is_restrictive_after_node_reduction() {
+        let mut sched = BackfillScheduler::new(100);
+        let nodes = make_nodes(4);
+        let partitions = vec![Partition {
+            name: "default".into(),
+            ..Default::default()
+        }];
+
+        // num_nodes already reduced to 1 (as submit_job would do for -N4 -n1).
+        let pending = vec![make_job_with_nodelist(
+            1,
+            1,
+            Some("node001,node002,node003,node004"),
+            None,
+        )];
+        let cluster = ClusterState {
+            nodes: &nodes,
+            partitions: &partitions,
+            reservations: &[],
+            topology: None,
+        };
+
+        let assignments = sched.schedule(&pending, &cluster);
+        assert_eq!(assignments.len(), 1);
+        assert_eq!(assignments[0].nodes.len(), 1);
+        assert!(["node001", "node002", "node003", "node004"]
+            .contains(&assignments[0].nodes[0].as_str()));
     }
 
     fn make_gpu_node(num_gpus: u32) -> Node {
@@ -2048,25 +2260,74 @@ mod tests {
     }
 
     #[test]
-    fn base_node_request_scales_cpus_per_task_when_tasks_below_nodes() {
-        assert_eq!(cpu_request(4, 1, 4), 4);
+    fn base_node_request_is_minimum_per_node_share() {
+        // Even split: the min (feasibility) share equals the exact share.
+        // 4 tasks over 2 nodes = 2 tasks/node * 3 cpus = 6.
+        assert_eq!(cpu_request(2, 4, 3), 6);
     }
 
     #[test]
-    fn base_node_request_rounds_partial_task_share_up() {
-        assert_eq!(cpu_request(4, 3, 2), 2);
-    }
-
-    #[test]
-    fn base_node_request_rounds_uneven_share_up() {
-        // 7 tasks over 2 nodes: the busiest node runs 4, so reserve for 4.
-        assert_eq!(cpu_request(2, 7, 1), 4);
+    fn base_node_request_uneven_uses_lightest_share() {
+        // 3 tasks over 2 nodes -> [2,1] tasks; the base is the lightest node's
+        // share (1 task * 2 cpus = 2). The exact per-node counts come from
+        // cpu_per_node_counts; feasibility must not exclude the lighter node.
+        assert_eq!(cpu_request(2, 3, 2), 2);
+        // 7 tasks over 2 nodes -> [4,3]; lightest share is 3.
+        assert_eq!(cpu_request(2, 7, 1), 3);
     }
 
     #[test]
     fn base_node_request_keeps_exact_fit_unchanged() {
         assert_eq!(cpu_request(4, 4, 1), 1);
         assert_eq!(cpu_request(4, 8, 2), 4);
+    }
+
+    #[test]
+    fn cpu_per_node_counts_splits_uneven_tasks() {
+        let job = Job::new(
+            1,
+            JobSpec {
+                num_nodes: 2,
+                num_tasks: 7,
+                cpus_per_task: 1,
+                ..Default::default()
+            },
+        );
+        // Block distribution: 4 tasks on node 0, 3 on node 1.
+        assert_eq!(cpu_per_node_counts(&job), vec![4, 3]);
+        assert!(cpu_is_heterogeneous(&job));
+    }
+
+    #[test]
+    fn cpu_per_node_counts_scales_cpus_per_task_and_sums_to_total() {
+        let job = Job::new(
+            1,
+            JobSpec {
+                num_nodes: 2,
+                num_tasks: 7,
+                cpus_per_task: 2,
+                ..Default::default()
+            },
+        );
+        // [4,3] tasks * 2 cpus/task = [8,6], summing to num_tasks*cpus = 14.
+        let counts = cpu_per_node_counts(&job);
+        assert_eq!(counts, vec![8, 6]);
+        assert_eq!(counts.iter().sum::<u32>(), 7 * 2);
+    }
+
+    #[test]
+    fn cpu_per_node_counts_uniform_is_homogeneous() {
+        let job = Job::new(
+            1,
+            JobSpec {
+                num_nodes: 2,
+                num_tasks: 4,
+                cpus_per_task: 3,
+                ..Default::default()
+            },
+        );
+        assert_eq!(cpu_per_node_counts(&job), vec![6, 6]);
+        assert!(!cpu_is_heterogeneous(&job));
     }
 
     #[test]
@@ -2088,22 +2349,23 @@ mod tests {
     }
 
     #[test]
-    fn base_node_request_derives_memory_from_corrected_cpu_count() {
+    fn base_node_request_derives_memory_from_cpu_share() {
         let job = Job::new(
             1,
             JobSpec {
                 name: "cpu-job".into(),
                 partition: Some("default".into()),
                 user: "test".into(),
-                num_nodes: 4,
-                num_tasks: 1,
+                num_nodes: 2,
+                num_tasks: 4,
                 cpus_per_task: 2,
                 memory_per_cpu_mb: Some(512),
                 ..Default::default()
             },
         );
         let request = base_node_request(&job);
-        assert_eq!(request.cpus, 2);
-        assert_eq!(request.memory_mb, 1024);
+        // 4 tasks / 2 nodes = 2 tasks/node * 2 cpus = 4 cpus; 4 * 512 MB.
+        assert_eq!(request.cpus, 4);
+        assert_eq!(request.memory_mb, 2048);
     }
 }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -159,6 +159,14 @@ impl SubmitError {
     }
 }
 
+/// A successful submission: the (parent) job id plus any user-facing warnings
+/// (e.g. a node-count reduction) to surface at the CLI and REST response.
+#[derive(Debug, Clone, Default)]
+pub struct SubmitOutcome {
+    pub job_id: JobId,
+    pub warnings: Vec<String>,
+}
+
 /// Maximum serialized size of a single job submission, in bytes.
 ///
 /// A submission becomes one Raft log entry (`WalOperation::JobSubmit`) that is
@@ -407,7 +415,7 @@ impl ClusterManager {
     }
 
     /// Submit a new job. If it has an array spec, expand into individual tasks.
-    pub fn submit_job(&self, mut spec: JobSpec) -> Result<JobId, SubmitError> {
+    pub fn submit_job(&self, mut spec: JobSpec) -> Result<SubmitOutcome, SubmitError> {
         apply_default_partition(&mut spec, &self.partitions.read());
         apply_default_time_limit(&mut spec, &self.partitions.read());
         apply_default_account(&mut spec, &self.association_cache);
@@ -423,11 +431,35 @@ impl ClusterManager {
         )?;
         self.validate_partition(&spec)?;
 
-        // A job with fewer tasks than nodes (and no explicit per-node layout)
-        // cannot place work on the surplus nodes. Reduce to what will actually
-        // be allocated so reported node/GPU counts match the allocation and the
-        // in-job SLURM_NNODES, matching Slurm's submission-time reduction.
+        // Fewer tasks than nodes cannot use the surplus nodes; cap at the task
+        // count so reported node/GPU counts match the allocation (unless a
+        // per-node layout is pinned).
+        let requested_nodes = spec.num_nodes.max(1);
         spec.num_nodes = spec.effective_num_nodes();
+
+        let mut warnings = Vec::new();
+        if spec.num_nodes < requested_nodes {
+            warn!(
+                requested_nodes,
+                allocated_nodes = spec.num_nodes,
+                num_tasks = spec.num_tasks,
+                "reduced requested node count to task count at submit"
+            );
+            warnings.push(format!(
+                "requested {requested_nodes} nodes but only {} will be allocated \
+                 ({} task(s), one per node)",
+                spec.num_nodes, spec.num_tasks
+            ));
+        }
+
+        // Validate GPU demand against the normalized node count so a request
+        // like `-N4 -n1 --gpus=2` (valid once reduced to one node) is accepted.
+        spur_core::gpu_request::resolve_gpu_demand(&spec)
+            .map_err(|e| SubmitError::invalid(e.to_string()))?;
+
+        // Reject a node count outside the partition's bounds at submit, matching
+        // Slurm, instead of accepting a job that would pend forever.
+        self.validate_partition_node_bounds(&spec)?;
 
         let mpi = spec.mpi.as_deref().unwrap_or(spur_core::mpi::MPI_NONE);
         spur_core::mpi::validate_single_node_pmix(mpi, spec.num_nodes)
@@ -471,7 +503,46 @@ impl ClusterManager {
         self.scheduler_notify.notify_one();
 
         info!(job_id, "job submitted");
-        Ok(job_id)
+        Ok(SubmitOutcome { job_id, warnings })
+    }
+
+    /// Reject a submission whose (normalized) node count falls outside the
+    /// bounds of every requested partition. Matches Slurm, which rejects such
+    /// jobs at submit rather than leaving them permanently pending. A partition
+    /// list is accepted if any one partition can hold the request.
+    fn validate_partition_node_bounds(&self, spec: &JobSpec) -> Result<(), SubmitError> {
+        let Some(partition_spec) = spec.partition.as_deref().filter(|p| !p.is_empty()) else {
+            return Ok(());
+        };
+
+        let partitions = self.partitions.read();
+        let requested: Vec<&Partition> = requested_partition_names(Some(partition_spec))
+            .filter_map(|name| partitions.iter().find(|part| part.name == name))
+            .collect();
+        // Existence was already checked in validate_partition.
+        if requested.is_empty() {
+            return Ok(());
+        }
+
+        let nodes = spec.num_nodes;
+        let fits = |part: &Partition| {
+            let below_min = part.min_nodes > 0 && nodes < part.min_nodes;
+            let above_max = part.max_nodes.is_some_and(|max| nodes > max);
+            !below_min && !above_max
+        };
+        if requested.iter().copied().any(fits) {
+            return Ok(());
+        }
+
+        let part = requested[0];
+        let max = part
+            .max_nodes
+            .map(|m| m.to_string())
+            .unwrap_or_else(|| "unlimited".into());
+        Err(SubmitError::invalid(format!(
+            "requested node count {nodes} is outside partition '{}' limits (min {}, max {})",
+            part.name, part.min_nodes, max
+        )))
     }
 
     /// Validate partition constraints: access control and node limits.
@@ -6055,7 +6126,7 @@ mod tests {
     }
 
     fn submit_and_wait(cm: &ClusterManager, spec: JobSpec) -> JobId {
-        let id = cm.submit_job(spec).unwrap();
+        let id = cm.submit_job(spec).unwrap().job_id;
         wait_for(&format!("job {id} applied"), || cm.get_job(id).is_some());
         id
     }
@@ -6595,6 +6666,138 @@ mod tests {
         // An explicit per-node layout pins the node count regardless of the
         // task total.
         assert_eq!(cm.get_job(id).unwrap().spec.num_nodes, 4);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_accepts_gpu_after_node_reduction() {
+        // C3: -N4 -n1 --gpus=2 is valid once the node count is reduced to one;
+        // the pre-normalization guard used to reject it.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        let mut spec = basic_spec("gpu-reduced");
+        spec.num_nodes = 4;
+        spec.num_tasks = 1;
+        spec.gpus = Some(spur_core::gpu_request::GpuRequest::new(2, None));
+        let outcome = cm.submit_job(spec).unwrap();
+        wait_for("job applied", || cm.get_job(outcome.job_id).is_some());
+        assert_eq!(cm.get_job(outcome.job_id).unwrap().spec.num_nodes, 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_warns_when_node_count_reduced() {
+        // I2: a shrunk request returns a user-facing warning; an exact-fit
+        // request returns none.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        let mut shrunk = basic_spec("shrunk");
+        shrunk.num_nodes = 4;
+        shrunk.num_tasks = 1;
+        let outcome = cm.submit_job(shrunk).unwrap();
+        assert!(
+            outcome
+                .warnings
+                .iter()
+                .any(|w| w.contains("requested 4 nodes but only 1")),
+            "expected a node-reduction warning, got {:?}",
+            outcome.warnings
+        );
+
+        let mut exact = basic_spec("exact");
+        exact.num_nodes = 4;
+        exact.num_tasks = 4;
+        let outcome = cm.submit_job(exact).unwrap();
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_rejects_below_partition_min_nodes() {
+        // I1: -N4 -n1 on a MinNodes=4 partition is rejected at submit, not left
+        // pending forever.
+        let dir = TempDir::new().unwrap();
+        let mut config = test_config();
+        config.partitions[0].min_nodes = 4;
+        let cm = test_cluster_with_config(&dir, config).await;
+
+        let mut spec = basic_spec("undersize");
+        spec.partition = Some("default".into());
+        spec.num_nodes = 4;
+        spec.num_tasks = 1; // reduces to 1 node, below min 4
+        let err = cm.submit_job(spec).unwrap_err();
+        assert!(matches!(err, SubmitError::InvalidArgument(_)));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_rejects_above_partition_max_nodes() {
+        let dir = TempDir::new().unwrap();
+        let mut config = test_config();
+        config.partitions[0].max_nodes = Some(1);
+        let cm = test_cluster_with_config(&dir, config).await;
+
+        let mut spec = basic_spec("oversize");
+        spec.partition = Some("default".into());
+        spec.num_nodes = 2;
+        spec.num_tasks = 2;
+        assert!(cm.submit_job(spec).is_err());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_accepts_within_partition_node_bounds() {
+        let dir = TempDir::new().unwrap();
+        let mut config = test_config();
+        config.partitions[0].min_nodes = 1;
+        config.partitions[0].max_nodes = Some(4);
+        let cm = test_cluster_with_config(&dir, config).await;
+
+        let mut spec = basic_spec("fits");
+        spec.partition = Some("default".into());
+        spec.num_nodes = 2;
+        spec.num_tasks = 2;
+        assert!(cm.submit_job(spec).is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_pmix_accepts_single_node_after_reduction() {
+        // I5: -N4 -n1 --mpi=pmix reduces to one node and is accepted.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        let mut spec = basic_spec("pmix-one");
+        spec.num_nodes = 4;
+        spec.num_tasks = 1;
+        spec.mpi = Some(spur_core::mpi::MPI_PMIX.into());
+        assert!(cm.submit_job(spec).is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_pmix_rejects_multi_node() {
+        // I5: -N4 -n4 --mpi=pmix stays multi-node and is rejected.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        let mut spec = basic_spec("pmix-many");
+        spec.num_nodes = 4;
+        spec.num_tasks = 4;
+        spec.mpi = Some(spur_core::mpi::MPI_PMIX.into());
+        assert!(cm.submit_job(spec).is_err());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_keeps_full_node_count_for_total_gpus() {
+        // C2: -N4 --gpus=8 (ntasks defaulted to nodes) keeps all four nodes so
+        // the eight GPUs spread across them instead of collapsing to one node.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        let mut spec = basic_spec("gpu-spread");
+        spec.num_nodes = 4;
+        spec.num_tasks = 4; // one task per node (adapter default for absent -n)
+        spec.gpus = Some(spur_core::gpu_request::GpuRequest::new(8, None));
+        let outcome = cm.submit_job(spec).unwrap();
+        wait_for("job applied", || cm.get_job(outcome.job_id).is_some());
+        assert_eq!(cm.get_job(outcome.job_id).unwrap().spec.num_nodes, 4);
+        assert!(outcome.warnings.is_empty());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -8903,7 +9106,10 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn tag_blocked_sets_partition_config_reason() {
-        // Request exceeds partition max_nodes -> PartitionConfig, not Resources.
+        // A job exceeding partition max_nodes that reaches the scheduler (e.g. a
+        // replayed pre-upgrade WAL entry predating submit-time bounds checking)
+        // must be tagged PartitionConfig and dropped, not scheduled. Fresh
+        // submits are rejected earlier (see submit_rejects_node_bounds_*).
         let dir = TempDir::new().unwrap();
         let mut config = test_config();
         config.partitions[0].max_nodes = Some(1);
@@ -8913,7 +9119,12 @@ mod tests {
         spec.partition = Some("default".into());
         spec.num_nodes = 2;
         spec.num_tasks = 2;
-        let job_id = submit_and_wait(&cm, spec);
+        let job_id = 1;
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id,
+            spec: Box::new(spec),
+        });
+        wait_for("job applied", || cm.get_job(job_id).is_some());
 
         cm.tag_blocked_pending_reasons();
         assert_eq!(
@@ -8936,15 +9147,26 @@ mod tests {
         config.partitions[0].min_nodes = 2;
         let cm = test_cluster_with_config(&dir, config).await;
 
+        // Meets min_nodes but exceeds max_time: the time cap is not a
+        // submit-time bound, so this is admitted and pends with PartitionConfig.
         let mut over_time = basic_spec("overtime");
         over_time.partition = Some("default".into());
+        over_time.num_nodes = 2;
+        over_time.num_tasks = 2;
         over_time.time_limit = Some(chrono::Duration::hours(1));
         let t_id = submit_and_wait(&cm, over_time);
 
+        // Below min_nodes is rejected at submit now, so inject directly to
+        // exercise the scheduler's PartitionConfig tagging for replayed entries.
         let mut under_nodes = basic_spec("undernodes");
         under_nodes.partition = Some("default".into());
         under_nodes.num_nodes = 1; // below min_nodes=2
-        let n_id = submit_and_wait(&cm, under_nodes);
+        let n_id = 999;
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: n_id,
+            spec: Box::new(under_nodes),
+        });
+        wait_for("undernodes applied", || cm.get_job(n_id).is_some());
 
         cm.tag_blocked_pending_reasons();
         assert_eq!(
@@ -11066,7 +11288,7 @@ mod tests {
 
         let mut spec = basic_spec("arr-throttle-pass");
         spec.array_spec = Some("0-2%1".into());
-        let parent_id = cm.submit_job(spec).unwrap();
+        let parent_id = cm.submit_job(spec).unwrap().job_id;
         let task_ids: Vec<JobId> = (1..=3).map(|offset| parent_id + offset).collect();
         for id in &task_ids {
             wait_for(&format!("array task {id}"), || cm.get_job(*id).is_some());
@@ -11089,7 +11311,7 @@ mod tests {
 
         let mut spec = basic_spec("arr-throttle");
         spec.array_spec = Some("0-2%1".into());
-        let parent_id = cm.submit_job(spec).unwrap();
+        let parent_id = cm.submit_job(spec).unwrap().job_id;
         let task_ids: Vec<JobId> = (1..=3).map(|offset| parent_id + offset).collect();
         for id in &task_ids {
             wait_for(&format!("array task {id}"), || cm.get_job(*id).is_some());
@@ -11121,7 +11343,7 @@ mod tests {
         let mut spec = basic_spec("arr-lic");
         spec.array_spec = Some("0-1%1".into());
         spec.gres = vec!["license:fluent:1".into()];
-        let parent_id = cm.submit_job(spec).unwrap();
+        let parent_id = cm.submit_job(spec).unwrap().job_id;
         let t1 = parent_id + 1;
         let t2 = parent_id + 2;
         wait_for("array license tasks", || {
@@ -11173,7 +11395,7 @@ mod tests {
         let mut spec = basic_spec("arr-bb");
         spec.array_spec = Some("0-1%1".into());
         spec.burst_buffer = Some("capacity=60".into());
-        let parent_id = cm.submit_job(spec).unwrap();
+        let parent_id = cm.submit_job(spec).unwrap().job_id;
         let t1 = parent_id + 1;
         let t2 = parent_id + 2;
         wait_for("array bb tasks", || {
@@ -14806,7 +15028,7 @@ mod tests {
         // array parent id, which is not stored — only per-task ids exist in `jobs`.
         let mut spec = basic_spec("array");
         spec.array_spec = Some("0-2".into()); // Creates 3 tasks
-        let parent_id = cm.submit_job(spec).unwrap();
+        let parent_id = cm.submit_job(spec).unwrap().job_id;
         let first_task_id = parent_id + 1;
         wait_for(&format!("array task {first_task_id} applied"), || {
             cm.get_job(first_task_id).is_some()
@@ -15923,7 +16145,8 @@ mod tests {
         spec.qos = None;
         let id = cm
             .submit_job(spec)
-            .expect("association default QoS must satisfy the partition allow_qos");
+            .expect("association default QoS must satisfy the partition allow_qos")
+            .job_id;
         assert_eq!(
             cm.get_job(id).unwrap().spec.qos.as_deref(),
             Some("premium"),

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -422,6 +422,13 @@ impl ClusterManager {
             &config.accounting,
         )?;
         self.validate_partition(&spec)?;
+
+        // A job with fewer tasks than nodes (and no explicit per-node layout)
+        // cannot place work on the surplus nodes. Reduce to what will actually
+        // be allocated so reported node/GPU counts match the allocation and the
+        // in-job SLURM_NNODES, matching Slurm's submission-time reduction.
+        spec.num_nodes = spec.effective_num_nodes();
+
         let mpi = spec.mpi.as_deref().unwrap_or(spur_core::mpi::MPI_NONE);
         spur_core::mpi::validate_single_node_pmix(mpi, spec.num_nodes)
             .map_err(SubmitError::invalid)?;
@@ -6547,6 +6554,50 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_job_reduces_nodes_to_task_count() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        let mut spec = basic_spec("fewer-tasks");
+        spec.num_nodes = 4;
+        spec.num_tasks = 1;
+        let id = submit_and_wait(&cm, spec);
+
+        // The persisted spec (what all reporting reads) reflects the node count
+        // actually allocatable, not the over-request.
+        assert_eq!(cm.get_job(id).unwrap().spec.num_nodes, 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_job_keeps_nodes_when_tasks_match() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        let mut spec = basic_spec("full-fit");
+        spec.num_nodes = 4;
+        spec.num_tasks = 4;
+        let id = submit_and_wait(&cm, spec);
+
+        assert_eq!(cm.get_job(id).unwrap().spec.num_nodes, 4);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn submit_job_keeps_nodes_with_explicit_tasks_per_node() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        let mut spec = basic_spec("per-node-layout");
+        spec.num_nodes = 4;
+        spec.num_tasks = 1;
+        spec.tasks_per_node = Some(2);
+        let id = submit_and_wait(&cm, spec);
+
+        // An explicit per-node layout pins the node count regardless of the
+        // task total.
+        assert_eq!(cm.get_job(id).unwrap().spec.num_nodes, 4);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn submit_multiple_jobs_increments_ids() {
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
@@ -8861,6 +8912,7 @@ mod tests {
         let mut spec = basic_spec("toobig");
         spec.partition = Some("default".into());
         spec.num_nodes = 2;
+        spec.num_tasks = 2;
         let job_id = submit_and_wait(&cm, spec);
 
         cm.tag_blocked_pending_reasons();
@@ -11302,6 +11354,7 @@ mod tests {
         let mut big = basic_spec("big");
         big.qos = Some("burst".into());
         big.num_nodes = 2;
+        big.num_tasks = 2;
         big.priority = Some(1000);
         let big_id = submit_and_wait(&cm, big);
 

--- a/crates/spurctld/src/rest/handlers.rs
+++ b/crates/spurctld/src/rest/handlers.rs
@@ -68,6 +68,14 @@ pub async fn get_job(
     }))
 }
 
+/// Default an absent or zero REST `ntasks` to one task per requested node
+/// (Slurm's default), so a multi-node request is not silently collapsed to one.
+fn rest_effective_ntasks(ntasks: Option<u32>, nodes: Option<u32>) -> u32 {
+    ntasks
+        .filter(|&n| n > 0)
+        .unwrap_or_else(|| nodes.unwrap_or(1).max(1))
+}
+
 pub async fn submit_job(
     State(state): State<Arc<RestState>>,
     Json(body): Json<SubmitRequest>,
@@ -89,7 +97,7 @@ pub async fn submit_job(
         partition: body.job.partition,
         account: body.job.account,
         num_nodes: body.job.nodes.unwrap_or(1),
-        num_tasks: body.job.ntasks.unwrap_or(1),
+        num_tasks: rest_effective_ntasks(body.job.ntasks, body.job.nodes),
         cpus_per_task: body.job.cpus_per_task.unwrap_or(1),
         time_limit,
         script: body.job.script,
@@ -101,13 +109,13 @@ pub async fn submit_job(
         ..Default::default()
     };
 
-    // Validate the GPU request (mutually exclusive forms, --gpus >= num_nodes).
-    spur_core::gpu_request::resolve_gpu_demand(&spec)
-        .map_err(|e| bad_request_response(&e.to_string()))?;
+    // GPU demand is validated in submit_job after node-count normalization.
+    let outcome = state.cluster.submit_job(spec).map_err(submit_rest_error)?;
 
-    let job_id = state.cluster.submit_job(spec).map_err(submit_rest_error)?;
-
-    Ok(ApiResponse::ok(SubmitResponse { job_id }))
+    Ok(ApiResponse::ok(SubmitResponse {
+        job_id: outcome.job_id,
+        warnings: outcome.warnings,
+    }))
 }
 
 /// Parse a REST GPU field ("4" or "mi300x:4") into a core GPU request.
@@ -191,6 +199,18 @@ pub async fn get_partitions(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rest_effective_ntasks_defaults_absent_to_nodes() {
+        // C1 (REST): absent ntasks -> one task per node, not 1.
+        assert_eq!(rest_effective_ntasks(None, Some(4)), 4);
+        // Zero is treated as unset.
+        assert_eq!(rest_effective_ntasks(Some(0), Some(4)), 4);
+        // Explicit ntasks is preserved (reduces the job to one node later).
+        assert_eq!(rest_effective_ntasks(Some(1), Some(4)), 1);
+        // No nodes given falls back to a single task.
+        assert_eq!(rest_effective_ntasks(None, None), 1);
+    }
 
     #[test]
     fn parse_rest_gpu_valid() {

--- a/crates/spurctld/src/rest/types.rs
+++ b/crates/spurctld/src/rest/types.rs
@@ -168,6 +168,8 @@ pub struct SubmitJobFields {
 #[derive(Serialize)]
 pub struct SubmitResponse {
     pub job_id: u32,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
 }
 
 #[cfg(test)]

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -2616,7 +2616,7 @@ mod tests {
         }
 
         fn submit_and_wait(cm: &ClusterManager, spec: JobSpec) -> spur_core::job::JobId {
-            let id = cm.submit_job(spec).unwrap();
+            let id = cm.submit_job(spec).unwrap().job_id;
             wait_for(&format!("job {id} applied"), || cm.get_job(id).is_some());
             id
         }

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -372,12 +372,15 @@ impl SlurmController for ControllerService {
             .ok_or_else(|| Status::invalid_argument("missing job spec"))?;
 
         let core_spec = proto_to_job_spec(spec)?;
-        let job_id = self
+        let outcome = self
             .cluster
             .submit_job(core_spec)
             .map_err(submit_rpc_status)?;
 
-        Ok(Response::new(SubmitJobResponse { job_id }))
+        Ok(Response::new(SubmitJobResponse {
+            job_id: outcome.job_id,
+            warnings: outcome.warnings,
+        }))
     }
 
     async fn get_jobs(
@@ -2429,7 +2432,13 @@ fn proto_to_job_spec(spec: JobSpec) -> Result<spur_core::job::JobSpec, Status> {
         uid: spec.uid,
         gid: spec.gid,
         num_nodes: spec.num_nodes.max(1),
-        num_tasks: spec.num_tasks.max(1),
+        // 0 means the caller did not set ntasks: default to one task per node
+        // (Slurm's default) so it scales with num_nodes rather than collapsing.
+        num_tasks: if spec.num_tasks > 0 {
+            spec.num_tasks
+        } else {
+            spec.num_nodes.max(1)
+        },
         tasks_per_node: if spec.tasks_per_node > 0 {
             Some(spec.tasks_per_node)
         } else {
@@ -2618,9 +2627,9 @@ fn proto_to_job_spec(spec: JobSpec) -> Result<spur_core::job::JobSpec, Status> {
         pty: spec.pty,
     };
 
-    spur_core::gpu_request::resolve_gpu_demand(&job_spec)
-        .map_err(|e| Status::invalid_argument(e.to_string()))?;
-
+    // GPU demand is validated in `Cluster::submit_job` after node-count
+    // normalization, so `-N4 -n1 --gpus=2` (valid once reduced to one node)
+    // is not rejected against the pre-normalization node count.
     Ok(job_spec)
 }
 
@@ -3396,7 +3405,7 @@ mod tests {
             ..Default::default()
         };
         spec.srun_job = true;
-        let job_id = svc.cluster.submit_job(spec).unwrap();
+        let job_id = svc.cluster.submit_job(spec).unwrap().job_id;
         // Allocate to a real node plus a ghost node that is never registered.
         let res = ResourceAllocations::with_scalar(2, 4000);
         let per_node: std::collections::HashMap<_, _> = [
@@ -3463,7 +3472,7 @@ mod tests {
             work_dir: "/tmp".into(),
             ..Default::default()
         };
-        let job_id = svc.cluster.submit_job(spec).unwrap();
+        let job_id = svc.cluster.submit_job(spec).unwrap().job_id;
 
         let err = svc
             .exec_in_job(Request::new(ExecInJobRequest {
@@ -3491,7 +3500,7 @@ mod tests {
             ..Default::default()
         };
         spec.srun_job = true;
-        let job_id = svc.cluster.submit_job(spec).unwrap();
+        let job_id = svc.cluster.submit_job(spec).unwrap().job_id;
 
         let err = svc
             .create_job_step(Request::new(CreateJobStepRequest {
@@ -3547,7 +3556,7 @@ mod tests {
             work_dir: "/tmp".into(),
             ..Default::default()
         };
-        let job_id = svc.cluster.submit_job(spec).unwrap();
+        let job_id = svc.cluster.submit_job(spec).unwrap().job_id;
 
         let res = ResourceAllocations::with_scalar(1, 1000);
         let per_node: std::collections::HashMap<_, _> =
@@ -4310,5 +4319,48 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(requested_gpus_detail(&spec), "gpu:4/node");
+    }
+
+    #[test]
+    fn proto_to_job_spec_defaults_absent_ntasks_to_nodes() {
+        // C1: num_tasks=0 (unset over the wire) defaults to one task per node,
+        // not 1, so the node count is not silently collapsed.
+        let spec = spur_proto::proto::JobSpec {
+            num_nodes: 4,
+            num_tasks: 0,
+            ..Default::default()
+        };
+        let core = proto_to_job_spec(spec).unwrap();
+        assert_eq!(core.num_tasks, 4);
+        assert_eq!(core.effective_num_nodes(), 4);
+    }
+
+    #[test]
+    fn proto_to_job_spec_respects_explicit_single_task() {
+        // An explicit --ntasks=1 is preserved and reduces the job to one node.
+        let spec = spur_proto::proto::JobSpec {
+            num_nodes: 4,
+            num_tasks: 1,
+            ..Default::default()
+        };
+        let core = proto_to_job_spec(spec).unwrap();
+        assert_eq!(core.num_tasks, 1);
+        assert_eq!(core.effective_num_nodes(), 1);
+    }
+
+    #[test]
+    fn proto_to_job_spec_defers_gpu_validation() {
+        // C3: proto_to_job_spec no longer rejects -N4 -n1 --gpus=2. GPU demand
+        // is validated in submit_job against the normalized (1) node count.
+        let spec = spur_proto::proto::JobSpec {
+            num_nodes: 4,
+            num_tasks: 1,
+            gpus: Some(spur_proto::proto::GpuRequest {
+                count: 2,
+                gpu_type: String::new(),
+            }),
+            ..Default::default()
+        };
+        assert!(proto_to_job_spec(spec).is_ok());
     }
 }

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -94,6 +94,8 @@ message JobSpec {
 
   // Resources
   uint32 num_nodes = 10;
+  // 0 means unset: the controller defaults it to one task per node (num_nodes),
+  // matching Slurm, rather than collapsing a multi-node request onto one node.
   uint32 num_tasks = 11;
   uint32 tasks_per_node = 12;
   uint32 cpus_per_task = 13;
@@ -456,6 +458,7 @@ message SubmitJobRequest {
 
 message SubmitJobResponse {
   uint32 job_id = 1;
+  repeated string warnings = 2;
 }
 
 message GetJobsRequest {


### PR DESCRIPTION
## What this fixes

CPU-only jobs requesting fewer tasks than nodes (e.g. `sbatch -N4 -n1`) reserved 0 CPUs per node. The per-node CPU share used floor division `num_tasks / num_nodes`, which truncates to 0 when tasks are fewer than nodes. The allocation was then invisible to resource tracking, so any number of such jobs stacked on the same nodes, and the job also held nodes it could never place work on. Tracked as SPUR-13.

## Approach

- `base_node_request` computes per-node CPUs with ceiling division and floors at one CPU. The busiest node's share is never under-reserved, and every allocated node consumes tracked capacity.
- `submit_job` normalizes `num_nodes` to `min(num_nodes, num_tasks)` at intake, unless `--ntasks-per-node` pins the per-node layout. This matches Slurm cons_tres. Because the persisted count equals what is allocated, squeue, scontrol, sacct, and the in-job `SLURM_NNODES` all stay consistent with the nodelist. The scheduler trusts `num_nodes` as the single source of truth.

## Design choices

- Normalization runs once at controller intake on the leader propose path, not in the scheduler, so reporting and allocation share one value.
- No schema, proto, or config change. `num_nodes` keeps its type; only its stored value is reduced for affected jobs, so serialized Raft/WAL state stays compatible.
- Pre-upgrade Raft entries replay unchanged (the apply path does not re-normalize). Old jobs may schedule with their original larger count; new submissions get the corrected count. This is non-crashing and acceptable.

## Testing

- `cargo test --locked`: 2521 passed, 0 failed. `cargo clippy --workspace --exclude spur-ffi --all-targets --locked`: clean.
- New unit tests cover `effective_num_nodes`, the `base_node_request` CPU cases, and `submit_job` normalization.
- Bare-metal (4 nodes, 4 CPUs each) vs Slurm 25.11.7, node-selection cases T1-T7:

| Test | Command | Slurm 25.11.7 | This PR |
|---|---|---|---|
| T1 | `-N4` | both RUNNING | both RUNNING |
| T2 | `-N4 -n1` | both RUNNING | both RUNNING |
| T3 | `-N4 -n1 -c1` | both RUNNING | both RUNNING |
| T4 | `-N4 -c4` | j2 PENDING | j2 PENDING |
| T5 | `-N2 -n1` (x2) | both RUNNING | both RUNNING |
| T6 | `-N4 --exclusive` | j2 PENDING | j2 PENDING |
| T7 | `-N4 --ntasks-per-node=1` | both RUNNING | both RUNNING |

Reporting: `-N4 -n1` now reports `NODES=1` / `NumNodes=1`, matching Slurm.

## Follow-ups

- A `-N4 -n1` job submitted to a partition with `min_nodes>1` now pends as PartitionConfig instead of running. Narrow edge case, arguably correct. Slurm's bump-up-to-`min_nodes` behavior can be added separately if wanted.