### PR TITLE
fix(spur-cli): compress sinfo NODELIST as a Slurm-style hostlist

### DIFF
--- a/crates/spur-cli/src/sinfo.rs
+++ b/crates/spur-cli/src/sinfo.rs
@@ -305,11 +305,24 @@ fn resolve_partition_field(
                 effective_state_str(nodes[0])
             }
         }
-        'N' => nodes
-            .iter()
-            .map(|n| n.name.as_str())
-            .collect::<Vec<_>>()
-            .join(","),
+        'N' => {
+            let names: Vec<String> = nodes.iter().map(|n| n.name.clone()).collect();
+            spur_core::hostlist::compress(&names)
+        }
+        'n' => {
+            // Expanded form of the same sorted hostlist as `%N`, so `%n` and
+            // `%N` stay consistent (Slurm derives both from one sorted list).
+            let names: Vec<String> = nodes.iter().map(|n| n.name.clone()).collect();
+            let compressed = spur_core::hostlist::compress(&names);
+            spur_core::hostlist::expand(&compressed)
+                .unwrap_or_else(|_| {
+                    let mut fallback = names;
+                    fallback.sort();
+                    fallback.dedup();
+                    fallback
+                })
+                .join(",")
+        }
         'c' => part.total_cpus.to_string(),
         _ => "?".into(),
     }
@@ -632,12 +645,8 @@ mod tests {
             "idle row should show 2 nodes: {idle_line}"
         );
         assert!(
-            idle_line.contains("n1"),
-            "idle row should list n1: {idle_line}"
-        );
-        assert!(
-            idle_line.contains("n2"),
-            "idle row should list n2: {idle_line}"
+            idle_line.contains("n[1-2]"),
+            "idle row should list a compressed n[1-2]: {idle_line}"
         );
         assert!(
             !idle_line.contains("n3"),
@@ -672,6 +681,39 @@ mod tests {
         assert_eq!(lines.len(), 1);
         assert!(lines[0].contains("idle"));
         assert!(lines[0].contains("3"));
+    }
+
+    #[test]
+    fn test_render_nodelist_compressed() {
+        let fields = default_fields();
+        let partitions = vec![make_partition("gpu", true)];
+        let nodes = vec![
+            make_node("gpu001", NodeState::NodeIdle, "gpu"),
+            make_node("gpu002", NodeState::NodeIdle, "gpu"),
+            make_node("gpu003", NodeState::NodeIdle, "gpu"),
+            make_node("gpu004", NodeState::NodeIdle, "gpu"),
+        ];
+
+        let lines = render_sinfo_output(&fields, &partitions, &nodes, false);
+        assert_eq!(lines.len(), 1);
+        assert!(
+            lines[0].contains("gpu[001-004]"),
+            "NODELIST should be a compressed hostlist: {}",
+            lines[0]
+        );
+    }
+
+    #[test]
+    fn test_render_nodelist_expanded_with_percent_n() {
+        let fields = format_engine::parse_format("%P|%n", &format_engine::sinfo_header);
+        let partitions = vec![make_partition("gpu", true)];
+        let nodes = vec![
+            make_node("gpu001", NodeState::NodeIdle, "gpu"),
+            make_node("gpu002", NodeState::NodeIdle, "gpu"),
+        ];
+
+        let lines = render_sinfo_output(&fields, &partitions, &nodes, false);
+        assert_eq!(lines, ["gpu*|gpu001,gpu002"]);
     }
 
     #[test]
@@ -818,8 +860,10 @@ mod tests {
             .iter()
             .find(|l| l.contains("idle"))
             .expect("no idle row");
-        assert!(idle_line.contains("n1"), "idle row should list n1");
-        assert!(idle_line.contains("n2"), "idle row should list n2");
+        assert!(
+            idle_line.contains("n[1-2]"),
+            "idle row should list a compressed n[1-2]: {idle_line}"
+        );
         assert!(!idle_line.contains("n3"), "idle row should not list n3");
 
         let resv_line = lines

--- a/crates/spur-core/src/hostlist.rs
+++ b/crates/spur-core/src/hostlist.rs
@@ -31,82 +31,224 @@ pub fn expand(pattern: &str) -> Result<Vec<String>, HostlistError> {
 /// Compress a list of hostnames into a compact hostlist pattern.
 ///
 /// Example: `["node001", "node002", "node003", "node005"]` → `"node[001-003,005]"`
+///
+/// Duplicates are removed and the output is deterministic regardless of input
+/// order (prefixes are natural-sorted, matching Slurm). All numbers under one
+/// prefix share a single bracket, even across differing zero-padding; paddings
+/// that cannot merge are emitted as separate terms so the result always
+/// round-trips through [`expand`] (e.g. `["node9", "node010", "node011"]` →
+/// `"node[9,010-011]"`).
 pub fn compress(hosts: &[String]) -> String {
-    if hosts.is_empty() {
+    let mut seen = std::collections::HashSet::new();
+    let unique: Vec<&str> = hosts
+        .iter()
+        .map(String::as_str)
+        .filter(|h| seen.insert(*h))
+        .collect();
+    if unique.is_empty() {
         return String::new();
     }
-    if hosts.len() == 1 {
-        return hosts[0].clone();
+
+    // Numeric hosts group by prefix; hosts without a trailing digit run stay as
+    // standalone bare names. A bare name must never merge into a numeric group
+    // of the same spelling (or vice versa), otherwise a bare `node` would be
+    // swallowed by `node1`'s prefix.
+    let mut numeric: Vec<(String, Vec<(u64, usize)>)> = Vec::new();
+    let mut bare: Vec<String> = Vec::new();
+
+    for host in unique {
+        match split_name_number(host) {
+            Some((prefix, num, width)) => {
+                if let Some(group) = numeric.iter_mut().find(|(p, _)| *p == prefix) {
+                    group.1.push((num, width));
+                } else {
+                    numeric.push((prefix, vec![(num, width)]));
+                }
+            }
+            None => bare.push(host.to_string()),
+        }
     }
 
-    // Group by prefix
-    let mut groups: Vec<(String, Vec<(u64, usize)>)> = Vec::new();
+    struct Term {
+        prefix: String,
+        bare: bool,
+        min_num: u64,
+        rendered: String,
+    }
+    let mut terms: Vec<Term> = Vec::new();
 
-    for host in hosts {
-        if let Some((prefix, num, width)) = split_name_number(host) {
-            if let Some(group) = groups.iter_mut().find(|(p, _)| p == &prefix) {
-                group.1.push((num, width));
-            } else {
-                groups.push((prefix, vec![(num, width)]));
+    for name in bare {
+        terms.push(Term {
+            prefix: name.clone(),
+            bare: true,
+            min_num: 0,
+            rendered: name,
+        });
+    }
+
+    for (prefix, mut nums) in numeric {
+        nums.sort_unstable();
+        let ranges = coalesce_ranges(&nums);
+        let min_num = ranges[0].0;
+        let rendered = render_prefix(&prefix, &ranges);
+        terms.push(Term {
+            prefix,
+            bare: false,
+            min_num,
+            rendered,
+        });
+    }
+
+    // Natural prefix order; a bare name sorts before numeric hosts of the same
+    // prefix (Slurm's singlehost-first), then by the term's lowest number.
+    terms.sort_by(|a, b| {
+        natural_cmp(&a.prefix, &b.prefix)
+            .then_with(|| b.bare.cmp(&a.bare))
+            .then_with(|| a.min_num.cmp(&b.min_num))
+            .then_with(|| a.rendered.cmp(&b.rendered))
+    });
+
+    terms
+        .into_iter()
+        .map(|t| t.rendered)
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+/// Input must be sorted. Consecutive numbers merge into one range only when
+/// contiguous and zero-padding-compatible ([`width_equiv`]); exact duplicates
+/// (same value and width) are dropped.
+fn coalesce_ranges(nums: &[(u64, usize)]) -> Vec<(u64, u64, usize)> {
+    let mut ranges: Vec<(u64, u64, usize)> = Vec::new();
+    for &(num, width) in nums {
+        if let Some(last) = ranges.last_mut() {
+            if num == last.1 && width == last.2 {
+                continue;
+            }
+            if last.1.checked_add(1) == Some(num) {
+                if let Some(combined) = width_equiv(last.0, last.2, num, width) {
+                    last.1 = num;
+                    last.2 = combined;
+                    continue;
+                }
+            }
+        }
+        ranges.push((num, num, width));
+    }
+    ranges
+}
+
+/// Brackets are omitted for a single one-host range (`prefix5`); every other
+/// case is bracketed (`prefix[...]`), matching Slurm's `_is_bracket_needed`.
+fn render_prefix(prefix: &str, ranges: &[(u64, u64, usize)]) -> String {
+    let body = ranges
+        .iter()
+        .map(|&(lo, hi, width)| format_range(lo, hi, width))
+        .collect::<Vec<_>>()
+        .join(",");
+    let bracket_needed = ranges.len() > 1 || ranges[0].0 != ranges[0].1;
+    if bracket_needed {
+        format!("{prefix}[{body}]")
+    } else {
+        format!("{prefix}{body}")
+    }
+}
+
+/// Slurm's `_width_equiv`: whether `n`@`wn` and `m`@`wm` can share a range.
+/// Returns the combined field width when they can, `None` otherwise.
+fn width_equiv(n: u64, wn: usize, m: u64, wm: usize) -> Option<usize> {
+    if wn == wm {
+        return Some(wn);
+    }
+    let npad = zero_padded(n, wn);
+    let nmpad = zero_padded(n, wm);
+    let mpad = zero_padded(m, wm);
+    let mnpad = zero_padded(m, wn);
+    if npad != nmpad && mpad != mnpad {
+        None
+    } else if npad != nmpad {
+        Some(wn)
+    } else {
+        Some(wm)
+    }
+}
+
+/// Slurm's `_zero_padded`: leading-zero count when `num` is printed at `width`.
+fn zero_padded(num: u64, width: usize) -> usize {
+    width.saturating_sub(digit_count(num))
+}
+
+fn digit_count(n: u64) -> usize {
+    n.checked_ilog10().unwrap_or(0) as usize + 1
+}
+
+/// Natural ("version") string comparison: digit runs compare by numeric value;
+/// on equal value the shorter run (less zero-padding) sorts first. Gives a
+/// deterministic, human-friendly order (`rack2` before `rack10`); this is our
+/// own ordering, not a port of Slurm's prefix sort (which uses plain `strcmp`).
+fn natural_cmp(a: &str, b: &str) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    let (a, b) = (a.as_bytes(), b.as_bytes());
+    let (mut i, mut j) = (0usize, 0usize);
+    while i < a.len() && j < b.len() {
+        if a[i].is_ascii_digit() && b[j].is_ascii_digit() {
+            let a_start = i;
+            let b_start = j;
+            while i < a.len() && a[i].is_ascii_digit() {
+                i += 1;
+            }
+            while j < b.len() && b[j].is_ascii_digit() {
+                j += 1;
+            }
+            let a_num = trim_leading_zeros(&a[a_start..i]);
+            let b_num = trim_leading_zeros(&b[b_start..j]);
+            let ord = a_num
+                .len()
+                .cmp(&b_num.len())
+                .then_with(|| a_num.cmp(b_num))
+                // Equal value: shorter run (less zero-padding) first.
+                .then_with(|| (i - a_start).cmp(&(j - b_start)));
+            if ord != Ordering::Equal {
+                return ord;
             }
         } else {
-            // No numeric suffix, standalone
-            groups.push((host.clone(), vec![]));
+            match a[i].cmp(&b[j]) {
+                Ordering::Equal => {
+                    i += 1;
+                    j += 1;
+                }
+                ord => return ord,
+            }
         }
     }
-
-    let mut parts = Vec::new();
-    for (prefix, mut nums) in groups {
-        if nums.is_empty() {
-            parts.push(prefix);
-            continue;
-        }
-        nums.sort_by_key(|(n, _)| *n);
-        let width = nums[0].1;
-        let ranges = compress_ranges(&nums.iter().map(|(n, _)| *n).collect::<Vec<_>>(), width);
-        if nums.len() == 1 {
-            parts.push(format!("{}{:0>width$}", prefix, nums[0].0, width = width));
-        } else {
-            parts.push(format!("{}[{}]", prefix, ranges));
-        }
-    }
-
-    parts.join(",")
+    (a.len() - i).cmp(&(b.len() - j))
 }
 
-/// Split a hostname into (prefix, number, zero-padding width).
+fn trim_leading_zeros(s: &[u8]) -> &[u8] {
+    let k = s[..s.len().saturating_sub(1)]
+        .iter()
+        .take_while(|&&b| b == b'0')
+        .count();
+    &s[k..]
+}
+
+/// Split a hostname into (prefix, number, zero-padding width). Returns `None`
+/// when the name has no trailing digit run or is entirely digits (no prefix).
+///
+/// Digits are ASCII, so scanning bytes keeps the split on a valid char boundary
+/// even when the prefix ends in a multi-byte character.
 fn split_name_number(name: &str) -> Option<(String, u64, usize)> {
-    let num_start = name.rfind(|c: char| !c.is_ascii_digit())?;
-    let num_str = &name[num_start + 1..];
-    if num_str.is_empty() {
+    let bytes = name.as_bytes();
+    let start = bytes
+        .iter()
+        .rposition(|b| !b.is_ascii_digit())
+        .map_or(0, |i| i + 1);
+    if start == 0 || start == bytes.len() {
         return None;
     }
+    let num_str = &name[start..];
     let num = num_str.parse::<u64>().ok()?;
-    let width = num_str.len();
-    Some((name[..num_start + 1].to_string(), num, width))
-}
-
-/// Compress a sorted list of numbers into range strings.
-fn compress_ranges(nums: &[u64], width: usize) -> String {
-    if nums.is_empty() {
-        return String::new();
-    }
-
-    let mut ranges = Vec::new();
-    let mut start = nums[0];
-    let mut end = nums[0];
-
-    for &n in &nums[1..] {
-        if n == end + 1 {
-            end = n;
-        } else {
-            ranges.push(format_range(start, end, width));
-            start = n;
-            end = n;
-        }
-    }
-    ranges.push(format_range(start, end, width));
-    ranges.join(",")
+    Some((name[..start].to_string(), num, num_str.len()))
 }
 
 fn format_range(start: u64, end: u64, width: usize) -> String {
@@ -329,5 +471,122 @@ mod tests {
             hosts,
             vec!["rack1-node1", "rack1-node2", "rack2-node1", "rack2-node2"]
         );
+    }
+
+    fn strings(hosts: &[&str]) -> Vec<String> {
+        hosts.iter().map(|h| h.to_string()).collect()
+    }
+
+    #[test]
+    fn test_compress_multiple_prefixes() {
+        assert_eq!(
+            compress(&strings(&["cpu001", "cpu002", "gpu001", "gpu002"])),
+            "cpu[001-002],gpu[001-002]"
+        );
+    }
+
+    #[test]
+    fn test_compress_multiple_prefixes_input_order_independent() {
+        assert_eq!(
+            compress(&strings(&["gpu002", "cpu001", "gpu001", "cpu002"])),
+            "cpu[001-002],gpu[001-002]"
+        );
+    }
+
+    #[test]
+    fn test_compress_multi_field_prefix() {
+        // Only the trailing digit run is compressed; the prefix is preserved.
+        assert_eq!(
+            compress(&strings(&["crsuse2-m2m-028", "crsuse2-m2m-219"])),
+            "crsuse2-m2m-[028,219]"
+        );
+    }
+
+    #[test]
+    fn test_compress_bare_and_numeric_same_spelling() {
+        // A bare `node` must not be swallowed by `node1`'s prefix.
+        assert_eq!(compress(&strings(&["node", "node1"])), "node,node1");
+        assert_eq!(compress(&strings(&["node1", "node"])), "node,node1");
+    }
+
+    #[test]
+    fn test_compress_bare_names_sorted() {
+        assert_eq!(compress(&strings(&["master", "login"])), "login,master");
+    }
+
+    #[test]
+    fn test_compress_mixed_zero_pad_width() {
+        // Incompatible paddings share the prefix bracket but stay separate
+        // terms, so the result round-trips (Slurm's `node[9,010-011]`).
+        assert_eq!(
+            compress(&strings(&["node9", "node010", "node011"])),
+            "node[9,010-011]"
+        );
+    }
+
+    #[test]
+    fn test_compress_prefixes_natural_sorted() {
+        // Natural order: rack2 before rack10 (not lexicographic rack10 first).
+        assert_eq!(
+            compress(&strings(&["rack10-n1", "rack2-n1", "rack1-n1"])),
+            "rack1-n1,rack2-n1,rack10-n1"
+        );
+    }
+
+    #[test]
+    fn test_compress_unpadded_across_digit_lengths() {
+        assert_eq!(
+            compress(&strings(&["node8", "node9", "node10"])),
+            "node[8-10]"
+        );
+    }
+
+    #[test]
+    fn test_compress_dedup() {
+        assert_eq!(compress(&strings(&["node001", "node001"])), "node001");
+        assert_eq!(
+            compress(&strings(&["node001", "node002", "node001"])),
+            "node[001-002]"
+        );
+    }
+
+    #[test]
+    fn test_compress_single_host_verbatim() {
+        assert_eq!(compress(&strings(&["gpu001"])), "gpu001");
+        assert_eq!(compress(&strings(&["master"])), "master");
+    }
+
+    #[test]
+    fn test_compress_empty() {
+        assert_eq!(compress(&[]), "");
+    }
+
+    #[test]
+    fn test_compress_multibyte_prefix_no_panic() {
+        // Prefix ending in a multi-byte char must not panic on the digit split.
+        assert_eq!(compress(&strings(&["café1", "café2"])), "café[1-2]");
+    }
+
+    #[test]
+    fn test_compress_all_digit_names_are_bare() {
+        // Names that are entirely digits have no prefix; kept verbatim, deduped.
+        assert_eq!(compress(&strings(&["12345"])), "12345");
+        assert_eq!(compress(&strings(&["7", "7"])), "7");
+    }
+
+    #[test]
+    fn test_compress_roundtrip_mixed() {
+        // Any set survives expand(compress(x)) once both sides are sorted.
+        let hosts = strings(&[
+            "node9", "node010", "node011", "gpu001", "gpu003", "master", "cpu10", "cpu8",
+        ]);
+        let mut expected = hosts.clone();
+        expected.sort();
+        expected.dedup();
+
+        let mut round_tripped = expand(&compress(&hosts)).unwrap();
+        round_tripped.sort();
+
+        assert_eq!(round_tripped, expected);
     }
 }

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -436,6 +436,41 @@ class SpurCluster:
     def sinfo(self) -> str:
         return self.cli(["sinfo"])
 
+    def sinfo_nodes(self, controller_addr: str | None = None) -> dict[str, str]:
+        """Map node name to state via node-oriented sinfo.
+
+        ``sinfo -N`` emits one line per node with the full, uncompressed name,
+        so this is agnostic to NODELIST hostlist compression (``node[1-4]``).
+        The state is the short form (idle/mix/alloc/down/drain/resv), with any
+        trailing ``*`` (non-responding marker) stripped.
+
+        *controller_addr* overrides the endpoint(s) as in :meth:`cli`.
+        """
+        out = self.cli(["sinfo", "-N", "-h", "-o", "%N %t"],
+                       controller_addr=controller_addr)
+        states: dict[str, str] = {}
+        for line in out.splitlines():
+            fields = line.split()
+            if len(fields) >= 2:
+                states[fields[0]] = fields[1].rstrip("*")
+        return states
+
+    def nodes_in_partition(self, partition: str) -> set[str]:
+        """Return the set of node names belonging to *partition*.
+
+        Uses node-oriented sinfo so membership is exact even when the default
+        output would compress several nodes into one bracketed hostlist. A node
+        in multiple partitions appears once per partition. The partition name
+        carries a trailing ``*`` when it is the default, so that is stripped.
+        """
+        out = self.cli(["sinfo", "-N", "-h", "-o", "%N %P"])
+        members: set[str] = set()
+        for line in out.splitlines():
+            fields = line.split()
+            if len(fields) >= 2 and fields[1].rstrip("*") == partition:
+                members.add(fields[0])
+        return members
+
     def scancel(self, job_id: str) -> str:
         return self.cli(["scancel", job_id])
 
@@ -776,7 +811,8 @@ class SpurCluster:
         deadline = time.time() + 60
         while time.time() < deadline:
             try:
-                if all(n in self.sinfo() for n in self.node_names):
+                nodes = self.sinfo_nodes()
+                if all(n in nodes for n in self.node_names):
                     return
             except Exception:
                 pass
@@ -1034,8 +1070,7 @@ mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
         deadline = time.time() + timeout
         while time.time() < deadline:
             try:
-                out = self.sinfo()
-                if self._cluster_is_ready(out):
+                if self._cluster_is_ready():
                     return
             except Exception:
                 pass
@@ -1046,22 +1081,14 @@ mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
             f"sinfo output:\n{self.sinfo()}"
         )
 
-    def _cluster_is_ready(self, sinfo_output: str) -> bool:
-        for name in self.node_names:
-            if name not in sinfo_output:
-                return False
-        total_idle = 0
-        for line in sinfo_output.splitlines():
-            if "idle" not in line:
-                continue
-            fields = line.split()
-            for j, field in enumerate(fields):
-                if field == "idle" and j > 0:
-                    try:
-                        total_idle += int(fields[j - 1])
-                    except ValueError:
-                        pass
-        return total_idle >= len(self.node_names)
+    def _cluster_is_ready(self) -> bool:
+        states = self.sinfo_nodes()
+        if not all(name in states for name in self.node_names):
+            return False
+        idle = sum(
+            1 for name in self.node_names if states[name].startswith("idle")
+        )
+        return idle >= len(self.node_names)
 
 
 # --- Job helpers ---

--- a/tests/native_host/e2e/test_admission.py
+++ b/tests/native_host/e2e/test_admission.py
@@ -13,16 +13,16 @@ def _wait_registered(cluster, timeout=30):
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:
-            out = cluster.sinfo()
-            if all(name in out for name in cluster.node_names):
-                return out
+            nodes = cluster.sinfo_nodes()
+            if all(name in nodes for name in cluster.node_names):
+                return nodes
         except Exception:
             pass
         time.sleep(2)
-    out = cluster.sinfo()
+    nodes = cluster.sinfo_nodes()
     for name in cluster.node_names:
-        assert name in out, f"node {name} not registered within {timeout}s"
-    return out
+        assert name in nodes, f"node {name} not registered within {timeout}s"
+    return nodes
 
 
 def _assert_not_registered(cluster, timeout=15):
@@ -30,12 +30,12 @@ def _assert_not_registered(cluster, timeout=15):
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:
-            out = cluster.sinfo()
+            nodes = cluster.sinfo_nodes()
         except Exception:
             time.sleep(2)
             continue
         for name in cluster.node_names:
-            assert name not in out, (
+            assert name not in nodes, (
                 f"node {name} registered unexpectedly"
             )
         time.sleep(2)
@@ -45,10 +45,10 @@ class TestAdmissionOpen:
     """Verify open mode (default) works without tokens."""
 
     def test_open_mode_agents_register_without_token(self, cluster):
-        out = cluster.sinfo()
+        states = cluster.sinfo_nodes()
         for name in cluster.node_names:
-            assert name in out, f"node {name} not found in sinfo"
-        assert "idle" in out
+            assert name in states, f"node {name} not found in sinfo"
+        assert any(s.startswith("idle") for s in states.values())
 
 
 class TestAdmissionToken:
@@ -130,9 +130,9 @@ class TestAdmissionToken:
 
         time.sleep(45)
 
-        out = cluster.sinfo()
+        states = cluster.sinfo_nodes()
         for name in cluster.node_names:
-            assert name in out, f"node {name} disappeared after heartbeat interval"
-        for line in out.splitlines():
-            if any(name in line for name in cluster.node_names):
-                assert "down" not in line.split(), "node marked down - heartbeat JWT likely failing"
+            assert name in states, f"node {name} disappeared after heartbeat interval"
+            assert not states[name].startswith("down"), (
+                "node marked down - heartbeat JWT likely failing"
+            )

--- a/tests/native_host/e2e/test_controller_failover.py
+++ b/tests/native_host/e2e/test_controller_failover.py
@@ -25,17 +25,17 @@ def _dead(cluster) -> str:
 class TestControllerFailover:
     def test_rotates_past_dead_first_endpoint(self, cluster):
         endpoints = f"{_dead(cluster)},{cluster.controller_addr}"
-        out = cluster.cli(["sinfo"], controller_addr=endpoints)
+        nodes = cluster.sinfo_nodes(controller_addr=endpoints)
         for name in cluster.node_names:
-            assert name in out, (
-                f"node {name} missing after rotating past dead endpoint:\n{out}"
+            assert name in nodes, (
+                f"node {name} missing after rotating past dead endpoint:\n{nodes}"
             )
 
     def test_live_first_endpoint_still_works(self, cluster):
         endpoints = f"{cluster.controller_addr},{_dead(cluster)}"
-        out = cluster.cli(["sinfo"], controller_addr=endpoints)
+        nodes = cluster.sinfo_nodes(controller_addr=endpoints)
         for name in cluster.node_names:
-            assert name in out, f"node {name} missing with live-first list:\n{out}"
+            assert name in nodes, f"node {name} missing with live-first list:\n{nodes}"
 
     def test_all_endpoints_down_fails_cleanly(self, cluster):
         endpoints = f"{_dead(cluster)},http://{cluster.nodes[0].host}:2"

--- a/tests/native_host/e2e/test_deregistration.py
+++ b/tests/native_host/e2e/test_deregistration.py
@@ -38,12 +38,11 @@ def _wait_node_state(cluster, node_name, target_states, timeout=60):
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:
-            out = cluster.sinfo()
-            for line in out.splitlines():
-                if node_name in line:
-                    for state in target_states:
-                        if state in line:
-                            return state
+            state = cluster.sinfo_nodes().get(node_name)
+            if state is not None:
+                for target in target_states:
+                    if state.startswith(target):
+                        return state
         except Exception:
             pass
         time.sleep(2)
@@ -57,8 +56,7 @@ def _wait_node_gone(cluster, node_name, timeout=60):
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:
-            out = cluster.sinfo()
-            if node_name not in out:
+            if node_name not in cluster.sinfo_nodes():
                 return
         except Exception:
             pass
@@ -165,7 +163,7 @@ class TestForcedEviction:
             f"expected rejection, got: {out}"
         )
 
-        assert node0 in cluster.sinfo()
+        assert node0 in cluster.sinfo_nodes()
         cluster.scancel(str(job_id))
 
 

--- a/tests/native_host/e2e/test_multi_node.py
+++ b/tests/native_host/e2e/test_multi_node.py
@@ -17,12 +17,11 @@ def _wait_node_state(cluster, node_name, target_states, timeout=60):
     deadline = time.time() + timeout
     while time.time() < deadline:
         try:
-            out = cluster.sinfo()
-            for line in out.splitlines():
-                if node_name in line:
-                    for state in target_states:
-                        if state in line:
-                            return state
+            state = cluster.sinfo_nodes().get(node_name)
+            if state is not None:
+                for target in target_states:
+                    if state.startswith(target):
+                        return state
         except Exception:
             pass
         time.sleep(2)

--- a/tests/native_host/e2e/test_node_labels.py
+++ b/tests/native_host/e2e/test_node_labels.py
@@ -9,16 +9,14 @@ import time
 def _wait_node_in_partition(cluster, node_name, partition, present=True, timeout=10):
     """Poll sinfo until node appears/disappears in partition."""
     deadline = time.time() + timeout
-    out = ""
+    members = set()
     while time.time() < deadline:
-        out = cluster.sinfo()
-        lines = [l for l in out.splitlines() if partition in l.split()[0:1]]
-        found = node_name in "\n".join(lines)
-        if found == present:
-            return out
+        members = cluster.nodes_in_partition(partition)
+        if (node_name in members) == present:
+            return members
         time.sleep(0.5)
     verb = "appear in" if present else "disappear from"
-    assert False, f"{node_name} did not {verb} {partition} within {timeout}s:\n{out}"
+    assert False, f"{node_name} did not {verb} {partition} within {timeout}s:\n{members}"
 
 
 class TestNodeLabels:
@@ -34,34 +32,30 @@ class TestNodeLabels:
 
     def test_selector_partition_routes_labeled_node(self, label_cluster):
         """Only the labeled node appears in the selector-based partition."""
-        out = label_cluster.sinfo()
         node0 = label_cluster.node_names[0]
         node1 = label_cluster.node_names[1]
 
-        gpu_lines = [l for l in out.splitlines() if "gpu" in l.split()[0:1]]
-        gpu_text = "\n".join(gpu_lines)
+        gpu_members = label_cluster.nodes_in_partition("gpu")
 
-        assert node0 in gpu_text, (
-            f"expected {node0} in gpu partition, sinfo:\n{out}"
+        assert node0 in gpu_members, (
+            f"expected {node0} in gpu partition, members:\n{gpu_members}"
         )
-        assert node1 not in gpu_text, (
-            f"expected {node1} NOT in gpu partition, sinfo:\n{out}"
+        assert node1 not in gpu_members, (
+            f"expected {node1} NOT in gpu partition, members:\n{gpu_members}"
         )
 
     def test_all_wildcard_includes_all_nodes(self, label_cluster):
         """The ALL-wildcard partition includes every node regardless of labels."""
-        out = label_cluster.sinfo()
         node0 = label_cluster.node_names[0]
         node1 = label_cluster.node_names[1]
 
-        catchall_lines = [l for l in out.splitlines() if l.split() and l.split()[0].startswith("catchall")]
-        catchall_text = "\n".join(catchall_lines)
+        catchall_members = label_cluster.nodes_in_partition("catchall")
 
-        assert node0 in catchall_text, (
-            f"expected {node0} in catchall partition via ALL wildcard, sinfo:\n{out}"
+        assert node0 in catchall_members, (
+            f"expected {node0} in catchall partition via ALL wildcard, members:\n{catchall_members}"
         )
-        assert node1 in catchall_text, (
-            f"expected {node1} in catchall partition via ALL wildcard, sinfo:\n{out}"
+        assert node1 in catchall_members, (
+            f"expected {node1} in catchall partition via ALL wildcard, members:\n{catchall_members}"
         )
 
     def test_admin_label_update_reroutes_partition(self, label_cluster):
@@ -69,11 +63,8 @@ class TestNodeLabels:
         node1 = label_cluster.node_names[1]
 
         # Node 1 should NOT be in gpu partition initially
-        out = label_cluster.sinfo()
-        gpu_lines = [l for l in out.splitlines() if "gpu" in l.split()[0:1]]
-        gpu_text = "\n".join(gpu_lines)
-        assert node1 not in gpu_text, (
-            f"precondition: {node1} should not be in gpu partition:\n{out}"
+        assert node1 not in label_cluster.nodes_in_partition("gpu"), (
+            f"precondition: {node1} should not be in gpu partition"
         )
 
         # Add label → node joins gpu partition

--- a/tests/native_host/e2e/test_prolog_epilog.py
+++ b/tests/native_host/e2e/test_prolog_epilog.py
@@ -131,14 +131,14 @@ def _wait_node_state(cluster, target_state, timeout=15):
     """Poll sinfo until any node shows *target_state* (case-insensitive)."""
     target = target_state.lower()
     deadline = time.time() + timeout
-    info = ""
+    states = {}
     while time.time() < deadline:
-        info = cluster.sinfo()
-        if target in info.lower():
-            return info
+        states = cluster.sinfo_nodes()
+        if any(target in s.lower() for s in states.values()):
+            return states
         time.sleep(1)
     assert False, (
-        f"no node reached '{target_state}' within {timeout}s:\n{info}"
+        f"no node reached '{target_state}' within {timeout}s:\n{states}"
     )
 
 
@@ -447,9 +447,9 @@ class TestHookFailure:
             f"job with a missing WorkDir should complete, got {state}"
         )
 
-        info = cluster.sinfo()
-        assert "drain" not in info.lower(), (
-            f"a missing WorkDir must not drain the node:\n{info}"
+        states = cluster.sinfo_nodes()
+        assert not any(s.startswith("drain") for s in states.values()), (
+            f"a missing WorkDir must not drain the node:\n{states}"
         )
 
         content = cluster.read_output_on_any_node(out_path)
@@ -481,7 +481,7 @@ class TestHookFailure:
         content = cluster.read_output_on_any_node(out_path)
         assert "NONFATAL_OK" in content
 
-        info = cluster.sinfo()
-        assert "drain" not in info.lower(), (
-            f"EpilogSlurmctld failure should not drain nodes:\n{info}"
+        states = cluster.sinfo_nodes()
+        assert not any(s.startswith("drain") for s in states.values()), (
+            f"EpilogSlurmctld failure should not drain nodes:\n{states}"
         )

--- a/tests/native_host/e2e/test_single_node.py
+++ b/tests/native_host/e2e/test_single_node.py
@@ -14,11 +14,11 @@ class TestClusterHealth:
         assert out.strip(), "sinfo produced no output"
 
     def test_all_nodes_registered_and_idle(self, cluster):
-        out = cluster.sinfo()
+        states = cluster.sinfo_nodes()
         for name in cluster.node_names:
-            assert name in out, f"node {name} not in sinfo:\n{out}"
-        assert cluster._cluster_is_ready(out), (
-            f"expected {len(cluster.node_names)} idle nodes, sinfo:\n{out}"
+            assert name in states, f"node {name} not in sinfo:\n{states}"
+        assert cluster._cluster_is_ready(), (
+            f"expected {len(cluster.node_names)} idle nodes, states:\n{states}"
         )
 
 
@@ -138,8 +138,8 @@ class TestJobLifecycle:
 
         deadline = time.time() + 15
         while time.time() < deadline:
-            info = cluster.sinfo()
-            if "idle" in info and "mix" not in info and "alloc" not in info:
+            states = cluster.sinfo_nodes()
+            if states and all(s.startswith("idle") for s in states.values()):
                 return
             time.sleep(2)
         assert False, "node should return to idle after cancel"

--- a/tests/native_host/e2e/test_srun_multi_node.py
+++ b/tests/native_host/e2e/test_srun_multi_node.py
@@ -82,15 +82,14 @@ class TestStandaloneSrun:
         assert re.search(r"NodeList=\S+", show), (
             f"missing NodeList in scontrol output:\n{show}"
         )
-        sinfo = cluster.sinfo()
-        assert not cluster._cluster_is_ready(sinfo), (
-            f"expected allocated nodes while srun sleep runs, sinfo:\n{sinfo}"
+        assert not cluster._cluster_is_ready(), (
+            f"expected allocated nodes while srun sleep runs, sinfo:\n{cluster.sinfo()}"
         )
 
         wait_job(cluster, job_id, timeout=60)
         deadline = time.time() + 60
         while time.time() < deadline:
-            if cluster._cluster_is_ready(cluster.sinfo()):
+            if cluster._cluster_is_ready():
                 return
             time.sleep(2)
         raise TimeoutError("nodes did not return to idle after srun completed")

--- a/tests/native_host/e2e/test_suspend_resume.py
+++ b/tests/native_host/e2e/test_suspend_resume.py
@@ -245,9 +245,9 @@ class TestSuspendScheduling:
             job_id = _submit_sleep(cluster, "sr-alloc")
             cluster.scontrol("suspend", str(job_id))
             assert _wait_state(cluster, job_id, "S")
-            info = cluster.sinfo()
-            assert ("alloc" in info or "mix" in info), (
-                f"node should remain allocated while job suspended:\n{info}"
+            states = cluster.sinfo_nodes()
+            assert any(s.startswith(("alloc", "mix")) for s in states.values()), (
+                f"node should remain allocated while job suspended:\n{states}"
             )
         finally:
             _cleanup(cluster, job_id)


### PR DESCRIPTION
## What

sinfo rendered the partition/state NODELIST (`%N`) column as an expanded, comma-joined list, diverging from Slurm and from Spur's own squeue (which already compresses). This makes sinfo emit a compact bracketed hostlist (e.g. `gpu[001-004]`) and hardens the shared compressor it now relies on.

Fixes SPUR-106.

## Approach

- `sinfo` `%N` now compresses via `spur_core::hostlist::compress`. Slurm's default format uses `%N`, so default output is corrected. `%n` is added as the expanded form (previously it fell through to `?`), derived from the same sorted list so `%N` and `%n` stay consistent.
- Hardened the shared `compress()` (also used by squeue, scontrol, and the REST API):
  - Keep numeric hosts separate from a bare name of the same spelling, so a bare `node` is no longer swallowed by `node1`.
  - Coalesce numbers using Slurm's `_width_equiv`/`_zero_padded` semantics, so mixed zero-padding (`node9` vs `node010`) round-trips through `expand` instead of collapsing to a lossy range. All numbers under one prefix share a single bracket, e.g. `node[9,010-011]`.
  - Natural-sort prefixes and dedup, so output is deterministic and independent of input order (matches Slurm).
  - Byte-scan the trailing digit split and guard the range increment, removing latent panics on multi-byte prefixes and `u64::MAX`.

## Design notes / compatibility

- `compress()` is display-only. Scheduling, dispatch, task-to-node mapping, and the agent-facing nodelist all use the raw `allocated_nodes` list, so the sort/dedup changes are cosmetic and cannot affect placement.
- No breaking changes: no persisted (Raft/WAL) type, proto field, or config changed. squeue/scontrol/REST already compressed; their output is now deterministic and correctly round-trips mixed padding. sinfo `%N` goes uncompressed to compressed (the intended fix); `%n` is additive.

## Testing

- Unit: new `hostlist` tests for multi-prefix, `crsuse2-m2m-[028,219]`, bare/numeric collision, mixed zero-pad width, natural sort, dedup, multi-byte prefix, all-digit names, and an `expand(compress(x))` round-trip. New `sinfo` tests for compressed `%N` and expanded `%n`.
- `cargo fmt`, `cargo clippy` (spur-core, spur-cli) clean; `cargo test` for spur-core, spur-cli, spurctld (561), and spur-tests all pass.
- Verified live on a 4-node bare-metal cluster: default/subset/gap/single/empty partitions, drain/resume state grouping, squeue vs sinfo parity, scontrol NodeList, multi-node jobs, and `-n`/`%n` all render correctly (e.g. `spur-node[1-4]`, `spur-node[1,3-4]`).

## Out of scope (follow-ups)

- `sinfo -p <part>` filters the node set but still renders rows for every partition those nodes belong to, instead of only the named partition. Pre-existing, unrelated to this change.
- `srun`/`sattach` pick the first node via `nodelist.split(',')`, which mis-parses a compressed multi-prefix list. Pre-existing.