### PR TITLE
refactor(priority): name default priority and document proto encoding

### DIFF
--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -438,8 +438,9 @@ pub struct JobSpec {
     // Scheduling
     pub qos: Option<String>,
     /// Explicit base priority request; `None` means "unset", resolved to
-    /// [`DEFAULT_PRIORITY`] in [`Job::new`]. Not the effective priority the
-    /// scheduler ranks on (that is derived from this each cycle).
+    /// [`DEFAULT_PRIORITY`] in [`Job::new`] (except when `hold` is set, which
+    /// forces base priority to 0). Not the effective priority the scheduler
+    /// ranks on (that is derived from this each cycle).
     pub priority: Option<u32>,
     pub reservation: Option<String>,
     pub dependency: Vec<String>,

--- a/crates/spur-core/src/job.rs
+++ b/crates/spur-core/src/job.rs
@@ -12,6 +12,11 @@ use crate::resource::ResourceAllocations;
 /// Unique job identifier assigned by the controller.
 pub type JobId = u32;
 
+/// Base priority assigned to a job that does not request one explicitly.
+/// Non-zero so the multiplicative effective-priority formula (fair-share, age,
+/// partition tier) has a factor to scale, rather than collapsing to the floor.
+pub const DEFAULT_PRIORITY: u32 = 1000;
+
 /// Job states matching Slurm's state model.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -432,6 +437,9 @@ pub struct JobSpec {
 
     // Scheduling
     pub qos: Option<String>,
+    /// Explicit base priority request; `None` means "unset", resolved to
+    /// [`DEFAULT_PRIORITY`] in [`Job::new`]. Not the effective priority the
+    /// scheduler ranks on (that is derived from this each cycle).
     pub priority: Option<u32>,
     pub reservation: Option<String>,
     pub dependency: Vec<String>,
@@ -748,7 +756,7 @@ impl Job {
         let priority = if spec.hold {
             0
         } else {
-            spec.priority.unwrap_or(1000)
+            spec.priority.unwrap_or(DEFAULT_PRIORITY)
         };
         let state = JobState::Pending;
         let pending_reason = if spec.hold {

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -789,6 +789,8 @@ fn core_job_spec_to_proto(spec: &spur_core::job::JobSpec) -> spur_proto::proto::
             nanos: 0,
         }),
         qos: spec.qos.clone().unwrap_or_default(),
+        // Proto `priority` is non-optional; 0 encodes "unset" and is resolved
+        // back to the default by the receiver, not a base priority of zero.
         priority: spec.priority.unwrap_or(0),
         reservation: spec.reservation.clone().unwrap_or_default(),
         dependency: spec.dependency.clone(),

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -789,8 +789,9 @@ fn core_job_spec_to_proto(spec: &spur_core::job::JobSpec) -> spur_proto::proto::
             nanos: 0,
         }),
         qos: spec.qos.clone().unwrap_or_default(),
-        // Proto `priority` is non-optional; 0 encodes "unset" and is resolved
-        // back to the default by the receiver, not a base priority of zero.
+        // Proto `priority` is non-optional; 0 encodes "unset", not a base
+        // priority of zero. The receiver decodes 0 back to `None`, which
+        // `Job::new` then resolves to the default.
         priority: spec.priority.unwrap_or(0),
         reservation: spec.reservation.clone().unwrap_or_default(),
         dependency: spec.dependency.clone(),

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -17,7 +17,7 @@ use spur_core::burst_buffer::BbStageState;
 use spur_core::config::SlurmConfig;
 use spur_core::job::{
     effective_gpus, effective_memory_mb, Job, JobId, JobSpec, JobState, NodeCompleteError,
-    PendingReason, TransitionOutcome,
+    PendingReason, TransitionOutcome, DEFAULT_PRIORITY,
 };
 use spur_core::node::{Node, NodeEvent, NodeSource, NodeState};
 use spur_core::partition::{requested_partition_names, Partition, PreemptMode};
@@ -1679,7 +1679,7 @@ impl ClusterManager {
         self.propose(WalOperation::JobPriorityChange {
             job_id,
             old_priority,
-            new_priority: 1000,
+            new_priority: DEFAULT_PRIORITY,
             pending_reason: Some(PendingReason::Priority),
             pending_reason_desc: None,
             reset_requeue_count: reset_requeue,

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -764,6 +764,8 @@ fn core_spec_to_proto(s: &spur_core::job::JobSpec) -> ProtoJobSpec {
             nanos: 0,
         }),
         qos: s.qos.clone().unwrap_or_default(),
+        // Proto `priority` is non-optional; 0 encodes "unset" and is resolved
+        // back to the default by the receiver, not a base priority of zero.
         priority: s.priority.unwrap_or(0),
         reservation: s.reservation.clone().unwrap_or_default(),
         dependency: s.dependency.clone(),
@@ -948,6 +950,8 @@ async fn dispatch_to_agent(
         }),
         time_min: None,
         qos: spec.qos.clone().unwrap_or_default(),
+        // Proto `priority` is non-optional; 0 encodes "unset". The agent does
+        // not schedule, so this value is carried for fidelity only.
         priority: spec.priority.unwrap_or(0),
         reservation: spec.reservation.clone().unwrap_or_default(),
         dependency: spec.dependency.clone(),

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -764,8 +764,9 @@ fn core_spec_to_proto(s: &spur_core::job::JobSpec) -> ProtoJobSpec {
             nanos: 0,
         }),
         qos: s.qos.clone().unwrap_or_default(),
-        // Proto `priority` is non-optional; 0 encodes "unset" and is resolved
-        // back to the default by the receiver, not a base priority of zero.
+        // Proto `priority` is non-optional; 0 encodes "unset", not a base
+        // priority of zero. The receiver decodes 0 back to `None`, which
+        // `Job::new` then resolves to the default.
         priority: s.priority.unwrap_or(0),
         reservation: s.reservation.clone().unwrap_or_default(),
         dependency: s.dependency.clone(),


### PR DESCRIPTION
## What

Names the default job base priority and documents the proto encoding of an unset priority. No behavior change.

## Why

Issue [#440](https://github.com/rocm/spur/issues/440) reads the codebase as having two competing defaults for base priority: `Job::new` uses `unwrap_or(1000)` while several `JobSpec` to proto helpers use `unwrap_or(0)`. Auditing the actual data flow, there is only one authoritative base-priority assignment (`Job::new`, default 1000). The `unwrap_or(0)` sites are serialization helpers: proto `JobSpec.priority` is a non-optional `uint32`, so `None` must encode as `0` on the wire, and the receiver (`proto_to_job_spec`) maps `0` back to `None`, which `Job::new` resolves to the default. So the "two defaults" are cosmetic, but the code does not say so, which is what generated the report.

## Change

- Add `DEFAULT_PRIORITY: u32 = 1000` in `spur-core::job` and use it in `Job::new`.
- Document `JobSpec::priority` (`None` = unset, resolved to the default; it is the base request, not the effective priority the scheduler ranks on).
- Add a one-line note at each of the three proto-encoding sites (`scheduler_loop.rs` federation forward and agent launch, `spur-k8s/job_controller.rs`) explaining that `0` encodes "unset", not a base priority of zero.

## Not addressed here

The other half of #440 (base-0 collapsing the multiplicative `effective_priority` to the floor of 1) is not reachable in live scheduling: base 0 only occurs on held / reservation-blocked jobs, which are filtered out of the candidate set before ranking. The `.max(1)` floor is intentional. If we ever want an explicit base priority of literally 0 to be expressible (distinct from unset), that needs `optional uint32 priority` in the proto, which touches the wire-compat surface and should be a separate, deliberate change.

## Testing

`cargo build` on the affected crates; `cargo test -p spur-tests t24_` (priority tests) pass.