### PR TITLE
fix(spur-net): support gzip, zstd, and uncompressed OCI layers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3570,6 +3570,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "whoami",
+ "zstd",
 ]
 
 [[package]]
@@ -3694,9 +3695,11 @@ dependencies = [
  "serde",
  "serde_json",
  "tar",
+ "tempfile",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
+ "zstd",
 ]
 
 [[package]]
@@ -5294,3 +5297,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ reqwest = { version = "0.13", default-features = false, features = ["json", "str
 futures-util = "0.3"
 flate2 = "1"
 tar = "0.4"
+zstd = "0.13"
 semver = "1"
 sha2 = "0.11"
 base64 = "0.23"

--- a/crates/spur-cli/Cargo.toml
+++ b/crates/spur-cli/Cargo.toml
@@ -29,13 +29,14 @@ whoami = "2.1.1"
 nix = { workspace = true, features = ["user"] }
 libc = "0.2"
 crossterm = "0.29"
-flate2 = { workspace = true }
 tar = { workspace = true }
 shlex = "2"
 
 [dev-dependencies]
+flate2 = { workspace = true }
 serial_test = { workspace = true }
 tempfile = "3"
+zstd = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/spur-cli/src/image.rs
+++ b/crates/spur-cli/src/image.rs
@@ -132,12 +132,10 @@ async fn cmd_import_dockerd(image: &str) -> Result<()> {
     let rootfs_str = rootfs.to_string_lossy();
     let output_path_str = output_path.to_string_lossy();
 
-    // Extract the docker save tar, then extract each layer
-    extract_docker_save_tar(&output.stdout, &rootfs_str)?;
-
-    // Pack into squashfs
-    pack_squashfs(&rootfs_str, &output_path_str)?;
+    let import_result = extract_docker_save_tar(&output.stdout, &rootfs_str)
+        .and_then(|()| pack_squashfs(&rootfs_str, &output_path_str));
     let _ = std::fs::remove_dir_all(&tmp_dir);
+    import_result?;
 
     let size = std::fs::metadata(&output_path)
         .map(|m| m.len())
@@ -184,9 +182,10 @@ async fn cmd_import_podman(image: &str) -> Result<()> {
     let rootfs_str = rootfs.to_string_lossy();
     let output_path_str = output_path.to_string_lossy();
 
-    extract_docker_save_tar(&output.stdout, &rootfs_str)?;
-    pack_squashfs(&rootfs_str, &output_path_str)?;
+    let import_result = extract_docker_save_tar(&output.stdout, &rootfs_str)
+        .and_then(|()| pack_squashfs(&rootfs_str, &output_path_str));
     let _ = std::fs::remove_dir_all(&tmp_dir);
+    import_result?;
 
     let size = std::fs::metadata(&output_path)
         .map(|m| m.len())
@@ -202,61 +201,49 @@ async fn cmd_import_podman(image: &str) -> Result<()> {
 /// Extract a `docker save` tar archive into a rootfs.
 /// The tar contains a manifest.json listing layer tarballs.
 fn extract_docker_save_tar(tar_data: &[u8], rootfs: &str) -> Result<()> {
-    use flate2::read::GzDecoder;
-
     let dest = std::path::Path::new(rootfs);
-    let mut archive = tar::Archive::new(tar_data);
-    let tmp = format!("{}/.docker_save", rootfs);
+    let tmp = dest.join(".docker_save");
     std::fs::create_dir_all(&tmp)?;
 
-    // First pass: extract all files from the docker save tar
-    archive.set_overwrite(true);
-    archive
-        .unpack(&tmp)
-        .context("failed to extract docker save archive")?;
+    let result = (|| {
+        let mut archive = tar::Archive::new(tar_data);
+        archive.set_overwrite(true);
+        archive
+            .unpack(&tmp)
+            .context("failed to extract docker save archive")?;
 
-    // Parse manifest.json to find layer order
-    let manifest_path = format!("{}/manifest.json", tmp);
-    let manifest_str =
-        std::fs::read_to_string(&manifest_path).context("no manifest.json in docker save")?;
-    let manifest: Vec<serde_json::Value> =
-        serde_json::from_str(&manifest_str).context("invalid manifest.json")?;
+        let manifest_str = std::fs::read_to_string(tmp.join("manifest.json"))
+            .context("no manifest.json in docker save")?;
+        let manifest: Vec<serde_json::Value> =
+            serde_json::from_str(&manifest_str).context("invalid manifest.json")?;
 
-    let layers = manifest
-        .first()
-        .and_then(|m| m.get("Layers"))
-        .and_then(|l| l.as_array())
-        .ok_or_else(|| anyhow::anyhow!("no layers in manifest.json"))?;
+        let layers = manifest
+            .first()
+            .and_then(|manifest| manifest.get("Layers"))
+            .and_then(|layers| layers.as_array())
+            .ok_or_else(|| anyhow::anyhow!("no layers in manifest.json"))?;
 
-    // Extract each layer in order
-    for layer_path in layers {
-        let layer_file = layer_path
-            .as_str()
-            .ok_or_else(|| anyhow::anyhow!("invalid layer path"))?;
-        let full_path = format!("{}/{}", tmp, layer_file);
-        let data = std::fs::read(&full_path)
-            .with_context(|| format!("failed to read layer {}", layer_file))?;
+        for layer_path in layers {
+            let layer_file = layer_path
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("invalid layer path"))?;
+            let data = std::fs::read(tmp.join(layer_file))
+                .with_context(|| format!("failed to read layer {}", layer_file))?;
 
-        // Try gzip decompress, fall back to plain tar
-        let result = if data.starts_with(&[0x1f, 0x8b]) {
-            let decoder = GzDecoder::new(data.as_slice());
-            let mut archive = tar::Archive::new(decoder);
+            let reader = spur_net::image_layer::decode(&data, None)
+                .with_context(|| format!("failed to decode layer {}", layer_file))?;
+            let mut archive = tar::Archive::new(reader);
             archive.set_overwrite(true);
-            archive.unpack(dest)
-        } else {
-            let mut archive = tar::Archive::new(data.as_slice());
-            archive.set_overwrite(true);
-            archive.unpack(dest)
-        };
-
-        if let Err(e) = result {
-            eprintln!("Warning: layer {} extraction had errors: {}", layer_file, e);
+            archive
+                .unpack(dest)
+                .with_context(|| format!("failed to extract layer {}", layer_file))?;
         }
-    }
 
-    // Clean up docker save temp files
+        Ok(())
+    })();
+
     let _ = std::fs::remove_dir_all(&tmp);
-    Ok(())
+    result
 }
 
 /// Pack a directory into a squashfs file.
@@ -420,5 +407,110 @@ fn is_dir_writable(path: &std::path::Path) -> bool {
         path.parent()
             .map(|p| p.exists() && is_dir_writable(p))
             .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use flate2::{write::GzEncoder, Compression};
+
+    use super::*;
+
+    fn tar_files(files: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut data = Vec::new();
+        let mut archive = tar::Builder::new(&mut data);
+        for (path, contents) in files {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(contents.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            archive.append_data(&mut header, path, *contents).unwrap();
+        }
+        archive.finish().unwrap();
+        drop(archive);
+        data
+    }
+
+    fn gzip(data: &[u8]) -> Vec<u8> {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(data).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    fn docker_save(layers: &[(&str, Vec<u8>)]) -> Vec<u8> {
+        let layer_names: Vec<&str> = layers.iter().map(|(name, _)| *name).collect();
+        let manifest = serde_json::to_vec(&serde_json::json!([{
+            "Config": "config.json",
+            "RepoTags": ["fixture:latest"],
+            "Layers": layer_names,
+        }]))
+        .unwrap();
+
+        let mut data = Vec::new();
+        let mut archive = tar::Builder::new(&mut data);
+        for (path, contents) in std::iter::once(("manifest.json", manifest.as_slice())).chain(
+            layers
+                .iter()
+                .map(|(path, contents)| (*path, contents.as_slice())),
+        ) {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(contents.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            archive.append_data(&mut header, path, contents).unwrap();
+        }
+        archive.finish().unwrap();
+        drop(archive);
+        data
+    }
+
+    #[test]
+    fn docker_save_import_supports_mixed_layer_compression() {
+        let gzip = gzip(&tar_files(&[("gzip.txt", b"gzip"), ("order.txt", b"gzip")]));
+        let zstd = zstd::stream::encode_all(
+            tar_files(&[("zstd.txt", b"zstd"), ("order.txt", b"zstd")]).as_slice(),
+            0,
+        )
+        .unwrap();
+        let plain = tar_files(&[("plain.txt", b"plain"), ("order.txt", b"plain")]);
+        let archive = docker_save(&[
+            ("gzip/layer.tar", gzip),
+            ("zstd/layer.tar", zstd),
+            ("plain/layer.tar", plain),
+        ]);
+        let rootfs = tempfile::tempdir().unwrap();
+
+        extract_docker_save_tar(&archive, rootfs.path().to_str().unwrap()).unwrap();
+
+        assert_eq!(
+            std::fs::read(rootfs.path().join("plain.txt")).unwrap(),
+            b"plain"
+        );
+        assert_eq!(
+            std::fs::read(rootfs.path().join("gzip.txt")).unwrap(),
+            b"gzip"
+        );
+        assert_eq!(
+            std::fs::read(rootfs.path().join("zstd.txt")).unwrap(),
+            b"zstd"
+        );
+        assert_eq!(
+            std::fs::read(rootfs.path().join("order.txt")).unwrap(),
+            b"plain"
+        );
+    }
+
+    #[test]
+    fn docker_save_import_cleans_up_after_invalid_layer() {
+        let archive =
+            docker_save(&[("broken/layer.tar", vec![0x28, 0xb5, 0x2f, 0xfd, 0, 0, 0, 0])]);
+        let rootfs = tempfile::tempdir().unwrap();
+
+        let error = extract_docker_save_tar(&archive, rootfs.path().to_str().unwrap()).unwrap_err();
+
+        assert!(error.to_string().contains("broken/layer.tar"));
+        assert!(!rootfs.path().join(".docker_save").exists());
     }
 }

--- a/crates/spur-cli/src/image.rs
+++ b/crates/spur-cli/src/image.rs
@@ -3,6 +3,7 @@
 
 //! `spur image` subcommands for container image management.
 
+use std::path::{Component, Path, PathBuf};
 use std::process::Stdio;
 
 use anyhow::{bail, Context, Result};
@@ -201,7 +202,7 @@ async fn cmd_import_podman(image: &str) -> Result<()> {
 /// Extract a `docker save` tar archive into a rootfs.
 /// The tar contains a manifest.json listing layer tarballs.
 fn extract_docker_save_tar(tar_data: &[u8], rootfs: &str) -> Result<()> {
-    let dest = std::path::Path::new(rootfs);
+    let dest = Path::new(rootfs);
     let tmp = dest.join(".docker_save");
     std::fs::create_dir_all(&tmp)?;
 
@@ -212,8 +213,13 @@ fn extract_docker_save_tar(tar_data: &[u8], rootfs: &str) -> Result<()> {
             .unpack(&tmp)
             .context("failed to extract docker save archive")?;
 
-        let manifest_str = std::fs::read_to_string(tmp.join("manifest.json"))
+        let archive_root = tmp
+            .canonicalize()
+            .context("failed to resolve docker save directory")?;
+        let manifest_path = resolve_docker_save_file(&archive_root, "manifest.json")
             .context("no manifest.json in docker save")?;
+        let manifest_str =
+            std::fs::read_to_string(manifest_path).context("no manifest.json in docker save")?;
         let manifest: Vec<serde_json::Value> =
             serde_json::from_str(&manifest_str).context("invalid manifest.json")?;
 
@@ -227,7 +233,8 @@ fn extract_docker_save_tar(tar_data: &[u8], rootfs: &str) -> Result<()> {
             let layer_file = layer_path
                 .as_str()
                 .ok_or_else(|| anyhow::anyhow!("invalid layer path"))?;
-            let data = std::fs::read(tmp.join(layer_file))
+            let layer_path = resolve_docker_save_file(&archive_root, layer_file)?;
+            let data = std::fs::read(layer_path)
                 .with_context(|| format!("failed to read layer {}", layer_file))?;
 
             let reader = spur_net::image_layer::decode(&data, None)
@@ -244,6 +251,30 @@ fn extract_docker_save_tar(tar_data: &[u8], rootfs: &str) -> Result<()> {
 
     let _ = std::fs::remove_dir_all(&tmp);
     result
+}
+
+fn resolve_docker_save_file(archive_root: &Path, entry: &str) -> Result<PathBuf> {
+    let relative = Path::new(entry);
+    if relative.as_os_str().is_empty()
+        || relative
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        bail!("invalid docker save path: {entry}");
+    }
+
+    let resolved = archive_root
+        .join(relative)
+        .canonicalize()
+        .with_context(|| format!("failed to resolve docker save path {entry}"))?;
+    if !resolved.starts_with(archive_root) {
+        bail!("docker save path escapes archive: {entry}");
+    }
+    if !resolved.is_file() {
+        bail!("docker save path is not a regular file: {entry}");
+    }
+
+    Ok(resolved)
 }
 
 /// Pack a directory into a squashfs file.
@@ -439,15 +470,17 @@ mod tests {
         encoder.finish().unwrap()
     }
 
-    fn docker_save(layers: &[(&str, Vec<u8>)]) -> Vec<u8> {
-        let layer_names: Vec<&str> = layers.iter().map(|(name, _)| *name).collect();
-        let manifest = serde_json::to_vec(&serde_json::json!([{
+    fn docker_manifest(layer_names: &[&str]) -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!([{
             "Config": "config.json",
             "RepoTags": ["fixture:latest"],
             "Layers": layer_names,
         }]))
-        .unwrap();
+        .unwrap()
+    }
 
+    fn docker_save_with_manifest(layer_names: &[&str], layers: &[(&str, Vec<u8>)]) -> Vec<u8> {
+        let manifest = docker_manifest(layer_names);
         let mut data = Vec::new();
         let mut archive = tar::Builder::new(&mut data);
         for (path, contents) in std::iter::once(("manifest.json", manifest.as_slice())).chain(
@@ -461,6 +494,38 @@ mod tests {
             header.set_cksum();
             archive.append_data(&mut header, path, contents).unwrap();
         }
+        archive.finish().unwrap();
+        drop(archive);
+        data
+    }
+
+    fn docker_save(layers: &[(&str, Vec<u8>)]) -> Vec<u8> {
+        let layer_names: Vec<&str> = layers.iter().map(|(name, _)| *name).collect();
+        docker_save_with_manifest(&layer_names, layers)
+    }
+
+    #[cfg(unix)]
+    fn docker_save_with_symlink_layer(layer_name: &str, target: &Path) -> Vec<u8> {
+        let manifest = docker_manifest(&[layer_name]);
+        let mut data = Vec::new();
+        let mut archive = tar::Builder::new(&mut data);
+
+        let mut manifest_header = tar::Header::new_gnu();
+        manifest_header.set_size(manifest.len() as u64);
+        manifest_header.set_mode(0o644);
+        manifest_header.set_cksum();
+        archive
+            .append_data(&mut manifest_header, "manifest.json", manifest.as_slice())
+            .unwrap();
+
+        let mut link_header = tar::Header::new_gnu();
+        link_header.set_entry_type(tar::EntryType::Symlink);
+        link_header.set_size(0);
+        link_header.set_mode(0o777);
+        archive
+            .append_link(&mut link_header, layer_name, target)
+            .unwrap();
+
         archive.finish().unwrap();
         drop(archive);
         data
@@ -512,5 +577,59 @@ mod tests {
 
         assert!(error.to_string().contains("broken/layer.tar"));
         assert!(!rootfs.path().join(".docker_save").exists());
+    }
+
+    #[test]
+    fn docker_save_import_rejects_absolute_layer_path() {
+        let base = tempfile::tempdir().unwrap();
+        let rootfs = base.path().join("rootfs");
+        let outside_layer = base.path().join("outside-layer.tar");
+        let layer_data = tar_files(&[("escaped.txt", b"escaped")]);
+        std::fs::write(&outside_layer, &layer_data).unwrap();
+        let layer_name = outside_layer.to_str().unwrap();
+        let archive = docker_save_with_manifest(&[layer_name], &[]);
+
+        let error = extract_docker_save_tar(&archive, rootfs.to_str().unwrap()).unwrap_err();
+
+        assert!(error.to_string().contains("invalid docker save path"));
+        assert!(!rootfs.join("escaped.txt").exists());
+        assert_eq!(std::fs::read(&outside_layer).unwrap(), layer_data);
+        assert!(!rootfs.join(".docker_save").exists());
+    }
+
+    #[test]
+    fn docker_save_import_rejects_parent_layer_path() {
+        let base = tempfile::tempdir().unwrap();
+        let rootfs = base.path().join("rootfs");
+        std::fs::create_dir_all(&rootfs).unwrap();
+        let outside_layer = rootfs.join("outside-layer.tar");
+        let layer_data = tar_files(&[("escaped.txt", b"escaped")]);
+        std::fs::write(&outside_layer, &layer_data).unwrap();
+        let archive = docker_save_with_manifest(&["../outside-layer.tar"], &[]);
+
+        let error = extract_docker_save_tar(&archive, rootfs.to_str().unwrap()).unwrap_err();
+
+        assert!(error.to_string().contains("invalid docker save path"));
+        assert!(!rootfs.join("escaped.txt").exists());
+        assert_eq!(std::fs::read(&outside_layer).unwrap(), layer_data);
+        assert!(!rootfs.join(".docker_save").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn docker_save_import_rejects_symlinked_layer_path() {
+        let base = tempfile::tempdir().unwrap();
+        let rootfs = base.path().join("rootfs");
+        let outside_layer = base.path().join("outside-layer.tar");
+        let layer_data = tar_files(&[("escaped.txt", b"escaped")]);
+        std::fs::write(&outside_layer, &layer_data).unwrap();
+        let archive = docker_save_with_symlink_layer("layers/escape.tar", &outside_layer);
+
+        let error = extract_docker_save_tar(&archive, rootfs.to_str().unwrap()).unwrap_err();
+
+        assert!(error.to_string().contains("escapes archive"));
+        assert!(!rootfs.join("escaped.txt").exists());
+        assert_eq!(std::fs::read(&outside_layer).unwrap(), layer_data);
+        assert!(!rootfs.join(".docker_save").exists());
     }
 }

--- a/crates/spur-net/Cargo.toml
+++ b/crates/spur-net/Cargo.toml
@@ -16,8 +16,12 @@ reqwest = { workspace = true }
 futures-util = { workspace = true }
 flate2 = { workspace = true }
 tar = { workspace = true }
+zstd = { workspace = true }
 bytes = { workspace = true }
 base64 = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/crates/spur-net/src/image_layer.rs
+++ b/crates/spur-net/src/image_layer.rs
@@ -1,0 +1,172 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::Read;
+
+use flate2::read::MultiGzDecoder;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum LayerCompression {
+    Gzip,
+    Uncompressed,
+    Zstd,
+}
+
+fn detect_compression(media_type: Option<&str>, data: &[u8]) -> LayerCompression {
+    match media_type.filter(|value| !value.is_empty()) {
+        Some(value) if value.ends_with("+gzip") || value.ends_with(".gzip") => {
+            LayerCompression::Gzip
+        }
+        Some(value) if value.ends_with("+zstd") || value.ends_with(".zstd") => {
+            LayerCompression::Zstd
+        }
+        Some(value) if value.ends_with(".tar") => LayerCompression::Uncompressed,
+        _ if data.starts_with(&[0x1f, 0x8b]) => LayerCompression::Gzip,
+        _ if is_zstd(data) => LayerCompression::Zstd,
+        _ => LayerCompression::Uncompressed,
+    }
+}
+
+fn is_zstd(data: &[u8]) -> bool {
+    data.starts_with(&[0x28, 0xb5, 0x2f, 0xfd])
+        || matches!(data, [0x50..=0x5f, 0x2a, 0x4d, 0x18, ..])
+}
+
+pub fn decode<'a>(data: &'a [u8], media_type: Option<&str>) -> anyhow::Result<Box<dyn Read + 'a>> {
+    match detect_compression(media_type, data) {
+        LayerCompression::Gzip => Ok(Box::new(MultiGzDecoder::new(data))),
+        LayerCompression::Uncompressed => Ok(Box::new(data)),
+        LayerCompression::Zstd => Ok(Box::new(zstd::stream::read::Decoder::new(data)?)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+
+    use flate2::{write::GzEncoder, Compression};
+
+    use super::*;
+
+    fn gzip(data: &[u8]) -> Vec<u8> {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(data).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    fn read_layer(data: &[u8], media_type: Option<&str>) -> anyhow::Result<Vec<u8>> {
+        let mut decoded = Vec::new();
+        decode(data, media_type)?.read_to_end(&mut decoded)?;
+        Ok(decoded)
+    }
+
+    #[test]
+    fn media_type_suffix_selects_compression_before_magic() {
+        assert_eq!(
+            detect_compression(Some("application/example+gzip"), b"plain"),
+            LayerCompression::Gzip
+        );
+        assert_eq!(
+            detect_compression(Some("application/example.tar.gzip"), b"plain"),
+            LayerCompression::Gzip
+        );
+        assert_eq!(
+            detect_compression(Some("application/example+zstd"), b"plain"),
+            LayerCompression::Zstd
+        );
+        assert_eq!(
+            detect_compression(Some("application/example.tar.zstd"), b"plain"),
+            LayerCompression::Zstd
+        );
+        assert_eq!(
+            detect_compression(Some("application/example.tar"), &[0x1f, 0x8b]),
+            LayerCompression::Uncompressed
+        );
+    }
+
+    #[test]
+    fn decode_supports_oci_and_docker_media_types() {
+        let payload = b"layer payload";
+        let gzip = gzip(payload);
+        let zstd = zstd::stream::encode_all(payload.as_slice(), 0).unwrap();
+
+        for media_type in [
+            "application/vnd.oci.image.layer.v1.tar+gzip",
+            "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip",
+            "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip",
+        ] {
+            assert_eq!(read_layer(&gzip, Some(media_type)).unwrap(), payload);
+        }
+
+        for media_type in [
+            "application/vnd.oci.image.layer.v1.tar+zstd",
+            "application/vnd.oci.image.layer.nondistributable.v1.tar+zstd",
+        ] {
+            assert_eq!(read_layer(&zstd, Some(media_type)).unwrap(), payload);
+        }
+
+        for media_type in [
+            "application/vnd.oci.image.layer.v1.tar",
+            "application/vnd.oci.image.layer.nondistributable.v1.tar",
+            "application/vnd.docker.image.rootfs.diff.tar",
+        ] {
+            assert_eq!(read_layer(payload, Some(media_type)).unwrap(), payload);
+        }
+    }
+
+    #[test]
+    fn decode_uses_magic_for_missing_or_unknown_media_type() {
+        let payload = b"layer payload";
+        let gzip = gzip(payload);
+        let zstd = zstd::stream::encode_all(payload.as_slice(), 0).unwrap();
+
+        for media_type in [None, Some(""), Some("application/octet-stream")] {
+            assert_eq!(read_layer(payload, media_type).unwrap(), payload);
+            assert_eq!(read_layer(&gzip, media_type).unwrap(), payload);
+            assert_eq!(read_layer(&zstd, media_type).unwrap(), payload);
+        }
+    }
+
+    #[test]
+    fn decode_uses_declared_compression_before_magic() {
+        let gzip = gzip(b"layer payload");
+        let zstd = zstd::stream::encode_all(b"layer payload".as_slice(), 0).unwrap();
+
+        assert!(read_layer(&zstd, Some("application/vnd.oci.image.layer.v1.tar+gzip")).is_err());
+        assert!(read_layer(&gzip, Some("application/vnd.oci.image.layer.v1.tar+zstd")).is_err());
+    }
+
+    #[test]
+    fn decode_supports_concatenated_compression_frames() {
+        let mut gzip_frames = gzip(b"first ");
+        gzip_frames.extend(gzip(b"second"));
+        assert_eq!(read_layer(&gzip_frames, None).unwrap(), b"first second");
+
+        let mut zstd_frames = zstd::stream::encode_all(b"first ".as_slice(), 0).unwrap();
+        zstd_frames.extend(zstd::stream::encode_all(b"second".as_slice(), 0).unwrap());
+        assert_eq!(read_layer(&zstd_frames, None).unwrap(), b"first second");
+    }
+
+    #[test]
+    fn decode_rejects_truncated_compression_frames() {
+        let mut gzip = gzip(b"layer payload");
+        gzip.truncate(gzip.len() - 1);
+        assert!(read_layer(&gzip, None).is_err());
+
+        let mut zstd = zstd::stream::encode_all(b"layer payload".as_slice(), 0).unwrap();
+        zstd.truncate(zstd.len() - 1);
+        assert!(read_layer(&zstd, None).is_err());
+    }
+
+    #[test]
+    fn decode_detects_zstd_skippable_magic() {
+        let mut layer = vec![0x50, 0x2a, 0x4d, 0x18, 0, 0, 0, 0];
+        layer.extend(zstd::stream::encode_all(b"zstd payload".as_slice(), 0).unwrap());
+
+        assert_eq!(
+            read_layer(&layer, Some("application/octet-stream")).unwrap(),
+            b"zstd payload"
+        );
+    }
+}

--- a/crates/spur-net/src/lib.rs
+++ b/crates/spur-net/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod address;
 pub mod comm_addr;
 pub mod detect;
+pub mod image_layer;
 pub mod mesh;
 pub mod oci;
 pub mod wireguard;

--- a/crates/spur-net/src/oci.rs
+++ b/crates/spur-net/src/oci.rs
@@ -11,15 +11,17 @@
 //! 1. Parse image reference (registry/repo:tag)
 //! 2. Authenticate (token-based for Docker Hub, anonymous for others)
 //! 3. Fetch manifest → list of layer digests
-//! 4. Download each layer (tar.gz blobs)
+//! 4. Download each layer blob
 //! 5. Extract layers in order to build rootfs
 //! 6. Pack rootfs into squashfs via mksquashfs
 
-use std::path::{Path, PathBuf};
+use std::{
+    io::Read,
+    path::{Path, PathBuf},
+};
 
 use anyhow::{bail, Context};
 use base64::{engine::general_purpose::STANDARD, Engine as _};
-use flate2::read::GzDecoder;
 use reqwest::header::{ACCEPT, AUTHORIZATION};
 use serde::Deserialize;
 use tracing::{debug, info};
@@ -355,10 +357,8 @@ async fn pull_and_extract(image_ref: &ImageRef, rootfs_dir: &Path) -> anyhow::Re
     // Extract layers sequentially (order matters for whiteout files)
     for (i, (_, data)) in layer_data.iter().enumerate() {
         let media_type = &manifest.layers[i].media_type;
-        if media_type.contains("gzip") || manifest.layers[i].digest.starts_with("sha256:") {
-            extract_tar_gz(data, rootfs_dir)
-                .with_context(|| format!("failed to extract layer {}", i + 1))?;
-        }
+        extract_layer(data, Some(media_type), rootfs_dir)
+            .with_context(|| format!("failed to extract layer {}", i + 1))?;
     }
 
     Ok(())
@@ -611,42 +611,38 @@ async fn resolve_manifest_list(
     Ok(manifest)
 }
 
-/// Extract a gzipped tarball into a directory.
-fn extract_tar_gz(data: &[u8], dest: &Path) -> anyhow::Result<()> {
-    let decoder = GzDecoder::new(data);
-    let mut archive = tar::Archive::new(decoder);
+fn extract_layer(data: &[u8], media_type: Option<&str>, dest: &Path) -> anyhow::Result<()> {
+    extract_tar(crate::image_layer::decode(data, media_type)?, dest)
+}
+
+fn extract_tar(reader: impl Read, dest: &Path) -> anyhow::Result<()> {
+    let mut archive = tar::Archive::new(reader);
     archive.set_overwrite(true);
     // Unpack, ignoring permission errors (common in rootless)
     for entry in archive.entries()? {
-        match entry {
-            Ok(mut entry) => {
-                // Skip whiteout files (.wh.*) — used for layer deletion
-                let path = entry.path()?.to_path_buf();
-                let filename = path.file_name().and_then(|f| f.to_str()).unwrap_or("");
-                if filename.starts_with(".wh.") {
-                    // Whiteout: delete the corresponding file
-                    let target = if filename == ".wh..wh..opq" {
-                        // Opaque whiteout: directory should be empty
-                        // (skip for now — complex to handle)
-                        continue;
-                    } else {
-                        let real_name = filename.strip_prefix(".wh.").unwrap();
-                        dest.join(path.parent().unwrap_or(Path::new("")))
-                            .join(real_name)
-                    };
-                    let _ = std::fs::remove_file(&target);
-                    let _ = std::fs::remove_dir_all(&target);
-                    continue;
-                }
+        let mut entry = entry?;
+        // Skip whiteout files (.wh.*) — used for layer deletion
+        let path = entry.path()?.to_path_buf();
+        let filename = path.file_name().and_then(|f| f.to_str()).unwrap_or("");
+        if filename.starts_with(".wh.") {
+            // Whiteout: delete the corresponding file
+            let target = if filename == ".wh..wh..opq" {
+                // Opaque whiteout: directory should be empty
+                // (skip for now — complex to handle)
+                continue;
+            } else {
+                let real_name = filename.strip_prefix(".wh.").unwrap();
+                dest.join(path.parent().unwrap_or(Path::new("")))
+                    .join(real_name)
+            };
+            let _ = std::fs::remove_file(&target);
+            let _ = std::fs::remove_dir_all(&target);
+            continue;
+        }
 
-                if let Err(e) = entry.unpack_in(dest) {
-                    // Ignore permission errors on special files
-                    debug!(path = %path.display(), error = %e, "skipping entry");
-                }
-            }
-            Err(e) => {
-                debug!(error = %e, "skipping tar entry");
-            }
+        if let Err(e) = entry.unpack_in(dest) {
+            // Ignore permission errors on special files
+            debug!(path = %path.display(), error = %e, "skipping entry");
         }
     }
     Ok(())
@@ -671,8 +667,108 @@ pub fn sanitize_name(name: &str) -> String {
 #[cfg(test)]
 mod tests {
     use base64::{engine::general_purpose::STANDARD, Engine as _};
+    use flate2::{write::GzEncoder, Compression};
 
     use super::*;
+
+    fn tar_layer(path: &str, contents: &[u8]) -> Vec<u8> {
+        let mut data = Vec::new();
+        let mut archive = tar::Builder::new(&mut data);
+        let mut header = tar::Header::new_gnu();
+        header.set_size(contents.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        archive.append_data(&mut header, path, contents).unwrap();
+        archive.finish().unwrap();
+        drop(archive);
+        data
+    }
+
+    fn gzip(data: &[u8]) -> Vec<u8> {
+        use std::io::Write;
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(data).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    #[test]
+    fn extract_layer_supports_uncompressed_tar() {
+        let rootfs = tempfile::tempdir().unwrap();
+        let layer = tar_layer("plain.txt", b"plain layer");
+
+        extract_layer(
+            &layer,
+            Some("application/vnd.oci.image.layer.v1.tar"),
+            rootfs.path(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read(rootfs.path().join("plain.txt")).unwrap(),
+            b"plain layer"
+        );
+    }
+
+    #[test]
+    fn extract_layer_supports_gzip_tar() {
+        let rootfs = tempfile::tempdir().unwrap();
+        let layer = gzip(&tar_layer("gzip.txt", b"gzip layer"));
+
+        extract_layer(
+            &layer,
+            Some("application/vnd.oci.image.layer.v1.tar+gzip"),
+            rootfs.path(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read(rootfs.path().join("gzip.txt")).unwrap(),
+            b"gzip layer"
+        );
+    }
+
+    #[test]
+    fn extract_layer_supports_zstd_tar() {
+        let rootfs = tempfile::tempdir().unwrap();
+        let layer =
+            zstd::stream::encode_all(tar_layer("zstd.txt", b"zstd layer").as_slice(), 0).unwrap();
+
+        extract_layer(
+            &layer,
+            Some("application/vnd.oci.image.layer.v1.tar+zstd"),
+            rootfs.path(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read(rootfs.path().join("zstd.txt")).unwrap(),
+            b"zstd layer"
+        );
+    }
+
+    #[test]
+    fn extract_layer_rejects_truncated_compressed_tar() {
+        let rootfs = tempfile::tempdir().unwrap();
+        let contents: Vec<u8> = (0..65_536)
+            .scan(0x1234_5678_u32, |state, _| {
+                *state ^= *state << 13;
+                *state ^= *state >> 17;
+                *state ^= *state << 5;
+                Some(*state as u8)
+            })
+            .collect();
+        let mut layer =
+            zstd::stream::encode_all(tar_layer("data.bin", &contents).as_slice(), 0).unwrap();
+        layer.truncate(layer.len() / 2);
+
+        assert!(extract_layer(
+            &layer,
+            Some("application/vnd.oci.image.layer.v1.tar+zstd"),
+            rootfs.path(),
+        )
+        .is_err());
+    }
 
     #[test]
     fn test_decode_registry_auth_b64_valid() {

--- a/crates/spur-net/src/oci.rs
+++ b/crates/spur-net/src/oci.rs
@@ -631,7 +631,7 @@ fn extract_tar(reader: impl Read, dest: &Path) -> anyhow::Result<()> {
                 // (skip for now — complex to handle)
                 continue;
             } else {
-                let real_name = filename.strip_prefix(".wh.").unwrap();
+                let real_name = filename.strip_prefix(".wh.").unwrap_or(filename);
                 dest.join(path.parent().unwrap_or(Path::new("")))
                     .join(real_name)
             };
@@ -745,6 +745,28 @@ mod tests {
             std::fs::read(rootfs.path().join("zstd.txt")).unwrap(),
             b"zstd layer"
         );
+    }
+
+    #[test]
+    fn extract_layer_applies_whiteout() {
+        let rootfs = tempfile::tempdir().unwrap();
+        let removed = rootfs.path().join("nested/removed.txt");
+        let retained = rootfs.path().join("nested/retained.txt");
+        std::fs::create_dir_all(removed.parent().unwrap()).unwrap();
+        std::fs::write(&removed, b"remove me").unwrap();
+        std::fs::write(&retained, b"keep me").unwrap();
+        let layer = tar_layer("nested/.wh.removed.txt", b"");
+
+        extract_layer(
+            &layer,
+            Some("application/vnd.oci.image.layer.v1.tar"),
+            rootfs.path(),
+        )
+        .unwrap();
+
+        assert!(!removed.exists());
+        assert_eq!(std::fs::read(retained).unwrap(), b"keep me");
+        assert!(!rootfs.path().join("nested/.wh.removed.txt").exists());
     }
 
     #[test]


### PR DESCRIPTION
## What

OCI pulls treated every layer as gzip-compressed because the `sha256:` digest check made the extraction gate unconditional. Zstd and uncompressed layers therefore failed, while Docker/Podman-save imports also lacked zstd support.

Closes #347.

## Approach

- Add one streaming layer decoder in `spur-net` and use it for registry pulls and Docker/Podman-save imports.
- Prefer declared gzip, zstd, or plain-tar media types; use gzip/zstd magic bytes and then plain tar when the media type is absent or unknown.
- Support concatenated gzip/zstd frames and zstd skippable frames.
- Fail clearly on malformed layers and clean temporary Docker/Podman import data on errors.

## Behavior change

Docker/Podman-save imports now abort if any layer fails to decode or unpack. Previously they printed a warning and continued, which could produce an incomplete image. The registry path continues to tolerate individual entry-unpack errors for rootless or special-file cases.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p spur-net --locked` (55 passed, including ordinary OCI whiteout extraction)
- `cargo test -p spur-cli --locked` (342 unit tests and the broken-pipe integration test passed)
- `cargo clippy -p spur-net -p spur-cli --all-targets --locked -- -D warnings`
- Local end-to-end smoke through the real `spur image import` CLI using a loopback OCI registry and a deterministic `docker save` fixture with gzip, zstd, uncompressed, and unknown-media zstd layers
- Real `mksquashfs` packaging and `unsquashfs` verification of exact rootfs contents and layer overwrite order for both import paths

Workspace-wide tests and Clippy were also attempted; on this macOS host they stop in the pre-existing `spur-mpi-pmix` build script because it passes GNU `ld` flags unsupported by Apple's linker. TLS/auth registries, multi-arch manifests, a live Docker/Podman daemon, and Linux `spurd` mounting remain CI/platform boundaries.
