### PR TITLE
test(e2e): expand native-host and k8s coverage for untested subsystems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,30 @@ jobs:
       - name: Test
         run: cargo test --locked
 
+  e2e-fixtures:
+    name: E2E fixture resolution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install E2E test dependencies
+        run: pip install -r tests/requirements.txt
+
+      # --setup-plan resolves every fixture without running one, so a missing or
+      # misnamed fixture fails here rather than an hour into E2E. The env vars
+      # only satisfy pytest_ignore_collect; nothing connects anywhere.
+      - name: Check every E2E fixture resolves
+        run: pytest --setup-plan -q
+        working-directory: tests
+        env:
+          SPUR_TEST_NODES: 192.0.2.1
+          SPUR_TEST_SSH_USER: nobody
+          KUBECONFIG: /dev/null
+
   test-db:
     name: DB tests (accounting)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,32 @@ jobs:
           SPUR_TEST_SSH_USER: nobody
           KUBECONFIG: /dev/null
 
+      - name: Native-host suite markers are complete and disjoint
+        working-directory: tests
+        env:
+          SPUR_TEST_NODES: 192.0.2.1
+          SPUR_TEST_SSH_USER: nobody
+          KUBECONFIG: /dev/null
+        run: |
+          all=$(pytest native_host/e2e --collect-only -q 2>/dev/null | grep -c '::' || true)
+          sel=$(pytest native_host/e2e --collect-only -q \
+            -m "suite_scheduling or suite_policy or suite_api or suite_runtime or suite_fabric or suite_ha" \
+            2>/dev/null | grep -c '::' || true)
+          echo "collected=$all selected-by-suites=$sel"
+          test "$all" -eq "$sel"
+
+      - name: K8s suite markers are complete and disjoint
+        working-directory: tests
+        env:
+          KUBECONFIG: /dev/null
+        run: |
+          all=$(pytest k8s/e2e --collect-only -q 2>/dev/null | grep -c '::' || true)
+          sel=$(pytest k8s/e2e --collect-only -q \
+            -m "suite_k8s_core or suite_k8s_spec or suite_k8s_quota or suite_k8s_ha or suite_k8s_nodes" \
+            2>/dev/null | grep -c '::' || true)
+          echo "collected=$all selected-by-suites=$sel"
+          test "$all" -eq "$sel"
+
   test-db:
     name: DB tests (accounting)
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,14 +68,33 @@ jobs:
       matrix:
         include:
           - cluster_type: native-host
-            STATUS_CONTEXT: "E2E / native-host"
+            suite: scheduling
+            STATUS_CONTEXT: "E2E / native-host / scheduling"
+          - cluster_type: native-host
+            suite: policy
+            STATUS_CONTEXT: "E2E / native-host / policy"
+          - cluster_type: native-host
+            suite: api
+            STATUS_CONTEXT: "E2E / native-host / api"
+          - cluster_type: native-host
+            suite: runtime
+            STATUS_CONTEXT: "E2E / native-host / runtime"
+          - cluster_type: native-host
+            suite: fabric
+            STATUS_CONTEXT: "E2E / native-host / fabric"
+          - cluster_type: native-host
+            suite: ha
+            STATUS_CONTEXT: "E2E / native-host / ha"
           - cluster_type: k8s
             STATUS_CONTEXT: "E2E / k8s"
     env:
       STATUS_CONTEXT: ${{ matrix.STATUS_CONTEXT }}
       # LogLevel=ERROR silences the known-hosts warning from UserKnownHostsFile=/dev/null.
       SSH_OPTS: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
-      RUN_DIR: /tmp/spur-e2e-${{ github.run_id }}
+      # Scoped per matrix entry so the six native-host suite jobs never collide
+      # on run dir, VM prefix, or artifact name. k8s falls back to its type.
+      RUN_SLUG: ${{ matrix.suite || matrix.cluster_type }}
+      RUN_DIR: /tmp/spur-e2e-${{ github.run_id }}-${{ matrix.suite || matrix.cluster_type }}
     steps:
       - name: Set pending status
         uses: actions/github-script@v9
@@ -140,7 +159,7 @@ jobs:
           CLUSTER_ENV=$(mktemp /tmp/cluster-env-XXXXXX.sh)
           echo "cluster_env=$CLUSTER_ENV" >> "$GITHUB_OUTPUT"
           /opt/spur-ci/bin/cluster-up.sh \
-            --prefix "${SPUR_CI_VM_PREFIX}-${{ github.run_id }}" \
+            --prefix "${SPUR_CI_VM_PREFIX}-${{ github.run_id }}-${{ env.RUN_SLUG }}" \
             --count 4 \
             --image "${{ steps.image.outputs.path }}" \
             --gpus-per-vm 1 \
@@ -233,28 +252,20 @@ jobs:
           export SPUR_TEST_GPU_VENV=/opt/spur-ci/gpu-venv
           chmod +x ${{ env.RUN_DIR }}/release-binaries/*
           source /opt/spur-ci/test-venv/bin/activate
-          pytest ${{ env.RUN_DIR }}/e2e-assets/tests/native_host/e2e/ -v --junitxml=${{ env.RUN_DIR }}/results.xml
+          pytest ${{ env.RUN_DIR }}/e2e-assets/tests/native_host/e2e/ -m "suite_${{ matrix.suite }}" -v --junitxml=${{ env.RUN_DIR }}/results.xml
           REMOTE
 
-      - name: Apply RBAC and verify cluster state (k8s)
+      - name: Verify cluster state (k8s)
         if: matrix.cluster_type == 'k8s'
         run: |
           DRIVER_IP="${{ steps.cluster.outputs.driver_ip }}"
           KEY="${{ steps.ssh.outputs.privkey }}"
-          NS="spur-ci-${{ github.run_id }}"
 
+          # Per-namespace RBAC is applied by the suite driver; here we only
+          # confirm the nodes came up labeled before launching the suites.
           ssh $SSH_OPTS -i "$KEY" ci@"$DRIVER_IP" bash -s <<REMOTE
           set -euo pipefail
           export KUBECONFIG=/home/ci/.kube/config
-
-          # Create test namespace
-          kubectl create namespace "$NS" --dry-run=client -o yaml | kubectl apply -f -
-
-          # Apply RBAC with namespace patched
-          sed "s/namespace: spur/namespace: $NS/g" \
-            ${{ env.RUN_DIR }}/e2e-assets/tests/k8s/e2e/manifests/rbac.yaml | kubectl apply -f -
-
-          # Verify nodes are labeled
           echo "=== Labeled nodes ==="
           kubectl get nodes -l spur.amd.com/managed=true -o wide
           REMOTE
@@ -264,15 +275,14 @@ jobs:
         run: |
           DRIVER_IP="${{ steps.cluster.outputs.driver_ip }}"
           KEY="${{ steps.ssh.outputs.privkey }}"
-          NS="spur-ci-${{ github.run_id }}"
 
           ssh $SSH_OPTS -i "$KEY" ci@"$DRIVER_IP" bash -s <<REMOTE
           set -euo pipefail
           export KUBECONFIG=/home/ci/.kube/config
           export SPUR_CI_IMAGE=docker.io/library/spur:ci
-          export SPUR_TEST_NS="$NS"
           source /opt/spur-ci/test-venv/bin/activate
-          pytest ${{ env.RUN_DIR }}/e2e-assets/tests/k8s/e2e/ -v --junitxml=${{ env.RUN_DIR }}/results.xml
+          bash ${{ env.RUN_DIR }}/e2e-assets/tests/k8s/e2e/run_suites.sh \
+            ${{ env.RUN_DIR }}/e2e-assets/tests/k8s/e2e "${{ github.run_id }}" "${{ env.RUN_DIR }}"
           REMOTE
 
       - name: Dump cluster diagnostics (k8s)
@@ -306,14 +316,15 @@ jobs:
           DRIVER_IP="${{ steps.cluster.outputs.driver_ip }}"
           KEY="${{ steps.ssh.outputs.privkey }}"
           mkdir -p "${{ env.RUN_DIR }}/e2e-results"
+          # native-host writes results.xml; the k8s driver writes results-<suite>.xml.
           scp $SSH_OPTS -i "$KEY" \
-            ci@"$DRIVER_IP":"${{ env.RUN_DIR }}/results.xml" "${{ env.RUN_DIR }}/e2e-results/" 2>/dev/null || true
+            ci@"$DRIVER_IP":"${{ env.RUN_DIR }}/results*.xml" "${{ env.RUN_DIR }}/e2e-results/" 2>/dev/null || true
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: e2e-results-${{ matrix.cluster_type }}
+          name: e2e-results-${{ matrix.cluster_type }}-${{ matrix.suite || 'all' }}
           path: ${{ env.RUN_DIR }}/e2e-results/
           retention-days: 3
           if-no-files-found: ignore
@@ -322,7 +333,7 @@ jobs:
         if: always()
         run: |
           /opt/spur-ci/bin/cluster-down.sh \
-            --prefix "${SPUR_CI_VM_PREFIX}-${{ github.run_id }}" \
+            --prefix "${SPUR_CI_VM_PREFIX}-${{ github.run_id }}-${{ env.RUN_SLUG }}" \
             --count 4
 
       - name: Cleanup ephemeral keys

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -4,6 +4,7 @@ backfilling
 CDI
 CIDR
 Cargo
+cgroup
 config
 cron
 crontab

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,22 @@ cargo test --locked                                                 # all tests 
 - Do not use `unwrap()` in library code. Use `?` or explicit error handling.
 - Do not commit files that may contain secrets.
 
+## E2E Suites
+
+E2E tests run as parallel CI suites selected by markers. Every
+`tests/native_host/e2e/test_*.py` must carry exactly one `suite_*` marker
+(`pytestmark = pytest.mark.suite_<name>`), and every `tests/k8s/e2e/test_*.py`
+exactly one `suite_k8s_*` marker. CI's `e2e-fixtures` job fails collection if a
+file has zero or two, so a new test file cannot silently escape a suite. Keep a
+file's tests within one domain; move a file between suites by editing its
+one-line `pytestmark`. Bare `pytest` (no `-m`) still runs everything locally.
+
+The k8s suites run concurrently on one bootstrapped cluster, each in its own
+namespace (`tests/k8s/e2e/run_suites.sh`). This is safe only because the
+destructive node tests stay skipped (`SPUR_TEST_DESTRUCTIVE_NODES` unset); if
+they are ever enabled, `suite_k8s_nodes` must run alone (drop it from the
+concurrent set in the driver), since it taints shared cluster-scoped Nodes.
+
 ## Further Reading
 
 See `README.md` and `docs/` for detailed documentation. End-to-end tests against real clusters live in `tests/native_host/e2e/` and `tests/k8s/e2e/`.

--- a/crates/spur-cli/src/sattach.rs
+++ b/crates/spur-cli/src/sattach.rs
@@ -72,8 +72,13 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
         anyhow::bail!("sattach: job {} has no allocated nodes", job_id);
     }
 
-    // Connect to the first node's agent
-    let first_node = nodelist.split(',').next().unwrap_or(nodelist).trim();
+    // The controller reports a hostlist, so `node[1-3]` has to be expanded
+    // before a name is usable as an address.
+    let nodes = spur_core::hostlist::expand(nodelist)
+        .with_context(|| format!("sattach: job {} has an unreadable nodelist", job_id))?;
+    let first_node = nodes
+        .first()
+        .with_context(|| format!("sattach: job {} has no allocated nodes", job_id))?;
     let agent_addr = format!("http://{}:6818", first_node);
     let mut agent = crate::interactive::connect_agent(&agent_addr).await?;
 

--- a/crates/spur-cli/src/scancel.rs
+++ b/crates/spur-cli/src/scancel.rs
@@ -64,7 +64,7 @@ pub async fn main() -> Result<()> {
 pub async fn main_with_args(args: Vec<String>) -> Result<()> {
     let args = ScancelArgs::try_parse_from(&args)?;
 
-    if args.job_ids.is_empty() && args.user.is_none() && args.name.is_none() {
+    if !has_selection(&args) {
         bail!("scancel: no job IDs or filters specified");
     }
 
@@ -159,6 +159,16 @@ fn is_cancellable(proto_state: i32) -> bool {
     }
 }
 
+/// Whether the caller named anything to cancel. `--state` alone does not
+/// count: it narrows a selection rather than making one.
+fn has_selection(args: &ScancelArgs) -> bool {
+    !args.job_ids.is_empty()
+        || args.user.is_some()
+        || args.name.is_some()
+        || args.partition.is_some()
+        || args.account.is_some()
+}
+
 fn filter_states(state: Option<&str>) -> Result<Vec<i32>> {
     let Some(states) = state else {
         return Ok(cancellable_states());
@@ -221,6 +231,38 @@ fn parse_state(s: &str) -> Option<spur_proto::proto::JobState> {
 mod tests {
     use super::*;
     use spur_proto::proto::JobState;
+
+    fn parse(args: &[&str]) -> ScancelArgs {
+        let mut argv = vec!["scancel"];
+        argv.extend_from_slice(args);
+        ScancelArgs::try_parse_from(argv).expect("args should parse")
+    }
+
+    #[test]
+    fn every_selection_flag_counts_as_a_selection() {
+        for args in [
+            vec!["123"],
+            vec!["-u", "alice"],
+            vec!["-n", "myjob"],
+            vec!["-p", "default"],
+            vec!["-A", "acct"],
+        ] {
+            assert!(
+                has_selection(&parse(&args)),
+                "{args:?} should select jobs to cancel"
+            );
+        }
+    }
+
+    #[test]
+    fn no_arguments_selects_nothing() {
+        assert!(!has_selection(&parse(&[])));
+    }
+
+    #[test]
+    fn state_alone_selects_nothing() {
+        assert!(!has_selection(&parse(&["-t", "RUNNING"])));
+    }
 
     #[test]
     fn active_states_are_cancellable() {

--- a/crates/spur-cli/src/spur_config.rs
+++ b/crates/spur-cli/src/spur_config.rs
@@ -34,6 +34,7 @@ pub fn load_spur_config() -> SlurmConfig {
             devices: Default::default(),
             admission: Default::default(),
             rlimits: Default::default(),
+            cgroup: Default::default(),
             mpi: Default::default(),
         },
     }

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -985,10 +985,14 @@ async fn try_stream_output(
     nodelist: &str,
     job_id: u32,
 ) -> bool {
-    let first_node = nodelist.split(',').next().unwrap_or_default().trim();
-    if first_node.is_empty() {
+    // The controller reports a hostlist, so `node[1-3]` has to be expanded
+    // before a name is usable as an address.
+    let Ok(nodes) = spur_core::hostlist::expand(nodelist) else {
         return false;
-    }
+    };
+    let Some(first_node) = nodes.first() else {
+        return false;
+    };
 
     if controller
         .get_node(GetNodeRequest {

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -112,6 +112,10 @@ pub struct SlurmConfig {
     #[serde(default)]
     pub rlimits: RlimitsConfig,
 
+    /// cgroup enforcement policy for job processes.
+    #[serde(default)]
+    pub cgroup: CgroupConfig,
+
     /// MPI plugin settings for `--mpi=pmix` job steps.
     #[serde(default)]
     pub mpi: MpiConfig,
@@ -1084,6 +1088,81 @@ impl MpiConfig {
             return std::path::PathBuf::from(&self.pmix_plugin);
         }
         std::path::Path::new(&self.plugin_dir).join("spur_mpi_pmix.so")
+    }
+}
+
+/// cgroup constraints applied to a job's processes (Slurm's `cgroup.conf`).
+///
+/// The limits themselves come from the allocation; this section only sets how
+/// they are enforced.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CgroupConfig {
+    /// Cap a job's swap alongside its memory (Slurm's `ConstrainSwapSpace`).
+    ///
+    /// Off by default, as in Slurm: while off, `memory.max` bounds resident
+    /// memory only and a job that outgrows `--mem` swaps instead of being killed.
+    #[serde(default)]
+    pub constrain_swap_space: bool,
+
+    /// Swap a job may use, as a percentage of its memory allocation (Slurm's
+    /// `AllowedSwapSpace`). Only consulted when `constrain_swap_space` is set.
+    #[serde(default)]
+    pub allowed_swap_space: u32,
+}
+
+/// Swap budget for a job's cgroup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SwapLimit {
+    /// Leave `memory.swap.max` alone; the job may swap without bound.
+    Unconstrained,
+    /// Cap swap at this percentage of the job's memory allocation.
+    Percent(u32),
+}
+
+impl SwapLimit {
+    /// Swap budget in bytes for a job capped at `memory_bytes`, or `None` when
+    /// swap is unconstrained.
+    pub fn bytes_for(&self, memory_bytes: u64) -> Option<u64> {
+        match self {
+            Self::Unconstrained => None,
+            Self::Percent(percent) => Some(memory_bytes.saturating_mul(u64::from(*percent)) / 100),
+        }
+    }
+}
+
+impl CgroupConfig {
+    pub fn swap_limit(&self) -> Result<SwapLimit, ConfigError> {
+        if !self.constrain_swap_space {
+            return Ok(SwapLimit::Unconstrained);
+        }
+        if self.allowed_swap_space > 100 {
+            return Err(ConfigError::InvalidValue {
+                field: "cgroup.allowed_swap_space".into(),
+                value: format!(
+                    "{} (expected a percentage of the memory allocation, 0 to 100)",
+                    self.allowed_swap_space
+                ),
+            });
+        }
+        Ok(SwapLimit::Percent(self.allowed_swap_space))
+    }
+}
+
+/// Resolved limits an agent applies to every job it launches, as opposed to
+/// the per-job sizes that come from the allocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct JobLimits {
+    /// Applied before exec, while still privileged.
+    pub memlock: MemlockLimit,
+    pub swap: SwapLimit,
+}
+
+impl Default for JobLimits {
+    fn default() -> Self {
+        Self {
+            memlock: MemlockLimit::Unlimited,
+            swap: SwapLimit::Unconstrained,
+        }
     }
 }
 
@@ -2086,6 +2165,76 @@ cluster_name = "test"
         assert_eq!(
             config.rlimits.memlock_limit().unwrap(),
             MemlockLimit::Unlimited
+        );
+    }
+
+    #[test]
+    fn cgroup_swap_is_unconstrained_by_default() {
+        let cfg = CgroupConfig::default();
+        assert_eq!(cfg.swap_limit().unwrap(), SwapLimit::Unconstrained);
+        assert_eq!(SwapLimit::Unconstrained.bytes_for(64 * 1024 * 1024), None);
+    }
+
+    #[test]
+    fn cgroup_constrained_swap_defaults_to_denying_swap() {
+        let cfg = CgroupConfig {
+            constrain_swap_space: true,
+            allowed_swap_space: 0,
+        };
+        let limit = cfg.swap_limit().unwrap();
+        assert_eq!(limit, SwapLimit::Percent(0));
+        assert_eq!(limit.bytes_for(64 * 1024 * 1024), Some(0));
+    }
+
+    #[test]
+    fn cgroup_allowed_swap_is_a_percentage_of_the_allocation() {
+        let cfg = CgroupConfig {
+            constrain_swap_space: true,
+            allowed_swap_space: 50,
+        };
+        assert_eq!(
+            cfg.swap_limit().unwrap().bytes_for(64 * 1024 * 1024),
+            Some(32 * 1024 * 1024)
+        );
+    }
+
+    #[test]
+    fn cgroup_allowed_swap_percentage_above_100_errors() {
+        let cfg = CgroupConfig {
+            constrain_swap_space: true,
+            allowed_swap_space: 101,
+        };
+        assert!(cfg.swap_limit().is_err());
+    }
+
+    #[test]
+    fn cgroup_allowed_swap_is_ignored_while_unconstrained() {
+        let cfg = CgroupConfig {
+            constrain_swap_space: false,
+            allowed_swap_space: 999,
+        };
+        assert_eq!(cfg.swap_limit().unwrap(), SwapLimit::Unconstrained);
+    }
+
+    #[test]
+    fn cgroup_from_toml_explicit() {
+        let toml = r#"
+cluster_name = "test"
+
+[cgroup]
+constrain_swap_space = true
+allowed_swap_space = 25
+"#;
+        let config = SlurmConfig::load_from_str(toml).unwrap();
+        assert_eq!(config.cgroup.swap_limit().unwrap(), SwapLimit::Percent(25));
+    }
+
+    #[test]
+    fn cgroup_from_toml_default() {
+        let config = SlurmConfig::load_from_str("cluster_name = \"test\"\n").unwrap();
+        assert_eq!(
+            config.cgroup.swap_limit().unwrap(),
+            SwapLimit::Unconstrained
         );
     }
 

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -108,22 +108,41 @@ fn should_submit(status: &SpurJobStatus) -> bool {
     status.spur_job_id.is_none()
 }
 
+/// Whether a failed submit is worth another attempt. Only "no controller
+/// answered" codes qualify; anything else faults the spec itself and would be
+/// rejected identically forever. Matches the agent's controller-RPC rule.
+fn submit_is_retryable(status: &tonic::Status) -> bool {
+    use tonic::Code;
+    matches!(
+        status.code(),
+        Code::Unavailable | Code::Internal | Code::DeadlineExceeded | Code::Unknown
+    )
+}
+
+/// Result of the submit phase.
+enum SubmitOutcome {
+    Submitted,
+    /// A prior reconcile already submitted this SpurJob.
+    AlreadySubmitted,
+    /// The controller refused the spec; the SpurJob is now Failed.
+    Rejected,
+}
+
 /// Submit to spurctld, apply job-id label, and patch CRD status.
 /// Re-reads from the API server first to guard against stale informer cache.
-/// Returns `Ok(None)` if a prior reconcile already submitted.
 async fn submit_to_controller(
     api: &Api<SpurJob>,
     ctx: &JobControllerCtx,
     name: &str,
     ns: &str,
     job: &SpurJob,
-) -> Result<Option<u32>, ReconcileError> {
+) -> Result<SubmitOutcome, ReconcileError> {
     // Fresh read from API server — informer cache may be stale after finalizer patch
     let fresh = api.get(name).await.map_err(ReconcileError::Kube)?;
     let fresh_status = fresh.status.clone().unwrap_or_default();
     if !should_submit(&fresh_status) {
         debug!(spurjob = %name, "already submitted by prior reconcile");
-        return Ok(None);
+        return Ok(SubmitOutcome::AlreadySubmitted);
     }
 
     let user = job
@@ -145,9 +164,19 @@ async fn submit_to_controller(
         .await
     {
         Ok(resp) => resp.into_inner().job_id,
-        Err(e) => {
+        Err(e) if submit_is_retryable(&e) => {
             error!(spurjob = %name, error = %e, "failed to submit SpurJob");
             return Err(ReconcileError::Grpc(e));
+        }
+        Err(e) => {
+            error!(spurjob = %name, error = %e, "SpurJob rejected by the controller");
+            let new_status = SpurJobStatus {
+                state: "Failed".into(),
+                message: Some(format!("rejected by spurctld: {}", e.message())),
+                ..fresh_status.clone()
+            };
+            patch_status(api, name, &new_status).await;
+            return Ok(SubmitOutcome::Rejected);
         }
     };
     drop(ctrl);
@@ -166,7 +195,7 @@ async fn submit_to_controller(
     };
     patch_status(api, name, &new_status).await;
 
-    Ok(Some(job_id))
+    Ok(SubmitOutcome::Submitted)
 }
 
 /// State-machine dispatcher: submit if no job_id, otherwise poll spurctld.
@@ -190,8 +219,9 @@ async fn handle_job(
     // Phase 1: Submit (no spur_job_id yet)
     if should_submit(&status) {
         return match submit_to_controller(api, ctx, &name, &ns, &job).await? {
-            Some(_job_id) => Ok(Action::requeue(Duration::from_secs(5))),
-            None => Ok(Action::requeue(Duration::from_secs(2))),
+            SubmitOutcome::Submitted => Ok(Action::requeue(Duration::from_secs(5))),
+            SubmitOutcome::AlreadySubmitted => Ok(Action::requeue(Duration::from_secs(2))),
+            SubmitOutcome::Rejected => Ok(Action::await_change()),
         };
     }
 
@@ -888,6 +918,33 @@ mod tests {
         assert!(!is_terminal("Suspended"));
         assert!(!is_terminal("Unknown"));
         assert!(!is_terminal(""));
+    }
+
+    // --- submit_is_retryable ---
+
+    #[test]
+    fn a_spec_rejection_is_not_retried() {
+        // What spurctld returns for an unknown partition or a denied account.
+        assert!(!submit_is_retryable(&tonic::Status::invalid_argument(
+            "partition 'gpu' not found"
+        )));
+        assert!(!submit_is_retryable(&tonic::Status::permission_denied(
+            "account denied"
+        )));
+    }
+
+    #[test]
+    fn a_controller_that_did_not_answer_is_retried() {
+        // "not the Raft leader" and a failed Raft propose are both transient.
+        assert!(submit_is_retryable(&tonic::Status::unavailable(
+            "not the Raft leader"
+        )));
+        assert!(submit_is_retryable(&tonic::Status::internal(
+            "raft propose failed"
+        )));
+        assert!(submit_is_retryable(&tonic::Status::deadline_exceeded(
+            "timed out"
+        )));
     }
 
     // --- resolve_reporting_node ---

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 use std::pin::pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
 use backon::{ExponentialBuilder, Retryable};
@@ -26,6 +26,7 @@ use spur_proto::proto::{
 };
 
 const FINALIZER: &str = "spur.amd.com/cleanup";
+const INITIAL_BACKOFF_SECS: u64 = 1;
 const MAX_BACKOFF_SECS: u64 = 60;
 const LABEL_PATCH_BUDGET: Duration = Duration::from_secs(3);
 
@@ -53,6 +54,50 @@ pub struct JobControllerCtx {
     pub ctrl_client: Mutex<SlurmControllerClient<Channel>>,
     /// Track multi-pod completion: job_id → (expected_count, completed_count, any_failed)
     pub(crate) pod_tracker: Mutex<HashMap<u32, PodTracker>>,
+    /// Consecutive reconcile failures per SpurJob, driving the retry delay.
+    /// Std mutex because `error_policy` is synchronous.
+    pub(crate) failures: StdMutex<HashMap<String, u32>>,
+}
+
+fn object_key(job: &SpurJob) -> String {
+    format!(
+        "{}/{}",
+        job.metadata.namespace.as_deref().unwrap_or_default(),
+        job.metadata.name.as_deref().unwrap_or_default()
+    )
+}
+
+type FailureCounts = StdMutex<HashMap<String, u32>>;
+
+/// Delay before the *attempt*-th retry: doubling from `INITIAL_BACKOFF_SECS`, capped.
+fn backoff_delay(attempt: u32) -> Duration {
+    // Cap the shift before the multiply so the doubling cannot overflow.
+    let shift = attempt.saturating_sub(1).min(u32::BITS - 1);
+    let secs = INITIAL_BACKOFF_SECS
+        .saturating_mul(1u64.checked_shl(shift).unwrap_or(u64::MAX))
+        .min(MAX_BACKOFF_SECS);
+    Duration::from_secs(secs)
+}
+
+/// Counts another consecutive failure for *key* and returns how long to wait.
+fn record_failure(failures: &FailureCounts, key: &str) -> Duration {
+    let mut counts = failures.lock().unwrap_or_else(|e| e.into_inner());
+    let attempt = counts.entry(key.to_string()).or_insert(0);
+    *attempt = attempt.saturating_add(1);
+    backoff_delay(*attempt)
+}
+
+impl JobControllerCtx {
+    fn next_backoff(&self, key: &str) -> Duration {
+        record_failure(&self.failures, key)
+    }
+
+    fn clear_backoff(&self, key: &str) {
+        self.failures
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(key);
+    }
 }
 
 pub(crate) struct PodTracker {
@@ -75,8 +120,9 @@ async fn reconcile(
         .clone()
         .ok_or_else(|| ReconcileError::Other("SpurJob has no namespace".into()))?;
     let api: Api<SpurJob> = Api::namespaced(ctx.client.clone(), &ns);
+    let key = object_key(&job);
 
-    finalizer(&api, FINALIZER, job, |event| {
+    let result = finalizer(&api, FINALIZER, job, |event| {
         let api = api.clone();
         let ctx = ctx.clone();
         async move {
@@ -87,7 +133,14 @@ async fn reconcile(
         }
     })
     .await
-    .map_err(map_finalizer_err)
+    .map_err(map_finalizer_err);
+
+    // A clean pass ends the retry sequence; cleanup also lands here, so the
+    // entry is dropped when the SpurJob goes away.
+    if result.is_ok() {
+        ctx.clear_backoff(&key);
+    }
+    result
 }
 
 fn map_finalizer_err(e: finalizer::Error<ReconcileError>) -> ReconcileError {
@@ -119,7 +172,6 @@ fn submit_is_retryable(status: &tonic::Status) -> bool {
     )
 }
 
-/// Result of the submit phase.
 enum SubmitOutcome {
     Submitted,
     /// A prior reconcile already submitted this SpurJob.
@@ -310,10 +362,15 @@ async fn handle_deletion(job: &SpurJob, ctx: &JobControllerCtx) -> Result<Action
     Ok(Action::await_change())
 }
 
-fn error_policy(_job: Arc<SpurJob>, error: &ReconcileError, _ctx: Arc<JobControllerCtx>) -> Action {
-    error!(error = %error, "SpurJob reconciler error");
-    // Exponential backoff capped at MAX_BACKOFF_SECS
-    Action::requeue(Duration::from_secs(MAX_BACKOFF_SECS))
+fn error_policy(job: Arc<SpurJob>, error: &ReconcileError, ctx: Arc<JobControllerCtx>) -> Action {
+    let delay = ctx.next_backoff(&object_key(&job));
+    error!(
+        spurjob = %object_key(&job),
+        error = %error,
+        retry_in_secs = delay.as_secs(),
+        "SpurJob reconciler error"
+    );
+    Action::requeue(delay)
 }
 
 /// Start the SpurJob controller and Pod watcher.
@@ -336,6 +393,7 @@ pub async fn run(
         client: client.clone(),
         ctrl_client: Mutex::new(ctrl_client),
         pod_tracker: Mutex::new(HashMap::new()),
+        failures: StdMutex::new(HashMap::new()),
     });
 
     let spurjobs: Api<SpurJob> = Api::all(client.clone());
@@ -888,6 +946,37 @@ mod tests {
         }
         assert_eq!(proto_job_state_to_string(-1), "Unknown");
         assert_eq!(proto_job_state_to_string(99), "Unknown");
+    }
+
+    // --- retry backoff ---
+
+    #[test]
+    fn test_backoff_doubles_from_one_second_and_caps() {
+        let seconds: Vec<u64> = (1..=10).map(|n| backoff_delay(n).as_secs()).collect();
+        assert_eq!(seconds, vec![1, 2, 4, 8, 16, 32, 60, 60, 60, 60]);
+        assert_eq!(backoff_delay(u32::MAX).as_secs(), MAX_BACKOFF_SECS);
+    }
+
+    #[test]
+    fn test_record_failure_counts_per_object() {
+        let failures = FailureCounts::default();
+        assert_eq!(record_failure(&failures, "ns/a").as_secs(), 1);
+        assert_eq!(record_failure(&failures, "ns/a").as_secs(), 2);
+        // A different SpurJob starts its own sequence.
+        assert_eq!(record_failure(&failures, "ns/b").as_secs(), 1);
+        assert_eq!(record_failure(&failures, "ns/a").as_secs(), 4);
+    }
+
+    #[test]
+    fn test_cleared_object_restarts_backoff() {
+        let failures = FailureCounts::default();
+        record_failure(&failures, "ns/a");
+        record_failure(&failures, "ns/a");
+        failures
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove("ns/a");
+        assert_eq!(record_failure(&failures, "ns/a").as_secs(), 1);
     }
 
     // --- is_terminal ---

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -6002,6 +6002,7 @@ mod tests {
             devices: Default::default(),
             admission: Default::default(),
             rlimits: Default::default(),
+            cgroup: Default::default(),
             mpi: Default::default(),
         }
     }

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -389,6 +389,7 @@ fn default_config() -> spur_core::config::SlurmConfig {
         devices: Default::default(),
         admission: Default::default(),
         rlimits: Default::default(),
+        cgroup: Default::default(),
         mpi: Default::default(),
     }
 }

--- a/crates/spurctld/src/metrics_server.rs
+++ b/crates/spurctld/src/metrics_server.rs
@@ -185,6 +185,7 @@ mod tests {
             admission: Default::default(),
             burst_buffer: Default::default(),
             rlimits: Default::default(),
+            cgroup: Default::default(),
             mpi: Default::default(),
         }
     }

--- a/crates/spurctld/src/rpc_middleware.rs
+++ b/crates/spurctld/src/rpc_middleware.rs
@@ -206,6 +206,7 @@ mod tests {
                 admission: Default::default(),
                 burst_buffer: Default::default(),
                 rlimits: Default::default(),
+                cgroup: Default::default(),
                 mpi: Default::default(),
             }
         }

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -2814,6 +2814,7 @@ mod tests {
                 devices: Default::default(),
                 admission: Default::default(),
                 rlimits: Default::default(),
+                cgroup: Default::default(),
                 mpi: Default::default(),
             }
         }

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -4511,7 +4511,7 @@ mod tests {
             HooksConfig::default(),
             Arc::new(Mutex::new(DeviceRegistry::new())),
             &spur_core::config::ClusterConfig::default(),
-            spur_core::config::MemlockLimit::Unlimited,
+            spur_core::config::JobLimits::default(),
             MpiConfig::default(),
             running,
         );

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -201,7 +201,7 @@ pub struct AgentService {
     spank: Arc<Option<SpankHost>>,
     mpi_host: Arc<MpiPluginHost>,
     hooks: Arc<HooksConfig>,
-    memlock: spur_core::config::MemlockLimit,
+    limits: spur_core::config::JobLimits,
     #[allow(dead_code)]
     device_registry: Arc<Mutex<DeviceRegistry>>,
     /// RPC-driven owner of this node's k0s systemd unit.
@@ -225,7 +225,10 @@ impl AgentService {
             hooks,
             device_registry,
             &spur_core::config::ClusterConfig::default(),
-            memlock,
+            spur_core::config::JobLimits {
+                memlock,
+                ..Default::default()
+            },
             MpiConfig::default(),
             new_running_jobs(),
         )
@@ -239,7 +242,7 @@ impl AgentService {
         hooks: HooksConfig,
         device_registry: Arc<Mutex<DeviceRegistry>>,
         cluster: &spur_core::config::ClusterConfig,
-        memlock: spur_core::config::MemlockLimit,
+        limits: spur_core::config::JobLimits,
         mpi: MpiConfig,
         running: RunningJobs,
     ) -> Self {
@@ -301,7 +304,7 @@ impl AgentService {
             spank: Arc::new(spank),
             mpi_host: Arc::new(MpiPluginHost::new(mpi)),
             hooks: Arc::new(hooks),
-            memlock,
+            limits,
             device_registry,
             k0s: Arc::new(crate::cluster::K0sAgent::from_config(cluster)),
             active_steps: Arc::new(Mutex::new(HashMap::new())),
@@ -1353,7 +1356,8 @@ impl SlurmAgent for AgentService {
             partition: spec.partition.clone(),
             nodelist: spec.nodelist.clone(),
             host_device_plan: Some(host_device_plan),
-            memlock: self.memlock,
+            memlock: self.limits.memlock,
+            swap_limit: self.limits.swap,
             io_mode: if spec.pty {
                 executor::LaunchIo::Pty
             } else {
@@ -2049,7 +2053,7 @@ impl SlurmAgent for AgentService {
             cmd.env(k, v);
         }
 
-        let memlock = self.memlock;
+        let memlock = self.limits.memlock;
         let priv_drop = crate::privdrop::PrivDrop::resolve_if_needed(req.uid, req.gid);
         unsafe {
             cmd.pre_exec(move || {

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -4,6 +4,7 @@
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::os::fd::{FromRawFd, OwnedFd, RawFd};
+use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -754,6 +755,22 @@ async fn spawn_job_process(
         });
     }
 
+    // Join the cgroup pre-exec, not from the parent after spawn: the rootful path
+    // runs under `unshare --fork`, whose forked workload only inherits the cgroup
+    // if we join before exec. A parent-side move races that fork and can leave the
+    // job unconstrained. Must precede the privilege drop -- only root writes here.
+    let cgroup_procs = cgroup_path
+        .as_ref()
+        .and_then(|p| CString::new(p.join("cgroup.procs").as_os_str().as_bytes()).ok());
+    if let Some(procs) = cgroup_procs {
+        unsafe {
+            cmd.pre_exec(move || {
+                join_cgroup_self(&procs);
+                Ok(())
+            });
+        }
+    }
+
     // Issue #99, #107: Run job as the submitting user (not root).
     // Must set supplementary groups (video, render) so the process can
     // access GPU device nodes.
@@ -847,12 +864,8 @@ async fn spawn_job_process(
     // Drop the slave fd immediately so the master gets EOF when the child exits.
     let pty_master = job_io.into_master();
 
-    // Move process into cgroup
-    if let Some(ref cgroup) = cgroup_path {
-        if let Some(pid) = child.id() {
-            move_to_cgroup(cgroup, pid);
-        }
-    }
+    // Cgroup placement already happened pre-exec (join_cgroup_self); a move here
+    // would race the wrapper's fork.
 
     debug!(
         job_id,
@@ -970,18 +983,33 @@ fn setup_cgroup(
     Ok(Some(cgroup_path))
 }
 
-/// Move a process into a cgroup. Returns true if successful.
-fn move_to_cgroup(cgroup_path: &Path, pid: u32) -> bool {
-    let procs_file = cgroup_path.join("cgroup.procs");
-    if let Err(e) = std::fs::write(&procs_file, pid.to_string()) {
-        warn!(
-            pid,
-            error = %e,
-            "failed to move process to cgroup — job runs without isolation"
-        );
-        false
-    } else {
-        true
+/// Move the calling process into a cgroup by writing its own pid to
+/// `cgroup.procs`. Runs in the post-fork child before exec, so it must be
+/// async-signal-safe: no heap allocation, only raw syscalls. Best-effort —
+/// on failure the job stays in the parent cgroup rather than aborting launch.
+fn join_cgroup_self(procs_path: &std::ffi::CStr) {
+    let pid = unsafe { libc::getpid() };
+
+    let mut buf = [0u8; 24];
+    let mut i = buf.len();
+    let mut n = pid.max(0) as u64;
+    loop {
+        i -= 1;
+        buf[i] = b'0' + (n % 10) as u8;
+        n /= 10;
+        if n == 0 {
+            break;
+        }
+    }
+    let digits = &buf[i..];
+
+    unsafe {
+        let fd = libc::open(procs_path.as_ptr(), libc::O_WRONLY);
+        if fd < 0 {
+            return;
+        }
+        libc::write(fd, digits.as_ptr() as *const libc::c_void, digits.len());
+        libc::close(fd);
     }
 }
 
@@ -2512,5 +2540,30 @@ mod tests {
             libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0,
             "wire() should have returned an error for bad fd"
         );
+    }
+
+    #[test]
+    fn join_cgroup_self_writes_own_pid() {
+        // cgroup.procs is a plain "write my decimal pid" interface, so a regular
+        // file exercises the hand-rolled formatting and write without a cgroup.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cgroup.procs");
+        // The real cgroup.procs is kernel-created; join_cgroup_self opens it
+        // without O_CREAT, so the stand-in must exist first.
+        std::fs::write(&path, "").unwrap();
+        let c_path = CString::new(path.as_os_str().as_bytes()).unwrap();
+
+        join_cgroup_self(&c_path);
+
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(written, std::process::id().to_string());
+    }
+
+    #[test]
+    fn join_cgroup_self_is_silent_when_the_path_is_missing() {
+        // Best-effort: a non-existent cgroup.procs must not panic, so a failed
+        // placement degrades to an unconstrained job instead of aborting launch.
+        let c_path = CString::new("/nonexistent/spur-test/cgroup.procs").unwrap();
+        join_cgroup_self(&c_path);
     }
 }

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -14,7 +14,7 @@ use nix::unistd::Pid;
 use tokio::process::Command;
 use tracing::{debug, info, warn};
 
-use spur_core::config::MemlockLimit;
+use spur_core::config::{MemlockLimit, SwapLimit};
 use spur_core::job::JobId;
 use spur_spank::{SpankContext, SpankHandle, SpankHost};
 
@@ -161,6 +161,8 @@ pub struct JobLaunchConfig {
     pub host_device_plan: Option<spur_devices::inject::HostInjectionPlan>,
     /// RLIMIT_MEMLOCK to apply before exec (while still privileged).
     pub memlock: MemlockLimit,
+    /// Swap budget for the job's cgroup.
+    pub swap_limit: SwapLimit,
     /// I/O mode for the job.
     pub io_mode: LaunchIo,
     /// Direct multi-rank PMIx launch via a wrapper script (batch `--mpi=pmix`).
@@ -502,7 +504,7 @@ async fn spawn_job_process(
     info!(job_id, work_dir, "launching job");
 
     // Set up cgroup for isolation
-    let cgroup_path = setup_cgroup(job_id, cpus, memory_mb, cpu_ids)?;
+    let cgroup_path = setup_cgroup(job_id, cpus, memory_mb, cpu_ids, cfg.swap_limit)?;
 
     // Ensure work_dir exists on this node (the submitted path may only exist on the submitting
     // node). If creation fails (e.g. path is under another user's home), fall back to /tmp so
@@ -873,6 +875,7 @@ fn setup_cgroup(
     cpus: u32,
     memory_mb: u64,
     cpu_ids: &[u32],
+    swap_limit: SwapLimit,
 ) -> anyhow::Result<Option<PathBuf>> {
     let cgroup_root = PathBuf::from(CGROUP_ROOT);
     let cgroup_path = cgroup_root.join(format!("job_{}", job_id));
@@ -918,6 +921,16 @@ fn setup_cgroup(
         let memory_bytes = memory_mb * 1024 * 1024;
         if let Err(e) = std::fs::write(cgroup_path.join("memory.max"), memory_bytes.to_string()) {
             warn!(job_id, error = %e, "failed to set memory.max");
+        }
+        // memory.max bounds resident memory only: with swap available the
+        // kernel pages the overflow out instead of OOM-killing. Opt-in, since
+        // capping swap starts killing jobs that used to survive.
+        if let Some(swap_bytes) = swap_limit.bytes_for(memory_bytes) {
+            if let Err(e) =
+                std::fs::write(cgroup_path.join("memory.swap.max"), swap_bytes.to_string())
+            {
+                warn!(job_id, error = %e, "failed to set memory.swap.max");
+            }
         }
     }
 
@@ -1407,7 +1420,13 @@ async fn launch_container_job(
     job_io: JobIo,
 ) -> anyhow::Result<(RunningJob, Option<OwnedFd>)> {
     let job_id = cfg.job_id;
-    let cgroup_path = setup_cgroup(job_id, cfg.cpus, cfg.memory_mb, &cfg.cpu_ids)?;
+    let cgroup_path = setup_cgroup(
+        job_id,
+        cfg.cpus,
+        cfg.memory_mb,
+        &cfg.cpu_ids,
+        cfg.swap_limit,
+    )?;
 
     // Sync pipe: child writes status, parent reads.
     // Convert OwnedFd to raw fds for manual lifecycle management across fork.
@@ -2159,6 +2178,7 @@ mod tests {
             nodelist: String::new(),
             host_device_plan: None,
             memlock: MemlockLimit::Unlimited,
+            swap_limit: SwapLimit::Unconstrained,
             io_mode: LaunchIo::File,
             pmix_multi_task: false,
         }

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -518,15 +518,11 @@ async fn spawn_job_process(
     };
     let work_dir = effective_work_dir.as_str();
 
-    // Wrap script with burst buffer stage-in/stage-out if configured
-    let script = if let Ok(bb) = std::env::var("SPUR_BURST_BUFFER") {
-        if !bb.is_empty() {
-            wrap_with_burst_buffer(script, &bb)
-        } else {
-            script.to_string()
-        }
-    } else {
-        script.to_string()
+    // The directive is per job, so it comes from the job's environment. Reading
+    // the daemon's own env instead would only ever see a cluster-wide value.
+    let script = match environment.get("SPUR_BURST_BUFFER") {
+        Some(bb) if !bb.is_empty() => wrap_with_burst_buffer(script, bb),
+        _ => script.to_string(),
     };
     let script = script.as_str();
 

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -109,6 +109,19 @@ struct Args {
     log_level: String,
 }
 
+fn log_swap_status(swap: spur_core::config::SwapLimit) {
+    use spur_core::config::SwapLimit;
+    match swap {
+        SwapLimit::Unconstrained => info!(
+            "job swap unconstrained; --mem bounds resident memory only \
+             (see cgroup.constrain_swap_space)"
+        ),
+        SwapLimit::Percent(percent) => {
+            info!(allowed_swap_space = percent, "job swap constrained")
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     if std::env::args_os()
@@ -296,11 +309,15 @@ async fn main() -> anyhow::Result<()> {
 
     // Start agent gRPC server (receives job launches + cluster-component RPCs from spurctld).
     // Pass the [cluster] config so the K0sAgent uses the operator's k0s version + install path.
-    let memlock = match config.as_ref() {
-        Some(c) => c.rlimits.memlock_limit()?,
-        None => spur_core::config::MemlockLimit::Unlimited,
+    let limits = match config.as_ref() {
+        Some(c) => spur_core::config::JobLimits {
+            memlock: c.rlimits.memlock_limit()?,
+            swap: c.cgroup.swap_limit()?,
+        },
+        None => spur_core::config::JobLimits::default(),
     };
-    log_memlock_status(memlock);
+    log_memlock_status(limits.memlock);
+    log_swap_status(limits.swap);
     let cluster_config = config
         .as_ref()
         .map(|c| c.cluster.clone())
@@ -311,7 +328,7 @@ async fn main() -> anyhow::Result<()> {
         hooks_config,
         registry.clone(),
         &cluster_config,
-        memlock,
+        limits,
         mpi_config,
         running_jobs,
     );

--- a/docs/admin-guide/configuration.rst
+++ b/docs/admin-guide/configuration.rst
@@ -14,7 +14,8 @@ and meaning.
 
    ``spurctld`` reads every section of ``spur.conf``. ``spurd`` reads the same file
    but only for local agent settings (``[hooks]``, ``[devices]``, ``rlimits.memlock``,
-   ``[cluster]``, and ``[mpi]``); its identity and networking come from CLI flags.
+   ``[cgroup]``, ``[cluster]``, and ``[mpi]``); its identity and networking come from
+   CLI flags.
    Node CPU, memory, and GRES are declared to the controller under ``[[nodes]]`` here.
 
 Minimal configuration
@@ -484,6 +485,43 @@ POSIX ``RLIMIT_*`` values ``spurd`` applies to job steps at launch.
 
    ``memlock = "unlimited"`` lets RDMA and NCCL workloads pin memory out of the box.
    Lower it only when a hard cap is required.
+
+``[cgroup]``
+------------
+
+How ``spurd`` enforces a job's cgroup limits. The limits themselves come from the
+allocation (``--mem``, ``--cpus-per-task``); this section only sets policy. The
+fields mirror ``ConstrainSwapSpace`` and ``AllowedSwapSpace`` in Slurm's
+``cgroup.conf``, including their defaults.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 10 12 54
+
+   * - Field
+     - Type
+     - Default
+     - Description
+   * - ``constrain_swap_space``
+     - bool
+     - ``false``
+     - Cap a job's swap along with its memory. While ``false``, ``memory.max``
+       bounds resident memory only: on a node with swap, a job that outgrows
+       ``--mem`` keeps running on swap instead of being killed.
+   * - ``allowed_swap_space``
+     - integer
+     - ``0``
+     - Swap a job may use, as a percentage (0-100) of its memory allocation.
+       Only consulted when ``constrain_swap_space`` is set; ``0`` denies swap
+       outright. A value above 100 errors at parse time.
+
+.. note::
+
+   Enabling ``constrain_swap_space`` is what makes ``--mem`` a hard cap and lets a
+   runaway job be reported as ``OUT_OF_MEMORY`` rather than completing slowly on
+   swap. It is off by default because turning it on starts killing jobs that
+   previously survived by swapping. Both fields are read at ``spurd`` startup, so
+   changing them needs an agent restart.
 
 ``[mpi]``
 ---------

--- a/tests/k8s/e2e/conftest.py
+++ b/tests/k8s/e2e/conftest.py
@@ -3,6 +3,8 @@
 
 """Pytest fixtures for Spur Kubernetes E2E tests."""
 
+from pathlib import Path
+
 import pytest
 
 from k8s_cluster import (
@@ -55,3 +57,27 @@ def _cleanup_between_tests(request):
         fixture.ensure_controllers_ready()
         if fixture.config.replicas > 1:
             assert_leader_elected(fixture.namespace, fixture.config.replicas)
+
+
+_K8S_SUITE_MARKERS = (
+    "suite_k8s_core", "suite_k8s_spec", "suite_k8s_quota",
+    "suite_k8s_ha", "suite_k8s_nodes",
+)
+_K8S_E2E_DIR = Path(__file__).parent
+
+
+def pytest_collection_modifyitems(config, items):
+    """Fail if any k8s e2e test lacks exactly one suite_k8s_* marker."""
+    bad = []
+    for item in items:
+        path = getattr(item, "path", None)
+        if path is None or (path != _K8S_E2E_DIR and _K8S_E2E_DIR not in path.parents):
+            continue
+        suites = [m.name for m in item.iter_markers() if m.name in _K8S_SUITE_MARKERS]
+        if len(suites) != 1:
+            bad.append(f"{item.nodeid}: {sorted(suites) or 'none'}")
+    if bad:
+        raise pytest.UsageError(
+            "each k8s e2e test needs exactly one suite_k8s_* marker:\n  "
+            + "\n  ".join(bad)
+        )

--- a/tests/k8s/e2e/conftest.py
+++ b/tests/k8s/e2e/conftest.py
@@ -34,12 +34,22 @@ def ha_cluster(k8s_suite):
     c.teardown_workloads()
 
 
+@pytest.fixture(scope="class")
+def quota_cluster(k8s_suite):
+    """Operator deployed with --enable-quota for the quota projection tests."""
+    c = ClusterFixture.deploy(k8s_suite, FixtureConfig.with_quota())
+    yield c
+    c.teardown_workloads()
+
+
 @pytest.fixture(autouse=True)
 def _cleanup_between_tests(request):
     yield
-    if "cluster" in request.fixturenames:
-        request.getfixturevalue("cluster").cleanup_test_workloads()
-    elif "ha_cluster" in request.fixturenames:
+    for name in ("cluster", "quota_cluster"):
+        if name in request.fixturenames:
+            request.getfixturevalue(name).cleanup_test_workloads()
+            return
+    if "ha_cluster" in request.fixturenames:
         fixture = request.getfixturevalue("ha_cluster")
         fixture.cleanup_test_workloads()
         fixture.ensure_controllers_ready()

--- a/tests/k8s/e2e/k8s_cluster.py
+++ b/tests/k8s/e2e/k8s_cluster.py
@@ -10,7 +10,7 @@ import logging
 import os
 import shlex
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable
 
@@ -119,6 +119,8 @@ class FixtureConfig:
     replicas: int
     image: str
     config_toml: str
+    extra_operator_args: list[str] = field(default_factory=list)
+    needs_postgres: bool = False
 
     @classmethod
     def single_node(cls) -> FixtureConfig:
@@ -133,6 +135,9 @@ cluster_name = "k8s-ci"
 interval_secs = 1
 plugin = "backfill"
 
+[metrics]
+bind = "all"
+
 [[partitions]]
 name = "default"
 state = "UP"
@@ -142,6 +147,23 @@ max_time = "1h"
 default_time = "10m"
 """.strip(),
         )
+
+    @classmethod
+    def with_quota(cls) -> FixtureConfig:
+        """Single controller with the operator's quota controller switched on.
+
+        Quota projection reads accounts over the SlurmAccounting RPC, which
+        spurctld only serves when accounting is backed by a database, so this
+        variant also brings up an ephemeral Postgres.
+        """
+        cfg = cls.single_node()
+        cfg.extra_operator_args = ["--enable-quota"]
+        cfg.needs_postgres = True
+        cfg.config_toml += (
+            "\n\n[accounting]\n"
+            'database_url = "postgresql://spur:spur@spur-postgres:5432/spur"\n'
+        )
+        return cfg
 
     @classmethod
     def raft_ha(cls) -> FixtureConfig:
@@ -253,6 +275,11 @@ class ClusterFixture:
         fixture.teardown_workloads()
         fixture.apply_rbac()
         fixture.apply_configmap()
+        if cfg.needs_postgres:
+            # spurctld only builds its accounting pool at startup, so the
+            # database has to be serving before the controller comes up.
+            fixture.apply_postgres()
+            fixture.wait_postgres_ready()
         fixture.apply_controller()
         fixture.apply_operator()
         fixture.wait_ready()
@@ -344,7 +371,12 @@ class ClusterFixture:
             if not _is_not_found(exc):
                 raise
 
-    def _apply_yaml_docs(self, yaml_path: Path, replicas: int | None) -> None:
+    def _apply_yaml_docs(
+        self,
+        yaml_path: Path,
+        replicas: int | None,
+        mutate: Callable[[dict], None] | None = None,
+    ) -> None:
         content = yaml_path.read_text()
         api_client = client.ApiClient()
         for doc in content.split("\n---"):
@@ -357,6 +389,8 @@ class ClusterFixture:
             value = yaml.safe_load(patched)
             value = patch_namespace_in_value(value, self.namespace)
             value.setdefault("metadata", {})["namespace"] = self.namespace
+            if mutate is not None:
+                mutate(value)
             kind = value.get("kind", "")
             name = value["metadata"]["name"]
             self._delete_resource(kind, name)
@@ -398,8 +432,37 @@ class ClusterFixture:
         )
 
     def apply_operator(self) -> None:
-        self._apply_yaml_docs(_MANIFESTS_DIR / "operator.yaml", None)
-        logger.info("operator Deployment applied (image=%s)", self.config.image)
+        def add_extra_args(value: dict) -> None:
+            if value.get("kind") != "Deployment":
+                return
+            for container in value["spec"]["template"]["spec"]["containers"]:
+                if container["name"] == "operator":
+                    container.setdefault("args", []).extend(
+                        self.config.extra_operator_args
+                    )
+
+        mutate = add_extra_args if self.config.extra_operator_args else None
+        self._apply_yaml_docs(_MANIFESTS_DIR / "operator.yaml", None, mutate)
+        logger.info(
+            "operator Deployment applied (image=%s, extra_args=%s)",
+            self.config.image,
+            self.config.extra_operator_args,
+        )
+
+    def apply_postgres(self) -> None:
+        self._apply_yaml_docs(_MANIFESTS_DIR / "postgres.yaml", None)
+        logger.info("postgres Deployment applied")
+
+    def wait_postgres_ready(self, timeout: int = 180) -> None:
+        wait_until(
+            lambda: count_ready_pods(self.namespace, "app=spur-postgres") >= 1,
+            timeout,
+            "postgres pod not ready",
+            interval=3,
+        )
+
+    def postgres_available(self) -> bool:
+        return count_ready_pods(self.namespace, "app=spur-postgres") >= 1
 
     def wait_ready(self, timeout: int = 120) -> None:
         wait_until(
@@ -433,8 +496,18 @@ class ClusterFixture:
     def teardown_workloads(self) -> None:
         self._force_delete_pods("app=spurctld")
         self._force_delete_pods("app=spur-k8s-operator")
+        self._force_delete_pods("app=spur-postgres")
 
         for delete_fn in [
+            lambda: self.apps_v1.delete_namespaced_deployment(
+                "spur-postgres",
+                self.namespace,
+                grace_period_seconds=0,
+                propagation_policy="Background",
+            ),
+            lambda: self.core_v1.delete_namespaced_service(
+                "spur-postgres", self.namespace
+            ),
             lambda: self.apps_v1.delete_namespaced_deployment(
                 "spur-k8s-operator",
                 self.namespace,
@@ -472,6 +545,7 @@ class ClusterFixture:
 
         self._wait_pods_gone("app=spurctld")
         self._wait_pods_gone("app=spur-k8s-operator")
+        self._wait_pods_gone("app=spur-postgres", raise_on_timeout=False)
         logger.info("workload teardown complete")
 
     def cleanup_test_workloads(self) -> None:
@@ -507,6 +581,48 @@ class ClusterFixture:
             lambda: self._operator_available(),
             timeout,
             "operator deployment not ready",
+        )
+
+    def spur_cli(self, args: list[str]) -> str:
+        """Run the Spur CLI inside the controller pod.
+
+        The controller pod is the only place that has both the binary and a
+        loopback route to spurctld, so admin commands go through it.
+        """
+        cmd = " ".join(shlex.quote(a) for a in ["spur", *args])
+        return exec_in_pod(self.namespace, "spurctld-0", ["sh", "-c", f"{cmd} 2>&1"])
+
+    def operator_pods(self) -> list:
+        return self.core_v1.list_namespaced_pod(
+            self.namespace, label_selector="app=spur-k8s-operator"
+        ).items
+
+    def operator_logs(self, tail_lines: int = 400) -> str:
+        return "\n".join(
+            self.core_v1.read_namespaced_pod_log(
+                pod.metadata.name, self.namespace, tail_lines=tail_lines
+            )
+            for pod in self.operator_pods()
+        )
+
+    def restart_operator(self, timeout: int = 150) -> None:
+        """Delete the operator pod and wait for a fresh one to be ready.
+
+        Startup-only paths (orphan pod cleanup) are only reachable this way.
+        """
+        before = {pod.metadata.name for pod in self.operator_pods()}
+        self._force_delete_pods("app=spur-k8s-operator")
+
+        def replaced() -> bool:
+            pods = self.operator_pods()
+            fresh = [p for p in pods if p.metadata.name not in before]
+            return bool(fresh) and all(
+                p.status.phase == "Running" for p in fresh
+            )
+
+        wait_until(replaced, timeout, "operator pod was not replaced", interval=3)
+        wait_until(
+            self._operator_available, timeout, "operator deployment not ready", interval=3
         )
 
     def create_spurjob(self, body: dict) -> dict:
@@ -588,6 +704,165 @@ def spurjob_with_env(name: str, command: list[str], env: dict[str, str]) -> dict
 
 def multinode_spurjob(name: str, command: list[str], num_nodes: int) -> dict:
     return spurjob_body(name, base_spec(name, command, num_nodes))
+
+
+def spurjob_with_spec(name: str, command: list[str], **overrides) -> dict:
+    """SpurJob with arbitrary spec fields layered onto the defaults.
+
+    Keys are CRD field names (camelCase), e.g. ``hostNetwork=True`` or
+    ``volumes=["/tmp:/mnt:ro"]``.
+    """
+    spec = base_spec(name, command, overrides.pop("numNodes", 1))
+    spec.update(overrides)
+    return spurjob_body(name, spec)
+
+
+def gpu_spurjob(name: str, command: list[str], count: int, gpu_type: str | None = None) -> dict:
+    gpus: dict = {"count": count}
+    if gpu_type:
+        gpus["gpuType"] = gpu_type
+    return spurjob_with_spec(name, command, gpus=gpus)
+
+
+def volume_spurjob(name: str, command: list[str], volumes: list[str]) -> dict:
+    return spurjob_with_spec(name, command, volumes=volumes)
+
+
+def secret_env_spurjob(name: str, command: list[str], secret_env: dict[str, str]) -> dict:
+    return spurjob_with_spec(name, command, secretEnv=secret_env)
+
+
+def security_spurjob(
+    name: str,
+    command: list[str],
+    *,
+    host_network: bool = False,
+    host_ipc: bool = False,
+    privileged: bool = False,
+    shm_size: str | None = None,
+) -> dict:
+    overrides: dict = {
+        "hostNetwork": host_network,
+        "hostIpc": host_ipc,
+        "privileged": privileged,
+    }
+    if shm_size:
+        overrides["shmSize"] = shm_size
+    return spurjob_with_spec(name, command, **overrides)
+
+
+def resource_spurjob(
+    name: str,
+    command: list[str],
+    *,
+    tasks_per_node: int = 1,
+    cpus_per_task: int = 1,
+    memory_per_node: str = "100Mi",
+    extra_resources: dict[str, str] | None = None,
+) -> dict:
+    return spurjob_with_spec(
+        name,
+        command,
+        tasksPerNode=tasks_per_node,
+        cpusPerTask=cpus_per_task,
+        memoryPerNode=memory_per_node,
+        extraResources=extra_resources or {},
+    )
+
+
+def list_spurjob_pods(fixture: ClusterFixture, name: str, namespace: str | None = None):
+    ns = namespace or fixture.namespace
+    return fixture.core_v1.list_namespaced_pod(
+        ns, label_selector=f"spur.amd.com/job-name={name}"
+    ).items
+
+
+def wait_spurjob_pod(
+    fixture: ClusterFixture,
+    name: str,
+    timeout: int = DEFAULT_TIMEOUT,
+    namespace: str | None = None,
+):
+    """Wait for the operator to create a pod for the SpurJob and return it."""
+    pods: list = []
+
+    def created() -> bool:
+        nonlocal pods
+        pods = list_spurjob_pods(fixture, name, namespace)
+        return bool(pods)
+
+    wait_until(created, timeout, f"no pods created for SpurJob {name}")
+    return pods[0]
+
+
+def _resolve_attr(obj, dotted: str):
+    for part in dotted.split("."):
+        if obj is None:
+            return None
+        if isinstance(obj, dict):
+            obj = obj.get(part)
+        elif isinstance(obj, list):
+            obj = obj[int(part)]
+        else:
+            obj = getattr(obj, part)
+    return obj
+
+
+def assert_pod_spec(
+    fixture: ClusterFixture,
+    name: str,
+    expected: dict,
+    namespace: str | None = None,
+) -> None:
+    """Assert dotted paths on the pod created for a SpurJob.
+
+    Paths are relative to the pod and use the Python client's snake_case
+    attribute names, e.g. ``spec.host_network`` or
+    ``spec.containers.0.resources.limits``.
+    """
+    pod = wait_spurjob_pod(fixture, name, namespace=namespace)
+    for path, want in expected.items():
+        got = _resolve_attr(pod, path)
+        assert got == want, (
+            f"SpurJob {name} pod {pod.metadata.name}: {path} is {got!r}, "
+            f"expected {want!r}"
+        )
+
+
+def job_service_exists(
+    fixture: ClusterFixture, spur_job_id: int | str, namespace: str | None = None
+) -> bool:
+    """Whether the headless Service for a multi-node job still exists.
+
+    The operator names it after the Spur job ID (`spur-job-{id}`), not the
+    SpurJob resource name.
+    """
+    ns = namespace or fixture.namespace
+    try:
+        fixture.core_v1.read_namespaced_service(f"spur-job-{spur_job_id}", ns)
+        return True
+    except ApiException as exc:
+        if _is_not_found(exc):
+            return False
+        raise
+
+
+def read_all_spurjob_pod_logs(
+    fixture: ClusterFixture,
+    name: str,
+    namespace: str | None = None,
+) -> dict[str, str]:
+    """Logs of every pod backing a SpurJob, keyed by pod name."""
+    ns = namespace or fixture.namespace
+    pods = list_spurjob_pods(fixture, name, ns)
+    if not pods:
+        raise AssertionError(f"no pods found for SpurJob {name} in namespace {ns}")
+    return {
+        pod.metadata.name: fixture.core_v1.read_namespaced_pod_log(
+            pod.metadata.name, ns
+        )
+        for pod in pods
+    }
 
 
 def wait_spurjob_state(
@@ -698,6 +973,25 @@ def delete_namespace(name: str, *, wait: bool = False, timeout: int = 120) -> No
         wait_until(gone, timeout, f"namespace {name} not deleted")
     except TimeoutError:
         logger.warning("timed out waiting for namespace %s to be deleted", name)
+
+
+def service_http_get(
+    namespace: str, service: str, port: str | int, path: str
+) -> tuple[int, str]:
+    """GET an in-cluster HTTP endpoint through the apiserver's service proxy.
+
+    The Spur image ships no HTTP client, so proxying through the apiserver is
+    the only way to reach operator endpoints without adding a sidecar.
+    """
+    _load_kube_config()
+    core = client.CoreV1Api()
+    try:
+        body = core.connect_get_namespaced_service_proxy_with_path(
+            f"{service}:{port}", namespace, path.lstrip("/")
+        )
+        return 200, body if isinstance(body, str) else str(body)
+    except ApiException as exc:
+        return exc.status, exc.body or ""
 
 
 def exec_in_pod(namespace: str, pod_name: str, command: list[str]) -> str:

--- a/tests/k8s/e2e/manifests/postgres.yaml
+++ b/tests/k8s/e2e/manifests/postgres.yaml
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Ephemeral Postgres for the accounting-backed suites (quota projection reads
+# accounts over the SlurmAccounting RPC, which spurctld only serves when
+# accounting.database_url is set). Storage is emptyDir: the data is disposable
+# and dies with the namespace.
+apiVersion: v1
+kind: Service
+metadata:
+  name: spur-postgres
+  namespace: spur
+  labels:
+    app: spur-postgres
+spec:
+  selector:
+    app: spur-postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spur-postgres
+  namespace: spur
+  labels:
+    app: spur-postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: spur-postgres
+  template:
+    metadata:
+      labels:
+        app: spur-postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          env:
+            - name: POSTGRES_USER
+              value: spur
+            - name: POSTGRES_PASSWORD
+              value: spur
+            - name: POSTGRES_DB
+              value: spur
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - containerPort: 5432
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "spur"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: data
+          emptyDir: {}

--- a/tests/k8s/e2e/manifests/rbac.yaml
+++ b/tests/k8s/e2e/manifests/rbac.yaml
@@ -31,6 +31,25 @@ rules:
   - apiGroups: [policy]
     resources: [poddisruptionbudgets]
     verbs: [get, list, watch, create, update, patch, delete]
+  # Quota projection (--enable-quota): one Namespace, ResourceQuota, LimitRange,
+  # Role and RoleBinding per Spur account.
+  - apiGroups: [""]
+    resources: [namespaces, resourcequotas, limitranges, serviceaccounts]
+    verbs: [get, list, watch, create, update, patch, delete]
+  # RBAC self-protection means granting a Role requires already holding its
+  # verbs, or escalate/bind.
+  - apiGroups: [rbac.authorization.k8s.io]
+    resources: [roles, rolebindings]
+    verbs: [get, list, watch, create, update, patch, delete, escalate, bind]
+  - apiGroups: [batch]
+    resources: [jobs, cronjobs]
+    verbs: [get, list, watch, create, update, patch, delete]
+  - apiGroups: [apps]
+    resources: [deployments, replicasets, statefulsets, daemonsets]
+    verbs: [get, list, watch, create, update, patch, delete]
+  - apiGroups: [""]
+    resources: [pods/exec, pods/attach, pods/portforward, secrets, persistentvolumeclaims]
+    verbs: [get, list, watch, create, update, patch, delete]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/tests/k8s/e2e/manifests/spurctld.yaml
+++ b/tests/k8s/e2e/manifests/spurctld.yaml
@@ -13,6 +13,12 @@ spec:
     - name: raft
       port: 6821
       targetPort: 6821
+    - name: rest
+      port: 6820
+      targetPort: 6820
+    - name: metrics
+      port: 6822
+      targetPort: 6822
   clusterIP: None  # headless for StatefulSet peer DNS
 ---
 apiVersion: apps/v1
@@ -47,6 +53,10 @@ spec:
               name: grpc
             - containerPort: 6821
               name: raft
+            - containerPort: 6820
+              name: rest
+            - containerPort: 6822
+              name: metrics
           volumeMounts:
             - name: config
               mountPath: /etc/spur

--- a/tests/k8s/e2e/run_suites.sh
+++ b/tests/k8s/e2e/run_suites.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Run the five k8s e2e suites concurrently, each in its own namespace so their
+# operator, spurctld, ConfigMap, and RBAC are isolated. Destructive node tests
+# stay skipped (SPUR_TEST_DESTRUCTIVE_NODES unset), so no suite mutates shared
+# cluster-scoped Nodes and the suites can safely overlap on one cluster.
+#
+# Usage: run_suites.sh <k8s-e2e-assets-dir> <run-id> <results-dir>
+
+set -uo pipefail
+
+ASSETS="$1"
+RUN_ID="$2"
+RESULTS="$3"
+RBAC="$ASSETS/manifests/rbac.yaml"
+SUITES="core spec quota ha nodes"
+
+mkdir -p "$RESULTS"
+pids=""
+rc=0
+
+for s in $SUITES; do
+  ns="spur-ci-${RUN_ID}-${s}"
+  kubectl create namespace "$ns" --dry-run=client -o yaml | kubectl apply -f -
+  sed "s/namespace: spur/namespace: $ns/g" "$RBAC" | kubectl apply -f -
+  (
+    SPUR_TEST_NS="$ns" pytest "$ASSETS" -m "suite_k8s_${s}" -v \
+      --junitxml="$RESULTS/results-${s}.xml"
+  ) &
+  pids="$pids $!"
+done
+
+for p in $pids; do
+  wait "$p" || rc=1
+done
+
+exit $rc

--- a/tests/k8s/e2e/test_node_watcher.py
+++ b/tests/k8s/e2e/test_node_watcher.py
@@ -18,6 +18,8 @@ from kubernetes.client.exceptions import ApiException
 
 from k8s_cluster import assert_eventually, simple_spurjob, wait_spurjob_state
 
+pytestmark = pytest.mark.suite_k8s_nodes
+
 MANAGED_SELECTOR = "spur.amd.com/managed=true"
 NOT_READY_TAINT = "node.kubernetes.io/not-ready"
 

--- a/tests/k8s/e2e/test_node_watcher.py
+++ b/tests/k8s/e2e/test_node_watcher.py
@@ -1,0 +1,280 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""K8s node watcher: node lifecycle projected into Spur node state.
+
+The operator watches Nodes carrying `spur.amd.com/managed=true`, registers them
+with spurctld from their allocatable resources, and mirrors health transitions.
+Tests that mutate a real Node (taints, deletion) are destructive to whatever
+else the cluster is running, so they are opt-in.
+"""
+
+import os
+import re
+
+import pytest
+from kubernetes import client
+from kubernetes.client.exceptions import ApiException
+
+from k8s_cluster import assert_eventually, simple_spurjob, wait_spurjob_state
+
+MANAGED_SELECTOR = "spur.amd.com/managed=true"
+NOT_READY_TAINT = "node.kubernetes.io/not-ready"
+
+DESTRUCTIVE = os.environ.get("SPUR_TEST_DESTRUCTIVE_NODES") == "1"
+destructive = pytest.mark.skipif(
+    not DESTRUCTIVE,
+    reason="tainting or deleting a real Node disrupts the cluster; "
+    "set SPUR_TEST_DESTRUCTIVE_NODES=1 to run",
+)
+
+
+def managed_nodes() -> list:
+    return client.CoreV1Api().list_node(label_selector=MANAGED_SELECTOR).items
+
+
+UP_STATES = {"idle", "mix", "alloc"}
+
+
+def spur_nodes(cluster) -> dict[str, str]:
+    """Node name to state, as spurctld sees it."""
+    out = cluster.spur_cli(["sinfo", "-N", "-h", "-o", "%N %T"])
+    states = {}
+    for line in out.splitlines():
+        parts = line.split()
+        if len(parts) >= 2:
+            states[parts[0]] = parts[1].lower()
+    return states
+
+
+def scontrol_field(cluster, node: str, field: str) -> str | None:
+    out = cluster.spur_cli(["scontrol", "show", "node", node])
+    match = re.search(rf"{field}=(\S+)", out)
+    return match.group(1) if match else None
+
+
+def pod_host_nodes(cluster) -> set[str]:
+    """Nodes hosting the control plane; those must not be tainted by a test."""
+    pods = cluster.core_v1.list_namespaced_pod(cluster.namespace)
+    return {p.spec.node_name for p in pods.items if p.spec.node_name}
+
+
+@pytest.fixture(scope="class")
+def watched_cluster(cluster):
+    if not managed_nodes():
+        pytest.skip(f"no K8s nodes carry {MANAGED_SELECTOR}")
+    return cluster
+
+
+class TestRegistration:
+    def test_every_managed_node_is_registered_with_spurctld(self, watched_cluster):
+        expected = {n.metadata.name for n in managed_nodes()}
+
+        def all_present() -> bool:
+            return expected <= set(spur_nodes(watched_cluster))
+
+        assert_eventually(
+            120,
+            5,
+            f"spurctld never saw every managed node ({sorted(expected)})",
+            all_present,
+        )
+
+    def test_registered_cpus_match_the_node_allocatable(self, watched_cluster):
+        """Spur schedules against these numbers, so a parsing slip here
+        overcommits or strands the whole node."""
+        node = managed_nodes()[0]
+        allocatable = node.status.allocatable["cpu"]
+        expected = (
+            int(allocatable[:-1]) // 1000 if allocatable.endswith("m") else int(allocatable)
+        )
+        reported = scontrol_field(watched_cluster, node.metadata.name, "CPUTot")
+        assert reported is not None, "scontrol reported no CPUTot"
+        assert int(reported) == expected
+
+    def test_a_managed_node_can_run_a_job(self, watched_cluster):
+        """Registration is only meaningful if the node is actually
+        schedulable afterwards."""
+        watched_cluster.create_spurjob(
+            simple_spurjob("it-node-sched", ["sh", "-c", "echo NODE_OK"])
+        )
+        job = wait_spurjob_state(watched_cluster, "it-node-sched", "Completed")
+        assigned = (job.get("status") or {}).get("assignedNodes") or []
+        assert assigned, "completed job reported no assigned node"
+        assert set(assigned) <= {n.metadata.name for n in managed_nodes()}
+
+    def test_gpu_nodes_advertise_a_vendor_gpu_type(self, watched_cluster):
+        """GPU type drives constraint matching, so an unlabelled GPU node must
+        still get a vendor-derived default rather than an empty string."""
+        gpu_nodes = [
+            n
+            for n in managed_nodes()
+            if (n.status.allocatable or {}).get("amd.com/gpu")
+            or (n.status.allocatable or {}).get("nvidia.com/gpu")
+        ]
+        if not gpu_nodes:
+            pytest.skip("no GPU nodes in this cluster")
+
+        node = gpu_nodes[0]
+        gres = scontrol_field(watched_cluster, node.metadata.name, "Gres")
+        assert gres and gres != "(null)", f"GPU node {node.metadata.name} has no Gres"
+        expected_type = (node.metadata.labels or {}).get("spur.amd.com/gpu-type")
+        if expected_type is None:
+            expected_type = (
+                "amd-gpu"
+                if (node.status.allocatable or {}).get("amd.com/gpu")
+                else "nvidia-gpu"
+            )
+        assert expected_type in gres, gres
+
+    def test_an_operator_restart_re_registers_every_node(self, watched_cluster):
+        """The fingerprint cache lives in memory, so a restart must re-drive
+        registration rather than assume spurctld still has the nodes."""
+        expected = {n.metadata.name for n in managed_nodes()}
+        watched_cluster.restart_operator()
+
+        assert_eventually(
+            150,
+            5,
+            "nodes were not re-registered after an operator restart",
+            lambda: expected <= set(spur_nodes(watched_cluster)),
+        )
+        logs = watched_cluster.operator_logs()
+        assert "registering K8s node" in logs, logs[-2000:]
+
+
+@destructive
+class TestHealthTransitions:
+    @pytest.fixture
+    def spare_node(self, watched_cluster):
+        """A managed node that hosts none of the Spur control plane."""
+        busy = pod_host_nodes(watched_cluster)
+        spare = [n for n in managed_nodes() if n.metadata.name not in busy]
+        if not spare:
+            pytest.skip("every managed node hosts control-plane pods")
+        name = spare[0].metadata.name
+        yield name
+        _remove_not_ready_taint(name)
+
+    def test_a_not_ready_taint_marks_the_node_down(self, watched_cluster, spare_node):
+        _add_not_ready_taint(spare_node)
+        assert_eventually(
+            120,
+            5,
+            f"{spare_node} never went down after the NotReady taint",
+            lambda: spur_nodes(watched_cluster).get(spare_node) == "down",
+        )
+
+    def test_the_down_reason_names_the_taint(self, watched_cluster, spare_node):
+        """The reason string is what an operator sees in sinfo, and it is the
+        only thing distinguishing a k8s-driven drain from an admin one."""
+        _add_not_ready_taint(spare_node)
+        assert_eventually(
+            120,
+            5,
+            "spurctld never recorded the NotReady reason",
+            lambda: "NotReady"
+            in watched_cluster.spur_cli(["scontrol", "show", "node", spare_node]),
+        )
+
+    def test_removing_the_taint_resumes_the_node(self, watched_cluster, spare_node):
+        _add_not_ready_taint(spare_node)
+        assert_eventually(
+            120,
+            5,
+            "node never went down",
+            lambda: spur_nodes(watched_cluster).get(spare_node) == "down",
+        )
+
+        _remove_not_ready_taint(spare_node)
+        assert_eventually(
+            120,
+            5,
+            f"{spare_node} never came back up after the taint was removed",
+            lambda: spur_nodes(watched_cluster).get(spare_node) in UP_STATES,
+        )
+
+    def test_a_down_node_stops_receiving_work(self, watched_cluster, spare_node):
+        """A node marked down that still gets dispatched to would strand jobs
+        on an unreachable kubelet."""
+        _add_not_ready_taint(spare_node)
+        assert_eventually(
+            120,
+            5,
+            "node never went down",
+            lambda: spur_nodes(watched_cluster).get(spare_node) == "down",
+        )
+
+        watched_cluster.create_spurjob(
+            simple_spurjob("it-avoid-down", ["sh", "-c", "echo AVOID_OK"])
+        )
+        job = wait_spurjob_state(watched_cluster, "it-avoid-down", "Completed")
+        assigned = (job.get("status") or {}).get("assignedNodes") or []
+        assert spare_node not in assigned, f"job landed on the down node: {assigned}"
+
+
+@destructive
+class TestNodeRemoval:
+    def test_deleting_the_node_object_marks_it_down(self, watched_cluster):
+        """The kubelet recreates the Node within seconds but without its
+        labels, so the test relabels it to put the cluster back."""
+        busy = pod_host_nodes(watched_cluster)
+        spare = [n for n in managed_nodes() if n.metadata.name not in busy]
+        if not spare:
+            pytest.skip("every managed node hosts control-plane pods")
+        name = spare[0].metadata.name
+        labels = dict(spare[0].metadata.labels or {})
+
+        core = client.CoreV1Api()
+        core.delete_node(name)
+        try:
+            assert_eventually(
+                120,
+                5,
+                f"{name} was not marked down after its Node object was deleted",
+                lambda: spur_nodes(watched_cluster).get(name) == "down",
+            )
+            assert "K8s node removed" in watched_cluster.spur_cli(
+                ["scontrol", "show", "node", name]
+            )
+        finally:
+            assert_eventually(
+                180, 5, f"kubelet never recreated Node {name}", lambda: _node_exists(name)
+            )
+            core.patch_node(name, {"metadata": {"labels": labels}})
+
+        assert_eventually(
+            180,
+            5,
+            f"{name} never re-registered after being relabelled",
+            lambda: spur_nodes(watched_cluster).get(name) in UP_STATES,
+        )
+
+
+def _node_exists(name: str) -> bool:
+    try:
+        client.CoreV1Api().read_node(name)
+        return True
+    except ApiException as exc:
+        if exc.status == 404:
+            return False
+        raise
+
+
+def _add_not_ready_taint(name: str) -> None:
+    core = client.CoreV1Api()
+    node = core.read_node(name)
+    taints = [t.to_dict() for t in (node.spec.taints or [])]
+    if any(t["key"] == NOT_READY_TAINT for t in taints):
+        return
+    taints.append({"key": NOT_READY_TAINT, "effect": "NoSchedule"})
+    core.patch_node(name, {"spec": {"taints": taints}})
+
+
+def _remove_not_ready_taint(name: str) -> None:
+    core = client.CoreV1Api()
+    node = core.read_node(name)
+    taints = [
+        t.to_dict() for t in (node.spec.taints or []) if t.key != NOT_READY_TAINT
+    ]
+    core.patch_node(name, {"spec": {"taints": taints}})

--- a/tests/k8s/e2e/test_operator_health.py
+++ b/tests/k8s/e2e/test_operator_health.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Operator health, readiness, and metrics endpoints.
+
+Kubernetes drives the operator's restart and endpoint membership entirely from
+these three routes, so their exact status codes matter more than their bodies:
+a /healthz that never fails means a wedged operator is never restarted, and a
+/readyz that never fails means traffic keeps flowing to one that cannot reach
+spurctld.
+"""
+
+from k8s_cluster import assert_eventually, service_http_get
+
+HEALTH_PORT = "health"
+OPERATOR_SERVICE = "spur-k8s-operator"
+
+
+def health_get(cluster, path: str) -> tuple[int, str]:
+    return service_http_get(cluster.namespace, OPERATOR_SERVICE, HEALTH_PORT, path)
+
+
+class TestLiveness:
+    def test_healthz_is_ok(self, cluster):
+        status, body = health_get(cluster, "/healthz")
+        assert status == 200, body
+        assert body.strip() == "ok"
+
+    def test_healthz_does_not_depend_on_spurctld(self, cluster):
+        """Liveness must stay green while dependencies are down, otherwise a
+        controller outage turns into an operator restart loop."""
+        cluster.apps_v1.patch_namespaced_stateful_set_scale(
+            "spurctld", cluster.namespace, {"spec": {"replicas": 0}}
+        )
+        try:
+            assert_eventually(
+                120,
+                5,
+                "readiness never dropped after scaling spurctld to zero",
+                lambda: health_get(cluster, "/readyz")[0] == 503,
+            )
+            status, body = health_get(cluster, "/healthz")
+            assert status == 200, body
+        finally:
+            cluster.apps_v1.patch_namespaced_stateful_set_scale(
+                "spurctld", cluster.namespace, {"spec": {"replicas": 1}}
+            )
+            cluster.ensure_controllers_ready(timeout=180)
+
+    def test_unknown_paths_are_not_served(self, cluster):
+        status, _ = health_get(cluster, "/does-not-exist")
+        assert status == 404
+
+
+class TestReadiness:
+    def test_readyz_is_ok_when_the_cluster_is_healthy(self, cluster):
+        status, body = health_get(cluster, "/readyz")
+        assert status == 200, body
+        assert body.strip() == "ok"
+
+    def test_readyz_reports_spurctld_as_the_reason_when_it_is_gone(self, cluster):
+        """The body names the failing dependency, which is the only signal an
+        operator gets from a probe failure."""
+        cluster.apps_v1.patch_namespaced_stateful_set_scale(
+            "spurctld", cluster.namespace, {"spec": {"replicas": 0}}
+        )
+        try:
+            reasons: list[str] = []
+
+            def unavailable() -> bool:
+                status, body = health_get(cluster, "/readyz")
+                if status == 503:
+                    reasons.append(body)
+                    return True
+                return False
+
+            assert_eventually(
+                120, 5, "readyz stayed green with spurctld scaled to zero", unavailable
+            )
+            assert "spurctld-unreachable" in reasons[-1], reasons[-1]
+        finally:
+            cluster.apps_v1.patch_namespaced_stateful_set_scale(
+                "spurctld", cluster.namespace, {"spec": {"replicas": 1}}
+            )
+            cluster.ensure_controllers_ready(timeout=180)
+
+    def test_readyz_recovers_once_spurctld_returns(self, cluster):
+        cluster.ensure_controllers_ready(timeout=180)
+        assert_eventually(
+            120,
+            5,
+            "readyz did not recover after spurctld came back",
+            lambda: health_get(cluster, "/readyz")[0] == 200,
+        )
+
+    def test_the_operator_endpoint_is_in_service(self, cluster):
+        """A failing readiness probe would strip the pod from the Service, so
+        reaching it through the Service at all proves the probe is passing."""
+        endpoints = cluster.core_v1.read_namespaced_endpoints(
+            OPERATOR_SERVICE, cluster.namespace
+        )
+        addresses = [a for s in (endpoints.subsets or []) for a in (s.addresses or [])]
+        assert addresses, "operator Service has no ready endpoints"
+
+
+class TestMetrics:
+    def test_metrics_returns_prometheus_text(self, cluster):
+        status, body = health_get(cluster, "/metrics")
+        assert status == 200, body
+        assert "# TYPE spur_k8s_operator_up gauge" in body
+        assert "spur_k8s_operator_up 1" in body
+
+    def test_metrics_carries_a_timestamp_gauge(self, cluster):
+        _, body = health_get(cluster, "/metrics")
+        line = next(
+            (
+                ln
+                for ln in body.splitlines()
+                if ln.startswith("spur_k8s_operator_timestamp_seconds ")
+            ),
+            None,
+        )
+        assert line is not None, body
+        assert float(line.split()[1]) > 0
+
+    def test_every_metric_has_a_help_and_type_line(self, cluster):
+        """Prometheus tolerates missing metadata but scrapers and dashboards
+        key off it, so a bare sample line is a regression."""
+        _, body = health_get(cluster, "/metrics")
+        samples = {
+            ln.split()[0]
+            for ln in body.splitlines()
+            if ln and not ln.startswith("#")
+        }
+        assert samples
+        for name in samples:
+            assert f"# HELP {name} " in body, f"{name} has no HELP line"
+            assert f"# TYPE {name} " in body, f"{name} has no TYPE line"
+
+    def test_metrics_is_stable_across_scrapes(self, cluster):
+        first = health_get(cluster, "/metrics")[1]
+        second = health_get(cluster, "/metrics")[1]
+        assert "spur_k8s_operator_up 1" in first
+        assert "spur_k8s_operator_up 1" in second
+
+
+class TestProbeConfiguration:
+    def test_the_deployment_probes_point_at_the_health_port(self, cluster):
+        """A probe aimed at the wrong port silently disables restart and
+        endpoint management, and nothing else in the suite would catch it."""
+        dep = cluster.apps_v1.read_namespaced_deployment(
+            "spur-k8s-operator", cluster.namespace
+        )
+        container = next(
+            c for c in dep.spec.template.spec.containers if c.name == "operator"
+        )
+        assert container.liveness_probe.http_get.path == "/healthz"
+        assert container.readiness_probe.http_get.path == "/readyz"
+
+    def test_the_operator_recovers_readiness_after_a_restart(self, cluster):
+        cluster.restart_operator()
+        assert_eventually(
+            120,
+            5,
+            "operator did not become ready again after a restart",
+            lambda: health_get(cluster, "/readyz")[0] == 200,
+        )

--- a/tests/k8s/e2e/test_operator_health.py
+++ b/tests/k8s/e2e/test_operator_health.py
@@ -11,6 +11,9 @@ spurctld.
 """
 
 from k8s_cluster import assert_eventually, service_http_get
+import pytest
+
+pytestmark = pytest.mark.suite_k8s_core
 
 HEALTH_PORT = "health"
 OPERATOR_SERVICE = "spur-k8s-operator"

--- a/tests/k8s/e2e/test_quota.py
+++ b/tests/k8s/e2e/test_quota.py
@@ -1,0 +1,329 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Quota projection: Spur accounts to native Kubernetes tenancy objects.
+
+The operator's quota reconciler turns every Spur account into a Namespace, a
+ResourceQuota built from the account's `grp_tres`, a LimitRange, and RBAC. It
+server-side-applies with force on a 30s loop, so it both fills gaps and reverts
+hand edits. These tests drive that loop against a real cluster.
+"""
+
+import time
+
+import pytest
+from kubernetes import client
+from kubernetes.client.exceptions import ApiException
+
+from k8s_cluster import assert_eventually, delete_namespace
+
+QUOTA_NAME = "spur-account-quota"
+LIMITS_NAME = "spur-account-defaults"
+ROLE_NAME = "spur-account-editor"
+BINDING_NAME = "spur-account-members"
+MANAGED_BY = "spur-quota"
+
+# The reconciler is level-triggered on a 30s interval, so anything it must
+# converge on needs room for two full ticks.
+RECONCILE_TIMEOUT = 100
+
+ACCOUNTS = {
+    "physics": "cpu=16,mem=32768,gres/gpu=8",
+    "chem": "cpu=4",
+}
+MEMBERS = {"physics": ["alice", "bob"], "chem": ["carol"]}
+
+
+def account_namespace(account: str) -> str:
+    return f"spur-acct-{account}"
+
+
+def rbac_api() -> client.RbacAuthorizationV1Api:
+    return client.RbacAuthorizationV1Api()
+
+
+def namespace_exists(name: str) -> bool:
+    try:
+        client.CoreV1Api().read_namespace(name)
+        return True
+    except ApiException as exc:
+        if exc.status == 404:
+            return False
+        raise
+
+
+@pytest.fixture(scope="class")
+def seeded_quota_cluster(quota_cluster):
+    """A quota cluster with accounts and members already projected.
+
+    Seeding is class-scoped because the reconcile interval makes per-test
+    seeding prohibitively slow.
+    """
+    if not quota_cluster.postgres_available():
+        pytest.skip("quota projection requires accounting; postgres is not running")
+
+    for account, grp_tres in ACCOUNTS.items():
+        out = quota_cluster.spur_cli(
+            ["sacctmgr", "add", "account", f"name={account}", f"grptres={grp_tres}"]
+        )
+        assert "Account added" in out, f"failed to create account {account}: {out}"
+        for user in MEMBERS[account]:
+            quota_cluster.spur_cli(
+                ["sacctmgr", "add", "user", f"name={user}", f"account={account}"]
+            )
+
+    for account in ACCOUNTS:
+        ns = account_namespace(account)
+        assert_eventually(
+            RECONCILE_TIMEOUT,
+            5,
+            f"quota reconciler never created namespace {ns}",
+            lambda ns=ns: namespace_exists(ns),
+        )
+
+    yield quota_cluster
+
+    for account in ACCOUNTS:
+        delete_namespace(account_namespace(account))
+
+
+class TestAccountProjection:
+    def test_each_account_gets_its_own_namespace(self, seeded_quota_cluster):
+        for account in ACCOUNTS:
+            assert namespace_exists(account_namespace(account))
+
+    def test_the_namespace_is_labelled_as_spur_managed(self, seeded_quota_cluster):
+        """The label is the ownership contract — it is how the reconciler finds
+        its objects and what makes drift correction safe."""
+        ns = client.CoreV1Api().read_namespace(account_namespace("physics"))
+        labels = ns.metadata.labels or {}
+        assert labels.get("app.kubernetes.io/managed-by") == MANAGED_BY
+        assert labels.get("spur.amd.com/account") == "physics"
+
+    def test_grp_tres_becomes_resource_quota_hard_caps(self, seeded_quota_cluster):
+        quota = client.CoreV1Api().read_namespaced_resource_quota(
+            QUOTA_NAME, account_namespace("physics")
+        )
+        hard = quota.spec.hard
+        assert hard["requests.cpu"] == "16"
+        assert hard["requests.memory"] == "32768M"
+        assert hard["requests.amd.com/gpu"] == "8"
+
+    def test_limits_are_never_capped(self, seeded_quota_cluster):
+        """A `limits.*` cap would force every pod in the namespace to declare a
+        limit or fail admission, so the projection must stay requests-only."""
+        quota = client.CoreV1Api().read_namespaced_resource_quota(
+            QUOTA_NAME, account_namespace("physics")
+        )
+        assert "limits.cpu" not in quota.spec.hard
+        assert "limits.memory" not in quota.spec.hard
+
+    def test_unset_dimensions_are_left_uncapped(self, seeded_quota_cluster):
+        """A 0 cap would block every pod, so an absent dimension must produce
+        no key at all."""
+        quota = client.CoreV1Api().read_namespaced_resource_quota(
+            QUOTA_NAME, account_namespace("chem")
+        )
+        assert quota.spec.hard["requests.cpu"] == "4"
+        assert "requests.memory" not in quota.spec.hard
+        assert "requests.amd.com/gpu" not in quota.spec.hard
+
+    def test_limit_range_defaults_requests_but_not_limits(self, seeded_quota_cluster):
+        """Without a default request, a pod that omits requests would not count
+        against the quota at all."""
+        lr = client.CoreV1Api().read_namespaced_limit_range(
+            LIMITS_NAME, account_namespace("physics")
+        )
+        item = lr.spec.limits[0]
+        assert item.type == "Container"
+        assert item.default_request["cpu"] == "100m"
+        assert item.default_request["memory"] == "128M"
+        assert item.default is None
+
+    def test_the_account_role_grants_workload_management(self, seeded_quota_cluster):
+        role = rbac_api().read_namespaced_role(
+            ROLE_NAME, account_namespace("physics")
+        )
+        resources = {r for rule in role.rules for r in (rule.resources or [])}
+        assert {"pods", "pods/log", "services", "configmaps"} <= resources
+
+    def test_the_account_role_cannot_edit_its_own_quota(self, seeded_quota_cluster):
+        """Self-editable quota would defeat the whole mechanism."""
+        role = rbac_api().read_namespaced_role(
+            ROLE_NAME, account_namespace("physics")
+        )
+        resources = {r for rule in role.rules for r in (rule.resources or [])}
+        assert not resources & {
+            "resourcequotas",
+            "limitranges",
+            "roles",
+            "rolebindings",
+        }
+
+    def test_members_get_a_role_binding_subject_each(self, seeded_quota_cluster):
+        binding = rbac_api().read_namespaced_role_binding(
+            BINDING_NAME, account_namespace("physics")
+        )
+        subjects = {s.name for s in binding.subjects or []}
+        assert subjects == {"spur-user-alice", "spur-user-bob"}
+        assert all(s.kind == "ServiceAccount" for s in binding.subjects)
+        assert binding.role_ref.name == ROLE_NAME
+
+    def test_accounts_do_not_share_members(self, seeded_quota_cluster):
+        binding = rbac_api().read_namespaced_role_binding(
+            BINDING_NAME, account_namespace("chem")
+        )
+        subjects = {s.name for s in binding.subjects or []}
+        assert subjects == {"spur-user-carol"}
+
+
+class TestDriftCorrection:
+    def test_a_hand_edited_quota_is_reverted(self, seeded_quota_cluster):
+        """Server-side apply with force is what makes the Spur account, not the
+        cluster admin, the source of truth."""
+        core = client.CoreV1Api()
+        ns = account_namespace("physics")
+        core.patch_namespaced_resource_quota(
+            QUOTA_NAME, ns, {"spec": {"hard": {"requests.cpu": "999"}}}
+        )
+
+        def restored() -> bool:
+            quota = core.read_namespaced_resource_quota(QUOTA_NAME, ns)
+            return quota.spec.hard.get("requests.cpu") == "16"
+
+        assert_eventually(
+            RECONCILE_TIMEOUT, 5, "hand-edited cpu cap was not reverted", restored
+        )
+
+    def test_a_deleted_limit_range_is_recreated(self, seeded_quota_cluster):
+        core = client.CoreV1Api()
+        ns = account_namespace("physics")
+        core.delete_namespaced_limit_range(LIMITS_NAME, ns)
+
+        def recreated() -> bool:
+            try:
+                core.read_namespaced_limit_range(LIMITS_NAME, ns)
+                return True
+            except ApiException as exc:
+                if exc.status == 404:
+                    return False
+                raise
+
+        assert_eventually(
+            RECONCILE_TIMEOUT, 5, "deleted LimitRange was not recreated", recreated
+        )
+
+    def test_a_deleted_role_binding_is_recreated_with_its_subjects(
+        self, seeded_quota_cluster
+    ):
+        ns = account_namespace("physics")
+        rbac_api().delete_namespaced_role_binding(BINDING_NAME, ns)
+
+        def restored() -> bool:
+            try:
+                binding = rbac_api().read_namespaced_role_binding(BINDING_NAME, ns)
+            except ApiException as exc:
+                if exc.status == 404:
+                    return False
+                raise
+            return {s.name for s in binding.subjects or []} == {
+                "spur-user-alice",
+                "spur-user-bob",
+            }
+
+        assert_eventually(
+            RECONCILE_TIMEOUT, 5, "deleted RoleBinding was not restored", restored
+        )
+
+    def test_a_stripped_managed_by_label_comes_back(self, seeded_quota_cluster):
+        core = client.CoreV1Api()
+        ns = account_namespace("physics")
+        core.patch_namespace(
+            ns, {"metadata": {"labels": {"app.kubernetes.io/managed-by": "someone-else"}}}
+        )
+
+        def restored() -> bool:
+            labels = core.read_namespace(ns).metadata.labels or {}
+            return labels.get("app.kubernetes.io/managed-by") == MANAGED_BY
+
+        assert_eventually(
+            RECONCILE_TIMEOUT, 5, "managed-by label was not restored", restored
+        )
+
+
+class TestAllocationChanges:
+    def test_raising_an_allocation_raises_the_cap(self, seeded_quota_cluster):
+        seeded_quota_cluster.spur_cli(
+            ["sacctmgr", "modify", "account", "name=chem", "grptres=cpu=64,mem=1024"]
+        )
+        core = client.CoreV1Api()
+        ns = account_namespace("chem")
+
+        def raised() -> bool:
+            hard = core.read_namespaced_resource_quota(QUOTA_NAME, ns).spec.hard
+            return hard.get("requests.cpu") == "64" and hard.get("requests.memory") == "1024M"
+
+        assert_eventually(
+            RECONCILE_TIMEOUT, 5, "cap did not follow the raised allocation", raised
+        )
+
+    def test_a_new_account_is_projected_without_a_restart(self, seeded_quota_cluster):
+        """The loop is level-triggered, so an account added long after startup
+        must still get picked up."""
+        out = seeded_quota_cluster.spur_cli(
+            ["sacctmgr", "add", "account", "name=bio", "grptres=cpu=2"]
+        )
+        assert "Account added" in out, out
+        try:
+            assert_eventually(
+                RECONCILE_TIMEOUT,
+                5,
+                "a newly added account was never projected",
+                lambda: namespace_exists(account_namespace("bio")),
+            )
+            quota = client.CoreV1Api().read_namespaced_resource_quota(
+                QUOTA_NAME, account_namespace("bio")
+            )
+            assert quota.spec.hard["requests.cpu"] == "2"
+        finally:
+            delete_namespace(account_namespace("bio"))
+
+
+class TestMalformedAllocation:
+    def test_an_unparseable_allocation_is_rejected_at_submission(
+        self, seeded_quota_cluster
+    ):
+        """Fail-closed starts at the accounting API: a grp_tres that could not
+        be projected never reaches the database, so the reconciler cannot be
+        tricked into leaving a namespace uncapped."""
+        out = seeded_quota_cluster.spur_cli(
+            ["sacctmgr", "add", "account", "name=broken", "grptres=cpu=notanumber"]
+        )
+        assert "Account added" not in out, out
+
+    def test_a_rejected_account_gets_no_namespace(self, seeded_quota_cluster):
+        seeded_quota_cluster.spur_cli(
+            ["sacctmgr", "add", "account", "name=broken2", "grptres=cpu=!!"]
+        )
+        # Two reconcile ticks: long enough that a projection would have appeared.
+        time.sleep(70)
+        assert not namespace_exists(account_namespace("broken2"))
+
+    def test_good_accounts_keep_reconciling(self, seeded_quota_cluster):
+        """One bad account must not stall the loop for everyone else."""
+        core = client.CoreV1Api()
+        ns = account_namespace("physics")
+        core.delete_namespaced_limit_range(LIMITS_NAME, ns)
+
+        def recreated() -> bool:
+            try:
+                core.read_namespaced_limit_range(LIMITS_NAME, ns)
+                return True
+            except ApiException as exc:
+                if exc.status == 404:
+                    return False
+                raise
+
+        assert_eventually(
+            RECONCILE_TIMEOUT, 5, "reconcile stalled after a bad account", recreated
+        )

--- a/tests/k8s/e2e/test_quota.py
+++ b/tests/k8s/e2e/test_quota.py
@@ -17,6 +17,8 @@ from kubernetes.client.exceptions import ApiException
 
 from k8s_cluster import assert_eventually, delete_namespace
 
+pytestmark = pytest.mark.suite_k8s_quota
+
 QUOTA_NAME = "spur-account-quota"
 LIMITS_NAME = "spur-account-defaults"
 ROLE_NAME = "spur-account-editor"

--- a/tests/k8s/e2e/test_raft_ha.py
+++ b/tests/k8s/e2e/test_raft_ha.py
@@ -29,6 +29,26 @@ def assert_all_pods_ready(namespace: str, count: int) -> None:
     )
 
 
+def wait_for_spur_job_id(cluster, name: str) -> int:
+    """Block until the operator records a spurJobId, then return it.
+
+    Reports the SpurJob's own status on timeout: a rejected submit leaves the
+    reason there, which a bare "no job ID" message would hide.
+    """
+
+    def has_id() -> bool:
+        return (cluster.get_spurjob(name).get("status") or {}).get("spurJobId") is not None
+
+    try:
+        assert_eventually(
+            DEFAULT_TIMEOUT, WAIT_INTERVAL, f"{name} never got a spurJobId", has_id
+        )
+    except AssertionError as exc:
+        status = cluster.get_spurjob(name).get("status") or {}
+        raise AssertionError(f"{exc}; status={status}") from exc
+    return (cluster.get_spurjob(name).get("status") or {})["spurJobId"]
+
+
 def find_leader_pod(namespace: str) -> str | None:
     for i in range(3):
         pod_name = f"spurctld-{i}"
@@ -111,16 +131,7 @@ class TestRaftHA:
             ["sh", "-c", "echo FAILOVER_STATE_OK && sleep 5"],
         )
         ha_cluster.create_spurjob(job)
-
-        def job_has_id() -> bool:
-            job_obj = ha_cluster.get_spurjob("it-failover-state")
-            return (job_obj.get("status") or {}).get("spurJobId") is not None
-
-        assert_eventually(
-            DEFAULT_TIMEOUT, WAIT_INTERVAL, "no job ID assigned before failover", job_has_id
-        )
-        job_before = ha_cluster.get_spurjob("it-failover-state")
-        job_id_before = (job_before.get("status") or {}).get("spurJobId")
+        job_id_before = wait_for_spur_job_id(ha_cluster, "it-failover-state")
 
         leader = find_leader_pod(ns) or "spurctld-0"
         delete_pod(ns, leader)
@@ -145,17 +156,7 @@ class TestRaftHA:
             ["sh", "-c", "echo PRE_FAILOVER && sleep 5"],
         )
         ha_cluster.create_spurjob(pre_job)
-
-        def pre_has_id() -> bool:
-            job_obj = ha_cluster.get_spurjob("it-pre-failover")
-            return (job_obj.get("status") or {}).get("spurJobId") is not None
-
-        assert_eventually(
-            DEFAULT_TIMEOUT, WAIT_INTERVAL, "pre-failover job not accepted", pre_has_id
-        )
-        job_id_before = (ha_cluster.get_spurjob("it-pre-failover").get("status") or {}).get(
-            "spurJobId"
-        )
+        job_id_before = wait_for_spur_job_id(ha_cluster, "it-pre-failover")
 
         leader = find_leader_pod(ns) or "spurctld-0"
         delete_pod(ns, leader)
@@ -168,17 +169,7 @@ class TestRaftHA:
             ["sh", "-c", "echo POST_FAILOVER && sleep 2"],
         )
         ha_cluster.create_spurjob(post_job)
-
-        def post_has_id() -> bool:
-            job_obj = ha_cluster.get_spurjob("it-post-failover")
-            return (job_obj.get("status") or {}).get("spurJobId") is not None
-
-        assert_eventually(
-            DEFAULT_TIMEOUT, WAIT_INTERVAL, "new job not accepted after failover", post_has_id
-        )
-        post_job_id = (ha_cluster.get_spurjob("it-post-failover").get("status") or {}).get(
-            "spurJobId"
-        )
+        post_job_id = wait_for_spur_job_id(ha_cluster, "it-post-failover")
         assert post_job_id > job_id_before, (
             f"job ID sequence broken: {post_job_id} <= {job_id_before}"
         )

--- a/tests/k8s/e2e/test_raft_ha.py
+++ b/tests/k8s/e2e/test_raft_ha.py
@@ -18,6 +18,9 @@ from k8s_cluster import (
     simple_spurjob,
     wait_pod_ready,
 )
+import pytest
+
+pytestmark = pytest.mark.suite_k8s_ha
 
 
 def assert_all_pods_ready(namespace: str, count: int) -> None:

--- a/tests/k8s/e2e/test_spurjob.py
+++ b/tests/k8s/e2e/test_spurjob.py
@@ -9,7 +9,9 @@ from k8s_cluster import (
     cross_namespace_name,
     delete_namespace,
     ensure_namespace,
+    job_service_exists,
     multinode_spurjob,
+    read_all_spurjob_pod_logs,
     read_spurjob_pod_logs,
     simple_spurjob,
     spurjob_with_env,
@@ -45,6 +47,27 @@ class TestSpurJobLifecycle:
         job_val = logs[job_idx + 4 :].split()[0] if logs[job_idx + 4 :] else ""
         assert job_val, f"expected non-empty SPUR_JOB_ID in logs:\n{logs}"
 
+    def test_job_passes_through_pending_before_running(self, cluster):
+        """The operator must surface the pre-Running state, not just terminal ones."""
+        job = simple_spurjob("it-pending", ["sh", "-c", "sleep 20"])
+        cluster.create_spurjob(job)
+
+        seen: set[str] = set()
+
+        def reached_running() -> bool:
+            state = (cluster.get_spurjob("it-pending").get("status") or {}).get("state")
+            if state:
+                seen.add(state)
+            return state == "Running"
+
+        assert_eventually(
+            DEFAULT_TIMEOUT, 1, "SpurJob never reached Running", reached_running
+        )
+        assert "Pending" in seen, (
+            f"expected a Pending observation before Running, saw {sorted(seen)}"
+        )
+        cluster.delete_spurjob("it-pending")
+
     def test_multinode_job_assigns_nodes(self, cluster):
         job = multinode_spurjob(
             "it-multi",
@@ -62,6 +85,69 @@ class TestSpurJobLifecycle:
         )
         assigned = (completed.get("status") or {}).get("assignedNodes") or []
         assert assigned, "multi-node job should have assigned nodes"
+
+    def test_multinode_ranks_and_master_addr_are_distinct(self, cluster):
+        """Each pod must get its own rank and a shared rendezvous address."""
+        job = multinode_spurjob(
+            "it-multi-env",
+            [
+                "sh",
+                "-c",
+                "echo rank=$SPUR_NODE_RANK nnodes=$SPUR_NNODES "
+                "master=$MASTER_ADDR world=$WORLD_SIZE",
+            ],
+            2,
+        )
+        cluster.create_spurjob(job)
+        wait_spurjob_state(cluster, "it-multi-env", "Completed", timeout=90)
+
+        logs = read_all_spurjob_pod_logs(cluster, "it-multi-env")
+        assert len(logs) == 2, f"expected 2 pods, got {sorted(logs)}"
+
+        def field(text: str, key: str) -> str:
+            for token in text.split():
+                if token.startswith(f"{key}="):
+                    return token.split("=", 1)[1]
+            return ""
+
+        ranks = {field(text, "rank") for text in logs.values()}
+        assert ranks == {"0", "1"}, f"expected ranks 0 and 1, got {ranks}:\n{logs}"
+
+        masters = {field(text, "master") for text in logs.values()}
+        assert len(masters) == 1 and masters != {""}, (
+            f"every pod must share one MASTER_ADDR, got {masters}:\n{logs}"
+        )
+
+        for text in logs.values():
+            assert field(text, "nnodes") == "2", f"SPUR_NNODES must be 2:\n{text}"
+            assert field(text, "world") == "2", f"WORLD_SIZE must be 2:\n{text}"
+
+    def test_headless_service_is_removed_on_cancel(self, cluster):
+        """Cancelling a multi-node job must clean up its Service, not just pods."""
+        job = multinode_spurjob("it-multi-svc", ["sleep", "600"], 2)
+        cluster.create_spurjob(job)
+
+        wait_spurjob_pods_exist(cluster, "it-multi-svc", timeout=90)
+        spur_job_id = (
+            cluster.get_spurjob("it-multi-svc").get("status") or {}
+        ).get("spurJobId")
+        assert spur_job_id is not None, "multi-node job never got a Spur job ID"
+
+        assert_eventually(
+            DEFAULT_TIMEOUT,
+            2,
+            f"headless Service spur-job-{spur_job_id} was never created",
+            lambda: job_service_exists(cluster, spur_job_id),
+        )
+
+        cluster.delete_spurjob("it-multi-svc")
+
+        assert_eventually(
+            DEFAULT_TIMEOUT,
+            2,
+            f"headless Service spur-job-{spur_job_id} outlived the cancelled job",
+            lambda: not job_service_exists(cluster, spur_job_id),
+        )
 
     def test_cancellation_cleans_up_pods(self, cluster):
         job = simple_spurjob("it-cancel", ["sleep", "600"])

--- a/tests/k8s/e2e/test_spurjob.py
+++ b/tests/k8s/e2e/test_spurjob.py
@@ -18,6 +18,9 @@ from k8s_cluster import (
     wait_spurjob_pods_exist,
     wait_spurjob_state,
 )
+import pytest
+
+pytestmark = pytest.mark.suite_k8s_core
 
 
 class TestSpurJobLifecycle:

--- a/tests/k8s/e2e/test_spurjob_failure_modes.py
+++ b/tests/k8s/e2e/test_spurjob_failure_modes.py
@@ -1,0 +1,238 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SpurJob failure paths.
+
+These cover the ways a pod can fail that are not a plain non-zero exit: the
+kernel killing it for memory, the kubelet never starting it, and pods left
+behind when the operator restarts. Each must land the SpurJob in a terminal
+state rather than leaving it stuck in Running.
+"""
+
+import time
+
+from kubernetes.client.exceptions import ApiException
+
+from k8s_cluster import (
+    DEFAULT_TIMEOUT,
+    assert_eventually,
+    list_spurjob_pods,
+    resource_spurjob,
+    simple_spurjob,
+    spurjob_with_spec,
+    wait_spurjob_pod,
+    wait_spurjob_pods_exist,
+    wait_spurjob_state,
+)
+
+# `tail` buffers its whole input, so this allocates far past the memory limit.
+MEMORY_HOG = "head -c 512m /dev/zero | tail -c 512m > /dev/null"
+
+UNPULLABLE_IMAGE = "ghcr.io/spur-e2e/definitely-not-a-real-image:v0"
+
+
+def _pod_names(cluster, name: str) -> set[str]:
+    return {p.metadata.name for p in list_spurjob_pods(cluster, name)}
+
+
+def _delete_pods(cluster, name: str) -> None:
+    for pod_name in _pod_names(cluster, name):
+        try:
+            cluster.core_v1.delete_namespaced_pod(
+                pod_name, cluster.namespace, grace_period_seconds=0
+            )
+        except ApiException:
+            pass
+
+
+def _assert_state_holds(cluster, name: str, expected: str, seconds: int = 20) -> None:
+    """Assert the SpurJob stays in `expected` for a while.
+
+    Late watch events arrive asynchronously, so a single read right after the
+    trigger proves nothing.
+    """
+    deadline = time.time() + seconds
+    while time.time() < deadline:
+        state = (cluster.get_spurjob(name).get("status") or {}).get("state")
+        assert state == expected, (
+            f"SpurJob {name} moved from {expected} to {state}"
+        )
+        time.sleep(2)
+
+
+def _container_states(cluster, name: str):
+    for pod in list_spurjob_pods(cluster, name):
+        for status in pod.status.container_statuses or []:
+            if status.state is not None:
+                yield status.state
+
+
+class TestOutOfMemory:
+    def test_oom_killed_pod_maps_to_the_oom_state(self, cluster):
+        """OOM travels out-of-band through the signal sentinel rather than the
+        wire state, so it is worth proving end to end that it survives the trip
+        from kubelet through the operator to spurctld."""
+        cluster.create_spurjob(
+            resource_spurjob(
+                "it-oom",
+                ["sh", "-c", MEMORY_HOG],
+                memory_per_node="64Mi",
+            )
+        )
+
+        result = wait_spurjob_state(cluster, "it-oom", "OutOfMemory", timeout=180)
+        assert (result.get("status") or {}).get("state") == "OutOfMemory"
+
+    def test_container_is_reported_oom_killed_by_kubelet(self, cluster):
+        """Guards the mapping above: the pod really was OOMKilled, so the state
+        is not arriving from some other failure path."""
+        cluster.create_spurjob(
+            resource_spurjob(
+                "it-oom-reason",
+                ["sh", "-c", MEMORY_HOG],
+                memory_per_node="64Mi",
+            )
+        )
+        wait_spurjob_pods_exist(cluster, "it-oom-reason", timeout=120)
+
+        def oom_killed() -> bool:
+            return any(
+                state.terminated is not None
+                and state.terminated.reason == "OOMKilled"
+                for state in _container_states(cluster, "it-oom-reason")
+            )
+
+        assert_eventually(180, 3, "kubelet never reported OOMKilled", oom_killed)
+
+    def test_the_same_workload_completes_under_a_generous_limit(self, cluster):
+        cluster.create_spurjob(
+            resource_spurjob(
+                "it-oom-ok",
+                ["sh", "-c", f"{MEMORY_HOG} && echo OOM_OK"],
+                memory_per_node="1Gi",
+            )
+        )
+        wait_spurjob_state(cluster, "it-oom-ok", "Completed", timeout=180)
+
+
+class TestImagePull:
+    def test_unpullable_image_fails_the_job(self, cluster):
+        """The container never starts, so nothing reports back on its own; the
+        operator has to notice the failure from the Pending phase."""
+        cluster.create_spurjob(
+            spurjob_with_spec("it-badimage", ["sh", "-c", "true"], image=UNPULLABLE_IMAGE)
+        )
+
+        result = wait_spurjob_state(cluster, "it-badimage", "Failed", timeout=240)
+        assert (result.get("status") or {}).get("state") == "Failed"
+
+    def test_image_pull_failure_is_visible_on_the_pod(self, cluster):
+        cluster.create_spurjob(
+            spurjob_with_spec(
+                "it-badimage-reason", ["sh", "-c", "true"], image=UNPULLABLE_IMAGE
+            )
+        )
+        wait_spurjob_pods_exist(cluster, "it-badimage-reason", timeout=120)
+
+        def pull_error() -> bool:
+            return any(
+                state.waiting is not None
+                and state.waiting.reason in ("ImagePullBackOff", "ErrImagePull")
+                for state in _container_states(cluster, "it-badimage-reason")
+            )
+
+        assert_eventually(
+            240, 3, "kubelet never reported an image pull failure", pull_error
+        )
+
+    def test_a_failed_pull_does_not_block_the_next_job(self, cluster):
+        cluster.create_spurjob(
+            spurjob_with_spec(
+                "it-badimage-first", ["sh", "-c", "true"], image=UNPULLABLE_IMAGE
+            )
+        )
+        wait_spurjob_state(cluster, "it-badimage-first", "Failed", timeout=240)
+
+        cluster.create_spurjob(
+            simple_spurjob("it-after-badimage", ["sh", "-c", "echo AFTER_OK"])
+        )
+        wait_spurjob_state(cluster, "it-after-badimage", "Completed")
+
+
+class TestStaleStatusReports:
+    def test_a_completed_job_is_not_reopened_by_a_late_pod_event(self, cluster):
+        """Deleting the pod after the job finished produces another watch event
+        for the same job id; the controller must not walk the job back out of
+        its terminal state."""
+        cluster.create_spurjob(simple_spurjob("it-stale", ["sh", "-c", "echo STALE_OK"]))
+        wait_spurjob_state(cluster, "it-stale", "Completed")
+
+        _delete_pods(cluster, "it-stale")
+        _assert_state_holds(cluster, "it-stale", "Completed")
+
+    def test_a_failed_job_keeps_its_identity_after_a_late_event(self, cluster):
+        cluster.create_spurjob(simple_spurjob("it-stale-fail", ["sh", "-c", "exit 3"]))
+        before = wait_spurjob_state(cluster, "it-stale-fail", "Failed")
+        job_id = (before.get("status") or {}).get("spurJobId")
+
+        _delete_pods(cluster, "it-stale-fail")
+        _assert_state_holds(cluster, "it-stale-fail", "Failed")
+
+        after = cluster.get_spurjob("it-stale-fail")
+        assert (after.get("status") or {}).get("spurJobId") == job_id, (
+            "a late pod event re-submitted the job under a new id"
+        )
+
+    def test_repeated_reads_of_a_terminal_job_are_stable(self, cluster):
+        """The reconciler stops polling spurctld once a job is terminal; a
+        drifting state here would mean it never stopped."""
+        cluster.create_spurjob(simple_spurjob("it-terminal", ["sh", "-c", "true"]))
+        wait_spurjob_state(cluster, "it-terminal", "Completed")
+        _assert_state_holds(cluster, "it-terminal", "Completed", seconds=30)
+
+
+class TestOrphanPodCleanup:
+    def test_terminal_pods_of_a_deleted_job_are_reaped_on_restart(self, cluster):
+        """Deleting the SpurJob leaves its finished pod behind with no matching
+        job id; the operator sweeps those at startup."""
+        cluster.create_spurjob(simple_spurjob("it-orphan", ["sh", "-c", "echo ORPHAN_OK"]))
+        wait_spurjob_state(cluster, "it-orphan", "Completed")
+
+        orphan = wait_spurjob_pod(cluster, "it-orphan").metadata.name
+        cluster.delete_spurjob("it-orphan")
+
+        cluster.restart_operator()
+
+        def gone() -> bool:
+            try:
+                cluster.core_v1.read_namespaced_pod(orphan, cluster.namespace)
+                return False
+            except ApiException as exc:
+                return exc.status == 404
+
+        assert_eventually(
+            DEFAULT_TIMEOUT, 3, f"orphan pod {orphan} was not cleaned up", gone
+        )
+
+    def test_pods_of_a_live_job_survive_an_operator_restart(self, cluster):
+        """The sweep keys off the SpurJob list, not pod age — a running job's
+        pod must not be collateral."""
+        cluster.create_spurjob(simple_spurjob("it-live-restart", ["sleep", "300"]))
+        wait_spurjob_pods_exist(cluster, "it-live-restart", timeout=120)
+        before = _pod_names(cluster, "it-live-restart")
+        assert before, "operator never created a pod"
+
+        cluster.restart_operator()
+
+        after = _pod_names(cluster, "it-live-restart")
+        assert before <= after, (
+            f"the restart reaped a live job's pods: {sorted(before)} -> {sorted(after)}"
+        )
+        cluster.delete_spurjob("it-live-restart")
+
+    def test_the_operator_serves_new_jobs_after_a_restart(self, cluster):
+        cluster.restart_operator()
+        cluster.create_spurjob(
+            simple_spurjob("it-post-restart", ["sh", "-c", "echo RESTART_OK"])
+        )
+        wait_spurjob_state(cluster, "it-post-restart", "Completed", timeout=180)

--- a/tests/k8s/e2e/test_spurjob_failure_modes.py
+++ b/tests/k8s/e2e/test_spurjob_failure_modes.py
@@ -24,6 +24,9 @@ from k8s_cluster import (
     wait_spurjob_pods_exist,
     wait_spurjob_state,
 )
+import pytest
+
+pytestmark = pytest.mark.suite_k8s_core
 
 # `tail` buffers its whole input, so this allocates far past the memory limit.
 MEMORY_HOG = "head -c 512m /dev/zero | tail -c 512m > /dev/null"

--- a/tests/k8s/e2e/test_spurjob_spec.py
+++ b/tests/k8s/e2e/test_spurjob_spec.py
@@ -1,0 +1,378 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SpurJob CRD spec field coverage.
+
+test_spurjob.py exercises the job lifecycle; this module checks that the spec
+fields a user writes actually reach the created Pod. Assertions go through
+assert_pod_spec, which reads the real PodSpec rather than inferring from logs.
+"""
+
+import pytest
+from kubernetes.client.exceptions import ApiException
+
+from k8s_cluster import (
+    assert_pod_spec,
+    read_spurjob_pod_logs,
+    resource_spurjob,
+    secret_env_spurjob,
+    security_spurjob,
+    spurjob_with_spec,
+    volume_spurjob,
+    wait_spurjob_pod,
+    wait_spurjob_state,
+)
+
+CONTAINER = "spec.containers.0"
+
+
+def _mount_paths(pod) -> dict[str, str]:
+    """Mount path -> volume name for the job container."""
+    return {m.mount_path: m.name for m in (pod.spec.containers[0].volume_mounts or [])}
+
+
+def _volumes(pod) -> dict:
+    return {v.name: v for v in (pod.spec.volumes or [])}
+
+
+class TestVolumes:
+    def test_host_path_volume_is_mounted(self, cluster):
+        job = volume_spurjob(
+            "it-vol-host", ["sh", "-c", "ls -d /mnt/host"], ["/tmp:/mnt/host"]
+        )
+        cluster.create_spurjob(job)
+
+        pod = wait_spurjob_pod(cluster, "it-vol-host")
+        mounts = _mount_paths(pod)
+        assert "/mnt/host" in mounts, f"hostPath was not mounted: {mounts}"
+
+        volume = _volumes(pod)[mounts["/mnt/host"]]
+        assert volume.host_path is not None, f"expected a hostPath volume: {volume}"
+        assert volume.host_path.path == "/tmp"
+        assert volume.host_path.type == "DirectoryOrCreate", (
+            "the operator must create the host directory rather than failing "
+            f"the pod, got {volume.host_path.type}"
+        )
+
+    def test_read_only_suffix_is_honored(self, cluster):
+        job = volume_spurjob(
+            "it-vol-ro", ["sh", "-c", "true"], ["/tmp:/mnt/ro:ro"]
+        )
+        cluster.create_spurjob(job)
+
+        pod = wait_spurjob_pod(cluster, "it-vol-ro")
+        mount = next(
+            m for m in pod.spec.containers[0].volume_mounts if m.mount_path == "/mnt/ro"
+        )
+        assert mount.read_only is True, f"the :ro suffix was dropped: {mount}"
+
+    def test_multiple_volumes_get_distinct_names(self, cluster):
+        job = volume_spurjob(
+            "it-vol-multi",
+            ["sh", "-c", "true"],
+            ["/tmp:/mnt/a", "/var/tmp:/mnt/b"],
+        )
+        cluster.create_spurjob(job)
+
+        pod = wait_spurjob_pod(cluster, "it-vol-multi")
+        mounts = _mount_paths(pod)
+        assert {"/mnt/a", "/mnt/b"} <= set(mounts), f"expected both mounts: {mounts}"
+        assert mounts["/mnt/a"] != mounts["/mnt/b"], (
+            f"volumes must not collide on one name: {mounts}"
+        )
+
+    def test_host_path_contents_are_visible_to_the_job(self, cluster):
+        job = volume_spurjob(
+            "it-vol-read",
+            ["sh", "-c", "test -d /mnt/host && echo VOLUME_OK"],
+            ["/tmp:/mnt/host"],
+        )
+        cluster.create_spurjob(job)
+        wait_spurjob_state(cluster, "it-vol-read", "Completed")
+        logs = read_spurjob_pod_logs(cluster, "it-vol-read")
+        assert "VOLUME_OK" in logs, f"the mount was not usable:\n{logs}"
+
+    def test_malformed_volume_is_ignored(self, cluster):
+        """A single-component entry has no target path, so it is dropped rather
+        than producing an unschedulable pod."""
+        job = volume_spurjob("it-vol-bad", ["sh", "-c", "echo BAD_VOL_OK"], ["/tmp"])
+        cluster.create_spurjob(job)
+        wait_spurjob_state(cluster, "it-vol-bad", "Completed")
+
+        pod = wait_spurjob_pod(cluster, "it-vol-bad")
+        assert "/tmp" not in _mount_paths(pod), (
+            "a malformed volume entry must not be mounted"
+        )
+
+
+class TestSecretEnv:
+    @pytest.fixture
+    def secret(self, cluster):
+        name = "it-secret"
+        body = {
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": {"name": name},
+            "stringData": {"token": "s3cr3t-value"},
+        }
+        try:
+            cluster.core_v1.create_namespaced_secret(cluster.namespace, body)
+        except ApiException as exc:
+            if exc.status != 409:
+                raise
+        yield name
+        try:
+            cluster.core_v1.delete_namespaced_secret(name, cluster.namespace)
+        except ApiException:
+            pass
+
+    def test_secret_env_becomes_a_secret_key_ref(self, cluster, secret):
+        job = secret_env_spurjob(
+            "it-secret-ref",
+            ["sh", "-c", "echo token=$MY_TOKEN"],
+            {"MY_TOKEN": f"{secret}/token"},
+        )
+        cluster.create_spurjob(job)
+
+        pod = wait_spurjob_pod(cluster, "it-secret-ref")
+        env = {e.name: e for e in pod.spec.containers[0].env or []}
+        assert "MY_TOKEN" in env, f"secretEnv did not reach the pod: {sorted(env)}"
+        ref = env["MY_TOKEN"].value_from.secret_key_ref
+        assert (ref.name, ref.key) == (secret, "token"), f"wrong secret ref: {ref}"
+        assert env["MY_TOKEN"].value is None, (
+            "the secret value must not be inlined into the PodSpec"
+        )
+
+    def test_secret_value_reaches_the_job(self, cluster, secret):
+        job = secret_env_spurjob(
+            "it-secret-val",
+            ["sh", "-c", "echo token=$MY_TOKEN"],
+            {"MY_TOKEN": f"{secret}/token"},
+        )
+        cluster.create_spurjob(job)
+        wait_spurjob_state(cluster, "it-secret-val", "Completed")
+        logs = read_spurjob_pod_logs(cluster, "it-secret-val")
+        assert "token=s3cr3t-value" in logs, f"secret was not injected:\n{logs}"
+
+    def test_missing_secret_is_optional(self, cluster):
+        """The reference is marked optional, so an absent Secret leaves the var
+        empty instead of wedging the pod."""
+        job = secret_env_spurjob(
+            "it-secret-missing",
+            ["sh", "-c", "echo token=[$MY_TOKEN] && echo MISSING_OK"],
+            {"MY_TOKEN": "no-such-secret/token"},
+        )
+        cluster.create_spurjob(job)
+        wait_spurjob_state(cluster, "it-secret-missing", "Completed")
+        logs = read_spurjob_pod_logs(cluster, "it-secret-missing")
+        assert "token=[]" in logs, f"expected an empty value:\n{logs}"
+
+    def test_malformed_secret_ref_is_ignored(self, cluster):
+        job = secret_env_spurjob(
+            "it-secret-bad", ["sh", "-c", "echo BAD_SECRET_OK"], {"MY_TOKEN": "nokey"}
+        )
+        cluster.create_spurjob(job)
+
+        pod = wait_spurjob_pod(cluster, "it-secret-bad")
+        names = {e.name for e in pod.spec.containers[0].env or []}
+        assert "MY_TOKEN" not in names, (
+            "a reference without a key must be dropped, not passed through"
+        )
+
+
+class TestSecurityContext:
+    def test_host_network_reaches_the_pod(self, cluster):
+        job = security_spurjob(
+            "it-hostnet", ["sh", "-c", "sleep 5"], host_network=True
+        )
+        cluster.create_spurjob(job)
+        assert_pod_spec(cluster, "it-hostnet", {"spec.host_network": True})
+
+    def test_host_ipc_reaches_the_pod(self, cluster):
+        job = security_spurjob("it-hostipc", ["sh", "-c", "sleep 5"], host_ipc=True)
+        cluster.create_spurjob(job)
+        assert_pod_spec(cluster, "it-hostipc", {"spec.host_ipc": True})
+
+    def test_privileged_reaches_the_container(self, cluster):
+        job = security_spurjob("it-priv", ["sh", "-c", "sleep 5"], privileged=True)
+        cluster.create_spurjob(job)
+        assert_pod_spec(
+            cluster, "it-priv", {f"{CONTAINER}.security_context.privileged": True}
+        )
+
+    def test_defaults_leave_the_pod_unprivileged(self, cluster):
+        job = security_spurjob("it-nopriv", ["sh", "-c", "echo NOPRIV_OK"])
+        cluster.create_spurjob(job)
+
+        pod = wait_spurjob_pod(cluster, "it-nopriv")
+        assert pod.spec.host_network in (None, False), (
+            "host networking must be opt-in"
+        )
+        assert pod.spec.host_ipc in (None, False), "host IPC must be opt-in"
+        ctx = pod.spec.containers[0].security_context
+        assert ctx is None or ctx.privileged in (None, False), (
+            f"privileged must be opt-in, got {ctx}"
+        )
+
+    def test_shm_size_creates_a_memory_backed_dev_shm(self, cluster):
+        """Multi-GPU collectives need a larger /dev/shm than the 64 MiB default."""
+        job = security_spurjob(
+            "it-shm", ["sh", "-c", "sleep 5"], shm_size="256Mi"
+        )
+        cluster.create_spurjob(job)
+
+        pod = wait_spurjob_pod(cluster, "it-shm")
+        assert _mount_paths(pod).get("/dev/shm") == "dshm", (
+            f"/dev/shm was not mounted: {_mount_paths(pod)}"
+        )
+        volume = _volumes(pod)["dshm"]
+        assert volume.empty_dir.medium == "Memory", (
+            f"/dev/shm must be tmpfs-backed, got {volume.empty_dir}"
+        )
+        assert volume.empty_dir.size_limit == "256Mi"
+
+    def test_no_shm_size_leaves_dev_shm_alone(self, cluster):
+        job = security_spurjob("it-noshm", ["sh", "-c", "echo NOSHM_OK"])
+        cluster.create_spurjob(job)
+
+        pod = wait_spurjob_pod(cluster, "it-noshm")
+        assert "/dev/shm" not in _mount_paths(pod), (
+            "the operator must not mount /dev/shm unless asked"
+        )
+
+
+class TestResources:
+    def test_cpu_request_scales_with_tasks_and_cpus_per_task(self, cluster):
+        job = resource_spurjob(
+            "it-res-cpu",
+            ["sh", "-c", "sleep 5"],
+            tasks_per_node=2,
+            cpus_per_task=2,
+        )
+        cluster.create_spurjob(job)
+
+        pod = wait_spurjob_pod(cluster, "it-res-cpu")
+        requests = pod.spec.containers[0].resources.requests or {}
+        limits = pod.spec.containers[0].resources.limits or {}
+        assert requests.get("cpu") == "4", (
+            f"cpu request should be tasksPerNode * cpusPerTask, got {requests}"
+        )
+        assert limits.get("cpu") == requests.get("cpu"), (
+            f"cpu request and limit must match, got {limits} vs {requests}"
+        )
+
+    def test_memory_per_node_reaches_pod_resources(self, cluster):
+        job = resource_spurjob(
+            "it-res-mem", ["sh", "-c", "sleep 5"], memory_per_node="256Mi"
+        )
+        cluster.create_spurjob(job)
+
+        pod = wait_spurjob_pod(cluster, "it-res-mem")
+        requests = pod.spec.containers[0].resources.requests or {}
+        assert requests.get("memory"), f"no memory request on the pod: {requests}"
+        assert requests["memory"].endswith("Mi"), (
+            f"memory should be expressed in MiB, got {requests['memory']}"
+        )
+
+    def test_extra_resources_appear_in_requests_and_limits(self, cluster):
+        job = resource_spurjob(
+            "it-res-extra",
+            ["sh", "-c", "sleep 5"],
+            extra_resources={"hugepages-2Mi": "64Mi"},
+        )
+        cluster.create_spurjob(job)
+
+        pod = wait_spurjob_pod(cluster, "it-res-extra")
+        requests = pod.spec.containers[0].resources.requests or {}
+        limits = pod.spec.containers[0].resources.limits or {}
+        assert requests.get("hugepages-2Mi") == "64Mi", (
+            f"extraResources missing from requests: {requests}"
+        )
+        assert limits.get("hugepages-2Mi") == "64Mi", (
+            f"extraResources missing from limits: {limits}"
+        )
+
+
+class TestCommandAndImage:
+    def test_args_are_appended_to_command(self, cluster):
+        job = spurjob_with_spec(
+            "it-args", ["echo"], args=["ARGS_APPENDED_OK"]
+        )
+        cluster.create_spurjob(job)
+        wait_spurjob_state(cluster, "it-args", "Completed")
+        logs = read_spurjob_pod_logs(cluster, "it-args")
+        assert "ARGS_APPENDED_OK" in logs, f"args were dropped:\n{logs}"
+
+    def test_args_alone_become_the_command(self, cluster):
+        job = spurjob_with_spec(
+            "it-args-only", [], args=["echo", "ARGS_ONLY_OK"]
+        )
+        cluster.create_spurjob(job)
+        wait_spurjob_state(cluster, "it-args-only", "Completed")
+        logs = read_spurjob_pod_logs(cluster, "it-args-only")
+        assert "ARGS_ONLY_OK" in logs, f"args-only job did not run:\n{logs}"
+
+    def test_custom_image_is_used(self, cluster):
+        job = spurjob_with_spec(
+            "it-image", ["sh", "-c", "echo IMAGE_OK"], image="busybox:1.36"
+        )
+        cluster.create_spurjob(job)
+        assert_pod_spec(cluster, "it-image", {f"{CONTAINER}.image": "busybox:1.36"})
+
+    def test_pod_carries_the_operator_labels(self, cluster):
+        job = spurjob_with_spec("it-labels", ["sh", "-c", "sleep 5"])
+        cluster.create_spurjob(job)
+
+        pod = wait_spurjob_pod(cluster, "it-labels")
+        labels = pod.metadata.labels or {}
+        assert labels.get("spur.amd.com/managed-by") == "spur-k8s-operator"
+        assert labels.get("spur.amd.com/job-name") == "it-labels"
+        assert labels.get("spur.amd.com/job-id"), (
+            f"the pod must carry its Spur job id: {labels}"
+        )
+        assert pod.spec.containers[0].name == "spur-job"
+
+
+class TestSchedulingFields:
+    def test_partition_and_account_reach_the_job_environment(self, cluster):
+        job = spurjob_with_spec(
+            "it-part-acct",
+            ["sh", "-c", "echo part=$SPUR_JOB_PARTITION acct=$SPUR_JOB_ACCOUNT"],
+            partition="default",
+            account="root",
+        )
+        cluster.create_spurjob(job)
+        wait_spurjob_state(cluster, "it-part-acct", "Completed")
+        logs = read_spurjob_pod_logs(cluster, "it-part-acct")
+        assert "part=default" in logs, f"partition was not propagated:\n{logs}"
+        assert "acct=root" in logs, f"account was not propagated:\n{logs}"
+
+    def test_unknown_partition_fails_the_job(self, cluster):
+        job = spurjob_with_spec(
+            "it-bad-part", ["sh", "-c", "true"], partition="no-such-partition"
+        )
+        cluster.create_spurjob(job)
+
+        state = wait_spurjob_state(
+            cluster, "it-bad-part", "Failed", timeout=90
+        )
+        assert (state.get("status") or {}).get("state") == "Failed"
+
+    def test_time_limit_is_accepted_and_enforced(self, cluster):
+        """timeLimit shapes the Spur job, not the PodSpec, so it is observed
+        through the job outcome."""
+        job = spurjob_with_spec(
+            "it-timelimit", ["sh", "-c", "sleep 600"], timeLimit="1m"
+        )
+        cluster.create_spurjob(job)
+
+        result = wait_spurjob_state(cluster, "it-timelimit", "Timeout", timeout=180)
+        assert (result.get("status") or {}).get("state") == "Timeout"
+
+    def test_generous_time_limit_lets_the_job_finish(self, cluster):
+        job = spurjob_with_spec(
+            "it-timelimit-ok", ["sh", "-c", "echo TIMELIMIT_OK"], timeLimit="1h"
+        )
+        cluster.create_spurjob(job)
+        wait_spurjob_state(cluster, "it-timelimit-ok", "Completed")
+        assert "TIMELIMIT_OK" in read_spurjob_pod_logs(cluster, "it-timelimit-ok")

--- a/tests/k8s/e2e/test_spurjob_spec.py
+++ b/tests/k8s/e2e/test_spurjob_spec.py
@@ -23,6 +23,8 @@ from k8s_cluster import (
     wait_spurjob_state,
 )
 
+pytestmark = pytest.mark.suite_k8s_spec
+
 CONTAINER = "spec.containers.0"
 
 

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -8,6 +8,7 @@ Handles SSH connections, binary deployment, cluster startup/teardown,
 and CLI wrappers for interacting with the running cluster.
 """
 
+import copy
 import os
 import re
 import shlex
@@ -40,6 +41,12 @@ METRICS_PORT = int(os.environ.get("SPUR_TEST_METRICS_PORT", "6822"))
 # curl writes the status code after the body; a sentinel keeps the split
 # unambiguous for payloads that themselves end in digits or newlines.
 _HTTP_STATUS_SENTINEL = "__SPUR_HTTP_STATUS__"
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
 
 
 def make_remote_dir() -> str:
@@ -215,11 +222,15 @@ class SpurCluster:
         self.log_dir = f"{remote_dir}/log"
         self.controller_addr = f"http://{nodes[0].host}:{CONTROLLER_PORT}"
         self.config_overrides: dict = {}
+        # Per-node config, merged over config_overrides for that node only.
+        # Raft needs it: node_id differs per controller.
+        self.node_config_overrides: dict[int, dict] = {}
         self.agent_as_root: bool = False
         self.agent_labels: dict[int, dict[str, str]] = {}
         self.agent_token: str | None = None
         self.accounting_enabled: bool = False
         self.controller_indices: list[int] = [0]
+        self.raft_peer_style: str = "ip"
         self.agent_env: dict[str, str] = {}
         self._pg_container = f"spur-e2e-pg-{os.getpid()}-{time.time_ns()}"
         self._pg_port = int(os.environ.get("SPUR_TEST_PG_PORT", "55432"))
@@ -325,11 +336,18 @@ class SpurCluster:
             raise RuntimeError("docker not usable on node 0; cannot run accounting")
         self.accounting_enabled = True
 
-    def enable_raft(self, replicas: int = 3):
+    def enable_raft(self, replicas: int = 3, peer_style: str = "ip"):
         """Run spurctld on the first *replicas* nodes as Raft peers.
 
         Clients get the full endpoint list so they keep working across a
         leader change. Call before provision()/start().
+
+        *peer_style* selects how peers address each other. ``"ip"`` (default)
+        pairs IP peers with an explicit per-node ``node_id``, which works on
+        any set of hosts. ``"hostname"`` lets each controller derive its
+        node_id from its position in the peer list, but only works where every
+        node can resolve every peer's hostname -- use
+        :meth:`peer_resolution_preflight` to gate it.
         """
         if replicas > len(self.nodes):
             raise RuntimeError(
@@ -337,7 +355,10 @@ class SpurCluster:
             )
         if replicas % 2 == 0:
             raise RuntimeError("raft replica count must be odd for a quorum")
+        if peer_style not in ("ip", "hostname"):
+            raise RuntimeError(f"unknown raft peer_style {peer_style!r}")
         self.controller_indices = list(range(replicas))
+        self.raft_peer_style = peer_style
         self.controller_addr = ",".join(
             f"http://{self.nodes[i].host}:{CONTROLLER_PORT}"
             for i in self.controller_indices
@@ -379,7 +400,34 @@ class SpurCluster:
             if len(leaders) == 1:
                 return leaders[0]
             time.sleep(2)
-        raise TimeoutError(f"no single Raft leader within {timeout}s (roles: {roles})")
+        raise TimeoutError(
+            f"no single Raft leader within {timeout}s (roles: {roles})\n"
+            f"{self.raft_diagnostics()}"
+        )
+
+    def raft_diagnostics(self, log_lines: int = 40) -> str:
+        """Per-controller log tail, for reporting a failed election.
+
+        A leaderless cluster is almost always explained by the controller's
+        own startup log (node_id resolution, bind failure, peer refused), and
+        that log is unreachable once the fixture has torn the cluster down.
+        """
+        parts = []
+        for i in self.controller_indices:
+            name = self.node_names[i] if self.node_names else self.nodes[i].host
+            tail = self.nodes[i].exec_allow_fail(
+                f"tail -{log_lines} '{self.log_dir}/spurctld.log' 2>&1"
+            )
+            listening = self.nodes[i].exec_allow_fail(
+                f"(ss -lntp 2>/dev/null || netstat -lntp 2>/dev/null) "
+                f"| grep -E ':({CONTROLLER_PORT}|{RAFT_PORT}|{REST_PORT})' || echo '(no listener)'"
+            )
+            parts.append(
+                f"--- controller {i} ({name}) ---\n"
+                f"listeners:\n{listening.strip()}\n"
+                f"spurctld.log (last {log_lines}):\n{_strip_ansi(tail)}"
+            )
+        return "\n".join(parts)
 
     def stop_controller(self):
         """Kill spurctld only."""
@@ -394,8 +442,7 @@ class SpurCluster:
         self._start_controller(node_index)
 
     def spurctld_log(self, node_index: int = 0) -> str:
-        raw = self.nodes[node_index].read_file(f"{self.log_dir}/spurctld.log")
-        return re.sub(r"\x1b\[[0-9;]*m", "", raw)
+        return _strip_ansi(self.nodes[node_index].read_file(f"{self.log_dir}/spurctld.log"))
 
     def stop_agents(self):
         """Kill spurd on all nodes only."""
@@ -899,6 +946,43 @@ class SpurCluster:
                 f"(apt install wireguard-tools)"
             )
 
+    def sinfo_node_names(
+        self,
+        extra_args: list[str] | None = None,
+        controller_addr: str | None = None,
+        allow_fail: bool = False,
+    ) -> set[str]:
+        """Node names reported by sinfo, one per node.
+
+        The default sinfo view collapses names into a hostlist range such as
+        ``spur-node[1-3]``, which no per-name check can match, so ask for the
+        node-oriented view and just the name field.
+        """
+        args = ["sinfo", "-N", "-h", "-o", "%n"] + list(extra_args or [])
+        run = self.cli_allow_fail if allow_fail else self.cli
+        out = run(args, controller_addr=controller_addr)
+        return {line.strip() for line in out.splitlines() if line.strip()}
+
+    def peer_resolution_preflight(self):
+        """Skip unless every controller node resolves every peer's hostname.
+
+        Deriving a Raft node_id from a hostname peer list only works where
+        name resolution is set up between the nodes; a stock host only has its
+        own name in /etc/hosts. Probing beats a 90s leaderless timeout.
+        """
+        for i in self.controller_indices:
+            for j in self.controller_indices:
+                name = self.node_names[j]
+                probe = self.nodes[i].exec_allow_fail(
+                    f"getent hosts {shlex.quote(name)} >/dev/null && echo OK || echo MISSING"
+                )
+                if "OK" not in probe:
+                    pytest.skip(
+                        f"{self.node_names[i]} cannot resolve peer {name!r}; "
+                        f"hostname-derived Raft node_id needs DNS or /etc/hosts "
+                        f"entries for every peer"
+                    )
+
     def require_nodes(self, min_nodes: int):
         """Skip the test if fewer than min_nodes are configured."""
         if len(self.nodes) < min_nodes:
@@ -1287,24 +1371,29 @@ mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
                 "fairshare_refresh_secs": 10,
             }
         if len(self.controller_indices) > 1:
-            # Peers are hostnames because spurctld derives its node_id from
-            # its own hostname's position in this list.
+            if self.raft_peer_style == "hostname":
+                hosts = [self.node_names[i] for i in self.controller_indices]
+            else:
+                hosts = [self.nodes[i].host for i in self.controller_indices]
             cfg["controller"] = {
-                "peers": [
-                    f"{self.node_names[i]}:{RAFT_PORT}"
-                    for i in self.controller_indices
-                ],
+                "peers": [f"{h}:{RAFT_PORT}" for h in hosts],
                 "raft_listen_addr": f"[::]:{RAFT_PORT}",
             }
         return cfg
 
     def _write_config(self):
-        cfg = self._default_config()
-        deep_merge(cfg, self.config_overrides)
-        config = tomli_w.dumps(cfg)
+        base = self._default_config()
+        deep_merge(base, self.config_overrides)
 
-        for node in self.nodes:
-            node.write_file(f"{self.etc_dir}/spur.conf", config)
+        for i, node in enumerate(self.nodes):
+            cfg = copy.deepcopy(base)
+            # IP peers give a controller no hostname to match itself against,
+            # so it needs to be told which peer it is.
+            if len(self.controller_indices) > 1 and self.raft_peer_style == "ip":
+                if i in self.controller_indices:
+                    cfg["controller"]["node_id"] = self.controller_indices.index(i) + 1
+            deep_merge(cfg, self.node_config_overrides.get(i, {}))
+            node.write_file(f"{self.etc_dir}/spur.conf", tomli_w.dumps(cfg))
 
     def _start_controller(self, node_index: int | None = None):
         listen = f"[::]:{CONTROLLER_PORT}"
@@ -1317,7 +1406,60 @@ mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
                 f"> '{self.log_dir}/spurctld.log' 2>&1 & echo $!"
             )
             pid = self.nodes[i].exec(cmd).strip()
+            self._verify_controller_started(i, pid)
             logger.info("spurctld started on %s (pid %s)", self.node_names[i], pid)
+
+    def _verify_controller_started(self, node_index: int, pid: str, timeout: int = 30):
+        """Fail loudly unless *our* spurctld owns the controller port.
+
+        Without this a bind failure is silent: the daemon exits and whatever
+        already held the port answers instead, so tests fail far away from the
+        cause with errors like "not the Raft leader".
+        """
+        node = self.nodes[node_index]
+        name = self.node_names[node_index]
+        if "YES" not in node.exec_allow_fail(
+            "command -v ss >/dev/null 2>&1 && echo YES || echo NO"
+        ):
+            # Without ss we can only tell whether the process stayed up.
+            time.sleep(2)
+            if "ALIVE" not in node.exec_allow_fail(
+                f"kill -0 {pid} 2>/dev/null && echo ALIVE || echo DEAD"
+            ):
+                raise RuntimeError(
+                    f"spurctld did not come up on {name}:\n"
+                    f"{self.spurctld_log(node_index)[-2000:]}"
+                )
+            return
+
+        deadline = time.time() + timeout
+        foreign = ""
+        while time.time() < deadline:
+            alive = "ALIVE" in node.exec_allow_fail(
+                f"kill -0 {pid} 2>/dev/null && echo ALIVE || echo DEAD"
+            )
+            if not alive:
+                break
+            listeners = node.exec_allow_fail(
+                f"ss -ltnp 2>/dev/null | grep ':{CONTROLLER_PORT} ' || true"
+            ).strip()
+            if f"pid={pid}," in listeners:
+                return
+            # A previous controller may still be releasing the port, so keep
+            # the holder around and only report it if it outlives the timeout.
+            foreign = listeners
+            time.sleep(0.5)
+
+        if foreign:
+            raise RuntimeError(
+                f"spurctld on {name} never acquired port {CONTROLLER_PORT}; it "
+                f"is held by another process:\n{foreign}\n"
+                f"Kill the stale daemon before running the e2e suite."
+            )
+        raise RuntimeError(
+            f"spurctld did not come up on {name}:\n"
+            f"{self.spurctld_log(node_index)[-2000:]}"
+        )
 
     def _start_postgres(self):
         """Bring up Postgres (Docker) on node 0. Accounting runs inside spurctld."""
@@ -1463,8 +1605,14 @@ def parse_job_id(sbatch_output: str) -> int | None:
 
 
 def job_state(squeue_output: str, job_id: int) -> str | None:
-    """Parse job state from squeue -t all output."""
-    valid_states = {"PD", "R", "CD", "CG", "F", "CA", "TO", "NF", "PR", "S"}
+    """Parse job state from squeue -t all output.
+
+    Must list every code JobState::code() can emit: an unlisted state reads as
+    "no state yet" and turns a correct result into a polling timeout.
+    """
+    valid_states = {
+        "PD", "R", "CG", "CD", "F", "CA", "TO", "NF", "PR", "S", "DL", "OOM",
+    }
     id_str = str(job_id)
     for line in squeue_output.splitlines()[1:]:
         fields = line.split()

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -24,11 +24,22 @@ import tomli_w
 logger = logging.getLogger(__name__)
 
 BINARIES = ["spurctld", "spurd", "spur"]
-CLI_SYMLINKS = ["sbatch", "srun", "squeue", "scancel", "sinfo", "scontrol"]
+CLI_SYMLINKS = [
+    "sbatch", "srun", "salloc", "squeue", "scancel", "sinfo", "scontrol",
+    "sattach", "sprio", "sstat", "sdiag", "smd",
+]
 ACCOUNTING_SYMLINKS = ["sacct", "sacctmgr", "sshare", "sreport"]
+FFI_LIB_NAME = "libspur_compat.so"
 
 CONTROLLER_PORT = int(os.environ.get("SPUR_TEST_CONTROLLER_PORT", "6817"))
 AGENT_PORT = int(os.environ.get("SPUR_TEST_AGENT_PORT", "6818"))
+REST_PORT = int(os.environ.get("SPUR_TEST_REST_PORT", "6820"))
+RAFT_PORT = int(os.environ.get("SPUR_TEST_RAFT_PORT", "6821"))
+METRICS_PORT = int(os.environ.get("SPUR_TEST_METRICS_PORT", "6822"))
+
+# curl writes the status code after the body; a sentinel keeps the split
+# unambiguous for payloads that themselves end in digits or newlines.
+_HTTP_STATUS_SENTINEL = "__SPUR_HTTP_STATUS__"
 
 
 def make_remote_dir() -> str:
@@ -208,6 +219,8 @@ class SpurCluster:
         self.agent_labels: dict[int, dict[str, str]] = {}
         self.agent_token: str | None = None
         self.accounting_enabled: bool = False
+        self.controller_indices: list[int] = [0]
+        self.agent_env: dict[str, str] = {}
         self._pg_container = f"spur-e2e-pg-{os.getpid()}-{time.time_ns()}"
         self._pg_port = int(os.environ.get("SPUR_TEST_PG_PORT", "55432"))
         self._db_url = (
@@ -259,6 +272,10 @@ class SpurCluster:
         if self.accounting_enabled:
             self._start_postgres()
         self.start_controller(config_overrides, kill_stale=False)
+        # Agents register through the leader, so wait for the election to
+        # settle before they start retrying against a leaderless cluster.
+        if len(self.controller_indices) > 1:
+            self.wait_raft_leader()
         self.start_agents(kill_stale=False)
         self.wait_ready()
         logger.info(
@@ -308,9 +325,77 @@ class SpurCluster:
             raise RuntimeError("docker not usable on node 0; cannot run accounting")
         self.accounting_enabled = True
 
+    def enable_raft(self, replicas: int = 3):
+        """Run spurctld on the first *replicas* nodes as Raft peers.
+
+        Clients get the full endpoint list so they keep working across a
+        leader change. Call before provision()/start().
+        """
+        if replicas > len(self.nodes):
+            raise RuntimeError(
+                f"raft needs {replicas} nodes, cluster has {len(self.nodes)}"
+            )
+        if replicas % 2 == 0:
+            raise RuntimeError("raft replica count must be odd for a quorum")
+        self.controller_indices = list(range(replicas))
+        self.controller_addr = ",".join(
+            f"http://{self.nodes[i].host}:{CONTROLLER_PORT}"
+            for i in self.controller_indices
+        )
+
+    def controller_addr_for(self, node_index: int) -> str:
+        """Single-endpoint address for one controller, bypassing failover."""
+        return f"http://{self.nodes[node_index].host}:{CONTROLLER_PORT}"
+
+    def raft_role(self, node_index: int) -> str | None:
+        """Raft role of one controller: 'primary', 'replica', or None if down.
+
+        REST /ping reports the role directly, which avoids parsing Raft
+        internals out of the controller log.
+        """
+        status, body = self.http_get("/api/v1/ping", node_index=node_index)
+        if status != 200:
+            return None
+        match = re.search(r'"mode"\s*:\s*"(\w+)"', body)
+        return match.group(1) if match else None
+
+    def raft_leader_index(self) -> int | None:
+        for i in self.controller_indices:
+            if self.raft_role(i) == "primary":
+                return i
+        return None
+
+    def wait_raft_leader(self, timeout: int = 90, exclude: set[int] | None = None) -> int:
+        """Poll until exactly one controller reports itself leader."""
+        excluded = exclude or set()
+        deadline = time.time() + timeout
+        roles: dict[int, str | None] = {}
+        while time.time() < deadline:
+            roles = {i: self.raft_role(i) for i in self.controller_indices}
+            leaders = [
+                i for i, role in roles.items()
+                if role == "primary" and i not in excluded
+            ]
+            if len(leaders) == 1:
+                return leaders[0]
+            time.sleep(2)
+        raise TimeoutError(f"no single Raft leader within {timeout}s (roles: {roles})")
+
     def stop_controller(self):
         """Kill spurctld only."""
         self._kill_controller()
+
+    def stop_controller_node(self, node_index: int):
+        """Kill spurctld on one node, leaving the other peers running."""
+        self._kill_controller(node_index)
+
+    def start_controller_node(self, node_index: int):
+        """Restart spurctld on one node against the existing config."""
+        self._start_controller(node_index)
+
+    def spurctld_log(self, node_index: int = 0) -> str:
+        raw = self.nodes[node_index].read_file(f"{self.log_dir}/spurctld.log")
+        return re.sub(r"\x1b\[[0-9;]*m", "", raw)
 
     def stop_agents(self):
         """Kill spurd on all nodes only."""
@@ -395,12 +480,76 @@ class SpurCluster:
             f"'{self.bin_dir}/{args[0]}'",
         ]
         cmd_parts.extend(f"'{a}'" for a in args[1:])
-        _, stdout, stderr = self.nodes[0].client.exec_command(" ".join(cmd_parts))
+        return self._exec_with_code(self.nodes[0], " ".join(cmd_parts))
+    
+    def cli_with_env(
+        self,
+        args: list[str],
+        env: dict[str, str],
+        controller_addr: str | None = None,
+    ) -> tuple[int, str]:
+        """Run a CLI command with extra environment variables set.
+
+        Returns (exit_code, stdout+stderr). Submit-time defaults such as
+        ``SPUR_PARTITION`` / ``SBATCH_ACCOUNT`` / ``SALLOC_QOS`` are read from
+        the CLI's own environment, which is what this controls — distinct from
+        ``--export``, which shapes the *job's* environment.
+        """
+        cmd_parts = [
+            f"SPUR_CONTROLLER_ADDR={shlex.quote(controller_addr or self.controller_addr)}",
+            f"PATH={shlex.quote(self.bin_dir)}:$PATH",
+        ]
+        cmd_parts.extend(f"{k}={shlex.quote(v)}" for k, v in env.items())
+        cmd_parts.append(shlex.quote(f"{self.bin_dir}/{args[0]}"))
+        cmd_parts.extend(shlex.quote(a) for a in args[1:])
+        return self._exec_with_code(self.nodes[0], " ".join(cmd_parts))
+
+    def _exec_with_code(self, node: SshNode, cmd: str) -> tuple[int, str]:
+        _, stdout, stderr = node.client.exec_command(cmd)
         code = stdout.channel.recv_exit_status()
         return code, stdout.read().decode() + stderr.read().decode()
 
     def sbatch(self, args: list[str]) -> str:
         return self.cli(["sbatch"] + args)
+
+    def sbatch_with_exit(self, args: list[str]) -> tuple[int, str]:
+        return self.cli_with_env(["sbatch"] + args, {})
+
+    def salloc_with_exit(self, args: list[str]) -> tuple[int, str]:
+        """Run salloc and return (exit_code, combined stdout+stderr).
+
+        salloc runs a command inside the allocation and exits, so it blocks
+        for the lifetime of that command.
+        """
+        return self.cli_with_env(["salloc"] + args, {})
+
+    def salloc(self, args: list[str]) -> str:
+        _, out = self.salloc_with_exit(args)
+        return out
+
+    def sattach(self, job_step: str, args: list[str] | None = None) -> tuple[int, str]:
+        return self.cli_with_env(["sattach", job_step] + (args or []), {})
+
+    def spur_exec(self, job_id: int, command: list[str]) -> tuple[int, str]:
+        return self.cli_with_env(["spur", "exec", str(job_id)] + command, {})
+
+    def sprio(self, args: list[str] | None = None) -> str:
+        return self.cli(["sprio"] + (args or []))
+
+    def sshare(self, args: list[str] | None = None) -> str:
+        return self.cli(["sshare"] + (args or []))
+
+    def sstat(self, args: list[str]) -> str:
+        return self.cli(["sstat"] + args)
+
+    def sdiag(self, args: list[str] | None = None) -> str:
+        return self.cli(["sdiag"] + (args or []))
+
+    def sreport(self, args: list[str]) -> str:
+        return self.cli(["sreport"] + args)
+
+    def smd(self, args: list[str] | None = None) -> str:
+        return self.cli(["smd"] + (args or []))
 
     def srun_with_exit(self, args: list[str]) -> tuple[int, str]:
         """Run srun and return (exit_code, combined stdout+stderr)."""
@@ -548,6 +697,58 @@ class SpurCluster:
                 return len(members)
         return 0
 
+    # --- HTTP wrappers (REST API, metrics) ---
+
+    def _curl(self, url: str, extra: list[str], node_index: int) -> tuple[int, str]:
+        """Run curl on a cluster node. Returns (http_status, body).
+
+        Status 0 means curl could not complete the request at all (connection
+        refused, DNS failure), which is distinct from an HTTP error response.
+        Requests go through the existing SSH channel so tests do not depend on
+        the pytest runner having network access to the cluster's HTTP ports.
+        """
+        parts = ["curl", "-sS", "-m", "20", "-w", f"{_HTTP_STATUS_SENTINEL}%{{http_code}}"]
+        parts.extend(extra)
+        parts.append(url)
+        cmd = " ".join(shlex.quote(p) for p in parts)
+        out = self.nodes[node_index].exec_allow_fail(cmd)
+        if _HTTP_STATUS_SENTINEL not in out:
+            return 0, out
+        body, _, status = out.rpartition(_HTTP_STATUS_SENTINEL)
+        try:
+            return int(status.strip()), body
+        except ValueError:
+            return 0, out
+
+    def http_get(
+        self, path: str, port: int = REST_PORT, node_index: int = 0
+    ) -> tuple[int, str]:
+        url = f"http://127.0.0.1:{port}{path}"
+        return self._curl(url, [], node_index)
+
+    def http_post(
+        self, path: str, body: str, port: int = REST_PORT, node_index: int = 0
+    ) -> tuple[int, str]:
+        url = f"http://127.0.0.1:{port}{path}"
+        return self._curl(
+            url, ["-X", "POST", "-H", "Content-Type: application/json", "-d", body],
+            node_index,
+        )
+
+    def http_delete(
+        self, path: str, port: int = REST_PORT, node_index: int = 0
+    ) -> tuple[int, str]:
+        url = f"http://127.0.0.1:{port}{path}"
+        return self._curl(url, ["-X", "DELETE"], node_index)
+
+    def curl_preflight(self, node_index: int = 0):
+        """Skip the test unless curl is available on the target node."""
+        probe = self.nodes[node_index].exec_allow_fail(
+            "command -v curl >/dev/null && echo OK || echo MISSING"
+        )
+        if "OK" not in probe:
+            pytest.skip(f"curl not found on {self.node_names[node_index]}")
+
     def sacct(self, args: list[str]) -> str:
         return self.cli(["sacct"] + args)
 
@@ -657,6 +858,47 @@ class SpurCluster:
                     f"(set SPUR_TEST_SSH_PASSWORD or configure NOPASSWD sudo)"
                 )
 
+    def sudo_cli(self, args: list[str], node_index: int = 0) -> tuple[int, str]:
+        """Run a spur CLI command as root. Returns (exit_code, output).
+
+        `spur net` writes /etc/wireguard and drives `wg-quick`, so it is only
+        meaningful with root.
+        """
+        parts = [self._sudo_prefix(), "env", f"PATH={shlex.quote(self.bin_dir)}:$PATH"]
+        parts.append(shlex.quote(f"{self.bin_dir}/{args[0]}"))
+        parts.extend(shlex.quote(a) for a in args[1:])
+        return self._exec_with_code(self.nodes[node_index], " ".join(parts))
+
+    def image_preflight(self, node_index: int = 0):
+        """Skip unless the node can build squashfs images."""
+        probe = self.nodes[node_index].exec_allow_fail(
+            "command -v mksquashfs >/dev/null && echo OK || echo MISSING"
+        )
+        if "OK" not in probe:
+            pytest.skip(
+                f"mksquashfs not found on {self.node_names[node_index]} "
+                f"(apt install squashfs-tools)"
+            )
+
+    def docker_preflight(self, node_index: int = 0):
+        probe = self.nodes[node_index].exec_allow_fail(
+            "docker info >/dev/null 2>&1 && echo OK || echo MISSING"
+        )
+        if "OK" not in probe:
+            pytest.skip(f"docker not usable on {self.node_names[node_index]}")
+
+    def wireguard_preflight(self, node_index: int = 0):
+        """Skip unless wireguard-tools is installed on the node."""
+        probe = self.nodes[node_index].exec_allow_fail(
+            "command -v wg >/dev/null && command -v wg-quick >/dev/null "
+            "&& echo OK || echo MISSING"
+        )
+        if "OK" not in probe:
+            pytest.skip(
+                f"wireguard-tools not found on {self.node_names[node_index]} "
+                f"(apt install wireguard-tools)"
+            )
+
     def require_nodes(self, min_nodes: int):
         """Skip the test if fewer than min_nodes are configured."""
         if len(self.nodes) < min_nodes:
@@ -746,6 +988,77 @@ class SpurCluster:
                 pytest.skip(f"hipcc could not build {hip_filename} on {node.host}")
         return remote_bin
 
+    def compile_c_fixture(
+        self,
+        source_name: str,
+        *,
+        output_name: str | None = None,
+        extra_flags: list[str] | None = None,
+        all_nodes: bool = True,
+    ) -> str:
+        """Ship and compile a C fixture with cc. Returns the remote output path.
+
+        Skips the test if cc is missing or the build fails, matching how the
+        HIP and MPI fixtures degrade on under-provisioned nodes.
+        """
+        self.ship_fixture(source_name)
+        out_name = output_name or source_name.rsplit(".", 1)[0]
+        remote_src = f"{self.remote_dir}/{source_name}"
+        remote_out = f"{self.remote_dir}/{out_name}"
+        flags = " ".join(shlex.quote(f) for f in (extra_flags or []))
+        targets = self.nodes if all_nodes else self.nodes[:1]
+
+        for i, node in enumerate(targets):
+            if "OK" not in node.exec_allow_fail(
+                "command -v cc >/dev/null && echo OK || echo MISSING"
+            ):
+                pytest.skip(f"cc not found on {self.node_names[i]}")
+            build = node.exec_allow_fail(
+                f"cc -o {shlex.quote(remote_out)} {shlex.quote(remote_src)} {flags} 2>&1"
+            )
+            if not node.exec_allow_fail(f"test -e '{remote_out}' && echo OK").strip():
+                pytest.skip(
+                    f"cc could not build {source_name} on {self.node_names[i]}:\n{build}"
+                )
+        return remote_out
+
+    def ship_ffi_library(self, all_nodes: bool = False) -> str:
+        """Upload libspur_compat.so and return its remote path.
+
+        Skips the test when the library has not been built, matching how the
+        MPI plugin degrades on an unbuilt tree.
+        """
+        local = os.environ.get("SPUR_TEST_FFI_LIB", "").strip()
+        if not local:
+            binaries_dir = os.environ.get(
+                "SPUR_TEST_BINARIES_DIR",
+                str(Path(__file__).resolve().parents[3] / "target" / "release"),
+            )
+            local = str(Path(binaries_dir) / FFI_LIB_NAME)
+        if not Path(local).is_file():
+            pytest.skip(
+                f"{FFI_LIB_NAME} not found at {local}\n"
+                "Build with: cargo build --release -p spur-ffi\n"
+                "Or set SPUR_TEST_FFI_LIB"
+            )
+        remote = f"{self.remote_dir}/{FFI_LIB_NAME}"
+        for node in self.nodes if all_nodes else self.nodes[:1]:
+            node.upload(local, remote)
+        return remote
+
+    def write_plugstack(self, entries: list[str]) -> str:
+        """Write plugstack.conf on all nodes and point spurd at it.
+
+        Each entry is a full ``required|optional <path> [args]`` line. Takes
+        effect on the next agent start, so call before start()/restart_agent().
+        """
+        path = f"{self.etc_dir}/plugstack.conf"
+        body = "\n".join(entries) + "\n"
+        for node in self.nodes:
+            node.write_file(path, body)
+        self.agent_env["SPUR_PLUGSTACK"] = path
+        return path
+
     def mpi_preflight(self, min_nodes: int = 1):
         """Skip unless MPI plugin, libpmix, and mpicc are available."""
         missing = []
@@ -806,6 +1119,14 @@ class SpurCluster:
     def mpi_plugin_dir(self) -> str:
         return str(Path(self.bin_dir).parent / "lib" / "spur")
 
+    def stop_agent(self, node_index: int = 0):
+        """Kill spurd on one node without touching the controller."""
+        self._pkill(
+            self.nodes[node_index],
+            f"{self.bin_dir}/spurd",
+            use_sudo=self.agent_as_root,
+        )
+
     def restart_agent(self, node_index: int = 0):
         """Restart spurd on one node without touching the controller."""
         node = self.nodes[node_index]
@@ -814,14 +1135,14 @@ class SpurCluster:
         node.exec(self._spurd_start_cmd(node_index))
         time.sleep(5)
 
-    def restart_controller(self):
+    def restart_controller(self, node_index: int = 0):
         """Restart spurctld without touching the agents. State is recovered
         from the Raft log on the existing state-dir. Waits for the controller
         to answer queries again (does not require nodes to be idle, since a
         suspended job keeps its allocation)."""
-        self._pkill(self.nodes[0], f"{self.bin_dir}/spurctld", use_sudo=False)
+        self._pkill(self.nodes[node_index], f"{self.bin_dir}/spurctld", use_sudo=False)
         time.sleep(1)
-        self._start_controller()
+        self._start_controller(node_index)
         deadline = time.time() + 60
         while time.time() < deadline:
             try:
@@ -965,6 +1286,16 @@ mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
                 "database_url": self._db_url,
                 "fairshare_refresh_secs": 10,
             }
+        if len(self.controller_indices) > 1:
+            # Peers are hostnames because spurctld derives its node_id from
+            # its own hostname's position in this list.
+            cfg["controller"] = {
+                "peers": [
+                    f"{self.node_names[i]}:{RAFT_PORT}"
+                    for i in self.controller_indices
+                ],
+                "raft_listen_addr": f"[::]:{RAFT_PORT}",
+            }
         return cfg
 
     def _write_config(self):
@@ -975,16 +1306,18 @@ mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
         for node in self.nodes:
             node.write_file(f"{self.etc_dir}/spur.conf", config)
 
-    def _start_controller(self):
+    def _start_controller(self, node_index: int | None = None):
         listen = f"[::]:{CONTROLLER_PORT}"
-        cmd = (
-            f"nohup '{self.bin_dir}/spurctld' "
-            f"-f '{self.etc_dir}/spur.conf' "
-            f"--listen '{listen}' --state-dir '{self.state_dir}' --log-level info -D "
-            f"> '{self.log_dir}/spurctld.log' 2>&1 & echo $!"
-        )
-        pid = self.nodes[0].exec(cmd).strip()
-        logger.info("spurctld started on %s (pid %s)", self.node_names[0], pid)
+        targets = self.controller_indices if node_index is None else [node_index]
+        for i in targets:
+            cmd = (
+                f"nohup '{self.bin_dir}/spurctld' "
+                f"-f '{self.etc_dir}/spur.conf' "
+                f"--listen '{listen}' --state-dir '{self.state_dir}' --log-level info -D "
+                f"> '{self.log_dir}/spurctld.log' 2>&1 & echo $!"
+            )
+            pid = self.nodes[i].exec(cmd).strip()
+            logger.info("spurctld started on %s (pid %s)", self.node_names[i], pid)
 
     def _start_postgres(self):
         """Bring up Postgres (Docker) on node 0. Accounting runs inside spurctld."""
@@ -1025,8 +1358,10 @@ mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
         prefix = self._sudo_prefix() if use_sudo else ""
         node.exec_allow_fail(f"{prefix}pkill -f '{pattern}' 2>/dev/null || true")
 
-    def _kill_controller(self):
-        self._pkill(self.nodes[0], f"{self.bin_dir}/spurctld")
+    def _kill_controller(self, node_index: int | None = None):
+        targets = self.controller_indices if node_index is None else [node_index]
+        for i in targets:
+            self._pkill(self.nodes[i], f"{self.bin_dir}/spurctld")
 
     def _kill_agents(self, use_sudo: bool = False, broad: bool = False):
         for node in self.nodes:
@@ -1044,10 +1379,18 @@ mksquashfs "$R" '{local_img}' -noappend -quiet >/dev/null 2>&1
         hostname = self.node_names[node_index]
         address = node.host
         agent_listen = f"0.0.0.0:{AGENT_PORT}"
+        # `env` must sit between sudo and the binary so the vars survive the
+        # privilege drop; `nohup VAR=x cmd` would try to exec "VAR=x".
+        env_prefix = ""
+        if self.agent_env:
+            assignments = " ".join(
+                f"{k}={shlex.quote(v)}" for k, v in self.agent_env.items()
+            )
+            env_prefix = f"env {assignments} "
         spurd_bin = (
-            f"{self._sudo_prefix()}'{self.bin_dir}/spurd'"
+            f"{self._sudo_prefix()}{env_prefix}'{self.bin_dir}/spurd'"
             if self.agent_as_root
-            else f"'{self.bin_dir}/spurd'"
+            else f"{env_prefix}'{self.bin_dir}/spurd'"
         )
         label_args = ""
         labels = self.agent_labels.get(node_index, {})

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -267,8 +267,8 @@ class SpurCluster:
         self.log_dir = f"{remote_dir}/log"
         self.controller_addr = f"http://{nodes[0].host}:{CONTROLLER_PORT}"
         self.config_overrides: dict = {}
-        # Per-node config, merged over config_overrides for that node only.
-        # Raft needs it: node_id differs per controller.
+        # Merged over config_overrides for one node alone; Raft needs it,
+        # since node_id differs per controller.
         self.node_config_overrides: dict[int, dict] = {}
         self.agent_as_root: bool = False
         self.agent_labels: dict[int, dict[str, str]] = {}

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -1074,6 +1074,14 @@ class SpurCluster:
         raw = self.nodes[node_index].read_file(f"{self.log_dir}/spurd.log")
         return re.sub(r"\x1b\[[0-9;]*m", "", raw)
 
+    def spurd_log_all_nodes(self) -> str:
+        """Every agent's log joined together.
+
+        Job-scoped lines are only written by the node the scheduler picked, so
+        reading a fixed node asserts against a log that never saw the job.
+        """
+        return "\n".join(self.spurd_log(i) for i in range(len(self.nodes)))
+
     def spurd_registry_gpu_count(self, node_index: int = 0) -> int | None:
         """Parse cdi_devices count from spurd startup log."""
         log = self.spurd_log(node_index)
@@ -1695,6 +1703,25 @@ def job_state(squeue_output: str, job_id: int) -> str | None:
             if field in valid_states:
                 return field
     return None
+
+
+def job_node_names(cluster: SpurCluster, job_id: int) -> list[str]:
+    """Nodes allocated to *job_id*, from the controller's own view.
+
+    The scheduler is free to place a job on any node that fits, so a test that
+    hardcodes an index asserts against a node that may never have seen it.
+    """
+    show = cluster.scontrol("show", "job", str(job_id))
+    match = re.search(r"NodeList=(\S+)", show)
+    assert match, f"job {job_id} has no NodeList:\n{show}"
+    names = expand_hostlist(match.group(1))
+    assert names, f"job {job_id} has an empty NodeList:\n{show}"
+    return names
+
+
+def job_node_indices(cluster: SpurCluster, job_id: int) -> list[int]:
+    """Positions in ``cluster.nodes`` of the nodes allocated to *job_id*."""
+    return [cluster.node_names.index(name) for name in job_node_names(cluster, job_id)]
 
 
 def wait_job_state(

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -54,6 +54,51 @@ def make_remote_dir() -> str:
     return f"/tmp/spur-e2e-{os.getpid()}-{time.time_ns()}"
 
 
+def expand_hostlist(spec: str) -> list[str]:
+    """Expand a Slurm-style hostlist into individual node names.
+
+    Every node-facing surface (``squeue`` NODELIST, ``scontrol show job``,
+    ``sinfo``) renders node sets in bracket form -- ``node[1-3,7]`` -- so
+    splitting on commas yields fragments like ``node[1`` rather than names.
+    """
+    names: list[str] = []
+    for item in _split_hostlist(spec):
+        match = re.fullmatch(r"(.*?)\[([^\]]+)\](.*)", item)
+        if not match:
+            names.append(item)
+            continue
+        prefix, body, suffix = match.groups()
+        for part in body.split(","):
+            low, _, high = part.partition("-")
+            if not high:
+                names.append(f"{prefix}{low}{suffix}")
+                continue
+            # A range keeps the zero padding of its lower bound: node[08-10].
+            width = len(low)
+            for number in range(int(low), int(high) + 1):
+                names.append(f"{prefix}{number:0{width}d}{suffix}")
+    return names
+
+
+def _split_hostlist(spec: str) -> list[str]:
+    """Split a hostlist on its top-level commas, ignoring bracketed ones."""
+    items: list[str] = []
+    current = ""
+    depth = 0
+    for char in spec:
+        if char == "," and depth == 0:
+            items.append(current)
+            current = ""
+            continue
+        if char == "[":
+            depth += 1
+        elif char == "]":
+            depth -= 1
+        current += char
+    items.append(current)
+    return [item.strip() for item in items if item.strip()]
+
+
 def deep_merge(base: dict, overrides: dict) -> dict:
     """Deep-merge *overrides* into *base* (mutates and returns *base*).
 
@@ -596,7 +641,12 @@ class SpurCluster:
         return self.cli(["sreport"] + args)
 
     def smd(self, args: list[str] | None = None) -> str:
-        return self.cli(["smd"] + (args or []))
+        """Run smd, returning the report and its trailing health summary.
+
+        smd prints the table on stdout but the summary line on stderr, so the
+        merged capture is the only view that carries both.
+        """
+        return self.cli_allow_fail(["smd"] + (args or []))
 
     def srun_with_exit(self, args: list[str]) -> tuple[int, str]:
         """Run srun and return (exit_code, combined stdout+stderr)."""
@@ -627,7 +677,14 @@ class SpurCluster:
         return self.cli(["squeue"] + args)
 
     def squeue_all(self) -> str:
-        return self.cli(["squeue", "-t", "all"])
+        """`squeue -t all` with a state column wide enough for every code.
+
+        Slurm's default format clips ST to two characters, which renders the
+        only three-character code, OOM, as a state that does not exist.
+        """
+        return self.cli(
+            ["squeue", "-t", "all", "-o", "%.18i %.9P %.8j %.8u %.4t %10M %6D %R"]
+        )
 
     def running_job_ids_by_name(self, name: str) -> list[int]:
         """Return running job IDs matching *name* (uses server-side name filter)."""
@@ -982,6 +1039,22 @@ class SpurCluster:
                         f"hostname-derived Raft node_id needs DNS or /etc/hosts "
                         f"entries for every peer"
                     )
+
+    def agent_resolution_preflight(self):
+        """Skip unless the client node resolves every node's hostname.
+
+        `sattach` builds its endpoint as ``http://<name>:6818`` from the job's
+        NodeList, so probing turns an opaque "dns error" into a stated skip.
+        """
+        for name in self.node_names:
+            probe = self.nodes[0].exec_allow_fail(
+                f"getent hosts {shlex.quote(name)} >/dev/null && echo OK || echo MISSING"
+            )
+            if "OK" not in probe:
+                pytest.skip(
+                    f"{self.node_names[0]} cannot resolve {name!r}; attaching to "
+                    f"an agent needs DNS or /etc/hosts entries for every node"
+                )
 
     def require_nodes(self, min_nodes: int):
         """Skip the test if fewer than min_nodes are configured."""
@@ -1639,6 +1712,12 @@ def wait_job_state(
     )
 
 
+# Mirrors JobState::is_terminal(); Preempted is excluded there because it may
+# still requeue. A code missing here does not just slow the poll -- the job is
+# purged from the queue and its last transient state is returned instead.
+TERMINAL_STATES = {"CD", "F", "CA", "TO", "NF", "DL", "OOM"}
+
+
 def wait_job(cluster: SpurCluster, job_id: int, timeout: int = 120) -> str:
     """
     Wait for a job to reach a terminal state. Returns the final state string.
@@ -1651,7 +1730,7 @@ def wait_job(cluster: SpurCluster, job_id: int, timeout: int = 120) -> str:
     while time.time() < deadline:
         sq = cluster.squeue_all()
         state = job_state(sq, job_id)
-        if state in ("CD", "F", "CA", "TO"):
+        if state in TERMINAL_STATES:
             return state
         if state is None:
             if seen:

--- a/tests/native_host/e2e/conftest.py
+++ b/tests/native_host/e2e/conftest.py
@@ -29,6 +29,35 @@ def pytest_configure(config):
     )
 
 
+_SUITE_MARKERS = (
+    "suite_scheduling", "suite_policy", "suite_api",
+    "suite_runtime", "suite_fabric", "suite_ha",
+)
+_E2E_DIR = Path(__file__).parent
+
+
+def pytest_collection_modifyitems(config, items):
+    """Fail if any native-host e2e test lacks exactly one suite_* marker.
+
+    Markers select CI suites; a file with none would never run in any suite,
+    and one with two would run twice. Enforced at collection so the mistake
+    surfaces in the fast fixture job, not an hour into E2E.
+    """
+    bad = []
+    for item in items:
+        path = getattr(item, "path", None)
+        if path is None or (path != _E2E_DIR and _E2E_DIR not in path.parents):
+            continue
+        suites = [m.name for m in item.iter_markers() if m.name in _SUITE_MARKERS]
+        if len(suites) != 1:
+            bad.append(f"{item.nodeid}: {sorted(suites) or 'none'}")
+    if bad:
+        raise pytest.UsageError(
+            "each native-host e2e test needs exactly one suite_* marker:\n  "
+            + "\n  ".join(bad)
+        )
+
+
 def _get_nodes_config() -> list[str]:
     raw = os.environ.get("SPUR_TEST_NODES", "")
     nodes = [n.strip() for n in raw.split(",") if n.strip()]

--- a/tests/native_host/e2e/conftest.py
+++ b/tests/native_host/e2e/conftest.py
@@ -7,6 +7,7 @@ Pytest configuration and fixtures for Spur native-host E2E tests.
 See docs/developer/building.rst for full environment variable reference.
 """
 
+import contextlib
 import os
 import time
 from pathlib import Path
@@ -369,12 +370,46 @@ def metrics_cluster(ssh_nodes, remote_bin_dir, cluster_config_overrides):
 
 
 @pytest.fixture
+def hostname_raft_cluster(ssh_nodes, remote_bin_dir):
+    """
+    Raft cluster whose peers are listed by hostname, so each controller
+    derives its node_id from its position in that list.
+
+    Separate from raft_cluster, which uses IP peers and an explicit node_id:
+    that works anywhere, while this needs every node to resolve every peer.
+    """
+    if len(ssh_nodes) < 3:
+        pytest.skip(
+            f"Raft HA tests require at least 3 nodes for a quorum "
+            f"(got {len(ssh_nodes)})"
+        )
+
+    c = SpurCluster(ssh_nodes, make_remote_dir(), remote_bin_dir)
+    c.enable_raft(3, peer_style="hostname")
+    try:
+        c.provision()
+        c.curl_preflight()
+        c.peer_resolution_preflight()
+        c.start()
+    except Exception:
+        c.teardown()
+        raise
+    yield c
+    c.teardown()
+
+
+@pytest.fixture(scope="module")
 def raft_cluster(ssh_nodes, remote_bin_dir):
     """
-    Per-test fixture running spurctld on three nodes as Raft peers.
+    Module-scoped fixture running spurctld on three nodes as Raft peers.
 
     Clients address the full endpoint list, so CLI calls survive a leader
     change. Skips unless three nodes are available for a quorum.
+
+    Scoped to the module rather than the test: a three-controller cluster is
+    the most expensive fixture in the suite, and every test here restores the
+    controller it killed, so one cluster serves the whole module. Tests that
+    leave a controller down must do so inside a ``finally``.
     """
     if len(ssh_nodes) < 3:
         pytest.skip(
@@ -388,9 +423,14 @@ def raft_cluster(ssh_nodes, remote_bin_dir):
         c.provision()
         c.curl_preflight()
         c.start()
-    except Exception:
+    except Exception as exc:
+        # The cluster is about to be torn down, so capture why the election
+        # failed while the controllers are still reachable.
+        diagnostics = ""
+        with contextlib.suppress(Exception):
+            diagnostics = c.raft_diagnostics()
         c.teardown()
-        raise
+        raise RuntimeError(f"raft_cluster failed to start: {exc}\n{diagnostics}") from exc
     yield c
     c.teardown()
 

--- a/tests/native_host/e2e/conftest.py
+++ b/tests/native_host/e2e/conftest.py
@@ -350,6 +350,63 @@ def mpi_multi_node_cluster(ssh_nodes, remote_bin_dir, cluster_config_overrides):
     yield c
     c.teardown()
 
+def metrics_cluster(ssh_nodes, remote_bin_dir, cluster_config_overrides):
+    """
+    Per-test fixture with the metrics server reachable off-loopback.
+
+    ``[metrics] bind`` defaults to ``loopback``; ``all`` lets a test scrape
+    from any node. ``high_cardinality`` is left off so the 404 gating on
+    /metrics/jobs-users-accts stays observable.
+    """
+    overrides = deep_merge(
+        dict(cluster_config_overrides or {}),
+        {"metrics": {"bind": "all"}},
+    )
+    spur_cluster = _deploy_cluster(ssh_nodes, remote_bin_dir, config_overrides=overrides)
+    spur_cluster.curl_preflight()
+    yield spur_cluster
+    spur_cluster.teardown()
+
+
+@pytest.fixture
+def raft_cluster(ssh_nodes, remote_bin_dir):
+    """
+    Per-test fixture running spurctld on three nodes as Raft peers.
+
+    Clients address the full endpoint list, so CLI calls survive a leader
+    change. Skips unless three nodes are available for a quorum.
+    """
+    if len(ssh_nodes) < 3:
+        pytest.skip(
+            f"Raft HA tests require at least 3 nodes for a quorum "
+            f"(got {len(ssh_nodes)})"
+        )
+
+    c = SpurCluster(ssh_nodes, make_remote_dir(), remote_bin_dir)
+    c.enable_raft(3)
+    try:
+        c.provision()
+        c.curl_preflight()
+        c.start()
+    except Exception:
+        c.teardown()
+        raise
+    yield c
+    c.teardown()
+
+
+@pytest.fixture
+def spank_cluster(ssh_nodes, remote_bin_dir):
+    """
+    Per-test fixture for SPANK plugin tests.
+
+    Provisioned but not started: the test compiles its plugin, calls
+    ``write_plugstack``, then ``start()`` so spurd picks up SPUR_PLUGSTACK.
+    """
+    spur_cluster = _provision_cluster(ssh_nodes, remote_bin_dir)
+    yield spur_cluster
+    spur_cluster.teardown()
+
 
 @pytest.fixture
 def mpi_cluster(ssh_nodes, remote_bin_dir, cluster_config_overrides):

--- a/tests/native_host/e2e/conftest.py
+++ b/tests/native_host/e2e/conftest.py
@@ -350,6 +350,8 @@ def mpi_multi_node_cluster(ssh_nodes, remote_bin_dir, cluster_config_overrides):
     yield c
     c.teardown()
 
+
+@pytest.fixture
 def metrics_cluster(ssh_nodes, remote_bin_dir, cluster_config_overrides):
     """
     Per-test fixture with the metrics server reachable off-loopback.

--- a/tests/native_host/e2e/conftest.py
+++ b/tests/native_host/e2e/conftest.py
@@ -9,7 +9,6 @@ See docs/developer/building.rst for full environment variable reference.
 
 import contextlib
 import os
-import time
 from pathlib import Path
 
 import pytest

--- a/tests/native_host/e2e/fixtures/ffi_smoke.c
+++ b/tests/native_host/e2e/fixtures/ffi_smoke.c
@@ -1,0 +1,247 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Driver for the Slurm-compatible FFI (libspur_compat.so).
+//
+// Declarations are hand-written because the library ships no slurm.h; they
+// must stay in sync with crates/spur-ffi/src/types.rs. Each subcommand prints
+// machine-readable `key=value` lines so the e2e test can assert on them
+// without parsing prose.
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define NO_VAL ((uint32_t)0xFFFFFFFF)
+
+typedef struct {
+    const char *name;
+    const char *partition;
+    const char *account;
+    const char *script;
+    const char *work_dir;
+    uint32_t min_nodes;
+    uint32_t max_nodes;
+    uint32_t num_tasks;
+    uint32_t cpus_per_task;
+    uint32_t time_limit;
+    uint32_t priority;
+} job_desc_msg_t;
+
+typedef struct {
+    uint32_t job_id;
+    char *name;
+    char *user_name;
+    char *partition;
+    char *account;
+    uint32_t job_state;
+    uint32_t num_nodes;
+    uint32_t num_tasks;
+    int32_t exit_code;
+    char *nodelist;
+} job_info_t;
+
+// The container structs are Rust-owned and carry trailing private storage;
+// only these leading fields are part of the C-visible layout.
+typedef struct {
+    uint32_t record_count;
+    job_info_t *job_array;
+} job_info_msg_t;
+
+typedef struct {
+    char *name;
+    uint32_t node_state;
+    uint32_t cpus;
+    uint64_t real_memory;
+    char *reason;
+} node_info_t;
+
+typedef struct {
+    uint32_t record_count;
+    node_info_t *node_array;
+} node_info_msg_t;
+
+typedef struct {
+    char *name;
+    uint32_t total_nodes;
+    uint32_t total_cpus;
+    char *nodes;
+} partition_info_t;
+
+typedef struct {
+    uint32_t record_count;
+    partition_info_t *partition_array;
+} partition_info_msg_t;
+
+extern void slurm_init_job_desc_msg(job_desc_msg_t *desc);
+extern int slurm_submit_batch_job(const job_desc_msg_t *desc, uint32_t *job_id);
+extern int slurm_load_jobs(int64_t update_time, job_info_msg_t **resp, uint32_t flags);
+extern void slurm_free_job_info_msg(job_info_msg_t *msg);
+extern int slurm_load_node(int64_t update_time, node_info_msg_t **resp, uint32_t flags);
+extern int slurm_load_partitions(int64_t update_time, partition_info_msg_t **resp,
+                                 uint32_t flags);
+extern int slurm_kill_job(uint32_t job_id, uint16_t signal, uint16_t flags);
+extern const char *slurm_strerror(int errnum);
+
+static const char *safe(const char *s)
+{
+    return s ? s : "";
+}
+
+static int cmd_defaults(void)
+{
+    job_desc_msg_t desc;
+    memset(&desc, 0xAB, sizeof(desc));
+    slurm_init_job_desc_msg(&desc);
+
+    printf("name_null=%d\n", desc.name == NULL);
+    printf("script_null=%d\n", desc.script == NULL);
+    printf("min_nodes=%u\n", desc.min_nodes);
+    printf("max_nodes=%u\n", desc.max_nodes);
+    printf("num_tasks_is_no_val=%d\n", desc.num_tasks == NO_VAL);
+    printf("cpus_per_task=%u\n", desc.cpus_per_task);
+    printf("time_limit=%u\n", desc.time_limit);
+    return 0;
+}
+
+static int cmd_submit(int argc, char **argv)
+{
+    if (argc < 4) {
+        fprintf(stderr, "usage: submit <name> <partition> <script> [nodes] [tasks]\n");
+        return 2;
+    }
+
+    job_desc_msg_t desc;
+    slurm_init_job_desc_msg(&desc);
+    desc.name = argv[1];
+    desc.partition = argv[2][0] ? argv[2] : NULL;
+    desc.script = argv[3];
+    desc.min_nodes = (argc > 4) ? (uint32_t)strtoul(argv[4], NULL, 10) : 1;
+    desc.max_nodes = desc.min_nodes;
+    desc.num_tasks = (argc > 5) ? (uint32_t)strtoul(argv[5], NULL, 10) : 1;
+
+    uint32_t job_id = 0;
+    int rc = slurm_submit_batch_job(&desc, &job_id);
+    printf("rc=%d\n", rc);
+    printf("job_id=%u\n", job_id);
+    return rc == 0 ? 0 : 1;
+}
+
+static int cmd_jobs(int argc, char **argv)
+{
+    job_info_msg_t *msg = NULL;
+    int rc = slurm_load_jobs(0, &msg, 0);
+    printf("rc=%d\n", rc);
+    if (rc != 0 || msg == NULL)
+        return 1;
+
+    uint32_t want = (argc > 1) ? (uint32_t)strtoul(argv[1], NULL, 10) : 0;
+    printf("record_count=%u\n", msg->record_count);
+    for (uint32_t i = 0; i < msg->record_count; i++) {
+        job_info_t *j = &msg->job_array[i];
+        if (want != 0 && j->job_id != want)
+            continue;
+        printf("job id=%u name=%s user=%s partition=%s account=%s state=%u "
+               "nodes=%u tasks=%u exit=%d nodelist=%s\n",
+               j->job_id, safe(j->name), safe(j->user_name), safe(j->partition),
+               safe(j->account), j->job_state, j->num_nodes, j->num_tasks,
+               j->exit_code, safe(j->nodelist));
+    }
+
+    slurm_free_job_info_msg(msg);
+    return 0;
+}
+
+static int cmd_nodes(void)
+{
+    node_info_msg_t *msg = NULL;
+    int rc = slurm_load_node(0, &msg, 0);
+    printf("rc=%d\n", rc);
+    if (rc != 0 || msg == NULL)
+        return 1;
+
+    printf("record_count=%u\n", msg->record_count);
+    for (uint32_t i = 0; i < msg->record_count; i++) {
+        node_info_t *n = &msg->node_array[i];
+        printf("node name=%s state=%u cpus=%u memory=%llu reason=%s\n",
+               safe(n->name), n->node_state, n->cpus,
+               (unsigned long long)n->real_memory, safe(n->reason));
+    }
+    return 0;
+}
+
+static int cmd_partitions(void)
+{
+    partition_info_msg_t *msg = NULL;
+    int rc = slurm_load_partitions(0, &msg, 0);
+    printf("rc=%d\n", rc);
+    if (rc != 0 || msg == NULL)
+        return 1;
+
+    printf("record_count=%u\n", msg->record_count);
+    for (uint32_t i = 0; i < msg->record_count; i++) {
+        partition_info_t *p = &msg->partition_array[i];
+        printf("partition name=%s total_nodes=%u total_cpus=%u nodes=%s\n",
+               safe(p->name), p->total_nodes, p->total_cpus, safe(p->nodes));
+    }
+    return 0;
+}
+
+static int cmd_kill(int argc, char **argv)
+{
+    if (argc < 2) {
+        fprintf(stderr, "usage: kill <job_id> [signal]\n");
+        return 2;
+    }
+    uint32_t job_id = (uint32_t)strtoul(argv[1], NULL, 10);
+    uint16_t signal = (argc > 2) ? (uint16_t)strtoul(argv[2], NULL, 10) : 9;
+    int rc = slurm_kill_job(job_id, signal, 0);
+    printf("rc=%d\n", rc);
+    return rc == 0 ? 0 : 1;
+}
+
+static int cmd_strerror(int argc, char **argv)
+{
+    if (argc < 2) {
+        fprintf(stderr, "usage: strerror <errnum>\n");
+        return 2;
+    }
+    printf("message=%s\n", safe(slurm_strerror((int)strtol(argv[1], NULL, 10))));
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    if (argc < 2) {
+        fprintf(stderr, "usage: %s <defaults|submit|jobs|nodes|partitions|kill|"
+                        "strerror> [args...]\n",
+                argv[0]);
+        return 2;
+    }
+
+    const char *cmd = argv[1];
+    int rc;
+
+    if (strcmp(cmd, "defaults") == 0)
+        rc = cmd_defaults();
+    else if (strcmp(cmd, "submit") == 0)
+        rc = cmd_submit(argc - 1, argv + 1);
+    else if (strcmp(cmd, "jobs") == 0)
+        rc = cmd_jobs(argc - 1, argv + 1);
+    else if (strcmp(cmd, "nodes") == 0)
+        rc = cmd_nodes();
+    else if (strcmp(cmd, "partitions") == 0)
+        rc = cmd_partitions();
+    else if (strcmp(cmd, "kill") == 0)
+        rc = cmd_kill(argc - 1, argv + 1);
+    else if (strcmp(cmd, "strerror") == 0)
+        rc = cmd_strerror(argc - 1, argv + 1);
+    else {
+        fprintf(stderr, "unknown command: %s\n", cmd);
+        return 2;
+    }
+
+    fflush(stdout);
+    return rc;
+}

--- a/tests/native_host/e2e/fixtures/spank_test.c
+++ b/tests/native_host/e2e/fixtures/spank_test.c
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// SPANK plugin used by the e2e suite.
+//
+// The spank_* symbols are resolved at dlopen time from the spurd executable's
+// dynamic symbol table, so the plugin declares them extern and links against
+// nothing. Behaviour is driven by plugstack args:
+//
+//   var=NAME        env var to inject (default SPANK_TEST_VAR)
+//   value=VALUE     value to inject (default injected)
+//   trace=PATH      append one line per hook to PATH
+//   fail=HOOK       return non-zero from HOOK (init|task_init|task_exit)
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct spank *spank_t;
+
+#define ESPANK_SUCCESS 0
+#define ESPANK_ERROR 1
+
+#define S_JOB_UID 0
+#define S_JOB_ID 2
+
+extern int spank_setenv(spank_t spank, const char *var, const char *val, int overwrite);
+extern int spank_getenv(spank_t spank, const char *var, char *buf, int len);
+extern int spank_get_item(spank_t spank, int item, void *val);
+
+// Slurm requires these; Spur does not read them, but a real plugin has them
+// and their presence keeps the fixture honest about the ABI.
+const char plugin_name[] = "spank_test";
+const char plugin_type[] = "spank";
+const unsigned int plugin_version = 1;
+
+static const char *arg_value(int ac, char **argv, const char *key)
+{
+    size_t klen = strlen(key);
+    for (int i = 0; i < ac; i++) {
+        if (argv[i] && strncmp(argv[i], key, klen) == 0 && argv[i][klen] == '=')
+            return argv[i] + klen + 1;
+    }
+    return NULL;
+}
+
+static void trace(int ac, char **argv, const char *hook)
+{
+    const char *path = arg_value(ac, argv, "trace");
+    if (!path)
+        return;
+    FILE *f = fopen(path, "a");
+    if (!f)
+        return;
+    fprintf(f, "%s ac=%d\n", hook, ac);
+    fclose(f);
+}
+
+static int should_fail(int ac, char **argv, const char *hook)
+{
+    const char *fail = arg_value(ac, argv, "fail");
+    return fail != NULL && strcmp(fail, hook) == 0;
+}
+
+int slurm_spank_init(spank_t sp, int ac, char **argv)
+{
+    trace(ac, argv, "init");
+    if (should_fail(ac, argv, "init"))
+        return ESPANK_ERROR;
+
+    if (spank_setenv(sp, "SPANK_TEST_INIT", "1", 1) != ESPANK_SUCCESS)
+        return ESPANK_ERROR;
+    return ESPANK_SUCCESS;
+}
+
+int slurm_spank_task_init(spank_t sp, int ac, char **argv)
+{
+    trace(ac, argv, "task_init");
+    if (should_fail(ac, argv, "task_init"))
+        return ESPANK_ERROR;
+
+    const char *var = arg_value(ac, argv, "var");
+    const char *value = arg_value(ac, argv, "value");
+    if (spank_setenv(sp, var ? var : "SPANK_TEST_VAR", value ? value : "injected", 1)
+        != ESPANK_SUCCESS)
+        return ESPANK_ERROR;
+
+    // Overwrite=0 must not clobber a value the plugin just set.
+    spank_setenv(sp, "SPANK_TEST_NOCLOBBER", "first", 1);
+    spank_setenv(sp, "SPANK_TEST_NOCLOBBER", "second", 0);
+
+    unsigned int job_id = 0;
+    if (spank_get_item(sp, S_JOB_ID, &job_id) == ESPANK_SUCCESS) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "%u", job_id);
+        spank_setenv(sp, "SPANK_TEST_JOB_ID", buf, 1);
+    }
+
+    unsigned int uid = 0;
+    if (spank_get_item(sp, S_JOB_UID, &uid) == ESPANK_SUCCESS) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "%u", uid);
+        spank_setenv(sp, "SPANK_TEST_UID", buf, 1);
+    }
+
+    // Read back through the handle to prove setenv and getenv share state.
+    char echo[64] = {0};
+    if (spank_getenv(sp, "SPANK_TEST_INIT", echo, (int)sizeof(echo)) == ESPANK_SUCCESS)
+        spank_setenv(sp, "SPANK_TEST_SAW_INIT", echo, 1);
+
+    return ESPANK_SUCCESS;
+}
+
+int slurm_spank_task_exit(spank_t sp, int ac, char **argv)
+{
+    (void)sp;
+    trace(ac, argv, "task_exit");
+    if (should_fail(ac, argv, "task_exit"))
+        return ESPANK_ERROR;
+    return ESPANK_SUCCESS;
+}

--- a/tests/native_host/e2e/test_accounting.py
+++ b/tests/native_host/e2e/test_accounting.py
@@ -11,6 +11,9 @@ import re
 import time
 
 from cluster import deep_merge, parse_job_id, wait_job, wait_job_state, wait_sacct_row
+import pytest
+
+pytestmark = pytest.mark.suite_runtime
 
 
 class TestSacctExitReporting:

--- a/tests/native_host/e2e/test_admission.py
+++ b/tests/native_host/e2e/test_admission.py
@@ -6,6 +6,9 @@ E2E tests for node admission.
 """
 
 import time
+import pytest
+
+pytestmark = pytest.mark.suite_policy
 
 
 def _wait_registered(cluster, timeout=30):

--- a/tests/native_host/e2e/test_burst_buffer.py
+++ b/tests/native_host/e2e/test_burst_buffer.py
@@ -151,18 +151,37 @@ class TestStaging:
     def test_a_failing_stage_in_fails_the_job(self, bb_cluster):
         """Running the script against half-staged data would corrupt results,
         so stage-in is fail-fast."""
+        marker = f"{bb_cluster.remote_dir}/bb-badin-ran.txt"
         job_id = submit_bb(
-            bb_cluster, "bb-badin", "stage_in:exit 7", "echo unreachable"
+            bb_cluster,
+            "bb-badin",
+            "stage_in:cp /nonexistent/src /nonexistent/dst",
+            f"echo ran > {marker}",
         )
         assert wait_job(bb_cluster, job_id, timeout=120) == "F", (
             bb_cluster.debug_job(job_id)
+        )
+        ran_on = [
+            name
+            for name, node in zip(bb_cluster.node_names, bb_cluster.nodes)
+            if "RAN" in node.exec_allow_fail(
+                f"test -e '{marker}' && echo RAN || echo ABSENT"
+            )
+        ]
+        assert not ran_on, (
+            f"stage-in is fail-fast, but the script still ran on {ran_on}"
         )
 
     def test_a_failing_stage_out_does_not_fail_the_job(self, bb_cluster):
         """Stage-out is best-effort: the job's real work is already done, so a
         copy failure must not retroactively mark it failed."""
+        # A command that exits non-zero, not `exit`, which would terminate the
+        # wrapper itself and prove nothing about stage-out being best-effort.
         job_id = submit_bb(
-            bb_cluster, "bb-badout", "stage_out:exit 7", "echo BB_OUT_OK"
+            bb_cluster,
+            "bb-badout",
+            "stage_out:cp /nonexistent/src /nonexistent/dst",
+            "echo BB_OUT_OK",
         )
         assert wait_job(bb_cluster, job_id, timeout=120) in ("CD", "GONE"), (
             bb_cluster.debug_job(job_id)

--- a/tests/native_host/e2e/test_burst_buffer.py
+++ b/tests/native_host/e2e/test_burst_buffer.py
@@ -20,6 +20,8 @@ import pytest
 
 from cluster import parse_job_id, wait_job, wait_job_state
 
+pytestmark = pytest.mark.suite_runtime
+
 POOL_GB = 64
 
 

--- a/tests/native_host/e2e/test_burst_buffer.py
+++ b/tests/native_host/e2e/test_burst_buffer.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for burst buffer capacity and staging.
+
+`--bb` carries two independent things: a `capacity=` reservation the controller
+holds against the `[burst_buffer]` pool, and `stage_in:`/`stage_out:` shell
+commands the agent wraps around the job script. Capacity gating and command
+wrapping are exercised separately because a spec can use either alone.
+
+Stage-in completes synchronously inside the controller today, so the
+`BurstBufferStageIn` hold is only observable for a scheduler tick and is not
+asserted here.
+"""
+
+import re
+import time
+
+import pytest
+
+from cluster import parse_job_id, wait_job, wait_job_state
+
+POOL_GB = 64
+
+
+@pytest.fixture
+def bb_cluster(unstarted_cluster):
+    unstarted_cluster.start(config_overrides={"burst_buffer": {"total_gb": POOL_GB}})
+    return unstarted_cluster
+
+
+def pending_reason(cluster, job_id: int) -> str:
+    out = cluster.scontrol("show", "job", str(job_id))
+    match = re.search(r"Reason=(\S+)", out)
+    return match.group(1) if match else ""
+
+
+def wait_reason(cluster, job_id: int, reason: str, timeout: int = 60) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if pending_reason(cluster, job_id) == reason:
+            return
+        time.sleep(2)
+    raise AssertionError(
+        f"job {job_id} never reported Reason={reason}\n"
+        f"{cluster.scontrol('show', 'job', str(job_id))}"
+    )
+
+
+def submit_bb(cluster, name: str, bb: str, body: str, out_path: str | None = None) -> int:
+    script = cluster.write_file(f"{name}.sh", f"#!/bin/bash\n{body}\n")
+    args = ["-J", name, "--bb", bb]
+    if out_path:
+        args += ["-o", out_path]
+    job_id = parse_job_id(cluster.sbatch(args + [script]))
+    assert job_id is not None
+    return job_id
+
+
+class TestCapacityPool:
+    def test_a_request_within_the_pool_runs(self, bb_cluster):
+        job_id = submit_bb(bb_cluster, "bb-fit", "capacity=32", "echo BB_FIT_OK")
+        assert wait_job(bb_cluster, job_id, timeout=120) in ("CD", "GONE"), (
+            bb_cluster.debug_job(job_id)
+        )
+
+    def test_a_request_larger_than_the_pool_stays_pending(self, bb_cluster):
+        job_id = submit_bb(
+            bb_cluster, "bb-huge", f"capacity={POOL_GB * 4}", "echo unreachable"
+        )
+        try:
+            wait_reason(bb_cluster, job_id, "BurstBufferResources")
+        finally:
+            bb_cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_capacity_is_disabled_by_default(self, cluster):
+        """With no `[burst_buffer]` section the pool is zero, so any capacity
+        request must block rather than silently succeed unmetered."""
+        job_id = submit_bb(cluster, "bb-nopool", "capacity=1", "echo unreachable")
+        try:
+            wait_reason(cluster, job_id, "BurstBufferResources")
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_a_second_job_waits_for_the_pool(self, bb_cluster):
+        holder = submit_bb(
+            bb_cluster, "bb-hold", f"capacity={POOL_GB}", "sleep 120"
+        )
+        wait_job_state(bb_cluster, holder, "R", timeout=90)
+
+        waiter = submit_bb(bb_cluster, "bb-wait", "capacity=32", "echo unreachable")
+        try:
+            wait_reason(bb_cluster, waiter, "BurstBufferResources")
+        finally:
+            for job_id in (holder, waiter):
+                bb_cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_capacity_is_returned_when_the_holder_ends(self, bb_cluster):
+        holder = submit_bb(bb_cluster, "bb-rel", f"capacity={POOL_GB}", "sleep 120")
+        wait_job_state(bb_cluster, holder, "R", timeout=90)
+
+        waiter = submit_bb(bb_cluster, "bb-next", f"capacity={POOL_GB}", "sleep 30")
+        wait_reason(bb_cluster, waiter, "BurstBufferResources")
+
+        bb_cluster.cli_allow_fail(["scancel", str(holder)])
+        try:
+            wait_job_state(bb_cluster, waiter, "R", timeout=120)
+        finally:
+            bb_cluster.cli_allow_fail(["scancel", str(waiter)])
+
+    def test_a_malformed_capacity_does_not_reserve(self, bb_cluster):
+        """An unparseable capacity reads as zero. That is permissive, but it
+        must at least not wedge the job in a permanent pending state."""
+        job_id = submit_bb(bb_cluster, "bb-bad", "capacity=abc", "echo BB_BAD_OK")
+        assert wait_job(bb_cluster, job_id, timeout=120) in ("CD", "GONE"), (
+            bb_cluster.debug_job(job_id)
+        )
+
+
+class TestStaging:
+    def test_stage_in_runs_before_the_script(self, bb_cluster):
+        marker = f"{bb_cluster.remote_dir}/bb-stage-in.txt"
+        out_path = f"{bb_cluster.remote_dir}/bb-in.out"
+        job_id = submit_bb(
+            bb_cluster,
+            "bb-in",
+            f"stage_in:echo staged > {marker}",
+            f"cat {marker}",
+            out_path,
+        )
+        assert wait_job(bb_cluster, job_id, timeout=120) in ("CD", "GONE"), (
+            bb_cluster.debug_job(job_id)
+        )
+        out = bb_cluster.read_output_on_any_node(out_path)
+        assert "staged" in out, f"stage_in output not visible to the script:\n{out}"
+
+    def test_stage_out_runs_after_the_script(self, bb_cluster):
+        src = f"{bb_cluster.remote_dir}/bb-out-src.txt"
+        dst = f"{bb_cluster.remote_dir}/bb-out-dst.txt"
+        job_id = submit_bb(
+            bb_cluster,
+            "bb-out",
+            f"stage_out:cp {src} {dst}",
+            f"echo produced > {src}",
+        )
+        assert wait_job(bb_cluster, job_id, timeout=120) in ("CD", "GONE"), (
+            bb_cluster.debug_job(job_id)
+        )
+        assert "produced" in bb_cluster.read_output_on_any_node(dst)
+
+    def test_a_failing_stage_in_fails_the_job(self, bb_cluster):
+        """Running the script against half-staged data would corrupt results,
+        so stage-in is fail-fast."""
+        job_id = submit_bb(
+            bb_cluster, "bb-badin", "stage_in:exit 7", "echo unreachable"
+        )
+        assert wait_job(bb_cluster, job_id, timeout=120) == "F", (
+            bb_cluster.debug_job(job_id)
+        )
+
+    def test_a_failing_stage_out_does_not_fail_the_job(self, bb_cluster):
+        """Stage-out is best-effort: the job's real work is already done, so a
+        copy failure must not retroactively mark it failed."""
+        job_id = submit_bb(
+            bb_cluster, "bb-badout", "stage_out:exit 7", "echo BB_OUT_OK"
+        )
+        assert wait_job(bb_cluster, job_id, timeout=120) in ("CD", "GONE"), (
+            bb_cluster.debug_job(job_id)
+        )
+
+    def test_the_script_exit_code_survives_the_wrapper(self, bb_cluster):
+        job_id = submit_bb(bb_cluster, "bb-exit", "stage_out:true", "exit 3")
+        assert wait_job(bb_cluster, job_id, timeout=120) == "F", (
+            bb_cluster.debug_job(job_id)
+        )
+        out = bb_cluster.scontrol("show", "job", str(job_id))
+        assert "ExitCode=3" in out, out
+
+    def test_the_spec_is_exported_to_the_job(self, bb_cluster):
+        spec = "capacity=8;stage_in:true"
+        out_path = f"{bb_cluster.remote_dir}/bb-env.out"
+        job_id = submit_bb(
+            bb_cluster, "bb-env", spec, 'echo "BB=$SPUR_BURST_BUFFER"', out_path
+        )
+        assert wait_job(bb_cluster, job_id, timeout=120) in ("CD", "GONE"), (
+            bb_cluster.debug_job(job_id)
+        )
+        out = bb_cluster.read_output_on_any_node(out_path)
+        assert f"BB={spec}" in out, out
+
+    def test_staging_without_capacity_needs_no_pool(self, bb_cluster):
+        """A stage-only spec parses to zero capacity, so it must dispatch even
+        when the pool is fully reserved."""
+        holder = submit_bb(bb_cluster, "bb-full", f"capacity={POOL_GB}", "sleep 120")
+        wait_job_state(bb_cluster, holder, "R", timeout=90)
+        try:
+            job_id = submit_bb(
+                bb_cluster, "bb-stageonly", "stage_in:true", "echo BB_STAGE_OK"
+            )
+            assert wait_job(bb_cluster, job_id, timeout=120) in ("CD", "GONE"), (
+                bb_cluster.debug_job(job_id)
+            )
+        finally:
+            bb_cluster.cli_allow_fail(["scancel", str(holder)])

--- a/tests/native_host/e2e/test_cli_env_defaults.py
+++ b/tests/native_host/e2e/test_cli_env_defaults.py
@@ -16,6 +16,8 @@ import pytest
 
 from cluster import parse_job_id, wait_job
 
+pytestmark = pytest.mark.suite_api
+
 TWO_PARTITIONS = {
     "partitions": [
         {

--- a/tests/native_host/e2e/test_cli_env_defaults.py
+++ b/tests/native_host/e2e/test_cli_env_defaults.py
@@ -86,9 +86,13 @@ class TestSbatchEnvDefaults:
 
     def test_timelimit_env_applies(self, cluster):
         job_id = self._submit(cluster, {"SPUR_TIMELIMIT": "00:07:00"})
-        show = cluster.scontrol("show", "job", str(job_id))
-        assert "7" in _show_field(show, "TimeLimit"), (
-            f"SPUR_TIMELIMIT must set the job time limit:\n{show}"
+        # `scontrol show job` does not render a time limit, so squeue's %l is
+        # the only place the applied value is observable.
+        shown = cluster.cli(
+            ["squeue", "-h", "-o", "%l", "-j", str(job_id)]
+        ).strip()
+        assert shown == "7:00", (
+            f"SPUR_TIMELIMIT must set the job time limit, squeue %l shows {shown!r}"
         )
         wait_job(cluster, job_id, timeout=90)
 

--- a/tests/native_host/e2e/test_cli_env_defaults.py
+++ b/tests/native_host/e2e/test_cli_env_defaults.py
@@ -1,0 +1,234 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for submit-time environment variable defaults.
+
+sbatch and salloc read per-command env vars (SBATCH_*, SALLOC_*) and their
+SPUR_* native twins as defaults for unset flags. These are submit-side
+defaults read from the CLI's own environment, distinct from --export, which
+shapes the job's environment.
+"""
+
+import re
+import time
+
+import pytest
+
+from cluster import parse_job_id, wait_job
+
+TWO_PARTITIONS = {
+    "partitions": [
+        {
+            "name": "default",
+            "state": "UP",
+            "default": True,
+            "nodes": "ALL",
+            "max_time": "24:00:00",
+            "default_time": "10:00",
+        },
+        {
+            "name": "envpart",
+            "state": "UP",
+            "nodes": "ALL",
+            "max_time": "24:00:00",
+            "default_time": "10:00",
+        },
+    ],
+}
+
+
+def _show_field(show_output: str, field: str) -> str:
+    match = re.search(rf"\b{field}=(\S+)", show_output)
+    assert match, f"missing {field} in scontrol output:\n{show_output}"
+    return match.group(1)
+
+
+class TestSbatchEnvDefaults:
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return TWO_PARTITIONS
+
+    def _submit(self, cluster, env, extra_args=None):
+        script = cluster.write_file("env-default.sh", "#!/bin/bash\nsleep 1\n")
+        code, out = cluster.cli_with_env(
+            ["sbatch", "-J", "env-default"] + (extra_args or []) + [script], env
+        )
+        assert code == 0, f"sbatch failed (exit {code}):\n{out}"
+        job_id = parse_job_id(out)
+        assert job_id is not None, f"could not parse job id from:\n{out}"
+        return job_id
+
+    def test_spur_partition_twin_routes_job(self, cluster):
+        job_id = self._submit(cluster, {"SPUR_PARTITION": "envpart"})
+        show = cluster.scontrol("show", "job", str(job_id))
+        assert _show_field(show, "Partition") == "envpart", (
+            f"SPUR_PARTITION must select the partition:\n{show}"
+        )
+        wait_job(cluster, job_id, timeout=90)
+
+    def test_sbatch_partition_env_routes_job(self, cluster):
+        job_id = self._submit(cluster, {"SBATCH_PARTITION": "envpart"})
+        show = cluster.scontrol("show", "job", str(job_id))
+        assert _show_field(show, "Partition") == "envpart", (
+            f"SBATCH_PARTITION must select the partition:\n{show}"
+        )
+        wait_job(cluster, job_id, timeout=90)
+
+    def test_cli_flag_overrides_env_partition(self, cluster):
+        job_id = self._submit(
+            cluster, {"SPUR_PARTITION": "envpart"}, extra_args=["-p", "default"]
+        )
+        show = cluster.scontrol("show", "job", str(job_id))
+        assert _show_field(show, "Partition") == "default", (
+            f"an explicit -p must beat SPUR_PARTITION:\n{show}"
+        )
+        wait_job(cluster, job_id, timeout=90)
+
+    def test_timelimit_env_applies(self, cluster):
+        job_id = self._submit(cluster, {"SPUR_TIMELIMIT": "00:07:00"})
+        show = cluster.scontrol("show", "job", str(job_id))
+        assert "7" in _show_field(show, "TimeLimit"), (
+            f"SPUR_TIMELIMIT must set the job time limit:\n{show}"
+        )
+        wait_job(cluster, job_id, timeout=90)
+
+    def test_job_name_env_twin_is_not_inherited(self, cluster):
+        """SPUR_JOB_NAME is injected into every running job, so sbatch must
+        ignore it — otherwise a nested submit silently inherits the enclosing
+        job's name. Only the SBATCH_-prefixed spelling is honored.
+        """
+        script = cluster.write_file("name-env.sh", "#!/bin/bash\nsleep 1\n")
+        code, out = cluster.cli_with_env(
+            ["sbatch", script], {"SPUR_JOB_NAME": "inherited"}
+        )
+        assert code == 0, f"sbatch failed (exit {code}):\n{out}"
+        job_id = parse_job_id(out)
+        assert job_id is not None
+
+        show = cluster.scontrol("show", "job", str(job_id))
+        assert _show_field(show, "JobName") != "inherited", (
+            f"SPUR_JOB_NAME must not be inherited by sbatch:\n{show}"
+        )
+        wait_job(cluster, job_id, timeout=90)
+
+    def test_sbatch_job_name_env_applies(self, cluster):
+        script = cluster.write_file("name-env2.sh", "#!/bin/bash\nsleep 1\n")
+        code, out = cluster.cli_with_env(
+            ["sbatch", script], {"SBATCH_JOB_NAME": "from-env"}
+        )
+        assert code == 0, f"sbatch failed (exit {code}):\n{out}"
+        job_id = parse_job_id(out)
+        assert job_id is not None
+
+        show = cluster.scontrol("show", "job", str(job_id))
+        assert _show_field(show, "JobName") == "from-env", (
+            f"SBATCH_JOB_NAME must set the job name:\n{show}"
+        )
+        wait_job(cluster, job_id, timeout=90)
+
+    def test_env_output_path_applies(self, cluster):
+        out_path = f"{cluster.remote_dir}/env-output.out"
+        script = cluster.write_file(
+            "env-output.sh", "#!/bin/bash\necho MARKER_FROM_ENV_OUTPUT\n"
+        )
+        code, out = cluster.cli_with_env(
+            ["sbatch", script], {"SPUR_OUTPUT": out_path}
+        )
+        assert code == 0, f"sbatch failed (exit {code}):\n{out}"
+        job_id = parse_job_id(out)
+        assert job_id is not None
+
+        assert wait_job(cluster, job_id, timeout=90) == "CD", cluster.debug_job(job_id)
+        content = cluster.read_output_on_any_node(out_path)
+        assert "MARKER_FROM_ENV_OUTPUT" in content, (
+            f"SPUR_OUTPUT must redirect job output to {out_path}, got:\n{content!r}"
+        )
+
+
+class TestSallocEnvDefaults:
+    """salloc spawns $SHELL inside the allocation.
+
+    Pointing SHELL at a probe script turns that into a synchronous assertion:
+    the script runs while the allocation is live, records what salloc injected,
+    and exits, which releases the allocation.
+    """
+
+    @pytest.fixture
+    def cluster_config_overrides(self):
+        return TWO_PARTITIONS
+
+    def _run_salloc(self, cluster, env, extra_args=None):
+        probe_out = f"{cluster.remote_dir}/salloc-probe.out"
+        probe = cluster.write_file(
+            "salloc-probe.sh",
+            "#!/bin/bash\n"
+            f'echo "partition=$SPUR_JOB_PARTITION" > {probe_out}\n'
+            f'echo "qos=$SPUR_JOB_QOS" >> {probe_out}\n'
+            f'echo "jobid=$SPUR_JOB_ID" >> {probe_out}\n',
+        )
+        code, out = cluster.cli_with_env(
+            ["salloc"] + (extra_args or []), {**env, "SHELL": probe}
+        )
+        assert code == 0, f"salloc failed (exit {code}):\n{out}"
+        content = cluster.read_output_on_any_node(probe_out)
+        assert content.strip(), f"salloc probe produced no output; salloc said:\n{out}"
+        return dict(
+            line.split("=", 1)
+            for line in content.splitlines()
+            if "=" in line
+        )
+
+    def test_spur_partition_twin_applies(self, cluster):
+        values = self._run_salloc(cluster, {"SPUR_PARTITION": "envpart"})
+        assert values["partition"] == "envpart", (
+            f"SPUR_PARTITION must select the salloc partition, got {values}"
+        )
+
+    def test_salloc_partition_env_applies(self, cluster):
+        values = self._run_salloc(cluster, {"SALLOC_PARTITION": "envpart"})
+        assert values["partition"] == "envpart", (
+            f"SALLOC_PARTITION must select the salloc partition, got {values}"
+        )
+
+    def test_cli_flag_overrides_env_partition(self, cluster):
+        values = self._run_salloc(
+            cluster, {"SALLOC_PARTITION": "envpart"}, extra_args=["-p", "default"]
+        )
+        assert values["partition"] == "default", (
+            f"an explicit -p must beat SALLOC_PARTITION, got {values}"
+        )
+
+
+class TestSallocQos:
+    """An explicit QOS must exist in the controller's cache to be accepted,
+    so these need the accounting fixture."""
+
+    def _run_salloc(self, cluster, env, extra_args=None):
+        probe_out = f"{cluster.remote_dir}/salloc-qos.out"
+        probe = cluster.write_file(
+            "salloc-qos-probe.sh",
+            "#!/bin/bash\n" f'echo "qos=$SPUR_JOB_QOS" > {probe_out}\n',
+        )
+        code, out = cluster.cli_with_env(
+            ["salloc"] + (extra_args or []), {**env, "SHELL": probe}
+        )
+        assert code == 0, f"salloc failed (exit {code}):\n{out}"
+        content = cluster.read_output_on_any_node(probe_out)
+        assert content.strip(), f"salloc probe produced no output; salloc said:\n{out}"
+        return content.split("qos=", 1)[1].strip()
+
+    def test_salloc_qos_flag_and_env(self, accounting_cluster):
+        c = accounting_cluster
+        c.sacctmgr(["add", "qos", "name=allocqos"])
+        # QoS cache refreshes on the fairshare interval (10s in e2e config).
+        time.sleep(15)
+
+        assert self._run_salloc(c, {}, extra_args=["-q", "allocqos"]) == "allocqos", (
+            "salloc --qos must reach the job spec"
+        )
+        assert self._run_salloc(c, {"SALLOC_QOS": "allocqos"}) == "allocqos", (
+            "SALLOC_QOS must default the QOS"
+        )
+        assert self._run_salloc(c, {"SPUR_QOS": "allocqos"}) == "allocqos", (
+            "the SPUR_QOS twin must default the QOS"
+        )

--- a/tests/native_host/e2e/test_cli_queries.py
+++ b/tests/native_host/e2e/test_cli_queries.py
@@ -61,21 +61,22 @@ class TestSqueueSorting:
 
 class TestSinfoFiltering:
     def test_state_filter_selects_idle_nodes(self, cluster):
-        out = cluster.cli(["sinfo", "-t", "idle"])
-        for name in cluster.node_names:
-            assert name in out, f"idle node {name} missing from `sinfo -t idle`:\n{out}"
+        shown = cluster.sinfo_node_names(["-t", "idle"])
+        assert shown == set(cluster.node_names), (
+            f"`sinfo -t idle` should list every idle node, got {sorted(shown)}"
+        )
 
     def test_state_filter_excludes_non_matching_states(self, cluster):
-        out = cluster.cli(["sinfo", "-t", "down"])
-        for name in cluster.node_names:
-            assert name not in out, (
-                f"idle node {name} must not appear under `sinfo -t down`:\n{out}"
-            )
+        shown = cluster.sinfo_node_names(["-t", "down"])
+        assert shown.isdisjoint(cluster.node_names), (
+            f"no idle node may appear under `sinfo -t down`, got {sorted(shown)}"
+        )
 
     def test_state_filter_all_disables_filtering(self, cluster):
-        out = cluster.cli(["sinfo", "-t", "all"])
-        for name in cluster.node_names:
-            assert name in out, f"node {name} missing from `sinfo -t all`:\n{out}"
+        shown = cluster.sinfo_node_names(["-t", "all"])
+        assert shown == set(cluster.node_names), (
+            f"`sinfo -t all` should list every node, got {sorted(shown)}"
+        )
 
     def test_invalid_state_is_rejected(self, cluster):
         out = cluster.cli_allow_fail(["sinfo", "-t", "notastate"])
@@ -90,7 +91,7 @@ class TestSinfoFiltering:
         try:
             deadline = time.time() + 30
             while time.time() < deadline:
-                if node in cluster.cli(["sinfo", "-t", "drain"]):
+                if node in cluster.sinfo_node_names(["-t", "drain"]):
                     break
                 time.sleep(2)
             else:
@@ -98,7 +99,7 @@ class TestSinfoFiltering:
                     f"drained node {node} never appeared under `sinfo -t drain`:\n"
                     f"{cluster.sinfo()}"
                 )
-            assert node not in cluster.cli(["sinfo", "-t", "idle"]), (
+            assert node not in cluster.sinfo_node_names(["-t", "idle"]), (
                 f"drained node {node} must leave the idle filter:\n{cluster.sinfo()}"
             )
         finally:

--- a/tests/native_host/e2e/test_cli_queries.py
+++ b/tests/native_host/e2e/test_cli_queries.py
@@ -10,6 +10,9 @@ scancel, which selects jobs by user/partition/name rather than by job ID.
 import time
 
 from cluster import job_state, parse_job_id, wait_job, wait_job_state
+import pytest
+
+pytestmark = pytest.mark.suite_api
 
 
 def _held_job_ids(cluster, name: str, count: int) -> list[int]:

--- a/tests/native_host/e2e/test_cli_queries.py
+++ b/tests/native_host/e2e/test_cli_queries.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for read-side CLI filtering, sorting, and formatting.
+
+squeue ordering, sinfo state/feature reporting, and the filter-based form of
+scancel, which selects jobs by user/partition/name rather than by job ID.
+"""
+
+import time
+
+from cluster import job_state, parse_job_id, wait_job, wait_job_state
+
+
+def _held_job_ids(cluster, name: str, count: int) -> list[int]:
+    """Submit *count* held jobs so they sit Pending for the whole test."""
+    script = cluster.write_file(f"{name}.sh", "#!/bin/bash\nsleep 1\n")
+    ids = []
+    for _ in range(count):
+        job_id = parse_job_id(cluster.sbatch(["-J", name, "-H", script]))
+        assert job_id is not None
+        ids.append(job_id)
+    return ids
+
+
+def _squeue_ids(cluster, args: list[str]) -> list[int]:
+    out = cluster.squeue(args + ["-h", "-o", "%i"])
+    return [int(line.strip()) for line in out.splitlines() if line.strip().isdigit()]
+
+
+class TestSqueueSorting:
+    def test_default_sort_is_ascending_by_job_id(self, cluster):
+        """Equal partition, state and priority fall through to jobid ascending."""
+        ids = _held_job_ids(cluster, "sort-default", 3)
+        try:
+            listed = _squeue_ids(cluster, ["-n", "sort-default"])
+            assert listed == sorted(ids), (
+                f"default squeue order must be ascending by job id: {listed} vs {sorted(ids)}"
+            )
+        finally:
+            for job_id in ids:
+                cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_sort_flag_reverses_job_id_order(self, cluster):
+        ids = _held_job_ids(cluster, "sort-desc", 3)
+        try:
+            listed = _squeue_ids(cluster, ["-n", "sort-desc", "-S", "-i"])
+            assert listed == sorted(ids, reverse=True), (
+                f"-S -i must sort descending by job id: {listed}"
+            )
+        finally:
+            for job_id in ids:
+                cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_invalid_sort_spec_is_rejected(self, cluster):
+        out = cluster.cli_allow_fail(["squeue", "-S", "zz"])
+        assert "Invalid sort specification" in out, (
+            f"an unknown sort spec must be rejected, got:\n{out}"
+        )
+
+
+class TestSinfoFiltering:
+    def test_state_filter_selects_idle_nodes(self, cluster):
+        out = cluster.cli(["sinfo", "-t", "idle"])
+        for name in cluster.node_names:
+            assert name in out, f"idle node {name} missing from `sinfo -t idle`:\n{out}"
+
+    def test_state_filter_excludes_non_matching_states(self, cluster):
+        out = cluster.cli(["sinfo", "-t", "down"])
+        for name in cluster.node_names:
+            assert name not in out, (
+                f"idle node {name} must not appear under `sinfo -t down`:\n{out}"
+            )
+
+    def test_state_filter_all_disables_filtering(self, cluster):
+        out = cluster.cli(["sinfo", "-t", "all"])
+        for name in cluster.node_names:
+            assert name in out, f"node {name} missing from `sinfo -t all`:\n{out}"
+
+    def test_invalid_state_is_rejected(self, cluster):
+        out = cluster.cli_allow_fail(["sinfo", "-t", "notastate"])
+        assert "Invalid node state" in out, (
+            f"an unknown node state must be rejected, got:\n{out}"
+        )
+
+    def test_drained_node_moves_between_state_filters(self, cluster):
+        node = cluster.node_names[0]
+        cluster.cli(["scontrol", "update", f"NodeName={node}", "State=DRAIN",
+                     "Reason=sinfo-filter-test"])
+        try:
+            deadline = time.time() + 30
+            while time.time() < deadline:
+                if node in cluster.cli(["sinfo", "-t", "drain"]):
+                    break
+                time.sleep(2)
+            else:
+                raise AssertionError(
+                    f"drained node {node} never appeared under `sinfo -t drain`:\n"
+                    f"{cluster.sinfo()}"
+                )
+            assert node not in cluster.cli(["sinfo", "-t", "idle"]), (
+                f"drained node {node} must leave the idle filter:\n{cluster.sinfo()}"
+            )
+        finally:
+            cluster.cli_allow_fail(
+                ["scontrol", "update", f"NodeName={node}", "State=RESUME"]
+            )
+
+
+class TestSinfoFeatures:
+    def test_node_features_are_displayed(self, unstarted_cluster):
+        """Configured [[nodes]] features must reach the sinfo %f column."""
+        cluster = unstarted_cluster
+        cluster.start(
+            config_overrides={
+                "nodes": [
+                    {
+                        "names": name,
+                        "cpus": 64,
+                        "memory_mb": 262144,
+                        "features": ["mi300x", "fastnet"],
+                    }
+                    for name in cluster.node_names
+                ],
+            }
+        )
+
+        out = cluster.cli(["sinfo", "-N", "-o", "%n|%f", "-h"])
+        rows = [line for line in out.splitlines() if line.strip()]
+        assert rows, f"sinfo -N produced no node rows:\n{out}"
+        for row in rows:
+            name, _, features = row.partition("|")
+            assert name.strip() in cluster.node_names, f"unexpected node row: {row}"
+            assert "mi300x" in features and "fastnet" in features, (
+                f"node {name} must report its configured features, got: {row}"
+            )
+
+    def test_missing_features_render_as_null(self, cluster):
+        out = cluster.cli(["sinfo", "-N", "-o", "%n|%f", "-h"])
+        rows = [line for line in out.splitlines() if line.strip()]
+        assert rows, f"sinfo -N produced no node rows:\n{out}"
+        for row in rows:
+            assert row.endswith("(null)"), (
+                f"a node with no configured features must render (null), got: {row}"
+            )
+
+
+class TestFilterScancel:
+    def test_scancel_by_name_skips_terminal_jobs(self, cluster):
+        """A finished job matched by the filter must be skipped silently.
+
+        Sending it to cancel_job would produce a spurious per-job error, so the
+        client drops terminal jobs before dispatching.
+        """
+        name = "filter-cancel"
+        finished_script = cluster.write_file(
+            "filter-done.sh", "#!/bin/bash\necho done\n"
+        )
+        finished_id = parse_job_id(cluster.sbatch(["-J", name, finished_script]))
+        assert finished_id is not None
+        assert wait_job(cluster, finished_id, timeout=90) == "CD", (
+            cluster.debug_job(finished_id)
+        )
+
+        running_script = cluster.write_file(
+            "filter-running.sh", "#!/bin/bash\nsleep 120\n"
+        )
+        running_id = parse_job_id(cluster.sbatch(["-J", name, running_script]))
+        assert running_id is not None
+        wait_job_state(cluster, running_id, "R", timeout=60)
+
+        out = cluster.cli_allow_fail(["scancel", "-n", name])
+        assert "error" not in out.lower(), (
+            f"scancel -n must not error on the already-finished job:\n{out}"
+        )
+
+        deadline = time.time() + 60
+        while time.time() < deadline:
+            if job_state(cluster.squeue_all(), running_id) == "CA":
+                break
+            time.sleep(2)
+        else:
+            raise AssertionError(
+                f"running job {running_id} was not cancelled by `scancel -n {name}`:\n"
+                f"{cluster.squeue_all()}"
+            )
+
+        assert job_state(cluster.squeue_all(), finished_id) == "CD", (
+            f"the finished job must stay COMPLETED, not flip to CANCELLED:\n"
+            f"{cluster.squeue_all()}"
+        )
+
+    def test_scancel_by_partition_cancels_active_jobs(self, cluster):
+        script = cluster.write_file("part-cancel.sh", "#!/bin/bash\nsleep 120\n")
+        job_id = parse_job_id(cluster.sbatch(["-J", "part-cancel", script]))
+        assert job_id is not None
+        wait_job_state(cluster, job_id, "R", timeout=60)
+
+        cluster.cli_allow_fail(["scancel", "-p", "default"])
+
+        deadline = time.time() + 60
+        while time.time() < deadline:
+            if job_state(cluster.squeue_all(), job_id) == "CA":
+                return
+            time.sleep(2)
+        raise AssertionError(
+            f"job {job_id} was not cancelled by `scancel -p default`:\n"
+            f"{cluster.squeue_all()}"
+        )

--- a/tests/native_host/e2e/test_completing_timeout.py
+++ b/tests/native_host/e2e/test_completing_timeout.py
@@ -25,6 +25,8 @@ import pytest
 
 from cluster import parse_job_id, wait_job
 
+pytestmark = pytest.mark.suite_scheduling
+
 
 class TestCompletingTimeoutCancel:
     # Well above the 10s force-finish tick, low enough to keep the test fast.

--- a/tests/native_host/e2e/test_container.py
+++ b/tests/native_host/e2e/test_container.py
@@ -13,6 +13,8 @@ import pytest
 
 from cluster import parse_job_id, job_state, wait_job
 
+pytestmark = pytest.mark.suite_runtime
+
 
 @pytest.fixture
 def container_cluster(cluster, tmp_path):

--- a/tests/native_host/e2e/test_controller_failover.py
+++ b/tests/native_host/e2e/test_controller_failover.py
@@ -9,7 +9,7 @@ run against the standard single-controller cluster; the dead endpoint is a
 closed port on the same host, so no extra topology is needed.
 
 Full multi-controller Raft failover (kill the connected controller, survivor
-takes over) lives in test_raft_ha.py.
+takes over) lives in test_controller_raft.py.
 """
 
 from cluster import parse_job_id, wait_job

--- a/tests/native_host/e2e/test_controller_failover.py
+++ b/tests/native_host/e2e/test_controller_failover.py
@@ -9,7 +9,7 @@ run against the standard single-controller cluster; the dead endpoint is a
 closed port on the same host, so no extra topology is needed.
 
 Full multi-controller Raft failover (kill the connected controller, survivor
-takes over) is covered separately once the harness grows Raft support.
+takes over) lives in test_raft_ha.py.
 """
 
 from cluster import parse_job_id, wait_job

--- a/tests/native_host/e2e/test_controller_failover.py
+++ b/tests/native_host/e2e/test_controller_failover.py
@@ -13,6 +13,9 @@ takes over) lives in test_controller_raft.py.
 """
 
 from cluster import parse_job_id, wait_job
+import pytest
+
+pytestmark = pytest.mark.suite_ha
 
 # Port with nothing listening — connections are refused immediately.
 DEAD_PORT = 1

--- a/tests/native_host/e2e/test_controller_raft.py
+++ b/tests/native_host/e2e/test_controller_raft.py
@@ -16,6 +16,8 @@ import pytest
 
 from cluster import parse_job_id, wait_job, wait_job_state
 
+pytestmark = pytest.mark.suite_ha
+
 
 @pytest.fixture(autouse=True)
 def _restore_quorum(raft_cluster):

--- a/tests/native_host/e2e/test_controller_raft.py
+++ b/tests/native_host/e2e/test_controller_raft.py
@@ -17,6 +17,24 @@ import pytest
 from cluster import parse_job_id, wait_job, wait_job_state
 
 
+@pytest.fixture(autouse=True)
+def _restore_quorum(raft_cluster):
+    """Return the cluster to three live controllers after every test.
+
+    raft_cluster is module-scoped, so a test that fails between killing a
+    controller and restarting it would leave every later test running against
+    a degraded quorum. Healing here keeps that failure local to one test.
+    """
+    yield
+    for i in raft_cluster.controller_indices:
+        if raft_cluster.raft_role(i) is None:
+            # Kill first: a wedged process still holding the port would make
+            # the replacement exit immediately on bind.
+            raft_cluster.stop_controller_node(i)
+            raft_cluster.start_controller_node(i)
+    raft_cluster.wait_raft_leader(timeout=120)
+
+
 def _job_visible(cluster, job_id: int, node_index: int) -> bool:
     out = cluster.cli_allow_fail(
         ["squeue", "-t", "all", "-j", str(job_id), "-h"],
@@ -34,27 +52,14 @@ class TestLeaderElection:
             f"expected one leader and two replicas, got {roles}"
         )
 
-    def test_node_id_is_derived_from_peer_position(self, raft_cluster):
-        """Peers are listed by hostname, so each controller must pick its id
-        from its own position rather than needing an explicit node_id."""
-        for i in raft_cluster.controller_indices:
-            log = raft_cluster.spurctld_log(i)
-            assert "position in controller.peers" in log, (
-                f"controller {i} did not derive its node_id from the peer list:\n{log}"
-            )
-            assert f"node_id={i + 1}" in log.replace('"', ""), (
-                f"controller {i} should be node_id {i + 1}:\n{log}"
-            )
-
     def test_every_controller_serves_the_same_node_view(self, raft_cluster):
         for i in raft_cluster.controller_indices:
-            out = raft_cluster.cli(
-                ["sinfo"], controller_addr=raft_cluster.controller_addr_for(i)
+            shown = raft_cluster.sinfo_node_names(
+                controller_addr=raft_cluster.controller_addr_for(i)
             )
-            for name in raft_cluster.node_names:
-                assert name in out, (
-                    f"controller {i} is missing node {name}:\n{out}"
-                )
+            assert shown == set(raft_cluster.node_names), (
+                f"controller {i} does not see every node, got {sorted(shown)}"
+            )
 
 
 class TestWriteForwarding:
@@ -209,14 +214,13 @@ class TestLeaderlessReads:
                     break
                 time.sleep(3)
 
-            out = raft_cluster.cli_allow_fail(
-                ["sinfo"],
+            shown = raft_cluster.sinfo_node_names(
                 controller_addr=raft_cluster.controller_addr_for(survivor),
+                allow_fail=True,
             )
-            for name in raft_cluster.node_names:
-                assert name in out, (
-                    f"a leaderless controller must still serve sinfo:\n{out}"
-                )
+            assert shown == set(raft_cluster.node_names), (
+                f"a leaderless controller must still serve sinfo, got {sorted(shown)}"
+            )
             assert _job_visible(raft_cluster, job_id, survivor), (
                 f"a leaderless controller must still serve squeue for {job_id}"
             )

--- a/tests/native_host/e2e/test_controller_raft_peers.py
+++ b/tests/native_host/e2e/test_controller_raft_peers.py
@@ -11,6 +11,9 @@ the same ports on the same nodes.
 The hostname form only works where every node resolves every peer, which a
 stock host does not do -- the fixture probes for it and skips otherwise.
 """
+import pytest
+
+pytestmark = pytest.mark.suite_ha
 
 
 class TestNodeIdDerivation:

--- a/tests/native_host/e2e/test_controller_raft_peers.py
+++ b/tests/native_host/e2e/test_controller_raft_peers.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for Raft node_id derivation from a hostname peer list.
+
+Separate module because it needs a differently configured cluster than
+test_controller_raft.py: peers addressed by hostname and no explicit node_id.
+That cluster cannot coexist with the module-scoped one there, since both bind
+the same ports on the same nodes.
+
+The hostname form only works where every node resolves every peer, which a
+stock host does not do -- the fixture probes for it and skips otherwise.
+"""
+
+
+class TestNodeIdDerivation:
+    def test_node_id_is_derived_from_peer_position(self, hostname_raft_cluster):
+        """Peers listed by hostname must let each controller pick its id from
+        its own position rather than needing an explicit node_id."""
+        cluster = hostname_raft_cluster
+        for i in cluster.controller_indices:
+            log = cluster.spurctld_log(i)
+            assert "position in controller.peers" in log, (
+                f"controller {i} did not derive its node_id from the peer list:\n{log}"
+            )
+            assert f"node_id={i + 1}" in log.replace('"', ""), (
+                f"controller {i} should be node_id {i + 1}:\n{log}"
+            )
+
+    def test_the_derived_cluster_elects_a_leader(self, hostname_raft_cluster):
+        """Derivation is only correct if it produces a working voter set: a
+        duplicated or out-of-range id would leave the cluster leaderless."""
+        leader = hostname_raft_cluster.wait_raft_leader()
+        assert leader in hostname_raft_cluster.controller_indices

--- a/tests/native_host/e2e/test_deregistration.py
+++ b/tests/native_host/e2e/test_deregistration.py
@@ -14,6 +14,8 @@ import pytest
 
 from cluster import parse_job_id, job_state, SpurCluster
 
+pytestmark = pytest.mark.suite_runtime
+
 
 def _wait_job_terminal(cluster, job_id, timeout=120):
     """Wait for a job to reach any terminal state including NODE_FAIL."""

--- a/tests/native_host/e2e/test_devices.py
+++ b/tests/native_host/e2e/test_devices.py
@@ -17,6 +17,8 @@ import pytest
 
 from cluster import SpurCluster, job_state, parse_job_id, wait_job
 
+pytestmark = pytest.mark.suite_fabric
+
 _FIXTURES = Path(__file__).resolve().parent / "fixtures"
 
 

--- a/tests/native_host/e2e/test_dispatch_resilience.py
+++ b/tests/native_host/e2e/test_dispatch_resilience.py
@@ -12,7 +12,13 @@ observable invariants rather than internal timing.
 import re
 import time
 
-from cluster import job_state, parse_job_id, wait_job, wait_job_state
+from cluster import (
+    job_node_indices,
+    job_state,
+    parse_job_id,
+    wait_job,
+    wait_job_state,
+)
 
 
 def _launched_job_ids(cluster, node_index: int) -> set[int]:
@@ -47,7 +53,7 @@ class TestAllNodeDispatchConfirmation:
             wait_job_state(cluster, job_id, "R", timeout=90)
             missing = [
                 cluster.node_names[i]
-                for i in range(2)
+                for i in job_node_indices(cluster, job_id)
                 if job_id not in _launched_job_ids(cluster, i)
             ]
             assert not missing, (

--- a/tests/native_host/e2e/test_dispatch_resilience.py
+++ b/tests/native_host/e2e/test_dispatch_resilience.py
@@ -1,0 +1,246 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for job dispatch under partial failure.
+
+The scheduler awaits every node's LaunchJob before flipping a job to Running,
+and settles a job back to Pending (rather than Failed) when a node cannot take
+it. These are multi-node race conditions, so the assertions target the
+observable invariants rather than internal timing.
+"""
+
+import re
+import time
+
+import pytest
+
+from cluster import job_state, parse_job_id, wait_job, wait_job_state
+
+
+def _launched_job_ids(cluster, node_index: int) -> set[int]:
+    """Job IDs whose launch spurd confirmed on this node."""
+    log = cluster.spurd_log(node_index)
+    ids = set()
+    for line in log.splitlines():
+        if "job launched successfully" not in line:
+            continue
+        match = re.search(r"job_id[=:\s]+(\d+)", line)
+        if match:
+            ids.add(int(match.group(1)))
+    return ids
+
+
+class TestAllNodeDispatchConfirmation:
+    def test_job_is_running_only_after_every_node_launched(self, multi_node_cluster):
+        """A job must not be visibly Running while a node is still mid-launch.
+
+        Consumers gate on Running before targeting a node, so the first moment
+        squeue reports Running is the moment every allocated node must already
+        have the job.
+        """
+        cluster = multi_node_cluster
+        script = cluster.write_file("dispatch-confirm.sh", "#!/bin/bash\nsleep 120\n")
+        job_id = parse_job_id(
+            cluster.sbatch(["-J", "dispatch-confirm", "-N", "2", script])
+        )
+        assert job_id is not None
+
+        try:
+            wait_job_state(cluster, job_id, "R", timeout=90)
+            missing = [
+                cluster.node_names[i]
+                for i in range(2)
+                if job_id not in _launched_job_ids(cluster, i)
+            ]
+            assert not missing, (
+                f"job {job_id} reported Running before {missing} confirmed its "
+                f"launch\n{cluster.debug_job(job_id)}"
+            )
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_running_job_accepts_exec_immediately(self, multi_node_cluster):
+        """No retry window: exec must succeed on the first attempt after Running."""
+        cluster = multi_node_cluster
+        script = cluster.write_file("dispatch-exec.sh", "#!/bin/bash\nsleep 120\n")
+        job_id = parse_job_id(
+            cluster.sbatch(["-J", "dispatch-exec", "-N", "2", script])
+        )
+        assert job_id is not None
+
+        try:
+            wait_job_state(cluster, job_id, "R", timeout=90)
+            code, out = cluster.spur_exec(job_id, ["true"])
+            assert code == 0, (
+                f"exec into job {job_id} failed on the first attempt after "
+                f"Running:\n{out}\n{cluster.debug_job(job_id)}"
+            )
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])
+
+
+class TestLaunchFailureBackoff:
+    def test_job_stays_pending_when_target_node_agent_is_down(self, multi_node_cluster):
+        """A non-prolog dispatch failure leaves the job Pending, not Failed.
+
+        The job never left Pending, so there is no Running -> Failed detour to
+        route the failure through; it must simply wait for the node to return.
+        """
+        cluster = multi_node_cluster
+        target = cluster.node_names[0]
+
+        cluster.stop_agent(0)
+        time.sleep(2)
+
+        script = cluster.write_file("backoff.sh", "#!/bin/bash\necho BACKOFF_RAN\n")
+        job_id = parse_job_id(
+            cluster.sbatch(["-J", "backoff", "-N", "1", "-w", target, script])
+        )
+        assert job_id is not None
+
+        try:
+            # Give the scheduler several cycles to try and fail.
+            time.sleep(15)
+            state = job_state(cluster.squeue_all(), job_id)
+            assert state == "PD", (
+                f"job targeting a down node must stay Pending, got {state}\n"
+                f"{cluster.debug_job(job_id)}"
+            )
+
+            cluster.restart_agent(0)
+            cluster.wait_ready(timeout=90)
+
+            assert wait_job(cluster, job_id, timeout=120) == "CD", (
+                f"job must run once the node returns\n{cluster.debug_job(job_id)}"
+            )
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])
+
+
+class TestRequeueDoesNotFinalizeNewRun:
+    def test_requeued_job_completes_its_second_run(self, cluster):
+        """A completion report from the first run must not finalize the second.
+
+        Requeue restarts the job under a new run attempt; the abandoned run's
+        completion report arrives late and must be discarded rather than
+        marking the fresh run terminal.
+        """
+        marker_dir = f"{cluster.remote_dir}/requeue-runs"
+        script = cluster.write_file(
+            "requeue-run.sh",
+            "#!/bin/bash\n"
+            f"mkdir -p {marker_dir}\n"
+            f"date +%s%N > {marker_dir}/run-$(date +%s%N)\n"
+            "sleep 20\n",
+        )
+        job_id = parse_job_id(
+            cluster.sbatch(["-J", "requeue-run", "--requeue", script])
+        )
+        assert job_id is not None
+        wait_job_state(cluster, job_id, "R", timeout=60)
+
+        out = cluster.cli_allow_fail(["scontrol", "requeue", str(job_id)])
+        if "not supported" in out.lower() or "unknown" in out.lower():
+            pytest.skip(f"scontrol requeue unavailable: {out.strip()}")
+
+        try:
+            wait_job_state(cluster, job_id, "R", timeout=120)
+            # The second run must survive its full duration rather than being
+            # finalized by the first run's late completion report.
+            time.sleep(10)
+            state = job_state(cluster.squeue_all(), job_id)
+            assert state == "R", (
+                f"the requeued run was finalized early (state {state})\n"
+                f"{cluster.debug_job(job_id)}"
+            )
+
+            assert wait_job(cluster, job_id, timeout=90) == "CD", (
+                cluster.debug_job(job_id)
+            )
+            runs = cluster.nodes[0].exec_allow_fail(
+                f"ls {marker_dir} 2>/dev/null | wc -l"
+            ).strip()
+            assert runs.isdigit() and int(runs) >= 2, (
+                f"expected the script to have run twice, saw {runs} run marker(s)"
+            )
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])
+
+
+class TestGpuReleaseOnLaunchFailure:
+    # Fails only the job under test, so a later job can prove the GPUs came
+    # back rather than being blocked by the same prolog.
+    SELECTIVE_PROLOG = (
+        "#!/bin/bash\n"
+        'if [ "$SPUR_JOB_NAME" = "gpu-fail" ]; then exit 1; fi\n'
+        "exit 0\n"
+    )
+
+    def test_gpus_are_released_when_launch_fails(self, unstarted_cluster):
+        """A job aborted mid-launch must not leak its GPU reservation.
+
+        `scontrol show node` reports configured GPUs, not free ones, so the
+        leak is detected by whether a later job can claim every GPU on the node.
+        """
+        cluster = unstarted_cluster
+        cluster.gpu_preflight(min_nodes=1)
+
+        prolog = cluster.write_file(
+            "selective-prolog.sh", self.SELECTIVE_PROLOG, all_nodes=True
+        )
+        cluster.start(
+            config_overrides={
+                "hooks": {"prolog": prolog},
+                "devices": {"auto_detect": True},
+            }
+        )
+        cluster.assert_sinfo_gpus(min_per_node=1)
+
+        target = cluster.node_names[0]
+        total_gpus = cluster.node_gpu_count(target)
+
+        fail_script = cluster.write_file(
+            "gpu-fail.sh", "#!/bin/bash\necho SHOULD_NOT_RUN\n"
+        )
+        failed_id = parse_job_id(
+            cluster.sbatch(
+                ["-J", "gpu-fail", "-N", "1", "-w", target, "--gpus", "1", fail_script]
+            )
+        )
+        assert failed_id is not None
+
+        deadline = time.time() + 60
+        while time.time() < deadline:
+            if job_state(cluster.squeue_all(), failed_id) in ("PD", "F", "CA", None):
+                break
+            time.sleep(2)
+        cluster.cli_allow_fail(["scancel", str(failed_id)])
+
+        # The prolog failure drains the node; clear it so the probe job can run.
+        cluster.cli_allow_fail(
+            ["scontrol", "update", f"NodeName={target}", "State=RESUME"]
+        )
+        cluster.wait_ready(timeout=90)
+
+        ok_script = cluster.write_file("gpu-ok.sh", "#!/bin/bash\necho GPU_OK\n")
+        probe_id = parse_job_id(
+            cluster.sbatch(
+                [
+                    "-J", "gpu-ok",
+                    "-N", "1",
+                    "-w", target,
+                    "--gpus", str(total_gpus),
+                    ok_script,
+                ]
+            )
+        )
+        assert probe_id is not None
+
+        try:
+            assert wait_job(cluster, probe_id, timeout=120) == "CD", (
+                f"a job claiming all {total_gpus} GPU(s) on {target} did not run, "
+                f"so the failed launch leaked its reservation\n"
+                f"{cluster.debug_job(probe_id)}"
+            )
+        finally:
+            cluster.cli_allow_fail(["scancel", str(probe_id)])

--- a/tests/native_host/e2e/test_dispatch_resilience.py
+++ b/tests/native_host/e2e/test_dispatch_resilience.py
@@ -121,10 +121,8 @@ class TestLaunchFailureBackoff:
             cluster.cli_allow_fail(["scancel", str(job_id)])
 
 
-# A late completion report finalizing a *newer* run attempt would need a job to
-# run twice. `scontrol requeue` only cancels today (see TestRequeue in
-# test_job_control.py), so there is no second attempt to race against and the
-# scenario cannot be built from the outside yet.
+# A late report finalizing a *newer* run attempt needs a job to run twice, which
+# no CLI path produces today, so that race cannot be built from the outside.
 
 
 class TestGpuReleaseOnLaunchFailure:

--- a/tests/native_host/e2e/test_dispatch_resilience.py
+++ b/tests/native_host/e2e/test_dispatch_resilience.py
@@ -19,6 +19,9 @@ from cluster import (
     wait_job,
     wait_job_state,
 )
+import pytest
+
+pytestmark = pytest.mark.suite_scheduling
 
 
 def _launched_job_ids(cluster, node_index: int) -> set[int]:

--- a/tests/native_host/e2e/test_dispatch_resilience.py
+++ b/tests/native_host/e2e/test_dispatch_resilience.py
@@ -12,8 +12,6 @@ observable invariants rather than internal timing.
 import re
 import time
 
-import pytest
-
 from cluster import job_state, parse_job_id, wait_job, wait_job_state
 
 
@@ -117,54 +115,10 @@ class TestLaunchFailureBackoff:
             cluster.cli_allow_fail(["scancel", str(job_id)])
 
 
-class TestRequeueDoesNotFinalizeNewRun:
-    def test_requeued_job_completes_its_second_run(self, cluster):
-        """A completion report from the first run must not finalize the second.
-
-        Requeue restarts the job under a new run attempt; the abandoned run's
-        completion report arrives late and must be discarded rather than
-        marking the fresh run terminal.
-        """
-        marker_dir = f"{cluster.remote_dir}/requeue-runs"
-        script = cluster.write_file(
-            "requeue-run.sh",
-            "#!/bin/bash\n"
-            f"mkdir -p {marker_dir}\n"
-            f"date +%s%N > {marker_dir}/run-$(date +%s%N)\n"
-            "sleep 20\n",
-        )
-        job_id = parse_job_id(
-            cluster.sbatch(["-J", "requeue-run", "--requeue", script])
-        )
-        assert job_id is not None
-        wait_job_state(cluster, job_id, "R", timeout=60)
-
-        out = cluster.cli_allow_fail(["scontrol", "requeue", str(job_id)])
-        if "not supported" in out.lower() or "unknown" in out.lower():
-            pytest.skip(f"scontrol requeue unavailable: {out.strip()}")
-
-        try:
-            wait_job_state(cluster, job_id, "R", timeout=120)
-            # The second run must survive its full duration rather than being
-            # finalized by the first run's late completion report.
-            time.sleep(10)
-            state = job_state(cluster.squeue_all(), job_id)
-            assert state == "R", (
-                f"the requeued run was finalized early (state {state})\n"
-                f"{cluster.debug_job(job_id)}"
-            )
-
-            assert wait_job(cluster, job_id, timeout=90) == "CD", (
-                cluster.debug_job(job_id)
-            )
-            runs = cluster.nodes[0].exec_allow_fail(
-                f"ls {marker_dir} 2>/dev/null | wc -l"
-            ).strip()
-            assert runs.isdigit() and int(runs) >= 2, (
-                f"expected the script to have run twice, saw {runs} run marker(s)"
-            )
-        finally:
-            cluster.cli_allow_fail(["scancel", str(job_id)])
+# A late completion report finalizing a *newer* run attempt would need a job to
+# run twice. `scontrol requeue` only cancels today (see TestRequeue in
+# test_job_control.py), so there is no second attempt to race against and the
+# scenario cannot be built from the outside yet.
 
 
 class TestGpuReleaseOnLaunchFailure:

--- a/tests/native_host/e2e/test_ffi.py
+++ b/tests/native_host/e2e/test_ffi.py
@@ -15,6 +15,8 @@ import pytest
 
 from cluster import parse_job_id, wait_job, wait_job_state
 
+pytestmark = pytest.mark.suite_api
+
 # proto JobState values as surfaced by job_info_t.job_state.
 JOB_PENDING = 0
 JOB_RUNNING = 1

--- a/tests/native_host/e2e/test_ffi.py
+++ b/tests/native_host/e2e/test_ffi.py
@@ -1,0 +1,220 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for the Slurm-compatible C FFI (libspur_compat.so).
+
+A C driver (fixtures/ffi_smoke.c) is compiled against the shipped shared
+library on the controller node and invoked per subcommand. The FFI reads the
+controller endpoint from SLURM_CONTROLLER_ADDR -- the Slurm-prefixed name,
+not SPUR_ -- so linked Slurm applications need no source change.
+"""
+
+import shlex
+
+import pytest
+
+from cluster import parse_job_id, wait_job, wait_job_state
+
+# proto JobState values as surfaced by job_info_t.job_state.
+JOB_PENDING = 0
+JOB_RUNNING = 1
+JOB_CANCELLED = 5
+
+
+def _parse_kv(output: str) -> dict[str, str]:
+    fields = {}
+    for line in output.splitlines():
+        key, sep, value = line.partition("=")
+        if sep and " " not in key:
+            fields[key.strip()] = value.strip()
+    return fields
+
+
+def _records(output: str, prefix: str) -> list[dict[str, str]]:
+    """Parse `<prefix> k=v k=v` lines into dicts."""
+    out = []
+    for line in output.splitlines():
+        if not line.startswith(f"{prefix} "):
+            continue
+        out.append(
+            dict(
+                token.split("=", 1)
+                for token in line[len(prefix) + 1 :].split(" ")
+                if "=" in token
+            )
+        )
+    return out
+
+
+class FfiDriver:
+    """Runs the compiled C driver on the controller node."""
+
+    def __init__(self, cluster, binary: str, lib_dir: str):
+        self.cluster = cluster
+        self.binary = binary
+        self.lib_dir = lib_dir
+
+    def run(self, args: list[str]) -> str:
+        cmd = (
+            f"SLURM_CONTROLLER_ADDR={shlex.quote(self.cluster.controller_addr)} "
+            f"LD_LIBRARY_PATH={shlex.quote(self.lib_dir)} "
+            + " ".join(shlex.quote(a) for a in [self.binary] + args)
+            + " 2>&1"
+        )
+        return self.cluster.nodes[0].exec_allow_fail(cmd)
+
+    def fields(self, args: list[str]) -> dict[str, str]:
+        return _parse_kv(self.run(args))
+
+
+@pytest.fixture
+def ffi(cluster):
+    lib = cluster.ship_ffi_library()
+    lib_dir = lib.rsplit("/", 1)[0]
+    binary = cluster.compile_c_fixture(
+        "ffi_smoke.c",
+        extra_flags=[
+            f"-L{lib_dir}",
+            "-lspur_compat",
+            f"-Wl,-rpath,{lib_dir}",
+            "-pthread",
+        ],
+        all_nodes=False,
+    )
+    return FfiDriver(cluster, binary, lib_dir)
+
+
+class TestJobDescDefaults:
+    def test_init_job_desc_msg_clears_the_struct(self, ffi):
+        """A caller passes in uninitialised stack memory; init must overwrite
+        every field, not just the ones it cares about."""
+        fields = ffi.fields(["defaults"])
+        assert fields["name_null"] == "1", f"name was not cleared: {fields}"
+        assert fields["script_null"] == "1", f"script was not cleared: {fields}"
+        assert fields["min_nodes"] == "1"
+        assert fields["max_nodes"] == "1"
+        assert fields["cpus_per_task"] == "1"
+        assert fields["time_limit"] == "0"
+        assert fields["num_tasks_is_no_val"] == "1", (
+            f"num_tasks must default to NO_VAL: {fields}"
+        )
+
+
+class TestSubmitAndQuery:
+    def test_submit_then_load_and_kill(self, ffi):
+        out = ffi.run(
+            ["submit", "ffi-job", "default", "#!/bin/bash\nsleep 120\n"]
+        )
+        fields = _parse_kv(out)
+        assert fields.get("rc") == "0", f"submit failed:\n{out}"
+        job_id = int(fields["job_id"])
+        assert job_id > 0, f"submit returned no job id:\n{out}"
+
+        try:
+            wait_job_state(ffi.cluster, job_id, "R", timeout=90)
+
+            listing = ffi.run(["jobs", str(job_id)])
+            assert _parse_kv(listing).get("rc") == "0", f"load_jobs failed:\n{listing}"
+            rows = _records(listing, "job")
+            assert len(rows) == 1, f"expected exactly one match:\n{listing}"
+            row = rows[0]
+            assert row["name"] == "ffi-job"
+            assert row["partition"] == "default"
+            assert int(row["state"]) == JOB_RUNNING, (
+                f"FFI must report the live state: {row}"
+            )
+            assert row["nodelist"], f"a running job must carry a nodelist: {row}"
+        finally:
+            killed = ffi.run(["kill", str(job_id), "9"])
+
+        assert _parse_kv(killed).get("rc") == "0", f"kill_job failed:\n{killed}"
+        assert wait_job(ffi.cluster, job_id, timeout=90) in ("CA", "GONE"), (
+            f"job {job_id} was not cancelled by slurm_kill_job"
+        )
+
+    def test_load_jobs_sees_a_cli_submitted_job(self, ffi):
+        """The FFI and the CLI must share one view of the queue."""
+        script = ffi.cluster.write_file("ffi-cli.sh", "#!/bin/bash\nsleep 60\n")
+        job_id = parse_job_id(ffi.cluster.sbatch(["-J", "ffi-cli", script]))
+        assert job_id is not None
+
+        try:
+            listing = ffi.run(["jobs", str(job_id)])
+            rows = _records(listing, "job")
+            assert len(rows) == 1, f"CLI job {job_id} not visible over FFI:\n{listing}"
+            assert rows[0]["name"] == "ffi-cli"
+        finally:
+            ffi.cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_submit_defaults_to_one_node(self, ffi):
+        out = ffi.run(["submit", "ffi-default", "", "#!/bin/bash\ntrue\n"])
+        job_id = int(_parse_kv(out)["job_id"])
+
+        try:
+            rows = _records(ffi.run(["jobs", str(job_id)]), "job")
+            assert rows[0]["nodes"] == "1", f"expected a one-node job: {rows[0]}"
+            assert rows[0]["partition"] == "default", (
+                f"an unset partition must fall back to the default: {rows[0]}"
+            )
+        finally:
+            ffi.cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_kill_of_a_pending_job_cancels_it(self, ffi):
+        script = ffi.cluster.write_file("ffi-held.sh", "#!/bin/bash\nsleep 60\n")
+        job_id = parse_job_id(ffi.cluster.sbatch(["-J", "ffi-held", "-H", script]))
+        assert job_id is not None
+        wait_job_state(ffi.cluster, job_id, "PD", timeout=30)
+
+        rows = _records(ffi.run(["jobs", str(job_id)]), "job")
+        assert int(rows[0]["state"]) == JOB_PENDING, (
+            f"held job must read back as pending: {rows[0]}"
+        )
+
+        assert _parse_kv(ffi.run(["kill", str(job_id), "9"])).get("rc") == "0"
+        assert wait_job(ffi.cluster, job_id, timeout=60) in ("CA", "GONE")
+
+
+class TestClusterQueries:
+    def test_load_node_reports_every_node(self, ffi):
+        out = ffi.run(["nodes"])
+        assert _parse_kv(out).get("rc") == "0", f"load_node failed:\n{out}"
+        rows = {r["name"]: r for r in _records(out, "node")}
+        assert set(ffi.cluster.node_names) <= set(rows), (
+            f"expected {ffi.cluster.node_names}, got {sorted(rows)}"
+        )
+        first = rows[ffi.cluster.node_names[0]]
+        assert int(first["cpus"]) > 0, f"node must report CPUs: {first}"
+        assert int(first["memory"]) > 0, f"node must report memory: {first}"
+
+    def test_load_partitions_reports_the_default_partition(self, ffi):
+        out = ffi.run(["partitions"])
+        assert _parse_kv(out).get("rc") == "0", f"load_partitions failed:\n{out}"
+        rows = {r["name"]: r for r in _records(out, "partition")}
+        assert "default" in rows, f"expected the default partition: {sorted(rows)}"
+        assert int(rows["default"]["total_nodes"]) >= len(ffi.cluster.node_names)
+
+
+class TestErrorPaths:
+    def test_calls_fail_cleanly_when_the_controller_is_unreachable(self, ffi):
+        """A wrong address must return -1, not hang or abort the process."""
+        cmd = (
+            "SLURM_CONTROLLER_ADDR=http://127.0.0.1:1 "
+            f"LD_LIBRARY_PATH={shlex.quote(ffi.lib_dir)} "
+            f"{shlex.quote(ffi.binary)} nodes 2>&1"
+        )
+        out = ffi.cluster.nodes[0].exec_allow_fail(cmd)
+        assert _parse_kv(out).get("rc") == "-1", (
+            f"an unreachable controller must return -1:\n{out}"
+        )
+
+    def test_kill_of_an_unknown_job_reports_failure(self, ffi):
+        out = ffi.run(["kill", "99999999", "9"])
+        assert _parse_kv(out).get("rc") == "-1", (
+            f"killing an unknown job must return -1:\n{out}"
+        )
+
+    def test_strerror_maps_known_codes(self, ffi):
+        assert ffi.fields(["strerror", "0"])["message"] == "Success"
+        assert ffi.fields(["strerror", "-2"])["message"] == "Invalid job id"
+        unknown = ffi.fields(["strerror", "-9999"])["message"]
+        assert unknown, "strerror must never return an empty string"

--- a/tests/native_host/e2e/test_gpu.py
+++ b/tests/native_host/e2e/test_gpu.py
@@ -15,6 +15,9 @@ import os
 from pathlib import Path
 
 from cluster import SpurCluster, parse_job_id, wait_job
+import pytest
+
+pytestmark = pytest.mark.suite_fabric
 
 _FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
 

--- a/tests/native_host/e2e/test_hetjob.py
+++ b/tests/native_host/e2e/test_hetjob.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for heterogeneous job components.
+
+Only `sbatch --het-group=N` exists today: there is no `:` multi-component
+submit, no het environment variables, and no het fields in `squeue`/`scontrol`.
+Component linking is also broken through the CLI, because group 0 is sent as
+the proto default and lands as "unset" on the controller, so the anchor a
+later component looks for never exists.
+
+These tests therefore pin the behaviour that is real — the flag is accepted
+from both the command line and a `#SBATCH` directive, and a component runs like
+any other job — plus the one property that must hold regardless of how linking
+is eventually fixed: a component must never be silently dropped.
+"""
+
+import pytest
+
+from cluster import parse_job_id, wait_job, wait_job_state
+
+
+def submit_component(cluster, name: str, group: int, body: str, out_path: str) -> int:
+    script = cluster.write_file(f"{name}.sh", f"#!/bin/bash\n{body}\n")
+    job_id = parse_job_id(
+        cluster.sbatch(
+            ["-J", name, f"--het-group={group}", "-o", out_path, script]
+        )
+    )
+    assert job_id is not None
+    return job_id
+
+
+class TestHetGroupFlag:
+    def test_the_anchor_component_runs(self, cluster):
+        out_path = f"{cluster.remote_dir}/het0.out"
+        job_id = submit_component(cluster, "het0", 0, "echo HET0_OK", out_path)
+        assert wait_job(cluster, job_id, timeout=120) in ("CD", "GONE"), (
+            cluster.debug_job(job_id)
+        )
+        assert "HET0_OK" in cluster.read_output_on_any_node(out_path)
+
+    def test_a_later_component_runs(self, cluster):
+        out_path = f"{cluster.remote_dir}/het1.out"
+        job_id = submit_component(cluster, "het1", 1, "echo HET1_OK", out_path)
+        assert wait_job(cluster, job_id, timeout=120) in ("CD", "GONE"), (
+            cluster.debug_job(job_id)
+        )
+        assert "HET1_OK" in cluster.read_output_on_any_node(out_path)
+
+    def test_the_sbatch_directive_form_is_accepted(self, cluster):
+        out_path = f"{cluster.remote_dir}/het-directive.out"
+        script = cluster.write_file(
+            "het-directive.sh",
+            "#!/bin/bash\n#SBATCH --het-group=1\necho HET_DIRECTIVE_OK\n",
+        )
+        job_id = parse_job_id(
+            cluster.sbatch(["-J", "het-directive", "-o", out_path, script])
+        )
+        assert job_id is not None
+        assert wait_job(cluster, job_id, timeout=120) in ("CD", "GONE"), (
+            cluster.debug_job(job_id)
+        )
+        assert "HET_DIRECTIVE_OK" in cluster.read_output_on_any_node(out_path)
+
+    def test_a_non_numeric_group_is_rejected(self, cluster):
+        script = cluster.write_file("het-bad.sh", "#!/bin/bash\ntrue\n")
+        code, out = cluster.sbatch_with_exit(
+            ["-J", "het-bad", "--het-group=abc", script]
+        )
+        assert code != 0, f"a non-numeric --het-group must be rejected:\n{out}"
+
+
+class TestComponentSubmission:
+    def test_each_component_gets_its_own_job_id(self, cluster):
+        """Components are independent jobs today. Reusing an id would break
+        cancel and accounting, so the ids must stay distinct."""
+        first = submit_component(
+            cluster, "het-a", 0, "sleep 30", f"{cluster.remote_dir}/het-a.out"
+        )
+        second = submit_component(
+            cluster, "het-b", 1, "sleep 30", f"{cluster.remote_dir}/het-b.out"
+        )
+        try:
+            assert first != second
+        finally:
+            for job_id in (first, second):
+                cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_every_component_reaches_the_queue(self, cluster):
+        """The gap that matters most while linking is unimplemented: a
+        component must not be swallowed on the way to the scheduler."""
+        ids = [
+            submit_component(
+                cluster, f"het-q{g}", g, "sleep 30", f"{cluster.remote_dir}/het-q{g}.out"
+            )
+            for g in range(3)
+        ]
+        try:
+            listed = cluster.squeue(["-h", "-o", "%i"])
+            queued = {int(ln.strip()) for ln in listed.splitlines() if ln.strip().isdigit()}
+            assert set(ids) <= queued, (
+                f"components {sorted(set(ids) - queued)} never reached the queue:\n"
+                f"{cluster.squeue_all()}"
+            )
+        finally:
+            for job_id in ids:
+                cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_cancelling_one_component_leaves_the_others(self, cluster):
+        """Without linking, scancel is per-component. Pinning that keeps a
+        future group-cancel change from going unnoticed."""
+        first = submit_component(
+            cluster, "het-c0", 0, "sleep 120", f"{cluster.remote_dir}/het-c0.out"
+        )
+        second = submit_component(
+            cluster, "het-c1", 1, "sleep 120", f"{cluster.remote_dir}/het-c1.out"
+        )
+        try:
+            wait_job_state(cluster, first, "R", timeout=90)
+            wait_job_state(cluster, second, "R", timeout=90)
+            cluster.scancel(str(first))
+            wait_job_state(cluster, second, "R", timeout=30)
+        finally:
+            for job_id in (first, second):
+                cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_components_can_request_different_shapes(self, cluster):
+        """The whole point of a het job is asymmetric components, so differing
+        resource requests must at least submit and run independently."""
+        if len(cluster.nodes) < 2:
+            pytest.skip("differing component shapes need at least 2 nodes")
+
+        script = cluster.write_file("het-shape.sh", "#!/bin/bash\nsleep 60\n")
+        small = parse_job_id(
+            cluster.sbatch(["-J", "het-small", "--het-group=0", "-N", "1", script])
+        )
+        large = parse_job_id(
+            cluster.sbatch(["-J", "het-large", "--het-group=1", "-N", "2", script])
+        )
+        assert small is not None and large is not None
+        try:
+            wait_job_state(cluster, small, "R", timeout=90)
+        finally:
+            for job_id in (small, large):
+                cluster.cli_allow_fail(["scancel", str(job_id)])

--- a/tests/native_host/e2e/test_hetjob.py
+++ b/tests/native_host/e2e/test_hetjob.py
@@ -19,6 +19,8 @@ import pytest
 
 from cluster import parse_job_id, wait_job, wait_job_state
 
+pytestmark = pytest.mark.suite_scheduling
+
 
 def submit_component(cluster, name: str, group: int, body: str, out_path: str) -> int:
     script = cluster.write_file(f"{name}.sh", f"#!/bin/bash\n{body}\n")

--- a/tests/native_host/e2e/test_image.py
+++ b/tests/native_host/e2e/test_image.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for `spur image`.
+
+Image management is entirely local: no controller RPC, just squashfs files in a
+directory. Every test points `SPUR_IMAGE_DIR` at a scratch path so it never
+touches `/var/spool/spur/images` or the invoking user's `~/.spur/images`.
+
+Registry pulls are not exercised — they need outbound network access that a
+test cluster cannot be assumed to have.
+"""
+
+import pytest
+
+from cluster import wait_job, parse_job_id
+
+
+@pytest.fixture
+def image_dir(cluster):
+    """A scratch image directory, created and torn down per test."""
+    cluster.image_preflight()
+    path = f"{cluster.remote_dir}/images"
+    cluster.nodes[0].exec(f"mkdir -p '{path}'")
+    yield path
+    cluster.nodes[0].exec_allow_fail(f"rm -rf '{path}'")
+
+
+def image_cli(cluster, image_dir: str, args: list[str]) -> tuple[int, str]:
+    return cluster.cli_with_env(["spur", "image"] + args, {"SPUR_IMAGE_DIR": image_dir})
+
+
+class TestListing:
+    def test_an_empty_directory_reports_no_images(self, cluster, image_dir):
+        code, out = image_cli(cluster, image_dir, ["list"])
+        assert code == 0, out
+        assert "No images imported yet." in out, out
+
+    def test_an_imported_image_is_listed(self, cluster, image_dir, tmp_path):
+        """`import` is not the only way an image lands in the directory, and
+        `list` has to reflect whatever is actually there."""
+        _place_image(cluster, image_dir, "demo", tmp_path)
+        code, out = image_cli(cluster, image_dir, ["list"])
+        assert code == 0, out
+        assert "demo" in out, out
+
+    def test_the_listing_has_a_header(self, cluster, image_dir, tmp_path):
+        _place_image(cluster, image_dir, "demo", tmp_path)
+        _, out = image_cli(cluster, image_dir, ["list"])
+        assert "IMAGE" in out and "SIZE" in out, out
+
+    def test_the_listing_reports_a_size(self, cluster, image_dir, tmp_path):
+        _place_image(cluster, image_dir, "demo", tmp_path)
+        _, out = image_cli(cluster, image_dir, ["list"])
+        row = next((ln for ln in out.splitlines() if "demo" in ln), "")
+        assert "MB" in row or "GB" in row, f"no size on the image row: {out}"
+
+
+class TestRemoval:
+    def test_removing_a_missing_image_fails(self, cluster, image_dir):
+        code, out = image_cli(cluster, image_dir, ["remove", "nosuchimage"])
+        assert code != 0, out
+        assert "not found" in out, out
+
+    def test_removing_an_image_deletes_it(self, cluster, image_dir, tmp_path):
+        _place_image(cluster, image_dir, "demo", tmp_path)
+        code, out = image_cli(cluster, image_dir, ["remove", "demo"])
+        assert code == 0, out
+        assert "Removed" in out, out
+
+        _, listing = image_cli(cluster, image_dir, ["list"])
+        assert "No images imported yet." in listing, listing
+
+    def test_removing_twice_fails_the_second_time(self, cluster, image_dir, tmp_path):
+        _place_image(cluster, image_dir, "demo", tmp_path)
+        assert image_cli(cluster, image_dir, ["remove", "demo"])[0] == 0
+        code, out = image_cli(cluster, image_dir, ["remove", "demo"])
+        assert code != 0, out
+        assert "not found" in out, out
+
+
+class TestExport:
+    def test_exporting_an_unknown_container_fails(self, cluster, image_dir):
+        """`export` works on named running containers, not on images; the error
+        has to say so or users will read it as a missing-image message."""
+        code, out = image_cli(cluster, image_dir, ["export", "nosuchcontainer"])
+        assert code != 0, out
+        assert "not found" in out, out
+        assert "--container-name" in out, out
+
+
+class TestImageDirectorySelection:
+    def test_the_env_var_selects_the_directory(self, cluster, image_dir, tmp_path):
+        """Two directories must stay independent, otherwise a shared default
+        would leak images between users."""
+        other = f"{cluster.remote_dir}/images-other"
+        cluster.nodes[0].exec(f"mkdir -p '{other}'")
+        try:
+            _place_image(cluster, image_dir, "demo", tmp_path)
+            _, listing = image_cli(cluster, other, ["list"])
+            assert "No images imported yet." in listing, listing
+        finally:
+            cluster.nodes[0].exec_allow_fail(f"rm -rf '{other}'")
+
+
+class TestJobIntegration:
+    def test_a_job_runs_against_an_imported_image(self, cluster, tmp_path):
+        """The payoff for import: a job can name the image and get its
+        filesystem."""
+        cluster.container_preflight()
+        remote_image = cluster.build_container_image(tmp_path)
+
+        out_path = f"{cluster.remote_dir}/image-job.out"
+        script = cluster.write_file(
+            "image-job.sh", "#!/bin/bash\necho IMAGE_JOB_OK\n"
+        )
+        job_id = parse_job_id(
+            cluster.sbatch(
+                [
+                    "-J",
+                    "image-job",
+                    f"--container-image={remote_image}",
+                    "-o",
+                    out_path,
+                    script,
+                ]
+            )
+        )
+        assert job_id is not None
+        assert wait_job(cluster, job_id, timeout=180) in ("CD", "GONE"), (
+            cluster.debug_job(job_id)
+        )
+        assert "IMAGE_JOB_OK" in cluster.read_output_on_any_node(out_path)
+
+    def test_an_unknown_image_fails_the_job(self, cluster):
+        script = cluster.write_file("image-missing.sh", "#!/bin/bash\ntrue\n")
+        job_id = parse_job_id(
+            cluster.sbatch(
+                [
+                    "-J",
+                    "image-missing",
+                    "--container-image=/nonexistent/nope.sqsh",
+                    script,
+                ]
+            )
+        )
+        assert job_id is not None
+        assert wait_job(cluster, job_id, timeout=120) in ("F", "NF"), (
+            cluster.debug_job(job_id)
+        )
+
+
+def _place_image(cluster, image_dir: str, name: str, tmp_path) -> str:
+    """Put a real squashfs image in *image_dir* under *name*.
+
+    `spur image import` needs a container runtime or a registry, neither of
+    which a test cluster is guaranteed to have, so the file is built the same
+    way the container tests build theirs and dropped in directly.
+    """
+    cluster.container_preflight()
+    built = cluster.build_container_image(tmp_path)
+    target = f"{image_dir}/{name}.sqsh"
+    cluster.nodes[0].exec(f"cp '{built}' '{target}'")
+    return target

--- a/tests/native_host/e2e/test_image.py
+++ b/tests/native_host/e2e/test_image.py
@@ -17,6 +17,8 @@ import pytest
 
 from cluster import wait_job, parse_job_id
 
+pytestmark = pytest.mark.suite_runtime
+
 IMAGE_NAME = "demo"
 # Images are stored under the canonical OCI reference, so a bare name lands as
 # docker.io/library/<name>:latest with `/` and `:` folded to `+`. The CLI is

--- a/tests/native_host/e2e/test_image.py
+++ b/tests/native_host/e2e/test_image.py
@@ -11,9 +11,17 @@ Registry pulls are not exercised — they need outbound network access that a
 test cluster cannot be assumed to have.
 """
 
+import time
+
 import pytest
 
 from cluster import wait_job, parse_job_id
+
+IMAGE_NAME = "demo"
+# Images are stored under the canonical OCI reference, so a bare name lands as
+# docker.io/library/<name>:latest with `/` and `:` folded to `+`. The CLI is
+# still driven with the bare name, which is what a user types.
+IMAGE_STEM = "docker.io+library+demo+latest"
 
 
 @pytest.fixture
@@ -39,20 +47,20 @@ class TestListing:
     def test_an_imported_image_is_listed(self, cluster, image_dir, tmp_path):
         """`import` is not the only way an image lands in the directory, and
         `list` has to reflect whatever is actually there."""
-        _place_image(cluster, image_dir, "demo", tmp_path)
+        _place_image(cluster, image_dir, tmp_path)
         code, out = image_cli(cluster, image_dir, ["list"])
         assert code == 0, out
-        assert "demo" in out, out
+        assert IMAGE_NAME in out, out
 
     def test_the_listing_has_a_header(self, cluster, image_dir, tmp_path):
-        _place_image(cluster, image_dir, "demo", tmp_path)
+        _place_image(cluster, image_dir, tmp_path)
         _, out = image_cli(cluster, image_dir, ["list"])
         assert "IMAGE" in out and "SIZE" in out, out
 
     def test_the_listing_reports_a_size(self, cluster, image_dir, tmp_path):
-        _place_image(cluster, image_dir, "demo", tmp_path)
+        _place_image(cluster, image_dir, tmp_path)
         _, out = image_cli(cluster, image_dir, ["list"])
-        row = next((ln for ln in out.splitlines() if "demo" in ln), "")
+        row = next((ln for ln in out.splitlines() if IMAGE_NAME in ln), "")
         assert "MB" in row or "GB" in row, f"no size on the image row: {out}"
 
 
@@ -63,8 +71,8 @@ class TestRemoval:
         assert "not found" in out, out
 
     def test_removing_an_image_deletes_it(self, cluster, image_dir, tmp_path):
-        _place_image(cluster, image_dir, "demo", tmp_path)
-        code, out = image_cli(cluster, image_dir, ["remove", "demo"])
+        _place_image(cluster, image_dir, tmp_path)
+        code, out = image_cli(cluster, image_dir, ["remove", IMAGE_NAME])
         assert code == 0, out
         assert "Removed" in out, out
 
@@ -72,9 +80,9 @@ class TestRemoval:
         assert "No images imported yet." in listing, listing
 
     def test_removing_twice_fails_the_second_time(self, cluster, image_dir, tmp_path):
-        _place_image(cluster, image_dir, "demo", tmp_path)
-        assert image_cli(cluster, image_dir, ["remove", "demo"])[0] == 0
-        code, out = image_cli(cluster, image_dir, ["remove", "demo"])
+        _place_image(cluster, image_dir, tmp_path)
+        assert image_cli(cluster, image_dir, ["remove", IMAGE_NAME])[0] == 0
+        code, out = image_cli(cluster, image_dir, ["remove", IMAGE_NAME])
         assert code != 0, out
         assert "not found" in out, out
 
@@ -96,7 +104,7 @@ class TestImageDirectorySelection:
         other = f"{cluster.remote_dir}/images-other"
         cluster.nodes[0].exec(f"mkdir -p '{other}'")
         try:
-            _place_image(cluster, image_dir, "demo", tmp_path)
+            _place_image(cluster, image_dir, tmp_path)
             _, listing = image_cli(cluster, other, ["list"])
             assert "No images imported yet." in listing, listing
         finally:
@@ -132,7 +140,11 @@ class TestJobIntegration:
         )
         assert "IMAGE_JOB_OK" in cluster.read_output_on_any_node(out_path)
 
-    def test_an_unknown_image_fails_the_job(self, cluster):
+    def test_an_unknown_image_keeps_the_job_out_of_running(self, cluster):
+        """A missing image is not terminal: the launch fails, the job returns
+        to pending as JobLaunchFailure and is retried. What must hold is that
+        it never runs and that the reason says why.
+        """
         script = cluster.write_file("image-missing.sh", "#!/bin/bash\ntrue\n")
         job_id = parse_job_id(
             cluster.sbatch(
@@ -145,13 +157,27 @@ class TestJobIntegration:
             )
         )
         assert job_id is not None
-        assert wait_job(cluster, job_id, timeout=120) in ("F", "NF"), (
-            cluster.debug_job(job_id)
-        )
+        try:
+            deadline = time.time() + 60
+            while time.time() < deadline:
+                detail = cluster.scontrol("show", "job", str(job_id))
+                if "Reason=JobLaunchFailure" in detail:
+                    break
+                assert "JobState=RUNNING" not in detail, (
+                    f"a job with a missing image must not run:\n{detail}"
+                )
+                time.sleep(3)
+            else:
+                raise AssertionError(
+                    f"job {job_id} never reported a launch failure:\n"
+                    f"{cluster.scontrol('show', 'job', str(job_id))}"
+                )
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])
 
 
-def _place_image(cluster, image_dir: str, name: str, tmp_path) -> str:
-    """Put a real squashfs image in *image_dir* under *name*.
+def _place_image(cluster, image_dir: str, tmp_path) -> str:
+    """Put a real squashfs image in *image_dir* under IMAGE_STEM.
 
     `spur image import` needs a container runtime or a registry, neither of
     which a test cluster is guaranteed to have, so the file is built the same
@@ -159,6 +185,6 @@ def _place_image(cluster, image_dir: str, name: str, tmp_path) -> str:
     """
     cluster.container_preflight()
     built = cluster.build_container_image(tmp_path)
-    target = f"{image_dir}/{name}.sqsh"
+    target = f"{image_dir}/{IMAGE_STEM}.sqsh"
     cluster.nodes[0].exec(f"cp '{built}' '{target}'")
     return target

--- a/tests/native_host/e2e/test_job_control.py
+++ b/tests/native_host/e2e/test_job_control.py
@@ -316,19 +316,35 @@ class TestOpenMode:
 
 
 class TestStdinRedirection:
-    def test_srun_input_file_is_piped_to_the_task(self, cluster):
+    """`srun` launches its command as a step, and the step path ignores
+    ``--input``. JobSpec, the proto and the agent all carry a stdin path, but
+    no CLI reaches it: sbatch has no ``-i`` at all. These pin the behaviour
+    users actually get so the gap is visible rather than assumed working.
+    """
+
+    def test_srun_warns_that_input_is_ignored(self, cluster):
         in_path = cluster.write_file(
             "stdin-input.txt", "STDIN_PAYLOAD\n", all_nodes=True, executable=False
         )
         code, out = cluster.srun_with_exit(["-N", "1", "-i", in_path, "cat"])
-        assert code == 0, f"srun -i failed:\n{out}"
-        assert "STDIN_PAYLOAD" in out, f"stdin was not forwarded:\n{out}"
-
-    def test_srun_rejects_an_unreadable_input_file(self, cluster):
-        code, out = cluster.srun_with_exit(
-            ["-N", "1", "-i", f"{cluster.remote_dir}/no-such-input.txt", "cat"]
+        assert code == 0, f"srun -i should still run the command:\n{out}"
+        assert "--input is not supported" in out, (
+            f"srun must say it is discarding --input:\n{out}"
         )
-        assert code != 0, f"a missing stdin file must fail:\n{out}"
+        assert "STDIN_PAYLOAD" not in out, (
+            f"srun claims to ignore --input but forwarded it anyway:\n{out}"
+        )
+
+    def test_srun_ignores_a_missing_input_file_too(self, cluster):
+        """Ignoring is unconditional: an unreadable path is not an error
+        either, since the flag never reaches the agent."""
+        code, out = cluster.srun_with_exit(
+            ["-N", "1", "-i", f"{cluster.remote_dir}/no-such-input.txt", "true"]
+        )
+        assert code == 0, f"a discarded --input must not fail the job:\n{out}"
+        assert "--input is not supported" in out, (
+            f"srun must say it is discarding --input:\n{out}"
+        )
 
 
 class TestConstraints:

--- a/tests/native_host/e2e/test_job_control.py
+++ b/tests/native_host/e2e/test_job_control.py
@@ -15,6 +15,8 @@ import pytest
 
 from cluster import job_state, parse_job_id, wait_job, wait_job_state
 
+pytestmark = pytest.mark.suite_scheduling
+
 
 def _running_count(cluster, job_ids: list[int]) -> int:
     sq = cluster.squeue_all()

--- a/tests/native_host/e2e/test_job_control.py
+++ b/tests/native_host/e2e/test_job_control.py
@@ -1,0 +1,408 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for job control surfaces: requeue, scheduling windows, array
+throttling, output modes, stdin, and feature constraints.
+
+Array submission returns a parent placeholder id P and the task jobs get ids
+P+1, P+2, ..., each carrying array_job_id = P. Tests address tasks by their
+own job id, which is what scancel and squeue accept.
+"""
+
+import time
+
+import pytest
+
+from cluster import job_state, parse_job_id, wait_job, wait_job_state
+
+
+def _running_count(cluster, job_ids: list[int]) -> int:
+    sq = cluster.squeue_all()
+    return sum(1 for jid in job_ids if job_state(sq, jid) == "R")
+
+
+class TestRequeue:
+    def test_requeue_of_a_running_job_ends_it(self, cluster):
+        """`scontrol requeue` today is cancel-for-resubmission, so the original
+        run must actually stop."""
+        script = cluster.write_file("rq-run.sh", "#!/bin/bash\nsleep 120\n")
+        job_id = parse_job_id(cluster.sbatch(["-J", "rq-run", script]))
+        assert job_id is not None
+        wait_job_state(cluster, job_id, "R", timeout=90)
+
+        out = cluster.scontrol("requeue", str(job_id))
+        assert "requeued" in out.lower(), f"unexpected requeue output:\n{out}"
+        assert wait_job(cluster, job_id, timeout=90) in ("CA", "GONE"), (
+            f"job {job_id} kept running after requeue:\n{cluster.squeue_all()}"
+        )
+
+    def test_requeue_of_a_terminal_job_is_rejected(self, cluster):
+        script = cluster.write_file("rq-done.sh", "#!/bin/bash\ntrue\n")
+        job_id = parse_job_id(cluster.sbatch(["-J", "rq-done", script]))
+        assert job_id is not None
+        wait_job(cluster, job_id, timeout=90)
+
+        out = cluster.cli_allow_fail(["scontrol", "requeue", str(job_id)])
+        assert "already" in out.lower() or "error" in out.lower(), (
+            f"requeueing a finished job must fail:\n{out}"
+        )
+
+    def test_requeue_of_an_unknown_job_is_rejected(self, cluster):
+        out = cluster.cli_allow_fail(["scontrol", "requeue", "99999999"])
+        assert "requeued" not in out.lower(), (
+            f"an unknown job must not report success:\n{out}"
+        )
+
+
+class TestBeginTime:
+    def test_future_begin_time_holds_the_job(self, cluster):
+        script = cluster.write_file("begin.sh", "#!/bin/bash\necho BEGIN_OK\n")
+        job_id = parse_job_id(
+            cluster.sbatch(["-J", "begin", "--begin", "now+1hours", script])
+        )
+        assert job_id is not None
+
+        try:
+            wait_job_state(cluster, job_id, "PD", timeout=30)
+            time.sleep(10)
+            assert job_state(cluster.squeue_all(), job_id) == "PD", (
+                f"a job with a future begin time must stay pending:\n"
+                f"{cluster.squeue_all()}"
+            )
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_begin_now_runs_immediately(self, cluster):
+        out_path = f"{cluster.remote_dir}/begin-now.out"
+        script = cluster.write_file("begin-now.sh", "#!/bin/bash\necho BEGIN_NOW_OK\n")
+        job_id = parse_job_id(
+            cluster.sbatch(
+                ["-J", "begin-now", "--begin", "now", "-o", out_path, script]
+            )
+        )
+        assert job_id is not None
+        assert wait_job(cluster, job_id, timeout=90) in ("CD", "GONE")
+        assert "BEGIN_NOW_OK" in cluster.read_output_on_any_node(out_path)
+
+    def test_begin_time_is_shown_by_scontrol(self, cluster):
+        script = cluster.write_file("begin-show.sh", "#!/bin/bash\ntrue\n")
+        job_id = parse_job_id(
+            cluster.sbatch(["-J", "begin-show", "--begin", "now+2hours", script])
+        )
+        assert job_id is not None
+        try:
+            detail = cluster.scontrol("show", "job", str(job_id))
+            assert "BeginTime" in detail or "StartTime" in detail, (
+                f"scontrol must surface the scheduling window:\n{detail}"
+            )
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_unparseable_begin_time_is_rejected(self, cluster):
+        script = cluster.write_file("begin-bad.sh", "#!/bin/bash\ntrue\n")
+        out = cluster.cli_allow_fail(
+            ["sbatch", "-J", "begin-bad", "--begin", "teatime", script]
+        )
+        assert parse_job_id(out) is None, f"expected a rejection, got:\n{out}"
+        assert "datetime" in out.lower() or "time" in out.lower(), (
+            f"expected a time-format error:\n{out}"
+        )
+
+
+class TestDeadline:
+    def test_past_deadline_moves_a_pending_job_to_deadline(self, cluster):
+        """Deadline enforcement only applies to pending jobs, so the job is
+        held first."""
+        script = cluster.write_file("dl.sh", "#!/bin/bash\nsleep 30\n")
+        job_id = parse_job_id(
+            cluster.sbatch(
+                ["-J", "dl", "-H", "--deadline", "2020-01-01T00:00:00Z", script]
+            )
+        )
+        assert job_id is not None
+
+        deadline = time.time() + 120
+        while time.time() < deadline:
+            if job_state(cluster.squeue_all(), job_id) == "DL":
+                return
+            time.sleep(3)
+        raise AssertionError(
+            f"job {job_id} never reached DEADLINE:\n{cluster.squeue_all()}"
+        )
+
+    def test_deadline_state_is_reported_by_scontrol(self, cluster):
+        script = cluster.write_file("dl-show.sh", "#!/bin/bash\nsleep 30\n")
+        job_id = parse_job_id(
+            cluster.sbatch(
+                ["-J", "dl-show", "-H", "--deadline", "2020-01-01T00:00:00Z", script]
+            )
+        )
+        assert job_id is not None
+
+        stop = time.time() + 120
+        while time.time() < stop:
+            if job_state(cluster.squeue_all(), job_id) == "DL":
+                break
+            time.sleep(3)
+        else:
+            pytest.fail(f"job {job_id} never reached DEADLINE")
+
+        detail = cluster.scontrol("show", "job", str(job_id))
+        assert "DEADLINE" in detail or "DeadLine" in detail, (
+            f"scontrol must report the deadline outcome:\n{detail}"
+        )
+
+    def test_generous_deadline_lets_the_job_run(self, cluster):
+        out_path = f"{cluster.remote_dir}/dl-ok.out"
+        script = cluster.write_file("dl-ok.sh", "#!/bin/bash\necho DEADLINE_OK\n")
+        job_id = parse_job_id(
+            cluster.sbatch(
+                ["-J", "dl-ok", "--deadline", "now+4hours", "-o", out_path, script]
+            )
+        )
+        assert job_id is not None
+        assert wait_job(cluster, job_id, timeout=90) in ("CD", "GONE")
+        assert "DEADLINE_OK" in cluster.read_output_on_any_node(out_path)
+
+
+class TestArrayThrottling:
+    def test_percent_limit_caps_concurrent_tasks(self, cluster):
+        """`%2` must hold the array to two running tasks even when the cluster
+        could run all of them."""
+        script = cluster.write_file(
+            "arr-throttle.sh", "#!/bin/bash\nsleep 25\n", all_nodes=True
+        )
+        parent = parse_job_id(
+            cluster.sbatch(["-J", "arr-throttle", "-N", "1", "-a", "0-5%2", script])
+        )
+        assert parent is not None
+        tasks = [parent + 1 + i for i in range(6)]
+
+        try:
+            peak = 0
+            deadline = time.time() + 60
+            while time.time() < deadline:
+                peak = max(peak, _running_count(cluster, tasks))
+                if peak >= 2:
+                    break
+                time.sleep(2)
+            assert peak >= 1, (
+                f"no array task ever started:\n{cluster.squeue_all()}"
+            )
+
+            stop = time.time() + 45
+            while time.time() < stop:
+                running = _running_count(cluster, tasks)
+                assert running <= 2, (
+                    f"array throttle allowed {running} concurrent tasks:\n"
+                    f"{cluster.squeue_all()}"
+                )
+                time.sleep(2)
+        finally:
+            for jid in tasks:
+                cluster.cli_allow_fail(["scancel", str(jid)])
+
+    def test_unthrottled_array_runs_tasks_in_parallel(self, cluster):
+        """Control for the throttle test: without `%`, more than two tasks may
+        run at once."""
+        script = cluster.write_file(
+            "arr-free.sh", "#!/bin/bash\nsleep 20\n", all_nodes=True
+        )
+        parent = parse_job_id(
+            cluster.sbatch(["-J", "arr-free", "-N", "1", "-a", "0-3", script])
+        )
+        assert parent is not None
+        tasks = [parent + 1 + i for i in range(4)]
+
+        try:
+            peak = 0
+            deadline = time.time() + 60
+            while time.time() < deadline:
+                peak = max(peak, _running_count(cluster, tasks))
+                if peak >= 3:
+                    return
+                time.sleep(2)
+            pytest.skip(
+                f"cluster only ran {peak} tasks concurrently; too small to "
+                "distinguish throttled from unthrottled"
+            )
+        finally:
+            for jid in tasks:
+                cluster.cli_allow_fail(["scancel", str(jid)])
+
+    def test_cancelling_one_element_leaves_the_others(self, cluster):
+        script = cluster.write_file(
+            "arr-cancel.sh", "#!/bin/bash\nsleep 45\n", all_nodes=True
+        )
+        parent = parse_job_id(
+            cluster.sbatch(["-J", "arr-cancel", "-N", "1", "-a", "0-2", script])
+        )
+        assert parent is not None
+        tasks = [parent + 1 + i for i in range(3)]
+
+        try:
+            wait_job_state(cluster, tasks[1], "R", timeout=90)
+            cluster.cli(["scancel", str(tasks[1])])
+
+            deadline = time.time() + 60
+            while time.time() < deadline:
+                if job_state(cluster.squeue_all(), tasks[1]) in ("CA", None):
+                    break
+                time.sleep(2)
+            else:
+                raise AssertionError(f"array element {tasks[1]} was not cancelled")
+
+            sq = cluster.squeue_all()
+            for other in (tasks[0], tasks[2]):
+                assert job_state(sq, other) != "CA", (
+                    f"cancelling {tasks[1]} must not touch {other}:\n{sq}"
+                )
+        finally:
+            for jid in tasks:
+                cluster.cli_allow_fail(["scancel", str(jid)])
+
+    def test_invalid_array_limit_is_rejected(self, cluster):
+        script = cluster.write_file("arr-bad.sh", "#!/bin/bash\ntrue\n")
+        out = cluster.cli_allow_fail(
+            ["sbatch", "-J", "arr-bad", "-a", "0-3%abc", script]
+        )
+        assert parse_job_id(out) is None, f"expected a rejection, got:\n{out}"
+        assert "limit" in out.lower() or "invalid" in out.lower(), (
+            f"expected an array-spec error:\n{out}"
+        )
+
+
+class TestOpenMode:
+    def test_append_preserves_previous_output(self, cluster):
+        out_path = f"{cluster.remote_dir}/open-append.out"
+        script = cluster.write_file("open-append.sh", "#!/bin/bash\necho RUN\n")
+
+        for _ in range(2):
+            job_id = parse_job_id(
+                cluster.sbatch(
+                    [
+                        "-J",
+                        "open-append",
+                        "-o",
+                        out_path,
+                        "--open-mode=append",
+                        script,
+                    ]
+                )
+            )
+            assert job_id is not None
+            wait_job(cluster, job_id, timeout=90)
+
+        content = cluster.read_output_on_any_node(out_path)
+        assert content.count("RUN") == 2, (
+            f"append mode must keep the first run's output:\n{content}"
+        )
+
+    def test_default_open_mode_truncates(self, cluster):
+        out_path = f"{cluster.remote_dir}/open-trunc.out"
+        script = cluster.write_file("open-trunc.sh", "#!/bin/bash\necho RUN\n")
+
+        for _ in range(2):
+            job_id = parse_job_id(
+                cluster.sbatch(["-J", "open-trunc", "-o", out_path, script])
+            )
+            assert job_id is not None
+            wait_job(cluster, job_id, timeout=90)
+
+        content = cluster.read_output_on_any_node(out_path)
+        assert content.count("RUN") == 1, (
+            f"the default open mode must truncate:\n{content}"
+        )
+
+
+class TestStdinRedirection:
+    def test_srun_input_file_is_piped_to_the_task(self, cluster):
+        in_path = cluster.write_file(
+            "stdin-input.txt", "STDIN_PAYLOAD\n", all_nodes=True, executable=False
+        )
+        code, out = cluster.srun_with_exit(["-N", "1", "-i", in_path, "cat"])
+        assert code == 0, f"srun -i failed:\n{out}"
+        assert "STDIN_PAYLOAD" in out, f"stdin was not forwarded:\n{out}"
+
+    def test_srun_rejects_an_unreadable_input_file(self, cluster):
+        code, out = cluster.srun_with_exit(
+            ["-N", "1", "-i", f"{cluster.remote_dir}/no-such-input.txt", "cat"]
+        )
+        assert code != 0, f"a missing stdin file must fail:\n{out}"
+
+
+class TestConstraints:
+    @pytest.fixture
+    def featured_cluster(self, unstarted_cluster):
+        """Node 0 gets a distinguishing feature so -C can be seen to select."""
+        cluster = unstarted_cluster
+        cluster.start(
+            config_overrides={
+                "nodes": [
+                    {
+                        "names": name,
+                        "cpus": 64,
+                        "memory_mb": 262144,
+                        "features": ["mi300x"] if i == 0 else ["cpuonly"],
+                    }
+                    for i, name in enumerate(cluster.node_names)
+                ],
+            }
+        )
+        return cluster
+
+    def test_constraint_selects_a_matching_node(self, featured_cluster):
+        cluster = featured_cluster
+        out_path = f"{cluster.remote_dir}/constraint.out"
+        script = cluster.write_file(
+            "constraint.sh",
+            '#!/bin/bash\necho "HOST=$(hostname)"\necho CONSTRAINT_OK\n',
+            all_nodes=True,
+        )
+        job_id = parse_job_id(
+            cluster.sbatch(
+                ["-J", "constraint", "-C", "mi300x", "-o", out_path, script]
+            )
+        )
+        assert job_id is not None
+        assert wait_job(cluster, job_id, timeout=90) in ("CD", "GONE")
+
+        content = cluster.read_output_on_any_node(out_path)
+        assert "CONSTRAINT_OK" in content, f"job produced no output:\n{content}"
+        assert cluster.node_names[0] in content, (
+            f"-C mi300x must land on the only matching node:\n{content}"
+        )
+
+    def test_unsatisfiable_constraint_reports_bad_constraints(self, featured_cluster):
+        cluster = featured_cluster
+        script = cluster.write_file("constraint-bad.sh", "#!/bin/bash\ntrue\n")
+        job_id = parse_job_id(
+            cluster.sbatch(["-J", "constraint-bad", "-C", "nosuchfeature", script])
+        )
+        assert job_id is not None
+
+        try:
+            wait_job_state(cluster, job_id, "PD", timeout=60)
+            reason = cluster.cli(["squeue", "-j", str(job_id), "-o", "%r", "-h"])
+            assert "BadConstraints" in reason, (
+                f"expected BadConstraints, got {reason!r}"
+            )
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_multiple_constraints_must_all_match(self, featured_cluster):
+        cluster = featured_cluster
+        script = cluster.write_file("constraint-and.sh", "#!/bin/bash\ntrue\n")
+        job_id = parse_job_id(
+            cluster.sbatch(["-J", "constraint-and", "-C", "mi300x,cpuonly", script])
+        )
+        assert job_id is not None
+
+        try:
+            wait_job_state(cluster, job_id, "PD", timeout=60)
+            reason = cluster.cli(["squeue", "-j", str(job_id), "-o", "%r", "-h"])
+            assert "BadConstraints" in reason, (
+                f"no node carries both features, expected BadConstraints, got {reason!r}"
+            )
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])

--- a/tests/native_host/e2e/test_job_ownership.py
+++ b/tests/native_host/e2e/test_job_ownership.py
@@ -16,13 +16,18 @@ import pytest
 from cluster import parse_job_id, wait_job_state
 
 
+# root is an administrative override in check_job_owner, so a denial test has
+# to run as an ordinary account instead.
+NON_OWNER = "nobody"
+
+
 def _require_second_identity(cluster) -> str:
     """Skip unless the environment can run the CLI as a second UNIX user."""
     submit_user = cluster.nodes[0].user
-    if submit_user == "root":
-        pytest.skip("need a non-root SSH user to test non-owner rejection")
+    if submit_user == NON_OWNER:
+        pytest.skip(f"SSH user is {NON_OWNER}; need a different account to submit as")
 
-    probe = cluster.cli_as_user("root", ["squeue", "-h"])
+    probe = cluster.cli_as_user(NON_OWNER, ["squeue", "-h"])
     if "sudo" in probe.lower() and (
         "password" in probe.lower() or "not allowed" in probe.lower()
     ):
@@ -39,8 +44,18 @@ def _start_long_job(cluster, name: str) -> int:
 
 
 def _denied(output: str) -> bool:
+    """Whether the controller refused the caller.
+
+    "job owned by" is how AuthError::NotJobOwner renders; the other spellings
+    cover refusals raised before the owner check.
+    """
     lowered = output.lower()
-    return "permission" in lowered or "denied" in lowered or "not authorized" in lowered
+    return (
+        "job owned by" in lowered
+        or "permission" in lowered
+        or "denied" in lowered
+        or "not authorized" in lowered
+    )
 
 
 class TestJobOwnership:
@@ -49,10 +64,10 @@ class TestJobOwnership:
         job_id = _start_long_job(cluster, "own-exec")
         try:
             out = cluster.cli_as_user(
-                "root", ["spur", "exec", str(job_id), "whoami"]
+                NON_OWNER, ["spur", "exec", str(job_id), "whoami"]
             )
-            # root is a distinct identity from the submitting SSH user, so the
-            # controller's owner check must reject it.
+            # A distinct, unprivileged identity, so the controller's owner
+            # check must reject it.
             assert _denied(out), (
                 f"a non-owner must be denied exec into job {job_id}, got:\n{out}"
             )
@@ -63,7 +78,7 @@ class TestJobOwnership:
         _require_second_identity(cluster)
         job_id = _start_long_job(cluster, "own-attach")
         try:
-            out = cluster.cli_as_user("root", ["sattach", str(job_id)])
+            out = cluster.cli_as_user(NON_OWNER, ["sattach", str(job_id)])
             assert _denied(out), (
                 f"a non-owner must be denied attach to job {job_id}, got:\n{out}"
             )
@@ -75,7 +90,7 @@ class TestJobOwnership:
         job_id = _start_long_job(cluster, "own-stream")
         try:
             out = cluster.cli_as_user(
-                "root", ["sattach", str(job_id), "--output-only"]
+                NON_OWNER, ["sattach", str(job_id), "--output-only"]
             )
             assert _denied(out), (
                 f"a non-owner must be denied output streaming for job {job_id}, "

--- a/tests/native_host/e2e/test_job_ownership.py
+++ b/tests/native_host/e2e/test_job_ownership.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for job ownership enforcement on interactive entry points.
+
+`spur exec`, `sattach` and output streaming all reach into a running job, so
+each must reject a caller who does not own it. The identity travels from the
+invoking UNIX account through the CLI to the controller, which is why these
+run the CLI under a second account via sudo.
+"""
+
+import time
+
+import pytest
+
+from cluster import parse_job_id, wait_job_state
+
+
+def _require_second_identity(cluster) -> str:
+    """Skip unless the environment can run the CLI as a second UNIX user."""
+    submit_user = cluster.nodes[0].user
+    if submit_user == "root":
+        pytest.skip("need a non-root SSH user to test non-owner rejection")
+
+    probe = cluster.cli_as_user("root", ["squeue", "-h"])
+    if "sudo" in probe.lower() and (
+        "password" in probe.lower() or "not allowed" in probe.lower()
+    ):
+        pytest.skip(f"sudo -u unavailable in this environment: {probe.strip()}")
+    return submit_user
+
+
+def _start_long_job(cluster, name: str) -> int:
+    script = cluster.write_file(f"{name}.sh", "#!/bin/bash\nsleep 300\n")
+    job_id = parse_job_id(cluster.sbatch(["-J", name, script]))
+    assert job_id is not None
+    wait_job_state(cluster, job_id, "R", timeout=60)
+    return job_id
+
+
+def _denied(output: str) -> bool:
+    lowered = output.lower()
+    return "permission" in lowered or "denied" in lowered or "not authorized" in lowered
+
+
+class TestJobOwnership:
+    def test_non_owner_cannot_exec_into_job(self, cluster):
+        _require_second_identity(cluster)
+        job_id = _start_long_job(cluster, "own-exec")
+        try:
+            out = cluster.cli_as_user(
+                "root", ["spur", "exec", str(job_id), "whoami"]
+            )
+            # root is a distinct identity from the submitting SSH user, so the
+            # controller's owner check must reject it.
+            assert _denied(out), (
+                f"a non-owner must be denied exec into job {job_id}, got:\n{out}"
+            )
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_non_owner_cannot_attach_to_job(self, cluster):
+        _require_second_identity(cluster)
+        job_id = _start_long_job(cluster, "own-attach")
+        try:
+            out = cluster.cli_as_user("root", ["sattach", str(job_id)])
+            assert _denied(out), (
+                f"a non-owner must be denied attach to job {job_id}, got:\n{out}"
+            )
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_non_owner_cannot_stream_job_output(self, cluster):
+        _require_second_identity(cluster)
+        job_id = _start_long_job(cluster, "own-stream")
+        try:
+            out = cluster.cli_as_user(
+                "root", ["sattach", str(job_id), "--output-only"]
+            )
+            assert _denied(out), (
+                f"a non-owner must be denied output streaming for job {job_id}, "
+                f"got:\n{out}"
+            )
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_owner_can_exec_into_own_job(self, cluster):
+        """The owner path must still work, so the denial above is about
+        identity rather than a broken exec."""
+        submit_user = _require_second_identity(cluster)
+        job_id = _start_long_job(cluster, "own-exec-ok")
+        try:
+            code, out = cluster.spur_exec(job_id, ["whoami"])
+            assert code == 0, f"owner exec into job {job_id} failed:\n{out}"
+            assert submit_user in out, (
+                f"exec must run as the job owner {submit_user}, got:\n{out}"
+            )
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_exec_rejects_unknown_job(self, cluster):
+        code, out = cluster.spur_exec(999999, ["whoami"])
+        assert code != 0, f"exec into a nonexistent job must fail, got:\n{out}"
+        assert "not found" in out.lower(), f"expected a not-found error, got:\n{out}"
+
+    def test_exec_rejects_job_that_is_not_running(self, cluster):
+        script = cluster.write_file("own-pending.sh", "#!/bin/bash\nsleep 30\n")
+        job_id = parse_job_id(cluster.sbatch(["-J", "own-pending", "-H", script]))
+        assert job_id is not None
+        wait_job_state(cluster, job_id, "PD", timeout=30)
+        try:
+            code, out = cluster.spur_exec(job_id, ["whoami"])
+            assert code != 0, f"exec into a held job must fail, got:\n{out}"
+            assert "not running" in out.lower(), (
+                f"expected a not-running error, got:\n{out}"
+            )
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])
+
+
+class TestRestSubmittedJobOwnership:
+    """A REST submission may omit `user`, leaving the job with no owner.
+
+    Such a job runs as root, so every non-root caller must be denied rather
+    than inheriting access to a root-owned process.
+    """
+
+    def test_non_root_denied_on_unowned_job(self, cluster):
+        submit_user = _require_second_identity(cluster)
+        cluster.curl_preflight()
+
+        script = "#!/bin/bash\nsleep 300\n"
+        body = (
+            '{"job":{"name":"unowned","script":'
+            f'"{script.encode("unicode_escape").decode()}"'
+            ',"nodes":1,"ntasks":1}}'
+        )
+        status, resp = cluster.http_post("/api/v1/job/submit", body)
+        if status != 200:
+            pytest.skip(f"REST submit unavailable (status {status}): {resp}")
+
+        job_id = None
+        deadline = time.time() + 30
+        while time.time() < deadline and job_id is None:
+            ids = cluster.running_job_ids_by_name("unowned")
+            job_id = ids[0] if ids else None
+            if job_id is None:
+                time.sleep(2)
+        assert job_id is not None, (
+            f"REST-submitted job never started:\n{cluster.squeue_all()}"
+        )
+
+        try:
+            out = cluster.cli_as_user(
+                submit_user, ["spur", "exec", str(job_id), "whoami"]
+            )
+            assert _denied(out), (
+                f"a non-root caller must be denied exec into an unowned job, "
+                f"got:\n{out}"
+            )
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])

--- a/tests/native_host/e2e/test_job_ownership.py
+++ b/tests/native_host/e2e/test_job_ownership.py
@@ -15,6 +15,8 @@ import pytest
 
 from cluster import parse_job_id, wait_job_state
 
+pytestmark = pytest.mark.suite_runtime
+
 
 # root is an administrative override in check_job_owner, so a denial test has
 # to run as an ordinary account instead.

--- a/tests/native_host/e2e/test_job_ownership.py
+++ b/tests/native_host/e2e/test_job_ownership.py
@@ -76,6 +76,9 @@ class TestJobOwnership:
 
     def test_non_owner_cannot_attach_to_job(self, cluster):
         _require_second_identity(cluster)
+        # The owner check lives on the agent, so the denial is only observable
+        # once the client can reach it.
+        cluster.agent_resolution_preflight()
         job_id = _start_long_job(cluster, "own-attach")
         try:
             out = cluster.cli_as_user(NON_OWNER, ["sattach", str(job_id)])
@@ -87,6 +90,7 @@ class TestJobOwnership:
 
     def test_non_owner_cannot_stream_job_output(self, cluster):
         _require_second_identity(cluster)
+        cluster.agent_resolution_preflight()
         job_id = _start_long_job(cluster, "own-stream")
         try:
             out = cluster.cli_as_user(

--- a/tests/native_host/e2e/test_k8s_auth.py
+++ b/tests/native_host/e2e/test_k8s_auth.py
@@ -6,6 +6,8 @@ control plane. Identity is whoami-derived, exercised via `cli_as_user`."""
 
 import pytest
 
+pytestmark = pytest.mark.suite_ha
+
 
 class TestK8sAuth:
     def _require_sudo_second_identity(self, cluster):

--- a/tests/native_host/e2e/test_k8s_multicp.py
+++ b/tests/native_host/e2e/test_k8s_multicp.py
@@ -5,6 +5,8 @@
 
 import pytest
 
+pytestmark = pytest.mark.suite_ha
+
 
 @pytest.mark.k0s
 class TestK8sMultiControlPlane:

--- a/tests/native_host/e2e/test_k8s_scheduling.py
+++ b/tests/native_host/e2e/test_k8s_scheduling.py
@@ -16,6 +16,8 @@ import pytest
 
 from cluster import parse_job_id, job_state, wait_job
 
+pytestmark = pytest.mark.suite_ha
+
 K8S_RESERVED = "Reserved for Kubernetes cluster"
 
 

--- a/tests/native_host/e2e/test_licenses.py
+++ b/tests/native_host/e2e/test_licenses.py
@@ -1,0 +1,191 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for cluster-wide software licenses.
+
+Licenses are a cluster-wide counted resource declared in `[licenses]`. Unlike
+node resources they are not attached to any node, and the pool total is never
+decremented — usage is derived from the set of running jobs. That derivation is
+what these tests exercise: a job holding the pool blocks others with
+`Reason=Licenses`, and finishing releases the count without drift.
+"""
+
+import re
+import time
+
+import pytest
+
+from cluster import parse_job_id, wait_job, wait_job_state
+
+LICENSES = {"fluent": 2, "matlab": 1}
+
+
+@pytest.fixture
+def license_cluster(unstarted_cluster):
+    """A cluster with a small, exhaustible license pool."""
+    unstarted_cluster.start(config_overrides={"licenses": LICENSES})
+    return unstarted_cluster
+
+
+def submit_holder(cluster, name: str, licenses: str, seconds: int = 120) -> int:
+    script = cluster.write_file(f"{name}.sh", f"#!/bin/bash\nsleep {seconds}\n")
+    job_id = parse_job_id(cluster.sbatch(["-J", name, "-L", licenses, script]))
+    assert job_id is not None
+    return job_id
+
+
+def pending_reason(cluster, job_id: int) -> str:
+    out = cluster.scontrol("show", "job", str(job_id))
+    match = re.search(r"Reason=(\S+)", out)
+    return match.group(1) if match else ""
+
+
+def wait_reason(cluster, job_id: int, reason: str, timeout: int = 60) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if pending_reason(cluster, job_id) == reason:
+            return
+        time.sleep(2)
+    raise AssertionError(
+        f"job {job_id} never reported Reason={reason}\n"
+        f"{cluster.scontrol('show', 'job', str(job_id))}"
+    )
+
+
+class TestLicenseAvailability:
+    def test_a_job_within_the_pool_runs(self, license_cluster):
+        job_id = submit_holder(license_cluster, "lic-fit", "fluent:2")
+        try:
+            wait_job_state(license_cluster, job_id, "R", timeout=90)
+        finally:
+            license_cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_a_job_exceeding_the_pool_total_never_starts(self, license_cluster):
+        """The request can never be satisfied, so it must stay pending on
+        Licenses rather than being rejected at submit or starved silently."""
+        job_id = submit_holder(license_cluster, "lic-too-big", "fluent:5")
+        try:
+            wait_reason(license_cluster, job_id, "Licenses")
+        finally:
+            license_cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_an_unconfigured_license_blocks_the_job(self, license_cluster):
+        """An unknown name has an implicit pool of zero. Treating it as
+        unlimited would let jobs bypass licensing entirely by typo."""
+        job_id = submit_holder(license_cluster, "lic-unknown", "nosuchlic:1")
+        try:
+            wait_reason(license_cluster, job_id, "Licenses")
+        finally:
+            license_cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_separate_pools_do_not_interfere(self, license_cluster):
+        holder = submit_holder(license_cluster, "lic-fluent", "fluent:2")
+        other = submit_holder(license_cluster, "lic-matlab", "matlab:1")
+        try:
+            wait_job_state(license_cluster, holder, "R", timeout=90)
+            wait_job_state(license_cluster, other, "R", timeout=90)
+        finally:
+            for job_id in (holder, other):
+                license_cluster.cli_allow_fail(["scancel", str(job_id)])
+
+
+class TestLicenseContention:
+    def test_a_second_job_waits_on_licenses(self, license_cluster):
+        holder = submit_holder(license_cluster, "lic-hold", "fluent:2")
+        wait_job_state(license_cluster, holder, "R", timeout=90)
+
+        waiter = submit_holder(license_cluster, "lic-wait", "fluent:1")
+        try:
+            wait_reason(license_cluster, waiter, "Licenses")
+        finally:
+            for job_id in (holder, waiter):
+                license_cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_squeue_shows_the_reason_in_the_nodelist_column(self, license_cluster):
+        holder = submit_holder(license_cluster, "lic-hold2", "fluent:2")
+        wait_job_state(license_cluster, holder, "R", timeout=90)
+        waiter = submit_holder(license_cluster, "lic-wait2", "fluent:1")
+        try:
+            wait_reason(license_cluster, waiter, "Licenses")
+            out = license_cluster.squeue(["-h", "-o", "%i %R"])
+            row = next(
+                (ln for ln in out.splitlines() if ln.split()[:1] == [str(waiter)]), ""
+            )
+            assert "(Licenses)" in row, f"expected (Licenses) in squeue row: {out}"
+        finally:
+            for job_id in (holder, waiter):
+                license_cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_licenses_are_released_when_the_holder_ends(self, license_cluster):
+        """Usage is derived from the running set, so a terminal job has to free
+        its licenses with no explicit release call."""
+        holder = submit_holder(license_cluster, "lic-release", "fluent:2")
+        wait_job_state(license_cluster, holder, "R", timeout=90)
+
+        waiter = submit_holder(license_cluster, "lic-next", "fluent:2", seconds=5)
+        wait_reason(license_cluster, waiter, "Licenses")
+
+        license_cluster.cli_allow_fail(["scancel", str(holder)])
+        try:
+            wait_job_state(license_cluster, waiter, "R", timeout=90)
+        finally:
+            license_cluster.cli_allow_fail(["scancel", str(waiter)])
+
+    def test_the_pool_does_not_drift_across_generations(self, license_cluster):
+        """A pool total decremented at allocation instead of derived would
+        shrink a little on every job; three full cycles would expose it."""
+        for i in range(3):
+            script = license_cluster.write_file(
+                f"lic-cycle{i}.sh", "#!/bin/bash\necho cycle\n"
+            )
+            job_id = parse_job_id(
+                license_cluster.sbatch(["-J", f"lic-cycle{i}", "-L", "fluent:2", script])
+            )
+            assert job_id is not None
+            assert wait_job(license_cluster, job_id, timeout=90) in ("CD", "GONE"), (
+                license_cluster.debug_job(job_id)
+            )
+
+
+class TestLicenseRequestForms:
+    def test_gres_license_syntax_is_equivalent(self, license_cluster):
+        """`--gres=license:...` is the older spelling and folds into the same
+        pool, so both forms must contend with each other."""
+        script = license_cluster.write_file("lic-gres.sh", "#!/bin/bash\nsleep 120\n")
+        holder = parse_job_id(
+            license_cluster.sbatch(
+                ["-J", "lic-gres", "--gres=license:fluent:2", script]
+            )
+        )
+        assert holder is not None
+        waiter = submit_holder(license_cluster, "lic-gres-wait", "fluent:1")
+        try:
+            wait_job_state(license_cluster, holder, "R", timeout=90)
+            wait_reason(license_cluster, waiter, "Licenses")
+        finally:
+            for job_id in (holder, waiter):
+                license_cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_repeated_flags_accumulate(self, license_cluster):
+        job_id = submit_holder(license_cluster, "lic-multi", "fluent:1")
+        # A second -L adds to the request rather than replacing it.
+        script = license_cluster.write_file("lic-both.sh", "#!/bin/bash\nsleep 60\n")
+        both = parse_job_id(
+            license_cluster.sbatch(
+                ["-J", "lic-both", "-L", "fluent:1", "-L", "matlab:1", script]
+            )
+        )
+        assert both is not None
+        try:
+            wait_job_state(license_cluster, job_id, "R", timeout=90)
+            wait_job_state(license_cluster, both, "R", timeout=90)
+        finally:
+            for jid in (job_id, both):
+                license_cluster.cli_allow_fail(["scancel", str(jid)])
+
+    def test_srun_accepts_the_licenses_flag(self, license_cluster):
+        code, out = license_cluster.srun_with_exit(
+            ["-L", "fluent:1", "echo", "SRUN_LIC_OK"]
+        )
+        assert code == 0, out
+        assert "SRUN_LIC_OK" in out, out

--- a/tests/native_host/e2e/test_licenses.py
+++ b/tests/native_host/e2e/test_licenses.py
@@ -17,6 +17,8 @@ import pytest
 
 from cluster import parse_job_id, wait_job, wait_job_state
 
+pytestmark = pytest.mark.suite_policy
+
 LICENSES = {"fluent": 2, "matlab": 1}
 
 

--- a/tests/native_host/e2e/test_metrics.py
+++ b/tests/native_host/e2e/test_metrics.py
@@ -16,6 +16,8 @@ import pytest
 
 from cluster import METRICS_PORT, parse_job_id, wait_job_state
 
+pytestmark = pytest.mark.suite_api
+
 # /metrics is an alias for /metrics/jobs.
 ROUTE_FAMILIES = {
     "/metrics": ["spur_jobs_pending", "spur_jobs_running"],

--- a/tests/native_host/e2e/test_metrics.py
+++ b/tests/native_host/e2e/test_metrics.py
@@ -82,10 +82,15 @@ class TestMetricsRoutes:
         ), "/metrics must expose the same families as /metrics/jobs"
 
     def test_node_gauges_match_the_cluster_size(self, scrapeable):
+        """The gauge has to agree with the node view a user gets from sinfo."""
         body = _scrape(scrapeable, "/metrics/nodes")
         cpus = _gauge(body, "spur_nodes_cpus")
-        assert cpus >= 64 * len(scrapeable.node_names), (
-            f"spur_nodes_cpus ({cpus}) is below the configured cluster size"
+        reported = scrapeable.cli(["sinfo", "-N", "-h", "-o", "%c"])
+        expected = sum(int(line) for line in reported.split() if line.isdigit())
+        assert expected > 0, f"sinfo reported no per-node CPU counts:\n{reported}"
+        assert cpus == expected, (
+            f"spur_nodes_cpus ({cpus}) disagrees with the {expected} CPUs "
+            f"sinfo reports across {len(scrapeable.node_names)} nodes"
         )
 
 

--- a/tests/native_host/e2e/test_metrics.py
+++ b/tests/native_host/e2e/test_metrics.py
@@ -1,0 +1,194 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for the spurctld OpenMetrics endpoint.
+
+The metrics server binds to loopback by default, so these use the
+metrics_cluster fixture, which sets `[metrics] bind = "all"`. It leaves
+`high_cardinality` off so the gating on /metrics/jobs-users-accts stays
+observable.
+"""
+
+import re
+import time
+
+import pytest
+
+from cluster import METRICS_PORT, parse_job_id, wait_job_state
+
+# /metrics is an alias for /metrics/jobs.
+ROUTE_FAMILIES = {
+    "/metrics": ["spur_jobs_pending", "spur_jobs_running"],
+    "/metrics/jobs": [
+        "spur_jobs_pending",
+        "spur_jobs_running",
+        "spur_jobs_completed",
+        "spur_jobs_cpus_alloc",
+        "spur_jobs_gpus_alloc",
+    ],
+    "/metrics/nodes": [
+        "spur_nodes_cpus",
+        "spur_nodes_cpus_alloc",
+        "spur_nodes_memory_bytes",
+    ],
+    "/metrics/partitions": ["spur_partitions", "spur_partition_nodes"],
+    "/metrics/rpc": ["spur_rpc_stats"],
+    "/metrics/scheduler": ["spur_scheduler_info", "spur_scheduler_cycle_last_time_us"],
+}
+
+
+def _scrape(cluster, path: str) -> str:
+    status, body = cluster.http_get(path, port=METRICS_PORT)
+    assert status == 200, f"GET {path} returned {status}:\n{body}"
+    return body
+
+
+def _gauge(body: str, name: str) -> float:
+    match = re.search(rf"^{re.escape(name)}\s+([0-9.eE+-]+)$", body, re.MULTILINE)
+    assert match, f"metric {name} missing from scrape:\n{body}"
+    return float(match.group(1))
+
+
+@pytest.fixture
+def scrapeable(metrics_cluster):
+    status, body = metrics_cluster.http_get("/metrics", port=METRICS_PORT)
+    if status == 0:
+        pytest.skip(f"metrics endpoint unreachable on {METRICS_PORT}: {body.strip()}")
+    return metrics_cluster
+
+
+class TestMetricsRoutes:
+    @pytest.mark.parametrize("path,families", sorted(ROUTE_FAMILIES.items()))
+    def test_route_exports_its_families(self, scrapeable, path, families):
+        body = _scrape(scrapeable, path)
+        for family in families:
+            assert family in body, f"{path} is missing {family}:\n{body}"
+
+    @pytest.mark.parametrize("path", sorted(ROUTE_FAMILIES))
+    def test_scrape_terminates_with_eof(self, scrapeable, path):
+        """OpenMetrics requires the trailing `# EOF`; without it a scraper
+        treats the payload as truncated."""
+        body = _scrape(scrapeable, path)
+        assert body.endswith("# EOF\n"), (
+            f"{path} must end with an OpenMetrics EOF marker, ends with "
+            f"{body[-40:]!r}"
+        )
+
+    def test_metrics_alias_matches_jobs_route(self, scrapeable):
+        alias = _scrape(scrapeable, "/metrics")
+        jobs = _scrape(scrapeable, "/metrics/jobs")
+        assert set(re.findall(r"^# TYPE (\S+)", alias, re.MULTILINE)) == set(
+            re.findall(r"^# TYPE (\S+)", jobs, re.MULTILINE)
+        ), "/metrics must expose the same families as /metrics/jobs"
+
+    def test_node_gauges_match_the_cluster_size(self, scrapeable):
+        body = _scrape(scrapeable, "/metrics/nodes")
+        cpus = _gauge(body, "spur_nodes_cpus")
+        assert cpus >= 64 * len(scrapeable.node_names), (
+            f"spur_nodes_cpus ({cpus}) is below the configured cluster size"
+        )
+
+
+class TestLiveGauges:
+    def test_running_gauge_tracks_a_job(self, scrapeable):
+        before = _gauge(_scrape(scrapeable, "/metrics/jobs"), "spur_jobs_running")
+
+        script = scrapeable.write_file("metrics-job.sh", "#!/bin/bash\nsleep 120\n")
+        job_id = parse_job_id(scrapeable.sbatch(["-J", "metrics-job", script]))
+        assert job_id is not None
+
+        try:
+            wait_job_state(scrapeable, job_id, "R", timeout=90)
+
+            deadline = time.time() + 30
+            while time.time() < deadline:
+                during = _gauge(
+                    _scrape(scrapeable, "/metrics/jobs"), "spur_jobs_running"
+                )
+                if during > before:
+                    break
+                time.sleep(2)
+            else:
+                raise AssertionError(
+                    f"spur_jobs_running did not rise above {before} while job "
+                    f"{job_id} was running"
+                )
+        finally:
+            scrapeable.cli_allow_fail(["scancel", str(job_id)])
+
+        deadline = time.time() + 60
+        while time.time() < deadline:
+            after = _gauge(_scrape(scrapeable, "/metrics/jobs"), "spur_jobs_running")
+            if after <= before:
+                return
+            time.sleep(2)
+        raise AssertionError(
+            f"spur_jobs_running stayed above {before} after job {job_id} ended"
+        )
+
+    def test_pending_gauge_tracks_a_held_job(self, scrapeable):
+        before = _gauge(_scrape(scrapeable, "/metrics/jobs"), "spur_jobs_hold")
+
+        script = scrapeable.write_file("metrics-held.sh", "#!/bin/bash\nsleep 30\n")
+        job_id = parse_job_id(
+            scrapeable.sbatch(["-J", "metrics-held", "-H", script])
+        )
+        assert job_id is not None
+
+        try:
+            wait_job_state(scrapeable, job_id, "PD", timeout=30)
+            deadline = time.time() + 30
+            while time.time() < deadline:
+                if _gauge(
+                    _scrape(scrapeable, "/metrics/jobs"), "spur_jobs_hold"
+                ) > before:
+                    return
+                time.sleep(2)
+            raise AssertionError(
+                f"spur_jobs_hold did not rise above {before} for held job {job_id}"
+            )
+        finally:
+            scrapeable.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_rpc_counters_advance_with_traffic(self, scrapeable):
+        scrapeable.squeue_all()
+        first = _scrape(scrapeable, "/metrics/rpc")
+        for _ in range(5):
+            scrapeable.squeue_all()
+        second = _scrape(scrapeable, "/metrics/rpc")
+        assert first != second, (
+            "RPC counters must advance after serving more requests:\n"
+            f"{second}"
+        )
+
+
+class TestHighCardinalityGating:
+    def test_jobs_users_accts_is_404_by_default(self, scrapeable):
+        status, body = scrapeable.http_get(
+            "/metrics/jobs-users-accts", port=METRICS_PORT
+        )
+        assert status == 404, (
+            f"per-user metrics must be off by default, got {status}:\n{body}"
+        )
+        assert "high_cardinality" in body, f"expected a config hint:\n{body}"
+
+    def test_jobs_users_accts_served_when_enabled(self, unstarted_cluster):
+        cluster = unstarted_cluster
+        cluster.curl_preflight()
+        cluster.start(
+            config_overrides={
+                "metrics": {"bind": "all", "high_cardinality": True},
+            }
+        )
+
+        status, body = cluster.http_get(
+            "/metrics/jobs-users-accts", port=METRICS_PORT
+        )
+        if status == 0:
+            pytest.skip(f"metrics endpoint unreachable: {body.strip()}")
+        assert status == 200, (
+            f"high_cardinality = true must expose the route, got {status}:\n{body}"
+        )
+        assert body.endswith("# EOF\n"), (
+            f"scrape must end with an OpenMetrics EOF marker:\n{body[-40:]!r}"
+        )

--- a/tests/native_host/e2e/test_mpi.py
+++ b/tests/native_host/e2e/test_mpi.py
@@ -11,6 +11,8 @@ import pytest
 
 from cluster import SpurCluster, ensure_bins, make_remote_dir, parse_job_id, wait_job, wait_job_state
 
+pytestmark = pytest.mark.suite_ha
+
 MPI_SOAK_ITERATIONS = max(1, int(os.environ.get("SPUR_MPI_SOAK_ITERATIONS", "1")))
 
 

--- a/tests/native_host/e2e/test_multi_node.py
+++ b/tests/native_host/e2e/test_multi_node.py
@@ -10,6 +10,9 @@ The multi_node_cluster fixture validates this and skips if insufficient.
 import time
 
 from cluster import parse_job_id, job_state, wait_job
+import pytest
+
+pytestmark = pytest.mark.suite_fabric
 
 
 def _wait_node_state(cluster, node_name, target_states, timeout=60):

--- a/tests/native_host/e2e/test_net_mesh.py
+++ b/tests/native_host/e2e/test_net_mesh.py
@@ -5,8 +5,8 @@
 
 Bringing an interface up rewrites `/etc/wireguard` and adds routes on a shared
 test node, so anything mutating is opt-in behind `SPUR_TEST_WIREGUARD=1`. The
-read-only and error paths run everywhere, since those are what a user hits
-first on a node where WireGuard was never set up.
+read-only and error paths need only the WireGuard tools installed, since those
+are what a user hits first on a node where WireGuard was never configured.
 """
 
 import os
@@ -29,11 +29,16 @@ def net_cli(cluster, args: list[str]) -> tuple[int, str]:
 
 
 class TestStatus:
+    @pytest.fixture(autouse=True)
+    def _wireguard_installed(self, cluster):
+        """`status` shells out to `wg`, so without the tools every assertion
+        here only ever sees a missing-binary errno."""
+        cluster.wireguard_preflight()
+
     def test_status_on_a_missing_interface_explains_itself(self, cluster):
         """The first thing a user runs on an unconfigured node. A bare `wg
         show` error would leave them with nothing to act on."""
-        code, out = net_cli(cluster, ["status", "--interface", "spurtest-absent"])
-        assert code != 0, out
+        _, out = net_cli(cluster, ["status", "--interface", "spurtest-absent"])
         assert "is not up" in out, out
         assert "spur net init" in out, out
 

--- a/tests/native_host/e2e/test_net_mesh.py
+++ b/tests/native_host/e2e/test_net_mesh.py
@@ -13,6 +13,8 @@ import os
 
 import pytest
 
+pytestmark = pytest.mark.suite_fabric
+
 MUTATING = os.environ.get("SPUR_TEST_WIREGUARD") == "1"
 mutating = pytest.mark.skipif(
     not MUTATING,

--- a/tests/native_host/e2e/test_net_mesh.py
+++ b/tests/native_host/e2e/test_net_mesh.py
@@ -1,0 +1,234 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for `spur net` (WireGuard mesh).
+
+Bringing an interface up rewrites `/etc/wireguard` and adds routes on a shared
+test node, so anything mutating is opt-in behind `SPUR_TEST_WIREGUARD=1`. The
+read-only and error paths run everywhere, since those are what a user hits
+first on a node where WireGuard was never set up.
+"""
+
+import os
+
+import pytest
+
+MUTATING = os.environ.get("SPUR_TEST_WIREGUARD") == "1"
+mutating = pytest.mark.skipif(
+    not MUTATING,
+    reason="brings a WireGuard interface up on a shared node; "
+    "set SPUR_TEST_WIREGUARD=1 to run",
+)
+
+TEST_IFACE = "spurtest0"
+TEST_CIDR = "10.45.0.0/24"
+
+
+def net_cli(cluster, args: list[str]) -> tuple[int, str]:
+    return cluster.cli_with_env(["spur", "net"] + args, {})
+
+
+class TestStatus:
+    def test_status_on_a_missing_interface_explains_itself(self, cluster):
+        """The first thing a user runs on an unconfigured node. A bare `wg
+        show` error would leave them with nothing to act on."""
+        code, out = net_cli(cluster, ["status", "--interface", "spurtest-absent"])
+        assert code != 0, out
+        assert "is not up" in out, out
+        assert "spur net init" in out, out
+
+    def test_status_names_the_interface_it_looked_for(self, cluster):
+        _, out = net_cli(cluster, ["status", "--interface", "spurtest-absent"])
+        assert "spurtest-absent" in out, out
+
+
+class TestArgumentValidation:
+    def test_join_requires_an_endpoint(self, cluster):
+        code, out = net_cli(
+            cluster, ["join", "--server-key", "x", "--address", "10.45.0.2"]
+        )
+        assert code != 0, out
+
+    def test_join_requires_a_server_key(self, cluster):
+        code, out = net_cli(
+            cluster, ["join", "--endpoint", "host:51820", "--address", "10.45.0.2"]
+        )
+        assert code != 0, out
+
+    def test_mesh_requires_a_config(self, cluster):
+        code, out = net_cli(cluster, ["mesh", "--self", "10.45.0.1"])
+        assert code != 0, out
+
+    def test_a_missing_mesh_config_is_reported_by_path(self, cluster):
+        code, out = net_cli(
+            cluster,
+            ["mesh", "--config", "/nonexistent/mesh.json", "--self", "10.45.0.1"],
+        )
+        assert code != 0, out
+        assert "/nonexistent/mesh.json" in out, out
+
+
+class TestMeshPlanning:
+    """`--dry-run` is the only way to inspect a mesh plan without root, so it
+    has to validate the membership fully and never reach `wg` or `ip`."""
+
+    def test_the_plan_lists_every_peer_but_self(self, cluster):
+        config = _membership(cluster, "mesh-plan.json", ["10.45.0.1", "10.45.0.2"])
+        code, out = net_cli(
+            cluster,
+            ["mesh", "--config", config, "--self", "10.45.0.1", "--dry-run",
+             "--interface", TEST_IFACE],
+        )
+        assert code == 0, out
+        assert "key-10.45.0.2" in out, out
+        assert "key-10.45.0.1" not in out, f"self must not be listed as a peer:\n{out}"
+
+    def test_the_plan_does_not_query_the_interface(self, cluster):
+        config = _membership(cluster, "mesh-noiface.json", ["10.45.0.1", "10.45.0.2"])
+        _, out = net_cli(
+            cluster,
+            ["mesh", "--config", config, "--self", "10.45.0.1", "--dry-run",
+             "--interface", "spurtest-absent"],
+        )
+        assert "is not up" not in out, (
+            f"--dry-run must not touch the interface:\n{out}"
+        )
+
+    def test_a_self_outside_the_membership_is_rejected(self, cluster):
+        """Applying a mesh that omits this node would strip its own peers, so
+        the mismatch has to fail before anything is written."""
+        config = _membership(cluster, "mesh-nostranger.json", ["10.45.0.1"])
+        code, out = net_cli(
+            cluster,
+            ["mesh", "--config", config, "--self", "10.45.0.9", "--dry-run"],
+        )
+        assert code != 0, out
+        assert "is not present in" in out, out
+
+    def test_a_malformed_mesh_ip_is_rejected(self, cluster):
+        config = cluster.write_file(
+            "mesh-badip.json",
+            '{"nodes": [{"public_key": "k", "mesh_ip": "not-an-ip", '
+            '"endpoint": "10.45.0.1:51820"}]}\n',
+            executable=False,
+        )
+        code, out = net_cli(
+            cluster, ["mesh", "--config", config, "--self", "not-an-ip", "--dry-run"]
+        )
+        assert code != 0, out
+        assert "mesh_ip" in out, out
+
+    def test_a_malformed_pod_cidr_is_rejected(self, cluster):
+        config = cluster.write_file(
+            "mesh-badcidr.json",
+            '{"nodes": [{"public_key": "k", "mesh_ip": "10.45.0.1", '
+            '"endpoint": "10.45.0.1:51820", "pod_cidr": "10.42.1.0"}]}\n',
+            executable=False,
+        )
+        code, out = net_cli(
+            cluster, ["mesh", "--config", config, "--self", "10.45.0.1", "--dry-run"]
+        )
+        assert code != 0, out
+        assert "pod_cidr" in out, out
+
+    def test_pod_routes_are_only_planned_when_requested(self, cluster):
+        """A CNI usually owns pod routes; installing them unasked would fight
+        it, so the plan must say it is leaving them alone."""
+        config = cluster.write_file(
+            "mesh-pod.json",
+            '{"nodes": ['
+            '{"public_key": "key-a", "mesh_ip": "10.45.0.1", '
+            '"endpoint": "10.45.0.1:51820", "pod_cidr": "10.42.1.0/24"},'
+            '{"public_key": "key-b", "mesh_ip": "10.45.0.2", '
+            '"endpoint": "10.45.0.2:51820", "pod_cidr": "10.42.2.0/24"}'
+            "]}\n",
+            executable=False,
+        )
+        code, out = net_cli(
+            cluster,
+            ["mesh", "--config", config, "--self", "10.45.0.1", "--dry-run"],
+        )
+        assert code == 0, out
+        assert "routes not programmed" in out, out
+
+        code, out = net_cli(
+            cluster,
+            ["mesh", "--config", config, "--self", "10.45.0.1", "--dry-run",
+             "--program-routes"],
+        )
+        assert code == 0, out
+        assert "route 10.42.2.0/24" in out, out
+
+
+def _membership(cluster, filename: str, mesh_ips: list[str]) -> str:
+    nodes = ", ".join(
+        f'{{"public_key": "key-{ip}", "mesh_ip": "{ip}", "endpoint": "{ip}:51820"}}'
+        for ip in mesh_ips
+    )
+    return cluster.write_file(
+        filename, f'{{"nodes": [{nodes}]}}\n', executable=False
+    )
+
+
+@mutating
+class TestInterfaceLifecycle:
+    @pytest.fixture
+    def wg_node(self, cluster):
+        cluster.wireguard_preflight()
+        cluster.root_agent_preflight()
+        yield cluster
+        cluster.nodes[0].exec_allow_fail(
+            f"sudo wg-quick down {TEST_IFACE} 2>/dev/null || true"
+        )
+        cluster.nodes[0].exec_allow_fail(
+            f"sudo rm -f /etc/wireguard/{TEST_IFACE}.conf"
+        )
+
+    def test_init_brings_the_interface_up(self, wg_node):
+        code, out = wg_node.sudo_cli(
+            ["spur", "net", "init", "--cidr", TEST_CIDR, "--interface", TEST_IFACE]
+        )
+        assert code == 0, out
+
+        code, status = net_cli(wg_node, ["status", "--interface", TEST_IFACE])
+        assert code == 0, status
+        assert "interface" in status.lower(), status
+
+    def test_init_writes_a_private_config(self, wg_node):
+        code, out = wg_node.sudo_cli(
+            ["spur", "net", "init", "--cidr", TEST_CIDR, "--interface", TEST_IFACE]
+        )
+        assert code == 0, out
+
+        mode = wg_node.nodes[0].exec_allow_fail(
+            f"sudo stat -c%a /etc/wireguard/{TEST_IFACE}.conf"
+        ).strip()
+        assert mode == "600", (
+            f"the config holds a private key and must not be world-readable, got {mode}"
+        )
+
+    def test_a_peer_can_be_added(self, wg_node):
+        code, out = wg_node.sudo_cli(
+            ["spur", "net", "init", "--cidr", TEST_CIDR, "--interface", TEST_IFACE]
+        )
+        assert code == 0, out
+
+        peer_key = wg_node.nodes[0].exec("wg genkey | wg pubkey").strip()
+        code, out = wg_node.sudo_cli(
+            [
+                "spur",
+                "net",
+                "add-peer",
+                "--key",
+                peer_key,
+                "--allowed-ip",
+                "10.45.0.9/32",
+                "--interface",
+                TEST_IFACE,
+            ]
+        )
+        assert code == 0, out
+        assert "Peer added" in out, out
+
+        _, status = net_cli(wg_node, ["status", "--interface", TEST_IFACE])
+        assert peer_key in status, status

--- a/tests/native_host/e2e/test_node_labels.py
+++ b/tests/native_host/e2e/test_node_labels.py
@@ -4,6 +4,9 @@
 """E2E tests for node labels and partition selector routing."""
 
 import time
+import pytest
+
+pytestmark = pytest.mark.suite_policy
 
 
 def _wait_node_in_partition(cluster, node_name, partition, present=True, timeout=10):

--- a/tests/native_host/e2e/test_partitions.py
+++ b/tests/native_host/e2e/test_partitions.py
@@ -9,6 +9,8 @@ import pytest
 
 from cluster import parse_job_id, wait_job, wait_job_state
 
+pytestmark = pytest.mark.suite_scheduling
+
 
 def _unique(prefix: str) -> str:
     return f"{prefix}-{int(time.time())}"

--- a/tests/native_host/e2e/test_preemption.py
+++ b/tests/native_host/e2e/test_preemption.py
@@ -16,6 +16,8 @@ import pytest
 
 from cluster import parse_job_id, wait_job, wait_job_state
 
+pytestmark = pytest.mark.suite_policy
+
 # Time allowed for a requeued low-priority job to get back to RUNNING after a
 # preemption cycle. Generous because it spans the eligibility hold plus node
 # release, scheduler pickup, and spurd relaunch, which is sensitive to CI host

--- a/tests/native_host/e2e/test_prolog_epilog.py
+++ b/tests/native_host/e2e/test_prolog_epilog.py
@@ -10,6 +10,9 @@ environment variable propagation, failure semantics, and execution ordering.
 import time
 
 from cluster import parse_job_id, wait_job, job_state
+import pytest
+
+pytestmark = pytest.mark.suite_runtime
 
 
 LOGGING_PROLOG = """\

--- a/tests/native_host/e2e/test_pty.py
+++ b/tests/native_host/e2e/test_pty.py
@@ -9,6 +9,9 @@ assertions match substrings rather than whole lines.
 """
 
 from cluster import parse_job_id, wait_job_state
+import pytest
+
+pytestmark = pytest.mark.suite_api
 
 
 def _clean(output: str) -> str:

--- a/tests/native_host/e2e/test_pty.py
+++ b/tests/native_host/e2e/test_pty.py
@@ -55,6 +55,7 @@ class TestSrunPty:
 
 class TestSattach:
     def test_output_only_streams_running_job(self, cluster):
+        cluster.agent_resolution_preflight()
         job_id = _start_long_job(
             cluster,
             "sattach-stream",

--- a/tests/native_host/e2e/test_pty.py
+++ b/tests/native_host/e2e/test_pty.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for interactive sessions: srun --pty, sattach, and --overlap.
+
+The CLI tolerates a non-TTY stdin (it warns and skips raw mode), so these run
+over the ordinary SSH channel. PTY output carries CR line endings, so
+assertions match substrings rather than whole lines.
+"""
+
+from cluster import parse_job_id, wait_job_state
+
+
+def _clean(output: str) -> str:
+    return output.replace("\r", "")
+
+
+def _start_long_job(cluster, name: str, body: str = "sleep 300") -> int:
+    script = cluster.write_file(f"{name}.sh", f"#!/bin/bash\n{body}\n")
+    job_id = parse_job_id(cluster.sbatch(["-J", name, script]))
+    assert job_id is not None
+    wait_job_state(cluster, job_id, "R", timeout=60)
+    return job_id
+
+
+class TestSrunPty:
+    def test_pty_runs_command_and_returns_output(self, cluster):
+        code, out = cluster.srun_with_exit(
+            ["--pty", "bash", "-c", "echo PTY_MARKER"]
+        )
+        assert code == 0, f"srun --pty failed (exit {code}):\n{out}"
+        assert "PTY_MARKER" in _clean(out), (
+            f"srun --pty must return the command's output:\n{out}"
+        )
+
+    def test_pty_propagates_exit_code(self, cluster):
+        code, out = cluster.srun_with_exit(["--pty", "bash", "-c", "exit 7"])
+        assert code == 7, f"srun --pty must propagate exit 7, got {code}:\n{out}"
+
+    def test_pty_attaches_to_requested_node(self, multi_node_cluster):
+        """--pty must open the session on the -w node, not the first allocated."""
+        cluster = multi_node_cluster
+        target = cluster.node_names[1]
+
+        code, out = cluster.srun_with_exit(
+            ["--pty", "-N", "1", "-w", target, "bash", "-c", "echo host=$(hostname -s)"]
+        )
+        assert code == 0, f"srun --pty -w {target} failed (exit {code}):\n{out}"
+
+        cleaned = _clean(out)
+        assert f"host={target}" in cleaned, (
+            f"--pty session must land on {target}, got:\n{cleaned}"
+        )
+
+
+class TestSattach:
+    def test_output_only_streams_running_job(self, cluster):
+        job_id = _start_long_job(
+            cluster,
+            "sattach-stream",
+            "for i in $(seq 1 15); do echo SATTACH_MARKER; sleep 1; done",
+        )
+        try:
+            code, out = cluster.sattach(str(job_id), ["--output-only"])
+            assert "SATTACH_MARKER" in _clean(out), (
+                f"sattach --output-only must stream the job's stdout (exit {code}):\n{out}"
+            )
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_attach_rejects_job_that_is_not_running(self, cluster):
+        script = cluster.write_file("sattach-held.sh", "#!/bin/bash\nsleep 30\n")
+        job_id = parse_job_id(cluster.sbatch(["-J", "sattach-held", "-H", script]))
+        assert job_id is not None
+        wait_job_state(cluster, job_id, "PD", timeout=30)
+        try:
+            code, out = cluster.sattach(str(job_id))
+            assert code != 0, f"sattach to a held job must fail, got:\n{out}"
+            assert "not running" in out.lower(), (
+                f"expected a not-running message, got:\n{out}"
+            )
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_attach_rejects_malformed_job_step(self, cluster):
+        code, out = cluster.sattach("not-a-job")
+        assert code != 0, f"a malformed job step must be rejected, got:\n{out}"
+        assert "invalid job id" in out.lower(), (
+            f"expected an invalid-job-ID message, got:\n{out}"
+        )
+
+
+class TestOverlapAttach:
+    def test_overlap_execs_inside_running_job(self, cluster):
+        job_id = _start_long_job(cluster, "overlap-job")
+        try:
+            code, out = cluster.srun_with_exit(
+                [
+                    "--jobid", str(job_id),
+                    "--overlap",
+                    "bash", "-c", "echo OVERLAP_MARKER",
+                ]
+            )
+            assert code == 0, f"--overlap exec failed (exit {code}):\n{out}"
+            assert "OVERLAP_MARKER" in _clean(out), (
+                f"--overlap must run the command inside job {job_id}:\n{out}"
+            )
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_overlap_lands_on_job_node(self, multi_node_cluster):
+        """The overlap session must join the job's node, not an arbitrary one."""
+        cluster = multi_node_cluster
+        target = cluster.node_names[1]
+        script = cluster.write_file("overlap-node.sh", "#!/bin/bash\nsleep 300\n")
+        job_id = parse_job_id(
+            cluster.sbatch(["-J", "overlap-node", "-N", "1", "-w", target, script])
+        )
+        assert job_id is not None
+        wait_job_state(cluster, job_id, "R", timeout=60)
+
+        try:
+            code, out = cluster.srun_with_exit(
+                [
+                    "--jobid", str(job_id),
+                    "--overlap",
+                    "bash", "-c", "echo host=$(hostname -s)",
+                ]
+            )
+            assert code == 0, f"--overlap exec failed (exit {code}):\n{out}"
+            assert f"host={target}" in _clean(out), (
+                f"overlap session must run on {target}, got:\n{out}"
+            )
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_jobid_without_overlap_is_rejected(self, cluster):
+        code, out = cluster.srun_with_exit(["--jobid", "1", "hostname"])
+        assert code != 0, f"--jobid without --overlap must fail, got:\n{out}"
+        assert "--overlap" in out, f"expected an --overlap hint, got:\n{out}"

--- a/tests/native_host/e2e/test_qos_preemption.py
+++ b/tests/native_host/e2e/test_qos_preemption.py
@@ -22,6 +22,8 @@ import pytest
 
 from cluster import parse_job_id, wait_job, wait_job_state
 
+pytestmark = pytest.mark.suite_policy
+
 
 class TestQosPriorityPreemption:
     """A low-QOS running job must be preempted by a high-QOS pending job

--- a/tests/native_host/e2e/test_raft_ha.py
+++ b/tests/native_host/e2e/test_raft_ha.py
@@ -1,0 +1,249 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for multi-controller Raft HA.
+
+The raft_cluster fixture runs spurctld on three nodes as peers and points
+clients at the full endpoint list. test_controller_failover.py covers only
+client-side endpoint rotation against a single controller; this module covers
+the replicated controller itself: election, write forwarding, and state
+survival across a leader kill.
+"""
+
+import time
+
+import pytest
+
+from cluster import parse_job_id, wait_job, wait_job_state
+
+
+def _job_visible(cluster, job_id: int, node_index: int) -> bool:
+    out = cluster.cli_allow_fail(
+        ["squeue", "-t", "all", "-j", str(job_id), "-h"],
+        controller_addr=cluster.controller_addr_for(node_index),
+    )
+    return str(job_id) in out
+
+
+class TestLeaderElection:
+    def test_exactly_one_leader_is_elected(self, raft_cluster):
+        leader = raft_cluster.wait_raft_leader()
+        roles = {i: raft_cluster.raft_role(i) for i in raft_cluster.controller_indices}
+        assert roles[leader] == "primary"
+        assert sorted(roles.values()) == ["primary", "replica", "replica"], (
+            f"expected one leader and two replicas, got {roles}"
+        )
+
+    def test_node_id_is_derived_from_peer_position(self, raft_cluster):
+        """Peers are listed by hostname, so each controller must pick its id
+        from its own position rather than needing an explicit node_id."""
+        for i in raft_cluster.controller_indices:
+            log = raft_cluster.spurctld_log(i)
+            assert "position in controller.peers" in log, (
+                f"controller {i} did not derive its node_id from the peer list:\n{log}"
+            )
+            assert f"node_id={i + 1}" in log.replace('"', ""), (
+                f"controller {i} should be node_id {i + 1}:\n{log}"
+            )
+
+    def test_every_controller_serves_the_same_node_view(self, raft_cluster):
+        for i in raft_cluster.controller_indices:
+            out = raft_cluster.cli(
+                ["sinfo"], controller_addr=raft_cluster.controller_addr_for(i)
+            )
+            for name in raft_cluster.node_names:
+                assert name in out, (
+                    f"controller {i} is missing node {name}:\n{out}"
+                )
+
+
+class TestWriteForwarding:
+    def test_submit_to_a_follower_is_forwarded_to_the_leader(self, raft_cluster):
+        """A client that happens to reach a follower must not get an error;
+        the follower forwards the write."""
+        leader = raft_cluster.wait_raft_leader()
+        follower = next(i for i in raft_cluster.controller_indices if i != leader)
+
+        script = raft_cluster.write_file(
+            "raft-forward.sh", "#!/bin/bash\necho RAFT_FORWARD_OK\n", all_nodes=True
+        )
+        out_path = f"{raft_cluster.remote_dir}/raft-forward.out"
+        submitted = raft_cluster.cli(
+            ["sbatch", "-J", "raft-forward", "-o", out_path, script],
+            controller_addr=raft_cluster.controller_addr_for(follower),
+        )
+        job_id = parse_job_id(submitted)
+        assert job_id is not None, f"follower rejected the submit:\n{submitted}"
+
+        assert wait_job(raft_cluster, job_id, timeout=120) in ("CD", "GONE")
+        assert "RAFT_FORWARD_OK" in raft_cluster.read_output_on_any_node(out_path)
+
+    def test_a_write_is_replicated_to_every_peer(self, raft_cluster):
+        script = raft_cluster.write_file(
+            "raft-replicate.sh", "#!/bin/bash\nsleep 120\n", all_nodes=True
+        )
+        job_id = parse_job_id(
+            raft_cluster.sbatch(["-J", "raft-replicate", script])
+        )
+        assert job_id is not None
+
+        try:
+            wait_job_state(raft_cluster, job_id, "R", timeout=120)
+            for i in raft_cluster.controller_indices:
+                assert _job_visible(raft_cluster, job_id, i), (
+                    f"job {job_id} did not replicate to controller {i}"
+                )
+        finally:
+            raft_cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_cancel_through_a_follower_takes_effect(self, raft_cluster):
+        leader = raft_cluster.wait_raft_leader()
+        follower = next(i for i in raft_cluster.controller_indices if i != leader)
+
+        script = raft_cluster.write_file(
+            "raft-cancel.sh", "#!/bin/bash\nsleep 120\n", all_nodes=True
+        )
+        job_id = parse_job_id(raft_cluster.sbatch(["-J", "raft-cancel", script]))
+        assert job_id is not None
+        wait_job_state(raft_cluster, job_id, "R", timeout=120)
+
+        raft_cluster.cli(
+            ["scancel", str(job_id)],
+            controller_addr=raft_cluster.controller_addr_for(follower),
+        )
+        assert wait_job(raft_cluster, job_id, timeout=90) in ("CA", "GONE")
+
+
+class TestLeaderFailover:
+    def test_a_new_leader_takes_over_when_the_leader_dies(self, raft_cluster):
+        leader = raft_cluster.wait_raft_leader()
+        raft_cluster.stop_controller_node(leader)
+        try:
+            new_leader = raft_cluster.wait_raft_leader(
+                timeout=120, exclude={leader}
+            )
+            assert new_leader != leader, "a survivor must win the new term"
+        finally:
+            raft_cluster.start_controller_node(leader)
+
+    def test_state_survives_a_leader_kill(self, raft_cluster):
+        """The whole point of replication: a job accepted by the old leader is
+        still there after it dies."""
+        script = raft_cluster.write_file(
+            "raft-survive.sh", "#!/bin/bash\nsleep 240\n", all_nodes=True
+        )
+        job_id = parse_job_id(raft_cluster.sbatch(["-J", "raft-survive", script]))
+        assert job_id is not None
+        wait_job_state(raft_cluster, job_id, "R", timeout=120)
+
+        leader = raft_cluster.wait_raft_leader()
+        raft_cluster.stop_controller_node(leader)
+        try:
+            survivor = raft_cluster.wait_raft_leader(timeout=120, exclude={leader})
+            assert _job_visible(raft_cluster, job_id, survivor), (
+                f"job {job_id} was lost when controller {leader} died"
+            )
+        finally:
+            raft_cluster.start_controller_node(leader)
+            raft_cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_clients_keep_working_across_a_leader_change(self, raft_cluster):
+        """The failover endpoint list must carry a submit through a leader
+        change without the caller retrying."""
+        leader = raft_cluster.wait_raft_leader()
+        raft_cluster.stop_controller_node(leader)
+        try:
+            raft_cluster.wait_raft_leader(timeout=120, exclude={leader})
+
+            script = raft_cluster.write_file(
+                "raft-after.sh", "#!/bin/bash\necho RAFT_AFTER_OK\n", all_nodes=True
+            )
+            out_path = f"{raft_cluster.remote_dir}/raft-after.out"
+            job_id = parse_job_id(
+                raft_cluster.sbatch(["-J", "raft-after", "-o", out_path, script])
+            )
+            assert job_id is not None, "submit failed after the leader changed"
+            assert wait_job(raft_cluster, job_id, timeout=120) in ("CD", "GONE")
+            assert "RAFT_AFTER_OK" in raft_cluster.read_output_on_any_node(out_path)
+        finally:
+            raft_cluster.start_controller_node(leader)
+
+    def test_a_restarted_peer_rejoins_as_a_replica(self, raft_cluster):
+        leader = raft_cluster.wait_raft_leader()
+        raft_cluster.stop_controller_node(leader)
+        raft_cluster.wait_raft_leader(timeout=120, exclude={leader})
+
+        raft_cluster.start_controller_node(leader)
+        deadline = time.time() + 120
+        while time.time() < deadline:
+            if raft_cluster.raft_role(leader) == "replica":
+                return
+            time.sleep(3)
+        pytest.fail(
+            f"controller {leader} did not rejoin as a replica "
+            f"(role: {raft_cluster.raft_role(leader)})"
+        )
+
+
+class TestLeaderlessReads:
+    def test_reads_are_served_without_a_quorum(self, raft_cluster):
+        """Reads come from local state, so losing quorum must degrade writes
+        only -- an operator still needs squeue and sinfo to triage."""
+        script = raft_cluster.write_file(
+            "raft-read.sh", "#!/bin/bash\nsleep 240\n", all_nodes=True
+        )
+        job_id = parse_job_id(raft_cluster.sbatch(["-J", "raft-read", script]))
+        assert job_id is not None
+        wait_job_state(raft_cluster, job_id, "R", timeout=120)
+
+        survivor = raft_cluster.controller_indices[-1]
+        downed = [i for i in raft_cluster.controller_indices if i != survivor]
+        for i in downed:
+            raft_cluster.stop_controller_node(i)
+
+        try:
+            # No quorum: the survivor cannot be leader, but must still answer.
+            deadline = time.time() + 60
+            while time.time() < deadline:
+                if raft_cluster.raft_role(survivor) == "replica":
+                    break
+                time.sleep(3)
+
+            out = raft_cluster.cli_allow_fail(
+                ["sinfo"],
+                controller_addr=raft_cluster.controller_addr_for(survivor),
+            )
+            for name in raft_cluster.node_names:
+                assert name in out, (
+                    f"a leaderless controller must still serve sinfo:\n{out}"
+                )
+            assert _job_visible(raft_cluster, job_id, survivor), (
+                f"a leaderless controller must still serve squeue for {job_id}"
+            )
+        finally:
+            for i in downed:
+                raft_cluster.start_controller_node(i)
+            raft_cluster.wait_raft_leader(timeout=120)
+            raft_cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_writes_are_refused_without_a_quorum(self, raft_cluster):
+        survivor = raft_cluster.controller_indices[-1]
+        downed = [i for i in raft_cluster.controller_indices if i != survivor]
+        for i in downed:
+            raft_cluster.stop_controller_node(i)
+
+        try:
+            script = raft_cluster.write_file(
+                "raft-noquorum.sh", "#!/bin/bash\ntrue\n", all_nodes=True
+            )
+            out = raft_cluster.cli_allow_fail(
+                ["sbatch", "-J", "raft-noquorum", script],
+                controller_addr=raft_cluster.controller_addr_for(survivor),
+            )
+            assert parse_job_id(out) is None, (
+                f"a write must not be accepted without a quorum:\n{out}"
+            )
+        finally:
+            for i in downed:
+                raft_cluster.start_controller_node(i)
+            raft_cluster.wait_raft_leader(timeout=120)

--- a/tests/native_host/e2e/test_readonly_cli.py
+++ b/tests/native_host/e2e/test_readonly_cli.py
@@ -15,6 +15,8 @@ import pytest
 
 from cluster import parse_job_id, wait_job_state
 
+pytestmark = pytest.mark.suite_api
+
 
 def _run(cluster, args: list[str]) -> tuple[int, str]:
     return cluster.cli_with_env(args, {})

--- a/tests/native_host/e2e/test_readonly_cli.py
+++ b/tests/native_host/e2e/test_readonly_cli.py
@@ -1,0 +1,270 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Smoke coverage for the read-only Slurm-compatible CLIs.
+
+sprio, sstat, sdiag, and smd talk to the controller only. sshare and sreport
+go through the accounting service, so they run against accounting_cluster.
+These assert the contract a migrating Slurm script depends on: exit status,
+header text, and that --noheader actually suppresses it.
+"""
+
+import re
+
+import pytest
+
+from cluster import parse_job_id, wait_job_state
+
+
+def _run(cluster, args: list[str]) -> tuple[int, str]:
+    return cluster.cli_with_env(args, {})
+
+
+@pytest.fixture
+def running_job(cluster):
+    script = cluster.write_file("readonly-cli.sh", "#!/bin/bash\nsleep 120\n")
+    job_id = parse_job_id(cluster.sbatch(["-J", "readonly-cli", script]))
+    assert job_id is not None
+    wait_job_state(cluster, job_id, "R", timeout=90)
+    yield job_id
+    cluster.cli_allow_fail(["scancel", str(job_id)])
+
+
+class TestSprio:
+    def test_prints_header(self, cluster):
+        out = cluster.sprio()
+        assert "JOBID" in out and "PRIORITY" in out, f"sprio header missing:\n{out}"
+        assert "FAIRSHARE" in out, f"sprio header missing FAIRSHARE:\n{out}"
+
+    def test_noheader_suppresses_the_header(self, cluster):
+        assert "JOBID" not in cluster.sprio(["-h"]), "sprio -h must drop the header"
+        assert "JOBID" not in cluster.sprio(["--noheader"])
+
+    def test_long_form_adds_columns(self, cluster):
+        out = cluster.sprio(["-l"])
+        assert "QOS" in out and "EFFECTIVE" in out, (
+            f"sprio -l must add QOS and EFFECTIVE:\n{out}"
+        )
+
+    def test_lists_a_pending_job(self, cluster):
+        """sprio reports the pending queue, so a held job must appear."""
+        script = cluster.write_file("sprio-held.sh", "#!/bin/bash\nsleep 60\n")
+        job_id = parse_job_id(cluster.sbatch(["-J", "sprio-held", "-H", script]))
+        assert job_id is not None
+        try:
+            wait_job_state(cluster, job_id, "PD", timeout=30)
+            out = cluster.sprio()
+            assert str(job_id) in out, f"pending job {job_id} missing from sprio:\n{out}"
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_job_filter_excludes_other_jobs(self, cluster):
+        code, out = _run(cluster, ["sprio", "-j", "99999999"])
+        assert code == 0, f"an empty filter is not an error:\n{out}"
+        assert "99999999" not in out
+
+
+class TestSstat:
+    def test_reports_a_running_job(self, cluster, running_job):
+        code, out = _run(cluster, ["sstat", "-j", str(running_job)])
+        assert code == 0, f"sstat failed:\n{out}"
+        assert "JobID" in out, f"sstat header missing:\n{out}"
+        assert str(running_job) in out, f"running job not in sstat output:\n{out}"
+
+    def test_noheader_suppresses_the_header(self, cluster, running_job):
+        code, out = _run(cluster, ["sstat", "-j", str(running_job), "--noheader"])
+        assert code == 0, out
+        assert "JobID" not in out, f"--noheader must drop the header:\n{out}"
+
+    def test_parsable_output_is_pipe_delimited(self, cluster, running_job):
+        code, out = _run(cluster, ["sstat", "-j", str(running_job), "-p"])
+        assert code == 0, out
+        assert "JobID|" in out, f"parsable header must be pipe-delimited:\n{out}"
+
+    def test_format_selects_columns(self, cluster, running_job):
+        code, out = _run(
+            cluster, ["sstat", "-j", str(running_job), "-o", "jobid,ntasks"]
+        )
+        assert code == 0, out
+        assert "NCPUS" not in out, f"-o must restrict the column set:\n{out}"
+
+    def test_non_running_job_is_reported_not_fatal(self, cluster):
+        script = cluster.write_file("sstat-held.sh", "#!/bin/bash\nsleep 60\n")
+        job_id = parse_job_id(cluster.sbatch(["-J", "sstat-held", "-H", script]))
+        assert job_id is not None
+        try:
+            wait_job_state(cluster, job_id, "PD", timeout=30)
+            code, out = _run(cluster, ["sstat", "-j", str(job_id)])
+            assert code == 0, f"a pending job is not an sstat error:\n{out}"
+            assert "is not running" in out, f"expected a diagnostic:\n{out}"
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_unknown_job_exits_nonzero(self, cluster):
+        code, out = _run(cluster, ["sstat", "-j", "99999999"])
+        assert code != 0, f"an unknown job must fail:\n{out}"
+
+    def test_non_numeric_job_is_rejected(self, cluster):
+        code, out = _run(cluster, ["sstat", "-j", "not-a-job"])
+        assert code != 0, f"a non-numeric job id must fail:\n{out}"
+        assert "no valid job IDs" in out, f"expected a specific message:\n{out}"
+
+    def test_missing_job_argument_is_rejected(self, cluster):
+        code, out = _run(cluster, ["sstat"])
+        assert code != 0, f"-j is required:\n{out}"
+
+
+class TestSdiag:
+    def test_prints_all_sections(self, cluster):
+        out = cluster.sdiag()
+        for section in (
+            "Server Information:",
+            "Job Statistics:",
+            "Node Statistics:",
+            "Scheduler Statistics:",
+            "Remote Procedure Call statistics by operation:",
+        ):
+            assert section in out, f"sdiag is missing {section!r}:\n{out}"
+
+    def test_noheader_suppresses_the_banner(self, cluster):
+        out = cluster.sdiag(["--noheader"])
+        assert "sdiag output at" not in out, f"--noheader must drop the banner:\n{out}"
+        assert "Server Information:" in out, (
+            f"--noheader must not drop the report body:\n{out}"
+        )
+
+    def test_node_counts_match_the_cluster(self, cluster):
+        out = cluster.sdiag()
+        match = re.search(r"Total Nodes\s*:\s*(\d+)", out)
+        assert match, f"sdiag did not report a node count:\n{out}"
+        assert int(match.group(1)) == len(cluster.node_names)
+
+    def test_reset_zeroes_accumulated_counters(self, cluster):
+        """Only the submission counter is asserted at zero: the scheduler loop
+        and agent heartbeats repopulate cycle and RPC counters immediately, so
+        those can only be checked as a drop."""
+        script = cluster.write_file("sdiag-job.sh", "#!/bin/bash\ntrue\n")
+        for _ in range(2):
+            cluster.sbatch(["-J", "sdiag-job", script])
+
+        before = cluster.sdiag()
+        submitted = int(re.search(r"Jobs submitted\s*:\s*(\d+)", before).group(1))
+        cycles_before = int(re.search(r"Cycles\s*:\s*(\d+)", before).group(1))
+        assert submitted > 0, f"expected submissions to be counted:\n{before}"
+
+        cluster.sdiag(["--reset"])
+        after = cluster.sdiag()
+        assert int(re.search(r"Jobs submitted\s*:\s*(\d+)", after).group(1)) == 0, (
+            f"--reset must zero the submission counter:\n{after}"
+        )
+        assert (
+            int(re.search(r"Cycles\s*:\s*(\d+)", after).group(1)) < cycles_before
+        ), f"--reset must drop the scheduler cycle count:\n{after}"
+
+
+class TestSmd:
+    def test_prints_a_health_report_for_every_node(self, cluster):
+        out = cluster.smd()
+        assert "=== Node Health Report" in out, f"smd banner missing:\n{out}"
+        assert "NODE" in out and "FREE_MEM_MB" in out, f"smd header missing:\n{out}"
+        for name in cluster.node_names:
+            assert name in out, f"node {name} missing from smd:\n{out}"
+
+    def test_healthy_cluster_reports_no_unhealthy_nodes(self, cluster):
+        out = cluster.smd()
+        assert f"All {len(cluster.node_names)} node(s) healthy" in out, (
+            f"an idle cluster must be reported healthy:\n{out}"
+        )
+
+    def test_unhealthy_only_hides_healthy_nodes(self, cluster):
+        out = cluster.smd(["-u"])
+        for name in cluster.node_names:
+            assert name not in out, (
+                f"--unhealthy-only must hide healthy node {name}:\n{out}"
+            )
+
+    def test_drained_node_is_reported_unhealthy(self, cluster):
+        target = cluster.node_names[0]
+        cluster.scontrol("update", f"nodename={target}", "state=drain", "reason=smd-test")
+        try:
+            out = cluster.smd(["-u"])
+            assert target in out, f"a drained node must show as unhealthy:\n{out}"
+            assert "unhealthy node(s) detected" in out, f"expected a count:\n{out}"
+        finally:
+            cluster.scontrol("update", f"nodename={target}", "state=resume")
+
+
+class TestSshare:
+    def test_prints_header(self, accounting_cluster):
+        out = accounting_cluster.sshare()
+        assert "Account" in out and "FairShare" in out, (
+            f"sshare header missing:\n{out}"
+        )
+
+    def test_noheader_suppresses_the_header(self, accounting_cluster):
+        assert "FairShare" not in accounting_cluster.sshare(["-h"])
+
+    def test_long_form_adds_group_limits(self, accounting_cluster):
+        out = accounting_cluster.sshare(["-l"])
+        assert "GrpCPUHrs" in out, f"sshare -l must add GrpCPUHrs:\n{out}"
+
+    def test_lists_a_seeded_account(self, accounting_cluster):
+        accounting_cluster.sacctmgr(["add", "account", "name=sharetest", "-i"])
+        out = accounting_cluster.sshare()
+        assert "sharetest" in out, f"seeded account missing from sshare:\n{out}"
+
+    def test_account_filter_narrows_the_report(self, accounting_cluster):
+        accounting_cluster.sacctmgr(["add", "account", "name=sharefilter", "-i"])
+        accounting_cluster.sacctmgr(["add", "account", "name=shareother", "-i"])
+        out = accounting_cluster.sshare(["-A", "sharefilter"])
+        assert "sharefilter" in out, f"filtered account missing:\n{out}"
+        assert "shareother" not in out, f"-A must exclude other accounts:\n{out}"
+
+
+class TestSreport:
+    def test_cluster_utilization_report(self, accounting_cluster):
+        code, out = _run(
+            accounting_cluster, ["sreport", "cluster", "AccountUtilizationByUser"]
+        )
+        assert code == 0, f"sreport failed:\n{out}"
+        assert "CPU Hours" in out and "Account" in out, (
+            f"utilization header missing:\n{out}"
+        )
+
+    def test_report_type_aliases_are_accepted(self, accounting_cluster):
+        code, out = _run(
+            accounting_cluster, ["sreport", "cluster", "userutilization"]
+        )
+        assert code == 0, f"alias was rejected:\n{out}"
+        assert "User" in out and "CPU Hours" in out
+
+    def test_job_sizes_report_has_a_total_row(self, accounting_cluster):
+        code, out = _run(accounting_cluster, ["sreport", "job", "sizes"])
+        assert code == 0, f"sreport job sizes failed:\n{out}"
+        assert "% of Tot" in out, f"sizes header missing:\n{out}"
+        assert "TOTAL" in out, f"sizes report must carry a total row:\n{out}"
+
+    def test_noheader_suppresses_the_header(self, accounting_cluster):
+        code, out = _run(
+            accounting_cluster,
+            ["sreport", "cluster", "AccountUtilizationByUser", "--noheader"],
+        )
+        assert code == 0, out
+        assert "CPU Hours" not in out, f"--noheader must drop the header:\n{out}"
+
+    def test_parsable_output_is_pipe_delimited(self, accounting_cluster):
+        code, out = _run(
+            accounting_cluster,
+            ["sreport", "cluster", "AccountUtilizationByUser", "-p"],
+        )
+        assert code == 0, out
+        assert "|" in out, f"parsable output must use a pipe delimiter:\n{out}"
+
+    def test_unknown_report_type_is_rejected(self, accounting_cluster):
+        code, out = _run(accounting_cluster, ["sreport", "cluster", "nonsense"])
+        assert code != 0, f"an unknown report must fail:\n{out}"
+        assert "unknown cluster report" in out, f"expected a specific message:\n{out}"
+
+    def test_missing_subcommand_is_rejected(self, accounting_cluster):
+        code, out = _run(accounting_cluster, ["sreport"])
+        assert code != 0, f"sreport requires a subcommand:\n{out}"

--- a/tests/native_host/e2e/test_reservations.py
+++ b/tests/native_host/e2e/test_reservations.py
@@ -9,6 +9,8 @@ import pytest
 
 from cluster import parse_job_id, wait_job, wait_job_state
 
+pytestmark = pytest.mark.suite_policy
+
 
 class TestReservations:
     def test_create_list_and_delete_reservation(self, cluster):

--- a/tests/native_host/e2e/test_resource_limits.py
+++ b/tests/native_host/e2e/test_resource_limits.py
@@ -1,0 +1,255 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for per-job resource limits.
+
+cgroup isolation only happens when spurd runs as root, so the enforcement
+tests use a rootful agent and skip without sudo or a cgroup v2 hierarchy. The
+env-var side of CPU limiting works unprivileged and runs against the default
+cluster.
+"""
+
+import re
+import time
+
+import pytest
+
+from cluster import parse_job_id, wait_job, wait_job_state
+
+CGROUP_ROOT = "/sys/fs/cgroup/spur"
+
+# `tail` buffers its whole input before writing, so this allocates ~512 MiB of
+# anonymous memory using only coreutils.
+MEMORY_HOG = "#!/bin/bash\nhead -c 512M /dev/zero | tail -c 512M > /dev/null\n"
+
+
+@pytest.fixture
+def rootful_cluster(unstarted_cluster):
+    """A cluster whose agents run as root, so cgroup limits are applied."""
+    cluster = unstarted_cluster
+    cluster.root_agent_preflight()
+    probe = cluster.nodes[0].exec_allow_fail(
+        "test -f /sys/fs/cgroup/cgroup.controllers && echo V2 || echo NO"
+    )
+    if "V2" not in probe:
+        pytest.skip("cgroup v2 unified hierarchy is not mounted")
+    cluster.start(agent_as_root=True)
+    return cluster
+
+
+def _read_cgroup(cluster, job_id: int, name: str) -> str:
+    """Read a cgroup file for a job from whichever node is running it."""
+    path = f"{CGROUP_ROOT}/job_{job_id}/{name}"
+    sudo = cluster._sudo_prefix()
+    for node in cluster.nodes:
+        out = node.exec_allow_fail(f"{sudo}cat '{path}' 2>/dev/null")
+        if out.strip():
+            return out.strip()
+    return ""
+
+
+def _wait_cgroup(cluster, job_id: int, name: str, timeout: int = 30) -> str:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        value = _read_cgroup(cluster, job_id, name)
+        if value:
+            return value
+        time.sleep(1)
+    pytest.skip(f"cgroup file {name} for job {job_id} never appeared under {CGROUP_ROOT}")
+
+
+def _run_and_read_cgroup(cluster, name: str, args: list[str], cgroup_file: str) -> str:
+    script = cluster.write_file(f"{name}.sh", "#!/bin/bash\nsleep 120\n")
+    job_id = parse_job_id(cluster.sbatch(["-J", name] + args + [script]))
+    assert job_id is not None, f"{name} was not submitted"
+    wait_job_state(cluster, job_id, "R", timeout=90)
+    try:
+        return _wait_cgroup(cluster, job_id, cgroup_file)
+    finally:
+        cluster.cli_allow_fail(["scancel", str(job_id)])
+
+
+class TestCgroupLimits:
+    def test_mem_flag_sets_memory_max(self, rootful_cluster):
+        value = _run_and_read_cgroup(
+            rootful_cluster, "cg-mem", ["--mem", "512M"], "memory.max"
+        )
+        assert int(value) == 512 * 1024 * 1024, (
+            f"memory.max should be the --mem value in bytes, got {value}"
+        )
+
+    def test_cpus_per_task_sets_cpu_max(self, rootful_cluster):
+        quota, period = _run_and_read_cgroup(
+            rootful_cluster, "cg-cpu", ["-c", "2"], "cpu.max"
+        ).split()
+        assert period == "100000", f"unexpected cpu period: {period}"
+        assert int(quota) == 2 * 100_000, (
+            f"cpu.max quota should scale with --cpus-per-task, got {quota}"
+        )
+
+    def test_oom_group_is_enabled(self, rootful_cluster):
+        """Without oom.group the kernel kills one process and the job limps on
+        with a broken task tree."""
+        value = _run_and_read_cgroup(
+            rootful_cluster, "cg-oomg", ["--mem", "256M"], "memory.oom.group"
+        )
+        assert value == "1", f"memory.oom.group should be enabled, got {value}"
+
+    def test_pids_max_has_a_floor(self, rootful_cluster):
+        value = _run_and_read_cgroup(
+            rootful_cluster, "cg-pids", ["-c", "1"], "pids.max"
+        )
+        assert int(value) >= 1024, f"pids.max should have a floor, got {value}"
+
+    def test_mem_per_cpu_alone_leaves_memory_unlimited(self, rootful_cluster):
+        """The agent derives memory.max from --mem only; --mem-per-cpu shapes
+        the allocation but not the cgroup."""
+        value = _run_and_read_cgroup(
+            rootful_cluster, "cg-mpc", ["--mem-per-cpu", "256M"], "memory.max"
+        )
+        assert value == "max", (
+            f"expected an unset memory.max for a --mem-per-cpu job, got {value}"
+        )
+
+    def test_cgroup_is_removed_after_the_job_ends(self, rootful_cluster):
+        script = rootful_cluster.write_file("cg-clean.sh", "#!/bin/bash\nsleep 5\n")
+        job_id = parse_job_id(
+            rootful_cluster.sbatch(["-J", "cg-clean", "--mem", "256M", script])
+        )
+        assert job_id is not None
+        wait_job(rootful_cluster, job_id, timeout=90)
+
+        sudo = rootful_cluster._sudo_prefix()
+        for node in rootful_cluster.nodes:
+            left = node.exec_allow_fail(
+                f"{sudo}test -d '{CGROUP_ROOT}/job_{job_id}' && echo LEFT || echo GONE"
+            )
+            assert "LEFT" not in left, (
+                f"cgroup for job {job_id} outlived the job on {node.host}"
+            )
+
+
+class TestOomDetection:
+    def test_memory_hog_is_reported_out_of_memory(self, rootful_cluster):
+        """A job that blows past --mem must land in OOM, not a generic failure
+        -- users triage on that state."""
+        script = rootful_cluster.write_file("oom.sh", MEMORY_HOG)
+        job_id = parse_job_id(
+            rootful_cluster.sbatch(["-J", "oom", "--mem", "64M", script])
+        )
+        assert job_id is not None
+
+        state = wait_job(rootful_cluster, job_id, timeout=180)
+        assert state == "OOM", (
+            f"expected OOM, got {state}:\n"
+            f"{rootful_cluster.scontrol('show', 'job', str(job_id))}"
+        )
+
+    def test_oom_reason_is_surfaced_in_scontrol(self, rootful_cluster):
+        script = rootful_cluster.write_file("oom-reason.sh", MEMORY_HOG)
+        job_id = parse_job_id(
+            rootful_cluster.sbatch(["-J", "oom-reason", "--mem", "64M", script])
+        )
+        assert job_id is not None
+        wait_job(rootful_cluster, job_id, timeout=180)
+
+        detail = rootful_cluster.scontrol("show", "job", str(job_id))
+        assert "OUT_OF_MEMORY" in detail or "OutOfMemory" in detail, (
+            f"scontrol must explain the OOM:\n{detail}"
+        )
+
+    def test_the_same_job_completes_under_a_generous_limit(self, rootful_cluster):
+        """Guards the OOM tests against a false positive: the workload itself
+        is fine, it is the limit that kills it."""
+        script = rootful_cluster.write_file("under-limit.sh", MEMORY_HOG)
+        job_id = parse_job_id(
+            rootful_cluster.sbatch(["-J", "under-limit", "--mem", "2048M", script])
+        )
+        assert job_id is not None
+        assert wait_job(rootful_cluster, job_id, timeout=180) in ("CD", "GONE")
+
+
+class TestCpuEnvironment:
+    def test_cpus_per_task_sets_thread_env(self, cluster):
+        """The env-var path is the only CPU limiting an unprivileged agent can
+        do, so it must hold with or without cgroups."""
+        out_path = f"{cluster.remote_dir}/cpu-env.out"
+        script = cluster.write_file(
+            "cpu-env.sh",
+            "#!/bin/bash\n"
+            'echo "OMP_NUM_THREADS=${OMP_NUM_THREADS}"\n'
+            'echo "MKL_NUM_THREADS=${MKL_NUM_THREADS}"\n'
+            'echo "OPENBLAS_NUM_THREADS=${OPENBLAS_NUM_THREADS}"\n'
+            'echo "NUMEXPR_NUM_THREADS=${NUMEXPR_NUM_THREADS}"\n'
+            "echo CPU_ENV_DONE\n",
+        )
+        job_id = parse_job_id(
+            cluster.sbatch(["-J", "cpu-env", "-c", "3", "-o", out_path, script])
+        )
+        assert job_id is not None
+        wait_job(cluster, job_id, timeout=90)
+
+        content = cluster.read_output_on_any_node(out_path)
+        assert "CPU_ENV_DONE" in content, f"job produced no output:\n{content}"
+        for var in (
+            "OMP_NUM_THREADS",
+            "MKL_NUM_THREADS",
+            "OPENBLAS_NUM_THREADS",
+            "NUMEXPR_NUM_THREADS",
+        ):
+            assert f"{var}=3" in content, f"{var} did not track -c 3:\n{content}"
+
+    def test_default_cpus_per_task_is_one(self, cluster):
+        out_path = f"{cluster.remote_dir}/cpu-default.out"
+        script = cluster.write_file(
+            "cpu-default.sh",
+            '#!/bin/bash\necho "OMP_NUM_THREADS=${OMP_NUM_THREADS}"\necho DONE\n',
+        )
+        job_id = parse_job_id(
+            cluster.sbatch(["-J", "cpu-default", "-o", out_path, script])
+        )
+        assert job_id is not None
+        wait_job(cluster, job_id, timeout=90)
+        assert "OMP_NUM_THREADS=1" in cluster.read_output_on_any_node(out_path)
+
+
+class TestMemlockRlimit:
+    def test_default_memlock_is_reported_at_startup(self, cluster):
+        log = cluster.spurd_log()
+        assert "memlock rlimit" in log, f"spurd must log its memlock state:\n{log}"
+
+    def test_configured_memlock_reaches_the_job(self, unstarted_cluster):
+        """RDMA and GPU-direct workloads fail obscurely when memlock is wrong,
+        so the configured value must land on the job process itself.
+
+        A 1 MiB cap is used because lowering the limit always succeeds, while
+        raising it depends on the agent's inherited hard limit.
+        """
+        cluster = unstarted_cluster
+        cluster.start(config_overrides={"rlimits": {"memlock": str(1024 * 1024)}})
+
+        out_path = f"{cluster.remote_dir}/memlock.out"
+        script = cluster.write_file(
+            "memlock.sh",
+            '#!/bin/bash\necho "MEMLOCK=$(ulimit -l)"\necho MEMLOCK_DONE\n',
+        )
+        job_id = parse_job_id(cluster.sbatch(["-J", "memlock", "-o", out_path, script]))
+        assert job_id is not None
+        wait_job(cluster, job_id, timeout=90)
+
+        content = cluster.read_output_on_any_node(out_path)
+        assert "MEMLOCK_DONE" in content, f"job produced no output:\n{content}"
+        match = re.search(r"MEMLOCK=(\S+)", content)
+        assert match, f"could not read ulimit -l:\n{content}"
+        # ulimit -l reports kibibytes.
+        assert match.group(1) == "1024", (
+            f"expected a 1 MiB memlock limit, got {match.group(1)} KB"
+        )
+
+    def test_inherit_leaves_the_agent_limit_alone(self, unstarted_cluster):
+        cluster = unstarted_cluster
+        cluster.start(config_overrides={"rlimits": {"memlock": "inherit"}})
+
+        log = cluster.spurd_log()
+        assert "memlock rlimit" in log, f"spurd must log its memlock state:\n{log}"
+        assert "inherit" in log, f"the configured mode must be logged:\n{log}"

--- a/tests/native_host/e2e/test_resource_limits.py
+++ b/tests/native_host/e2e/test_resource_limits.py
@@ -14,13 +14,37 @@ import time
 
 import pytest
 
-from cluster import expand_hostlist, parse_job_id, wait_job, wait_job_state
+from cluster import job_node_indices, parse_job_id, wait_job, wait_job_state
 
 CGROUP_ROOT = "/sys/fs/cgroup/spur"
 
 # `tail` buffers its whole input before writing, so this allocates ~512 MiB of
 # anonymous memory using only coreutils.
 MEMORY_HOG = "#!/bin/bash\nhead -c 512M /dev/zero | tail -c 512M > /dev/null\n"
+
+
+def _memory_controller_preflight(cluster):
+    """Skip unless a job cgroup would really get a memory limit.
+
+    spurd enables the controller on its own cgroup root, which only takes
+    effect if the parent delegated `memory` down to it. Containerised hosts
+    frequently have not, and spurd then logs a warning and runs the job with no
+    limit at all -- so a --mem test would quietly measure nothing.
+    """
+    probe = f"{CGROUP_ROOT}/e2e-memory-probe"
+    for i, node in enumerate(cluster.nodes):
+        out = node.exec_allow_fail(
+            f"{cluster._sudo_prefix()}bash -c 'mkdir -p {CGROUP_ROOT} && "
+            f"echo +memory > {CGROUP_ROOT}/cgroup.subtree_control 2>/dev/null; "
+            f"mkdir -p {probe} && test -f {probe}/memory.max && echo ENFORCED; "
+            f"rmdir {probe} 2>/dev/null'"
+        )
+        if "ENFORCED" not in out:
+            pytest.skip(
+                f"cgroup v2 memory controller is not delegated to "
+                f"{CGROUP_ROOT} on {cluster.node_names[i]}, so --mem cannot "
+                f"be enforced there"
+            )
 
 
 def _start_rootful(cluster, **start_kwargs):
@@ -31,6 +55,7 @@ def _start_rootful(cluster, **start_kwargs):
     )
     if "V2" not in probe:
         pytest.skip("cgroup v2 unified hierarchy is not mounted")
+    _memory_controller_preflight(cluster)
     # Job ids restart at 1 for every cluster while cgroup paths are global to
     # the host, so a leftover job_N from an earlier test reads as this one's.
     for node in cluster.nodes:
@@ -63,12 +88,7 @@ def _job_node(cluster, job_id: int):
     Reading whichever node happens to hold job_N's cgroup picks up an earlier
     test's leftovers as readily as this job's own.
     """
-    show = cluster.scontrol("show", "job", str(job_id))
-    match = re.search(r"NodeList=(\S+)", show)
-    assert match, f"job {job_id} has no NodeList:\n{show}"
-    names = expand_hostlist(match.group(1))
-    assert names, f"job {job_id} has an empty NodeList:\n{show}"
-    return cluster.nodes[cluster.node_names.index(names[0])]
+    return cluster.nodes[job_node_indices(cluster, job_id)[0]]
 
 
 def _read_cgroup(cluster, node, job_id: int, name: str) -> str:

--- a/tests/native_host/e2e/test_resource_limits.py
+++ b/tests/native_host/e2e/test_resource_limits.py
@@ -16,6 +16,8 @@ import pytest
 
 from cluster import job_node_indices, parse_job_id, wait_job, wait_job_state
 
+pytestmark = pytest.mark.suite_runtime
+
 CGROUP_ROOT = "/sys/fs/cgroup/spur"
 
 HOG_BYTES = 128 * 1024 * 1024

--- a/tests/native_host/e2e/test_resource_limits.py
+++ b/tests/native_host/e2e/test_resource_limits.py
@@ -18,9 +18,23 @@ from cluster import job_node_indices, parse_job_id, wait_job, wait_job_state
 
 CGROUP_ROOT = "/sys/fs/cgroup/spur"
 
-# `tail` buffers its whole input before writing, so this allocates ~512 MiB of
-# anonymous memory using only coreutils.
-MEMORY_HOG = "#!/bin/bash\nhead -c 512M /dev/zero | tail -c 512M > /dev/null\n"
+HOG_BYTES = 128 * 1024 * 1024
+
+# Grows a shell string past HOG_BYTES. Bash keeps the allocation independent of
+# how any external tool buffers, and reporting the cgroup + memory.max it ran
+# under is the only trace left once the job exits and its cgroup is gone.
+MEMORY_HOG = f"""#!/bin/bash
+report() {{
+  cg=$(awk -F: '/^0::/ {{print $3}}' /proc/self/cgroup)
+  echo "$1 cgroup=$cg memory.max=$(cat "/sys/fs/cgroup$cg/memory.max" 2>/dev/null || echo unreadable)"
+}}
+report pre-move
+sleep 1
+report post-move
+s=x
+while [ ${{#s}} -lt {HOG_BYTES} ]; do s=$s$s; done
+echo "allocated=${{#s}}"
+"""
 
 
 def _memory_controller_preflight(cluster):
@@ -79,6 +93,32 @@ def swap_constrained_cluster(unstarted_cluster):
     return _start_rootful(
         unstarted_cluster,
         config_overrides={"cgroup": {"constrain_swap_space": True}},
+    )
+
+
+def _enforcement_diagnosis(cluster, job_id: int, out_path: str) -> str:
+    """Why a job over its --mem might have survived.
+
+    Pins down which link broke: the job reports the cgroup it ran under (was it
+    moved out of the session scope?) and that cgroup's memory.max (did the limit
+    take?), alongside every spurd warning about applying one.
+    """
+    node = cluster.nodes[job_node_indices(cluster, job_id)[0]]
+    swap = node.exec_allow_fail("grep SwapTotal /proc/meminfo").strip()
+    warnings = [
+        line
+        for line in cluster.spurd_log_all_nodes().splitlines()
+        if any(
+            m in line
+            for m in ("cgroup", "isolation", "delegate", "memory.max", "memory.swap")
+        )
+        and ("WARN" in line or "ERROR" in line or "failed" in line)
+    ]
+    output = cluster.read_output_on_any_node(out_path).strip()
+    return (
+        f"job output: {output or '(empty)'}\n"
+        f"{swap or 'SwapTotal: unknown'}\n"
+        f"spurd cgroup warnings: {warnings or 'none'}"
     )
 
 
@@ -222,41 +262,58 @@ class TestOomDetection:
         -- users triage on that state."""
         cluster = swap_constrained_cluster
         script = cluster.write_file("oom.sh", MEMORY_HOG)
-        job_id = parse_job_id(cluster.sbatch(["-J", "oom", "--mem", "64M", script]))
+        out_path = f"{cluster.remote_dir}/oom.out"
+        job_id = parse_job_id(
+            cluster.sbatch(["-J", "oom", "--mem", "64M", "-o", out_path, script])
+        )
         assert job_id is not None
 
         state = wait_job(cluster, job_id, timeout=180)
         assert state == "OOM", (
             f"expected OOM, got {state}:\n"
-            f"{cluster.scontrol('show', 'job', str(job_id))}"
+            f"{cluster.scontrol('show', 'job', str(job_id))}\n"
+            f"{_enforcement_diagnosis(cluster, job_id, out_path)}"
         )
 
     def test_oom_reason_is_surfaced_in_scontrol(self, swap_constrained_cluster):
         cluster = swap_constrained_cluster
         script = cluster.write_file("oom-reason.sh", MEMORY_HOG)
+        out_path = f"{cluster.remote_dir}/oom-reason.out"
         job_id = parse_job_id(
-            cluster.sbatch(["-J", "oom-reason", "--mem", "64M", script])
+            cluster.sbatch(["-J", "oom-reason", "--mem", "64M", "-o", out_path, script])
         )
         assert job_id is not None
         wait_job(cluster, job_id, timeout=180)
 
         detail = cluster.scontrol("show", "job", str(job_id))
         assert "OUT_OF_MEMORY" in detail or "OutOfMemory" in detail, (
-            f"scontrol must explain the OOM:\n{detail}"
+            f"scontrol must explain the OOM:\n{detail}\n"
+            f"{_enforcement_diagnosis(cluster, job_id, out_path)}"
         )
 
     def test_the_same_job_completes_under_a_generous_limit(
         self, swap_constrained_cluster
     ):
         """Guards the OOM tests against a false positive: the workload itself
-        is fine, it is the limit that kills it."""
+        is fine, it is the limit that kills it. Asserting the byte count matters
+        -- a hog that quietly allocated nothing would also complete here."""
         cluster = swap_constrained_cluster
         script = cluster.write_file("under-limit.sh", MEMORY_HOG)
+        out_path = f"{cluster.remote_dir}/under-limit.out"
         job_id = parse_job_id(
-            cluster.sbatch(["-J", "under-limit", "--mem", "2048M", script])
+            cluster.sbatch(
+                ["-J", "under-limit", "--mem", "2048M", "-o", out_path, script]
+            )
         )
         assert job_id is not None
         assert wait_job(cluster, job_id, timeout=180) in ("CD", "GONE")
+
+        output = cluster.read_output_on_any_node(out_path)
+        match = re.search(r"allocated=(\d+)", output)
+        assert match, f"hog never reported an allocation:\n{output}"
+        assert int(match.group(1)) >= HOG_BYTES, (
+            f"hog allocated {match.group(1)} bytes, expected at least {HOG_BYTES}"
+        )
 
 
 class TestCpuEnvironment:

--- a/tests/native_host/e2e/test_resource_limits.py
+++ b/tests/native_host/e2e/test_resource_limits.py
@@ -14,7 +14,7 @@ import time
 
 import pytest
 
-from cluster import parse_job_id, wait_job, wait_job_state
+from cluster import expand_hostlist, parse_job_id, wait_job, wait_job_state
 
 CGROUP_ROOT = "/sys/fs/cgroup/spur"
 
@@ -23,35 +23,64 @@ CGROUP_ROOT = "/sys/fs/cgroup/spur"
 MEMORY_HOG = "#!/bin/bash\nhead -c 512M /dev/zero | tail -c 512M > /dev/null\n"
 
 
-@pytest.fixture
-def rootful_cluster(unstarted_cluster):
-    """A cluster whose agents run as root, so cgroup limits are applied."""
-    cluster = unstarted_cluster
+def _start_rootful(cluster, **start_kwargs):
+    """Start *cluster* with root agents, so cgroup limits are applied."""
     cluster.root_agent_preflight()
     probe = cluster.nodes[0].exec_allow_fail(
         "test -f /sys/fs/cgroup/cgroup.controllers && echo V2 || echo NO"
     )
     if "V2" not in probe:
         pytest.skip("cgroup v2 unified hierarchy is not mounted")
-    cluster.start(agent_as_root=True)
+    # Job ids restart at 1 for every cluster while cgroup paths are global to
+    # the host, so a leftover job_N from an earlier test reads as this one's.
+    for node in cluster.nodes:
+        node.exec_allow_fail(
+            f"{cluster._sudo_prefix()}bash -c 'for cg in {CGROUP_ROOT}/job_*; do "
+            f'[ -d "$cg" ] || continue; echo 1 > "$cg/cgroup.kill" 2>/dev/null; '
+            f"rmdir \"$cg\" 2>/dev/null; done'"
+        )
+    cluster.start(agent_as_root=True, **start_kwargs)
     return cluster
 
 
-def _read_cgroup(cluster, job_id: int, name: str) -> str:
-    """Read a cgroup file for a job from whichever node is running it."""
+@pytest.fixture
+def rootful_cluster(unstarted_cluster):
+    return _start_rootful(unstarted_cluster)
+
+
+@pytest.fixture
+def swap_constrained_cluster(unstarted_cluster):
+    """A rootful cluster that also caps swap."""
+    return _start_rootful(
+        unstarted_cluster,
+        config_overrides={"cgroup": {"constrain_swap_space": True}},
+    )
+
+
+def _job_node(cluster, job_id: int):
+    """The node running *job_id*.
+
+    Reading whichever node happens to hold job_N's cgroup picks up an earlier
+    test's leftovers as readily as this job's own.
+    """
+    show = cluster.scontrol("show", "job", str(job_id))
+    match = re.search(r"NodeList=(\S+)", show)
+    assert match, f"job {job_id} has no NodeList:\n{show}"
+    names = expand_hostlist(match.group(1))
+    assert names, f"job {job_id} has an empty NodeList:\n{show}"
+    return cluster.nodes[cluster.node_names.index(names[0])]
+
+
+def _read_cgroup(cluster, node, job_id: int, name: str) -> str:
     path = f"{CGROUP_ROOT}/job_{job_id}/{name}"
-    sudo = cluster._sudo_prefix()
-    for node in cluster.nodes:
-        out = node.exec_allow_fail(f"{sudo}cat '{path}' 2>/dev/null")
-        if out.strip():
-            return out.strip()
-    return ""
+    out = node.exec_allow_fail(f"{cluster._sudo_prefix()}cat '{path}' 2>/dev/null")
+    return out.strip()
 
 
-def _wait_cgroup(cluster, job_id: int, name: str, timeout: int = 30) -> str:
+def _wait_cgroup(cluster, node, job_id: int, name: str, timeout: int = 30) -> str:
     deadline = time.time() + timeout
     while time.time() < deadline:
-        value = _read_cgroup(cluster, job_id, name)
+        value = _read_cgroup(cluster, node, job_id, name)
         if value:
             return value
         time.sleep(1)
@@ -64,7 +93,7 @@ def _run_and_read_cgroup(cluster, name: str, args: list[str], cgroup_file: str) 
     assert job_id is not None, f"{name} was not submitted"
     wait_job_state(cluster, job_id, "R", timeout=90)
     try:
-        return _wait_cgroup(cluster, job_id, cgroup_file)
+        return _wait_cgroup(cluster, _job_node(cluster, job_id), job_id, cgroup_file)
     finally:
         cluster.cli_allow_fail(["scancel", str(job_id)])
 
@@ -111,62 +140,103 @@ class TestCgroupLimits:
             f"expected an unset memory.max for a --mem-per-cpu job, got {value}"
         )
 
+    def test_swap_is_left_alone_by_default(self, rootful_cluster):
+        """Capping swap kills jobs that used to survive on a swap-backed node,
+        so it stays opt-in."""
+        value = _run_and_read_cgroup(
+            rootful_cluster, "cg-swap-off", ["--mem", "512M"], "memory.swap.max"
+        )
+        assert value == "max", (
+            f"expected an untouched memory.swap.max without "
+            f"cgroup.constrain_swap_space, got {value}"
+        )
+
+    def test_constrain_swap_space_denies_swap(self, swap_constrained_cluster):
+        value = _run_and_read_cgroup(
+            swap_constrained_cluster, "cg-swap-on", ["--mem", "512M"], "memory.swap.max"
+        )
+        assert int(value) == 0, (
+            f"constrain_swap_space with the default allowance should deny swap "
+            f"outright, got {value}"
+        )
+
+    def test_allowed_swap_space_scales_with_the_allocation(self, unstarted_cluster):
+        cluster = _start_rootful(
+            unstarted_cluster,
+            config_overrides={
+                "cgroup": {"constrain_swap_space": True, "allowed_swap_space": 50}
+            },
+        )
+        value = _run_and_read_cgroup(
+            cluster, "cg-swap-pct", ["--mem", "512M"], "memory.swap.max"
+        )
+        assert int(value) == 256 * 1024 * 1024, (
+            f"memory.swap.max should be 50% of --mem, got {value}"
+        )
+
     def test_cgroup_is_removed_after_the_job_ends(self, rootful_cluster):
         script = rootful_cluster.write_file("cg-clean.sh", "#!/bin/bash\nsleep 5\n")
         job_id = parse_job_id(
             rootful_cluster.sbatch(["-J", "cg-clean", "--mem", "256M", script])
         )
         assert job_id is not None
+        wait_job_state(rootful_cluster, job_id, "R", timeout=90)
+        node = _job_node(rootful_cluster, job_id)
         wait_job(rootful_cluster, job_id, timeout=90)
 
-        sudo = rootful_cluster._sudo_prefix()
-        for node in rootful_cluster.nodes:
-            left = node.exec_allow_fail(
-                f"{sudo}test -d '{CGROUP_ROOT}/job_{job_id}' && echo LEFT || echo GONE"
-            )
-            assert "LEFT" not in left, (
-                f"cgroup for job {job_id} outlived the job on {node.host}"
-            )
+        left = node.exec_allow_fail(
+            f"{rootful_cluster._sudo_prefix()}test -d '{CGROUP_ROOT}/job_{job_id}' "
+            f"&& echo LEFT || echo GONE"
+        )
+        assert "LEFT" not in left, (
+            f"cgroup for job {job_id} outlived the job on {node.host}"
+        )
 
 
 class TestOomDetection:
-    def test_memory_hog_is_reported_out_of_memory(self, rootful_cluster):
+    """OOM only happens once swap is capped: with swap available the kernel
+    pages the overflow out and the job runs to completion over its --mem."""
+
+    def test_memory_hog_is_reported_out_of_memory(self, swap_constrained_cluster):
         """A job that blows past --mem must land in OOM, not a generic failure
         -- users triage on that state."""
-        script = rootful_cluster.write_file("oom.sh", MEMORY_HOG)
-        job_id = parse_job_id(
-            rootful_cluster.sbatch(["-J", "oom", "--mem", "64M", script])
-        )
+        cluster = swap_constrained_cluster
+        script = cluster.write_file("oom.sh", MEMORY_HOG)
+        job_id = parse_job_id(cluster.sbatch(["-J", "oom", "--mem", "64M", script]))
         assert job_id is not None
 
-        state = wait_job(rootful_cluster, job_id, timeout=180)
+        state = wait_job(cluster, job_id, timeout=180)
         assert state == "OOM", (
             f"expected OOM, got {state}:\n"
-            f"{rootful_cluster.scontrol('show', 'job', str(job_id))}"
+            f"{cluster.scontrol('show', 'job', str(job_id))}"
         )
 
-    def test_oom_reason_is_surfaced_in_scontrol(self, rootful_cluster):
-        script = rootful_cluster.write_file("oom-reason.sh", MEMORY_HOG)
+    def test_oom_reason_is_surfaced_in_scontrol(self, swap_constrained_cluster):
+        cluster = swap_constrained_cluster
+        script = cluster.write_file("oom-reason.sh", MEMORY_HOG)
         job_id = parse_job_id(
-            rootful_cluster.sbatch(["-J", "oom-reason", "--mem", "64M", script])
+            cluster.sbatch(["-J", "oom-reason", "--mem", "64M", script])
         )
         assert job_id is not None
-        wait_job(rootful_cluster, job_id, timeout=180)
+        wait_job(cluster, job_id, timeout=180)
 
-        detail = rootful_cluster.scontrol("show", "job", str(job_id))
+        detail = cluster.scontrol("show", "job", str(job_id))
         assert "OUT_OF_MEMORY" in detail or "OutOfMemory" in detail, (
             f"scontrol must explain the OOM:\n{detail}"
         )
 
-    def test_the_same_job_completes_under_a_generous_limit(self, rootful_cluster):
+    def test_the_same_job_completes_under_a_generous_limit(
+        self, swap_constrained_cluster
+    ):
         """Guards the OOM tests against a false positive: the workload itself
         is fine, it is the limit that kills it."""
-        script = rootful_cluster.write_file("under-limit.sh", MEMORY_HOG)
+        cluster = swap_constrained_cluster
+        script = cluster.write_file("under-limit.sh", MEMORY_HOG)
         job_id = parse_job_id(
-            rootful_cluster.sbatch(["-J", "under-limit", "--mem", "2048M", script])
+            cluster.sbatch(["-J", "under-limit", "--mem", "2048M", script])
         )
         assert job_id is not None
-        assert wait_job(rootful_cluster, job_id, timeout=180) in ("CD", "GONE")
+        assert wait_job(cluster, job_id, timeout=180) in ("CD", "GONE")
 
 
 class TestCpuEnvironment:

--- a/tests/native_host/e2e/test_rest_api.py
+++ b/tests/native_host/e2e/test_rest_api.py
@@ -1,0 +1,267 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for the spurctld REST API.
+
+The REST server is on by default (`rest_api.enabled`, `[::]:6820`), so these
+need no config override. Requests are issued with curl over SSH on the
+controller node, which keeps them independent of the pytest runner's network
+reachability.
+
+The API is served under two prefixes -- `/api/v1` and the Slurm-compatible
+`/slurm/v0.0.42` -- and both must expose the same routes.
+"""
+
+import json
+import time
+
+import pytest
+
+from cluster import REST_PORT, job_state, wait_job_state
+
+PREFIXES = ["/api/v1", "/slurm/v0.0.42"]
+
+
+def _json(status: int, body: str, path: str) -> dict:
+    assert status == 200, f"GET {path} returned {status}:\n{body}"
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise AssertionError(f"GET {path} returned non-JSON:\n{body}") from exc
+
+
+def _get_json(cluster, path: str) -> dict:
+    status, body = cluster.http_get(path)
+    return _json(status, body, path)
+
+
+def _submit(cluster, name: str, script: str, **fields) -> tuple[int, str]:
+    payload = {"job": {"name": name, "script": script, "nodes": 1, "ntasks": 1, **fields}}
+    return cluster.http_post("/api/v1/job/submit", json.dumps(payload))
+
+
+@pytest.fixture
+def rest_cluster(cluster):
+    cluster.curl_preflight()
+    status, body = cluster.http_get("/api/v1/ping")
+    if status == 0:
+        pytest.skip(f"REST API not reachable on port {REST_PORT}: {body.strip()}")
+    return cluster
+
+
+class TestPing:
+    def test_ping_reports_up_and_primary(self, rest_cluster):
+        data = _get_json(rest_cluster, "/api/v1/ping")
+        pings = data["ping"]
+        assert pings, f"ping returned no entries: {data}"
+        assert pings[0]["pinged"] == "UP", f"unexpected ping payload: {pings[0]}"
+        assert pings[0]["mode"] == "primary", (
+            f"a single-controller cluster is always the leader: {pings[0]}"
+        )
+
+    @pytest.mark.parametrize("prefix", PREFIXES)
+    def test_both_prefixes_serve_ping(self, rest_cluster, prefix):
+        data = _get_json(rest_cluster, f"{prefix}/ping")
+        assert data["ping"][0]["pinged"] == "UP"
+
+    def test_response_carries_slurm_version_meta(self, rest_cluster):
+        data = _get_json(rest_cluster, "/api/v1/ping")
+        version = data["meta"]["Slurm"]["version"]
+        assert version == {"major": 0, "minor": 0, "micro": 42}, (
+            f"unexpected version meta: {data['meta']}"
+        )
+
+
+class TestJobRoutes:
+    def test_submit_get_and_cancel(self, rest_cluster):
+        status, body = _submit(
+            rest_cluster, "rest-lifecycle", "#!/bin/bash\nsleep 120\n"
+        )
+        assert status == 200, f"submit returned {status}:\n{body}"
+        job_id = json.loads(body)["job_id"]
+        assert job_id > 0, f"submit returned no job id: {body}"
+
+        wait_job_state(rest_cluster, job_id, "R", timeout=90)
+
+        data = _get_json(rest_cluster, f"/api/v1/job/{job_id}")
+        assert data["jobs"][0]["job_id"] == job_id
+        assert data["jobs"][0]["job_state"] == "RUNNING", (
+            f"REST job state must track the running job: {data['jobs'][0]}"
+        )
+
+        status, body = rest_cluster.http_delete(f"/api/v1/job/{job_id}")
+        assert status == 200, f"cancel returned {status}:\n{body}"
+
+        deadline = time.time() + 60
+        while time.time() < deadline:
+            if job_state(rest_cluster.squeue_all(), job_id) == "CA":
+                return
+            time.sleep(2)
+        raise AssertionError(
+            f"job {job_id} was not cancelled via REST:\n{rest_cluster.squeue_all()}"
+        )
+
+    def test_jobs_list_includes_submitted_job(self, rest_cluster):
+        status, body = _submit(rest_cluster, "rest-list", "#!/bin/bash\nsleep 60\n")
+        assert status == 200, body
+        job_id = json.loads(body)["job_id"]
+
+        try:
+            data = _get_json(rest_cluster, "/api/v1/jobs")
+            assert any(j["job_id"] == job_id for j in data["jobs"]), (
+                f"job {job_id} missing from /jobs: {[j['job_id'] for j in data['jobs']]}"
+            )
+        finally:
+            rest_cluster.http_delete(f"/api/v1/job/{job_id}")
+
+    def test_jobs_name_filter(self, rest_cluster):
+        status, body = _submit(
+            rest_cluster, "rest-named", "#!/bin/bash\nsleep 60\n"
+        )
+        assert status == 200, body
+        job_id = json.loads(body)["job_id"]
+
+        try:
+            data = _get_json(rest_cluster, "/api/v1/jobs?name=rest-named")
+            names = {j["name"] for j in data["jobs"]}
+            assert names == {"rest-named"}, f"name filter leaked other jobs: {names}"
+
+            empty = _get_json(rest_cluster, "/api/v1/jobs?name=no-such-job")
+            assert empty["jobs"] == [], f"expected no matches, got {empty['jobs']}"
+        finally:
+            rest_cluster.http_delete(f"/api/v1/job/{job_id}")
+
+    def test_jobs_partition_and_state_filters(self, rest_cluster):
+        status, body = _submit(
+            rest_cluster,
+            "rest-filters",
+            "#!/bin/bash\nsleep 60\n",
+            partition="default",
+        )
+        assert status == 200, body
+        job_id = json.loads(body)["job_id"]
+
+        try:
+            wait_job_state(rest_cluster, job_id, "R", timeout=90)
+
+            by_partition = _get_json(
+                rest_cluster, "/api/v1/jobs?partition=default"
+            )
+            assert any(j["job_id"] == job_id for j in by_partition["jobs"]), (
+                f"partition filter dropped job {job_id}"
+            )
+
+            by_state = _get_json(rest_cluster, "/api/v1/jobs?state=RUNNING")
+            assert any(j["job_id"] == job_id for j in by_state["jobs"]), (
+                f"state filter dropped running job {job_id}"
+            )
+        finally:
+            rest_cluster.http_delete(f"/api/v1/job/{job_id}")
+
+    def test_unknown_job_returns_404_envelope(self, rest_cluster):
+        status, body = rest_cluster.http_get("/api/v1/job/99999999")
+        assert status == 404, f"expected 404, got {status}:\n{body}"
+        payload = json.loads(body)
+        assert payload["errors"], f"404 must carry an error entry: {payload}"
+        assert "not found" in payload["errors"][0]["error"].lower()
+
+    def test_invalid_state_filter_returns_400(self, rest_cluster):
+        status, body = rest_cluster.http_get("/api/v1/jobs?state=NOTASTATE")
+        assert status == 400, f"expected 400, got {status}:\n{body}"
+        assert json.loads(body)["errors"], f"400 must carry an error entry:\n{body}"
+
+    def test_malformed_submit_body_is_rejected(self, rest_cluster):
+        status, body = rest_cluster.http_post("/api/v1/job/submit", '{"nope":1}')
+        assert status >= 400, f"a body without a job object must fail:\n{body}"
+
+    def test_submit_rejects_unknown_partition(self, rest_cluster):
+        status, body = _submit(
+            rest_cluster,
+            "rest-badpart",
+            "#!/bin/bash\ntrue\n",
+            partition="no-such-partition",
+        )
+        assert status == 400, f"expected 400, got {status}:\n{body}"
+        assert "not found" in body.lower(), f"expected a partition error:\n{body}"
+
+
+class TestClusterRoutes:
+    def test_nodes_lists_every_registered_node(self, rest_cluster):
+        data = _get_json(rest_cluster, "/api/v1/nodes")
+        names = {n["name"] for n in data["nodes"]}
+        assert set(rest_cluster.node_names) <= names, (
+            f"expected {rest_cluster.node_names} in /nodes, got {sorted(names)}"
+        )
+
+    def test_node_detail_matches_the_named_node(self, rest_cluster):
+        target = rest_cluster.node_names[0]
+        data = _get_json(rest_cluster, f"/api/v1/node/{target}")
+        assert len(data["nodes"]) == 1, f"expected one node, got {data['nodes']}"
+        node = data["nodes"][0]
+        assert node["name"] == target
+        assert node["cpus"] > 0, f"node must report CPUs: {node}"
+
+    def test_unknown_node_returns_404(self, rest_cluster):
+        status, body = rest_cluster.http_get("/api/v1/node/no-such-node")
+        assert status == 404, f"expected 404, got {status}:\n{body}"
+        assert json.loads(body)["errors"], f"404 must carry an error entry:\n{body}"
+
+    def test_partitions_include_the_default_partition(self, rest_cluster):
+        data = _get_json(rest_cluster, "/api/v1/partitions")
+        by_name = {p["name"]: p for p in data["partitions"]}
+        assert "default" in by_name, f"expected the default partition: {by_name}"
+        assert by_name["default"]["is_default"] is True
+
+    @pytest.mark.parametrize("prefix", PREFIXES)
+    @pytest.mark.parametrize("route", ["/jobs", "/nodes", "/partitions"])
+    def test_collection_routes_on_both_prefixes(self, rest_cluster, prefix, route):
+        status, body = rest_cluster.http_get(f"{prefix}{route}")
+        assert status == 200, f"GET {prefix}{route} returned {status}:\n{body}"
+
+    @pytest.mark.parametrize("route", ["/jobs/", "/nodes/", "/partitions/"])
+    def test_trailing_slash_variants_are_served(self, rest_cluster, route):
+        status, body = rest_cluster.http_get(f"/api/v1{route}")
+        assert status == 200, f"GET /api/v1{route} returned {status}:\n{body}"
+
+    def test_unknown_route_returns_404(self, rest_cluster):
+        status, _ = rest_cluster.http_get("/api/v1/nope")
+        assert status == 404, f"an unrouted path must 404, got {status}"
+
+
+class TestRaftFollowerWrites:
+    def test_follower_rejects_submit_with_503(self, raft_cluster):
+        """Writes go through the leader; a follower must say so, not silently
+        accept and drop them."""
+        leader = raft_cluster.wait_raft_leader()
+        followers = [i for i in raft_cluster.controller_indices if i != leader]
+        assert followers, "a 3-node Raft cluster must have followers"
+
+        payload = json.dumps(
+            {"job": {"name": "raft-follower", "script": "#!/bin/bash\ntrue\n"}}
+        )
+        status, body = raft_cluster.http_post(
+            "/api/v1/job/submit", payload, node_index=followers[0]
+        )
+        assert status == 503, (
+            f"a follower must reject submits with 503, got {status}:\n{body}"
+        )
+        assert "leader" in body.lower(), f"expected a leader hint:\n{body}"
+
+    def test_follower_still_serves_reads(self, raft_cluster):
+        """Reads are served from local state, so a follower answers them."""
+        leader = raft_cluster.wait_raft_leader()
+        follower = next(i for i in raft_cluster.controller_indices if i != leader)
+
+        status, body = raft_cluster.http_get("/api/v1/nodes", node_index=follower)
+        assert status == 200, f"a follower must serve reads, got {status}:\n{body}"
+        names = {n["name"] for n in json.loads(body)["nodes"]}
+        assert set(raft_cluster.node_names) <= names, (
+            f"follower read is missing nodes: {sorted(names)}"
+        )
+
+    def test_follower_reports_replica_mode(self, raft_cluster):
+        leader = raft_cluster.wait_raft_leader()
+        follower = next(i for i in raft_cluster.controller_indices if i != leader)
+        assert raft_cluster.raft_role(follower) == "replica", (
+            f"controller {follower} should report replica mode"
+        )

--- a/tests/native_host/e2e/test_rest_api.py
+++ b/tests/native_host/e2e/test_rest_api.py
@@ -19,6 +19,8 @@ import pytest
 
 from cluster import REST_PORT, job_state, wait_job_state
 
+pytestmark = pytest.mark.suite_api
+
 PREFIXES = ["/api/v1", "/slurm/v0.0.42"]
 
 

--- a/tests/native_host/e2e/test_scheduling_placement.py
+++ b/tests/native_host/e2e/test_scheduling_placement.py
@@ -1,0 +1,292 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for node selection and placement.
+
+Covers partition OR-lists, the additive form of --nodelist, --nodefile, and
+how equal-weight jobs distribute across idle nodes.
+"""
+
+import re
+import time
+
+from cluster import parse_job_id, wait_job, wait_job_state
+
+
+def _job_nodes(cluster, job_id: int) -> list[str]:
+    show = cluster.scontrol("show", "job", str(job_id))
+    match = re.search(r"NodeList=(\S+)", show)
+    assert match, f"job {job_id} has no NodeList:\n{show}"
+    return [n for n in match.group(1).split(",") if n]
+
+
+def _split_partitions(cluster) -> dict:
+    """One partition per node, so partition choice is observable in placement."""
+    return {
+        "partitions": [
+            {
+                "name": "default",
+                "state": "UP",
+                "default": True,
+                "nodes": ",".join(cluster.node_names),
+                "max_time": "24:00:00",
+                "default_time": "10:00",
+            },
+            {
+                "name": "pa",
+                "state": "UP",
+                "nodes": cluster.node_names[0],
+                "max_time": "24:00:00",
+                "default_time": "10:00",
+            },
+            {
+                "name": "pb",
+                "state": "UP",
+                "nodes": cluster.node_names[1],
+                "max_time": "24:00:00",
+                "default_time": "10:00",
+            },
+        ],
+    }
+
+
+class TestPartitionOrLists:
+    def test_or_list_spans_both_partitions(self, unstarted_cluster):
+        """`-p pa,pb` must draw nodes from the union, not just the first name."""
+        cluster = unstarted_cluster
+        cluster.require_nodes(2)
+        cluster.start(config_overrides=_split_partitions(cluster))
+
+        script = cluster.write_file("or-list.sh", "#!/bin/bash\necho OR_LIST_OK\n")
+        job_id = parse_job_id(
+            cluster.sbatch(["-J", "or-list", "-p", "pa,pb", "-N", "2", script])
+        )
+        assert job_id is not None
+
+        assert wait_job(cluster, job_id, timeout=120) == "CD", (
+            f"a 2-node job across pa,pb must schedule; neither partition alone "
+            f"holds 2 nodes\n{cluster.debug_job(job_id)}"
+        )
+
+    def test_or_list_falls_back_to_the_available_partition(self, unstarted_cluster):
+        """With pa's node busy, the job must still land via pb."""
+        cluster = unstarted_cluster
+        cluster.require_nodes(2)
+        cluster.start(config_overrides=_split_partitions(cluster))
+
+        blocker_script = cluster.write_file(
+            "or-blocker.sh", "#!/bin/bash\nsleep 300\n"
+        )
+        blocker_id = parse_job_id(
+            cluster.sbatch(
+                ["-J", "or-blocker", "-p", "pa", "-N", "1", "--exclusive", blocker_script]
+            )
+        )
+        assert blocker_id is not None
+        wait_job_state(cluster, blocker_id, "R", timeout=60)
+
+        try:
+            script = cluster.write_file(
+                "or-fallback.sh", "#!/bin/bash\necho FALLBACK_OK\n"
+            )
+            job_id = parse_job_id(
+                cluster.sbatch(
+                    ["-J", "or-fallback", "-p", "pa,pb", "-N", "1", "--exclusive", script]
+                )
+            )
+            assert job_id is not None
+            wait_job_state(cluster, job_id, "R", timeout=90)
+
+            assert _job_nodes(cluster, job_id) == [cluster.node_names[1]], (
+                f"the job must fall back to pb's node\n{cluster.debug_job(job_id)}"
+            )
+            wait_job(cluster, job_id, timeout=90)
+        finally:
+            cluster.cli_allow_fail(["scancel", str(blocker_id)])
+
+    def test_or_list_rejects_an_unknown_partition(self, unstarted_cluster):
+        cluster = unstarted_cluster
+        cluster.require_nodes(2)
+        cluster.start(config_overrides=_split_partitions(cluster))
+
+        script = cluster.write_file("or-bad.sh", "#!/bin/bash\necho x\n")
+        out = cluster.cli_allow_fail(
+            ["sbatch", "-p", "pa,nosuchpart", "-N", "1", script]
+        )
+        assert "not found" in out.lower(), (
+            f"an unknown name anywhere in the list must be rejected, got:\n{out}"
+        )
+
+
+class TestNodelistSelection:
+    def test_additive_nodelist_adds_nodes_to_the_listed_one(self, multi_node_cluster):
+        """`-w nodeA -N 2` pins nodeA and lets the scheduler pick the rest."""
+        cluster = multi_node_cluster
+        pinned = cluster.node_names[0]
+
+        script = cluster.write_file("additive.sh", "#!/bin/bash\nsleep 30\n")
+        job_id = parse_job_id(
+            cluster.sbatch(["-J", "additive", "-w", pinned, "-N", "2", script])
+        )
+        assert job_id is not None
+        wait_job_state(cluster, job_id, "R", timeout=90)
+
+        try:
+            nodes = _job_nodes(cluster, job_id)
+            assert pinned in nodes, (
+                f"the listed node {pinned} must be in the allocation, got {nodes}"
+            )
+            assert len(nodes) == 2, (
+                f"-N 2 with a one-node list must allocate 2 nodes, got {nodes}"
+            )
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_exact_nodelist_is_not_additive(self, multi_node_cluster):
+        """A list that already covers -N stays an exact pin."""
+        cluster = multi_node_cluster
+        target = cluster.node_names[1]
+
+        script = cluster.write_file("exact.sh", "#!/bin/bash\nsleep 30\n")
+        job_id = parse_job_id(
+            cluster.sbatch(["-J", "exact", "-w", target, "-N", "1", script])
+        )
+        assert job_id is not None
+        wait_job_state(cluster, job_id, "R", timeout=90)
+
+        try:
+            assert _job_nodes(cluster, job_id) == [target], (
+                f"an exact nodelist must pin exactly {target}\n"
+                f"{cluster.debug_job(job_id)}"
+            )
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_nodefile_selects_the_listed_nodes(self, multi_node_cluster):
+        """-F reads the same selection from a file instead of the command line."""
+        cluster = multi_node_cluster
+        target = cluster.node_names[1]
+        nodefile = cluster.write_file(
+            "nodes.txt", f"{target}\n", executable=False
+        )
+
+        script = cluster.write_file("nodefile.sh", "#!/bin/bash\nsleep 30\n")
+        job_id = parse_job_id(
+            cluster.sbatch(["-J", "nodefile", "-F", nodefile, "-N", "1", script])
+        )
+        assert job_id is not None
+        wait_job_state(cluster, job_id, "R", timeout=90)
+
+        try:
+            assert _job_nodes(cluster, job_id) == [target], (
+                f"--nodefile must select {target}\n{cluster.debug_job(job_id)}"
+            )
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])
+
+
+class TestJobSpreading:
+    def test_equal_weight_jobs_spread_across_idle_nodes(self, multi_node_cluster):
+        """Two identical one-node jobs must not both pack onto the first node."""
+        cluster = multi_node_cluster
+        script = cluster.write_file("spread.sh", "#!/bin/bash\nsleep 60\n")
+
+        ids = []
+        for i in range(2):
+            job_id = parse_job_id(
+                cluster.sbatch(["-J", f"spread-{i}", "-N", "1", script])
+            )
+            assert job_id is not None
+            ids.append(job_id)
+
+        try:
+            for job_id in ids:
+                wait_job_state(cluster, job_id, "R", timeout=90)
+            placements = [_job_nodes(cluster, job_id)[0] for job_id in ids]
+            assert len(set(placements)) == 2, (
+                f"equal-weight jobs must spread across idle nodes, both landed "
+                f"on {placements}"
+            )
+        finally:
+            for job_id in ids:
+                cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_spread_job_flag_is_accepted(self, multi_node_cluster):
+        cluster = multi_node_cluster
+        script = cluster.write_file(
+            "spread-flag.sh", "#!/bin/bash\necho SPREAD_OK\n"
+        )
+        out_path = f"{cluster.remote_dir}/spread-flag.out"
+        job_id = parse_job_id(
+            cluster.sbatch(
+                ["-J", "spread-flag", "-N", "2", "--spread-job", "-o", out_path, script]
+            )
+        )
+        assert job_id is not None
+
+        assert wait_job(cluster, job_id, timeout=120) == "CD", (
+            cluster.debug_job(job_id)
+        )
+        content = cluster.read_output_all_nodes(out_path)
+        assert content.count("SPREAD_OK") == 2, (
+            f"--spread-job must still run the script on both nodes:\n{content}"
+        )
+
+
+class TestExcludeSelection:
+    def test_exclude_keeps_the_job_off_a_node(self, multi_node_cluster):
+        cluster = multi_node_cluster
+        excluded = cluster.node_names[0]
+
+        script = cluster.write_file("exclude.sh", "#!/bin/bash\nsleep 30\n")
+        job_id = parse_job_id(
+            cluster.sbatch(["-J", "exclude", "-x", excluded, "-N", "1", script])
+        )
+        assert job_id is not None
+        wait_job_state(cluster, job_id, "R", timeout=90)
+
+        try:
+            nodes = _job_nodes(cluster, job_id)
+            assert excluded not in nodes, (
+                f"-x {excluded} must keep the job off that node, got {nodes}"
+            )
+        finally:
+            cluster.cli_allow_fail(["scancel", str(job_id)])
+
+
+class TestPendingReasons:
+    def test_unavailable_pinned_node_reports_req_node_not_avail(
+        self, multi_node_cluster
+    ):
+        """An exact pin to a busy node reports why, rather than a bare Resources."""
+        cluster = multi_node_cluster
+        target = cluster.node_names[0]
+
+        blocker = cluster.write_file("pin-blocker.sh", "#!/bin/bash\nsleep 300\n")
+        blocker_id = parse_job_id(
+            cluster.sbatch(
+                ["-J", "pin-blocker", "-w", target, "-N", "1", "--exclusive", blocker]
+            )
+        )
+        assert blocker_id is not None
+        wait_job_state(cluster, blocker_id, "R", timeout=60)
+
+        script = cluster.write_file("pin-wait.sh", "#!/bin/bash\nsleep 5\n")
+        job_id = parse_job_id(
+            cluster.sbatch(
+                ["-J", "pin-wait", "-w", target, "-N", "1", "--exclusive", script]
+            )
+        )
+        assert job_id is not None
+
+        try:
+            wait_job_state(cluster, job_id, "PD", timeout=30)
+            # Give the controller a cycle to tag the reason.
+            time.sleep(5)
+            reason = cluster.squeue(["-j", str(job_id), "-h", "-o", "%r"]).strip()
+            assert "ReqNodeNotAvail" in reason or "Resources" in reason, (
+                f"expected a node-availability reason, got {reason!r}"
+            )
+        finally:
+            for jid in (job_id, blocker_id):
+                cluster.cli_allow_fail(["scancel", str(jid)])

--- a/tests/native_host/e2e/test_scheduling_placement.py
+++ b/tests/native_host/e2e/test_scheduling_placement.py
@@ -7,17 +7,13 @@ Covers partition OR-lists, the additive form of --nodelist, --nodefile, and
 how equal-weight jobs distribute across idle nodes.
 """
 
-import re
 import time
 
-from cluster import expand_hostlist, parse_job_id, wait_job, wait_job_state
+from cluster import job_node_names, parse_job_id, wait_job, wait_job_state
 
 
 def _job_nodes(cluster, job_id: int) -> list[str]:
-    show = cluster.scontrol("show", "job", str(job_id))
-    match = re.search(r"NodeList=(\S+)", show)
-    assert match, f"job {job_id} has no NodeList:\n{show}"
-    return expand_hostlist(match.group(1))
+    return job_node_names(cluster, job_id)
 
 
 def _split_partitions(cluster) -> dict:

--- a/tests/native_host/e2e/test_scheduling_placement.py
+++ b/tests/native_host/e2e/test_scheduling_placement.py
@@ -10,6 +10,9 @@ how equal-weight jobs distribute across idle nodes.
 import time
 
 from cluster import job_node_names, parse_job_id, wait_job, wait_job_state
+import pytest
+
+pytestmark = pytest.mark.suite_scheduling
 
 
 def _job_nodes(cluster, job_id: int) -> list[str]:

--- a/tests/native_host/e2e/test_scheduling_placement.py
+++ b/tests/native_host/e2e/test_scheduling_placement.py
@@ -10,14 +10,14 @@ how equal-weight jobs distribute across idle nodes.
 import re
 import time
 
-from cluster import parse_job_id, wait_job, wait_job_state
+from cluster import expand_hostlist, parse_job_id, wait_job, wait_job_state
 
 
 def _job_nodes(cluster, job_id: int) -> list[str]:
     show = cluster.scontrol("show", "job", str(job_id))
     match = re.search(r"NodeList=(\S+)", show)
     assert match, f"job {job_id} has no NodeList:\n{show}"
-    return [n for n in match.group(1).split(",") if n]
+    return expand_hostlist(match.group(1))
 
 
 def _split_partitions(cluster) -> dict:

--- a/tests/native_host/e2e/test_single_node.py
+++ b/tests/native_host/e2e/test_single_node.py
@@ -6,6 +6,9 @@
 import time
 
 from cluster import parse_job_id, job_state, wait_job
+import pytest
+
+pytestmark = pytest.mark.suite_runtime
 
 
 class TestClusterHealth:

--- a/tests/native_host/e2e/test_spank.py
+++ b/tests/native_host/e2e/test_spank.py
@@ -15,6 +15,8 @@ import pytest
 
 from cluster import parse_job_id, wait_job
 
+pytestmark = pytest.mark.suite_runtime
+
 ENV_PROBE = (
     "#!/bin/bash\n"
     'echo "SPANK_TEST_VAR=${SPANK_TEST_VAR}"\n'

--- a/tests/native_host/e2e/test_spank.py
+++ b/tests/native_host/e2e/test_spank.py
@@ -201,7 +201,7 @@ class TestFailureSemantics:
         assert wait_job(spank_cluster, job_id, timeout=90) in ("CD", "GONE")
         assert "RAN_ANYWAY" in spank_cluster.read_output_on_any_node(out_path)
 
-        log = spank_cluster.spurd_log()
+        log = spank_cluster.spurd_log_all_nodes()
         assert "SPANK hook returned error" in log, (
             f"a failing hook must be logged:\n{log}"
         )

--- a/tests/native_host/e2e/test_spank.py
+++ b/tests/native_host/e2e/test_spank.py
@@ -1,0 +1,240 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for SPANK plugin support.
+
+The plugin (fixtures/spank_test.c) is dlopen'd by spurd and resolves the
+spank_* API from the agent's exported dynamic symbols, so these tests cover
+the symbol export list in spurd's build script as much as the hook dispatch.
+
+spank_cluster is provisioned but not started: the plugin and plugstack.conf
+must be in place before spurd reads SPUR_PLUGSTACK at startup.
+"""
+
+import pytest
+
+from cluster import parse_job_id, wait_job
+
+ENV_PROBE = (
+    "#!/bin/bash\n"
+    'echo "SPANK_TEST_VAR=${SPANK_TEST_VAR}"\n'
+    'echo "SPANK_TEST_INIT=${SPANK_TEST_INIT}"\n'
+    'echo "SPANK_TEST_JOB_ID=${SPANK_TEST_JOB_ID}"\n'
+    'echo "SPANK_TEST_UID=${SPANK_TEST_UID}"\n'
+    'echo "SPANK_TEST_SAW_INIT=${SPANK_TEST_SAW_INIT}"\n'
+    'echo "SPANK_TEST_NOCLOBBER=${SPANK_TEST_NOCLOBBER}"\n'
+    "echo PROBE_DONE\n"
+)
+
+
+def _build_plugin(cluster) -> str:
+    return cluster.compile_c_fixture(
+        "spank_test.c",
+        output_name="spank_test.so",
+        extra_flags=["-shared", "-fPIC"],
+    )
+
+
+def _run_probe(cluster, name: str) -> str:
+    out_path = f"{cluster.remote_dir}/{name}.out"
+    script = cluster.write_file(f"{name}.sh", ENV_PROBE)
+    job_id = parse_job_id(cluster.sbatch(["-J", name, "-N", "1", "-o", out_path, script]))
+    assert job_id is not None, "sbatch did not return a job id"
+    state = wait_job(cluster, job_id, timeout=90)
+    assert state in ("CD", "GONE"), f"probe job ended in {state}"
+    content = cluster.read_output_on_any_node(out_path)
+    assert "PROBE_DONE" in content, f"probe job produced no output:\n{content}"
+    return content
+
+
+def _env(output: str) -> dict[str, str]:
+    return dict(
+        line.split("=", 1) for line in output.splitlines() if "=" in line
+    )
+
+
+@pytest.fixture
+def spank_plugin(spank_cluster):
+    """A started cluster with the test plugin loaded as a required entry."""
+    plugin = _build_plugin(spank_cluster)
+    spank_cluster.write_plugstack([f"required {plugin} var=SPANK_TEST_VAR value=hello"])
+    spank_cluster.start()
+    return spank_cluster
+
+
+class TestPluginLoading:
+    def test_plugin_is_loaded_at_agent_startup(self, spank_plugin):
+        log = spank_plugin.spurd_log()
+        assert "loaded SPANK plugin" in log, f"plugin was not loaded:\n{log}"
+        assert "SPANK plugins loaded" in log, f"load summary missing:\n{log}"
+
+    def test_plugin_args_reach_the_hooks(self, spank_cluster):
+        """Args after the path in plugstack.conf are passed as argv."""
+        plugin = _build_plugin(spank_cluster)
+        trace = f"{spank_cluster.remote_dir}/spank-trace.log"
+        spank_cluster.write_plugstack([f"required {plugin} trace={trace} var=X value=y"])
+        spank_cluster.start()
+
+        _run_probe(spank_cluster, "spank-args")
+
+        recorded = spank_cluster.read_output_on_any_node(trace)
+        assert "init ac=3" in recorded, (
+            f"init hook did not see all three args:\n{recorded}"
+        )
+        assert "task_init ac=3" in recorded, (
+            f"task_init hook did not see all three args:\n{recorded}"
+        )
+
+
+class TestEnvInjection:
+    def test_setenv_reaches_the_job_environment(self, spank_plugin):
+        env = _env(_run_probe(spank_plugin, "spank-env"))
+        assert env["SPANK_TEST_VAR"] == "hello", (
+            f"plugstack value did not reach the job: {env}"
+        )
+        assert env["SPANK_TEST_INIT"] == "1", (
+            f"init-hook env edit was dropped before task_init: {env}"
+        )
+
+    def test_init_edits_are_visible_to_task_init(self, spank_plugin):
+        """Both hooks share one handle, so task_init can read back what init
+        set."""
+        env = _env(_run_probe(spank_plugin, "spank-handle"))
+        assert env["SPANK_TEST_SAW_INIT"] == "1", (
+            f"task_init could not read the init hook's variable: {env}"
+        )
+
+    def test_setenv_without_overwrite_keeps_the_first_value(self, spank_plugin):
+        env = _env(_run_probe(spank_plugin, "spank-noclobber"))
+        assert env["SPANK_TEST_NOCLOBBER"] == "first", (
+            f"overwrite=0 must not replace an existing value: {env}"
+        )
+
+    def test_get_item_exposes_job_context(self, spank_plugin):
+        out_path = f"{spank_plugin.remote_dir}/spank-item.out"
+        script = spank_plugin.write_file("spank-item.sh", ENV_PROBE)
+        job_id = parse_job_id(
+            spank_plugin.sbatch(
+                ["-J", "spank-item", "-N", "1", "-o", out_path, script]
+            )
+        )
+        assert job_id is not None
+        wait_job(spank_plugin, job_id, timeout=90)
+
+        env = _env(spank_plugin.read_output_on_any_node(out_path))
+        assert env["SPANK_TEST_JOB_ID"] == str(job_id), (
+            f"S_JOB_ID did not match the running job: {env}"
+        )
+        assert env["SPANK_TEST_UID"].isdigit(), f"S_JOB_UID was not set: {env}"
+
+
+class TestHookLifecycle:
+    def test_task_exit_hook_runs_after_the_job(self, spank_cluster):
+        plugin = _build_plugin(spank_cluster)
+        trace = f"{spank_cluster.remote_dir}/spank-lifecycle.log"
+        spank_cluster.write_plugstack([f"required {plugin} trace={trace}"])
+        spank_cluster.start()
+
+        _run_probe(spank_cluster, "spank-lifecycle")
+
+        recorded = spank_cluster.read_output_on_any_node(trace)
+        for hook in ("init", "task_init", "task_exit"):
+            assert any(line.startswith(hook) for line in recorded.splitlines()), (
+                f"{hook} hook never ran:\n{recorded}"
+            )
+
+
+class TestFailureSemantics:
+    def test_missing_required_plugin_is_logged_and_survivable(self, spank_cluster):
+        """A required plugin that cannot be dlopen'd is loud but must not stop
+        the agent from serving jobs."""
+        spank_cluster.write_plugstack(
+            [f"required {spank_cluster.remote_dir}/no-such-plugin.so"]
+        )
+        spank_cluster.start()
+
+        log = spank_cluster.spurd_log()
+        assert "required SPANK plugin failed to load" in log, (
+            f"a missing required plugin must be logged at warn:\n{log}"
+        )
+
+        script = spank_cluster.write_file(
+            "spank-survive.sh", "#!/bin/bash\necho SURVIVED\n"
+        )
+        out_path = f"{spank_cluster.remote_dir}/spank-survive.out"
+        job_id = parse_job_id(
+            spank_cluster.sbatch(["-J", "spank-survive", "-o", out_path, script])
+        )
+        assert job_id is not None
+        assert wait_job(spank_cluster, job_id, timeout=90) in ("CD", "GONE")
+        assert "SURVIVED" in spank_cluster.read_output_on_any_node(out_path)
+
+    def test_missing_optional_plugin_is_skipped_quietly(self, spank_cluster):
+        spank_cluster.write_plugstack(
+            [f"optional {spank_cluster.remote_dir}/no-such-plugin.so"]
+        )
+        spank_cluster.start()
+
+        log = spank_cluster.spurd_log()
+        assert "optional SPANK plugin failed to load, skipping" in log, (
+            f"a missing optional plugin must be logged as skipped:\n{log}"
+        )
+        assert "required SPANK plugin failed to load" not in log, (
+            f"an optional entry must not be reported as required:\n{log}"
+        )
+
+    def test_failing_hook_is_logged_and_does_not_kill_the_job(self, spank_cluster):
+        """Spur treats a non-zero hook return as advisory: it is logged, but
+        the launch continues."""
+        plugin = _build_plugin(spank_cluster)
+        spank_cluster.write_plugstack([f"required {plugin} fail=init"])
+        spank_cluster.start()
+
+        out_path = f"{spank_cluster.remote_dir}/spank-failhook.out"
+        script = spank_cluster.write_file(
+            "spank-failhook.sh", "#!/bin/bash\necho RAN_ANYWAY\n"
+        )
+        job_id = parse_job_id(
+            spank_cluster.sbatch(["-J", "spank-failhook", "-o", out_path, script])
+        )
+        assert job_id is not None
+        assert wait_job(spank_cluster, job_id, timeout=90) in ("CD", "GONE")
+        assert "RAN_ANYWAY" in spank_cluster.read_output_on_any_node(out_path)
+
+        log = spank_cluster.spurd_log()
+        assert "SPANK hook returned error" in log, (
+            f"a failing hook must be logged:\n{log}"
+        )
+
+    def test_failing_init_hook_does_not_block_task_init(self, spank_cluster):
+        """Hooks are dispatched independently, so an init failure must not
+        silently disable env injection."""
+        plugin = _build_plugin(spank_cluster)
+        spank_cluster.write_plugstack(
+            [f"required {plugin} fail=init var=SPANK_TEST_VAR value=still-set"]
+        )
+        spank_cluster.start()
+
+        env = _env(_run_probe(spank_cluster, "spank-failinit"))
+        assert env["SPANK_TEST_VAR"] == "still-set", (
+            f"task_init must still run after init failed: {env}"
+        )
+        assert env["SPANK_TEST_INIT"] == "", (
+            f"the failing init hook must not have set its variable: {env}"
+        )
+
+
+class TestNoPlugstack:
+    def test_jobs_run_without_a_plugstack_file(self, cluster):
+        """The default deployment has no plugstack.conf; SPANK must stay
+        entirely out of the launch path."""
+        assert "SPANK plugins loaded" not in cluster.spurd_log()
+
+        out_path = f"{cluster.remote_dir}/no-spank.out"
+        script = cluster.write_file("no-spank.sh", ENV_PROBE)
+        job_id = parse_job_id(cluster.sbatch(["-J", "no-spank", "-o", out_path, script]))
+        assert job_id is not None
+        wait_job(cluster, job_id, timeout=90)
+
+        env = _env(cluster.read_output_on_any_node(out_path))
+        assert env["SPANK_TEST_VAR"] == "", f"unexpected SPANK env: {env}"

--- a/tests/native_host/e2e/test_srun_multi_node.py
+++ b/tests/native_host/e2e/test_srun_multi_node.py
@@ -8,6 +8,9 @@ import shlex
 import time
 
 from cluster import job_state, parse_job_id, wait_job, wait_job_state
+import pytest
+
+pytestmark = pytest.mark.suite_fabric
 
 
 class TestStandaloneSrun:

--- a/tests/native_host/e2e/test_srun_qos.py
+++ b/tests/native_host/e2e/test_srun_qos.py
@@ -12,6 +12,9 @@ import shlex
 import time
 
 from cluster import wait_job_state
+import pytest
+
+pytestmark = pytest.mark.suite_policy
 
 
 class TestSrunQos:

--- a/tests/native_host/e2e/test_suspend_resume.py
+++ b/tests/native_host/e2e/test_suspend_resume.py
@@ -12,6 +12,9 @@ dispatch. Each test cancels its job in a finally block.
 import time
 
 from cluster import parse_job_id, job_state
+import pytest
+
+pytestmark = pytest.mark.suite_policy
 
 
 def _wait_state(cluster, job_id, want, timeout=30):

--- a/tests/native_host/e2e/test_task_layout.py
+++ b/tests/native_host/e2e/test_task_layout.py
@@ -1,0 +1,245 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for task-count defaults and node/CPU allocation layout.
+
+Covers the interaction between -N, -n and --ntasks-per-node: how the task
+count is defaulted at submit, and how the controller caps the node count when
+a job asks for more nodes than it has tasks to put on them.
+"""
+
+import re
+
+from cluster import parse_job_id, wait_job
+
+
+def _job_field(show_output: str, field: str) -> int:
+    match = re.search(rf"\b{field}=(\d+)", show_output)
+    assert match, f"missing {field} in scontrol output:\n{show_output}"
+    return int(match.group(1))
+
+
+def _env_probe_script() -> str:
+    """Batch script echoing the layout vars spurd injects, one per line."""
+    return (
+        "#!/bin/bash\n"
+        'echo "host=$(hostname)"\n'
+        'echo "nnodes=$SPUR_NNODES"\n'
+        'echo "ntasks=$SPUR_NTASKS"\n'
+        'echo "tasks_per_node=$SPUR_TASKS_PER_NODE"\n'
+        'echo "cpus_on_node=$SPUR_CPUS_ON_NODE"\n'
+    )
+
+
+def _probe_values(content: str, key: str) -> list[str]:
+    return [
+        line.split("=", 1)[1].strip()
+        for line in content.splitlines()
+        if line.startswith(f"{key}=")
+    ]
+
+
+class TestSbatchTaskDefaults:
+    def test_ntasks_defaults_to_one_per_node(self, multi_node_cluster):
+        """-N 2 with no -n runs two tasks, not one."""
+        cluster = multi_node_cluster
+        out_path = f"{cluster.remote_dir}/default-ntasks.out"
+        script = cluster.write_file("default-ntasks.sh", _env_probe_script())
+
+        job_id = parse_job_id(
+            cluster.sbatch(["-J", "default-ntasks", "-N", "2", "-o", out_path, script])
+        )
+        assert job_id is not None
+
+        show = cluster.scontrol("show", "job", str(job_id))
+        assert _job_field(show, "NumTasks") == 2, (
+            f"-N 2 must default to 2 tasks:\n{show}"
+        )
+        assert _job_field(show, "NumNodes") == 2, f"expected a 2-node job:\n{show}"
+
+        assert wait_job(cluster, job_id, timeout=90) == "CD", cluster.debug_job(job_id)
+        content = cluster.read_output_all_nodes(out_path)
+        assert set(_probe_values(content, "ntasks")) == {"2"}, (
+            f"job env must report 2 tasks:\n{content}"
+        )
+
+    def test_ntasks_per_node_scales_default_task_count(self, multi_node_cluster):
+        """--ntasks-per-node raises the default to nodes * K."""
+        cluster = multi_node_cluster
+        out_path = f"{cluster.remote_dir}/tpn-scale.out"
+        script = cluster.write_file("tpn-scale.sh", _env_probe_script())
+
+        job_id = parse_job_id(
+            cluster.sbatch(
+                [
+                    "-J", "tpn-scale",
+                    "-N", "2",
+                    "--ntasks-per-node", "3",
+                    "-o", out_path,
+                    script,
+                ]
+            )
+        )
+        assert job_id is not None
+
+        show = cluster.scontrol("show", "job", str(job_id))
+        assert _job_field(show, "NumTasks") == 6, (
+            f"-N 2 --ntasks-per-node=3 must yield 6 tasks:\n{show}"
+        )
+
+        assert wait_job(cluster, job_id, timeout=90) == "CD", cluster.debug_job(job_id)
+        content = cluster.read_output_all_nodes(out_path)
+        assert set(_probe_values(content, "tasks_per_node")) == {"3"}, (
+            f"job env must report 3 tasks per node:\n{content}"
+        )
+
+    def test_explicit_ntasks_overrides_ntasks_per_node(self, multi_node_cluster):
+        """An explicit -n wins over the --ntasks-per-node derived default."""
+        cluster = multi_node_cluster
+        script = cluster.write_file("explicit-n.sh", "#!/bin/bash\nsleep 1\n")
+
+        job_id = parse_job_id(
+            cluster.sbatch(
+                [
+                    "-J", "explicit-n",
+                    "-N", "2",
+                    "--ntasks-per-node", "4",
+                    "-n", "3",
+                    script,
+                ]
+            )
+        )
+        assert job_id is not None
+
+        show = cluster.scontrol("show", "job", str(job_id))
+        assert _job_field(show, "NumTasks") == 3, (
+            f"explicit -n 3 must override the tasks-per-node default:\n{show}"
+        )
+        wait_job(cluster, job_id, timeout=90)
+
+
+class TestNodeCapping:
+    def test_fewer_tasks_than_nodes_caps_node_count(self, multi_node_cluster):
+        """-N 2 -n 1 cannot use the second node, so the allocation shrinks."""
+        cluster = multi_node_cluster
+        out_path = f"{cluster.remote_dir}/capped.out"
+        script = cluster.write_file("capped.sh", _env_probe_script())
+
+        job_id = parse_job_id(
+            cluster.sbatch(
+                ["-J", "capped", "-N", "2", "-n", "1", "-o", out_path, script]
+            )
+        )
+        assert job_id is not None
+
+        show = cluster.scontrol("show", "job", str(job_id))
+        assert _job_field(show, "NumNodes") == 1, (
+            f"-N 2 -n 1 must be capped to a single node:\n{show}"
+        )
+        assert _job_field(show, "NumTasks") == 1, f"expected a single task:\n{show}"
+
+        assert wait_job(cluster, job_id, timeout=90) == "CD", cluster.debug_job(job_id)
+        content = cluster.read_output_all_nodes(out_path)
+        hosts = set(_probe_values(content, "host"))
+        assert len(hosts) == 1, f"capped job must run on one host, got {hosts}"
+        assert set(_probe_values(content, "nnodes")) == {"1"}, (
+            f"job env must reflect the capped node count:\n{content}"
+        )
+
+    def test_ntasks_per_node_pins_node_count_against_capping(self, multi_node_cluster):
+        """An explicit per-node layout keeps every requested node.
+
+        --ntasks-per-node states the layout directly, so the task count must
+        not be used to shrink the allocation behind the user's back.
+        """
+        cluster = multi_node_cluster
+        out_path = f"{cluster.remote_dir}/pinned.out"
+        script = cluster.write_file("pinned.sh", _env_probe_script())
+
+        job_id = parse_job_id(
+            cluster.sbatch(
+                [
+                    "-J", "pinned",
+                    "-N", "2",
+                    "-n", "1",
+                    "--ntasks-per-node", "1",
+                    "-o", out_path,
+                    script,
+                ]
+            )
+        )
+        assert job_id is not None
+
+        show = cluster.scontrol("show", "job", str(job_id))
+        assert _job_field(show, "NumNodes") == 2, (
+            f"--ntasks-per-node must pin the node count at 2:\n{show}"
+        )
+
+        assert wait_job(cluster, job_id, timeout=90) == "CD", cluster.debug_job(job_id)
+        content = cluster.read_output_all_nodes(out_path)
+        assert len(set(_probe_values(content, "host"))) == 2, (
+            f"pinned job must run on both nodes:\n{content}"
+        )
+
+    def test_capped_job_still_allocates_cpus_per_task(self, multi_node_cluster):
+        """Capping the node count must not drop the CPU allocation."""
+        cluster = multi_node_cluster
+        out_path = f"{cluster.remote_dir}/capped-cpus.out"
+        script = cluster.write_file("capped-cpus.sh", _env_probe_script())
+
+        job_id = parse_job_id(
+            cluster.sbatch(
+                [
+                    "-J", "capped-cpus",
+                    "-N", "2",
+                    "-n", "1",
+                    "-c", "2",
+                    "-o", out_path,
+                    script,
+                ]
+            )
+        )
+        assert job_id is not None
+
+        assert wait_job(cluster, job_id, timeout=90) == "CD", cluster.debug_job(job_id)
+        content = cluster.read_output_all_nodes(out_path)
+        cpus = _probe_values(content, "cpus_on_node")
+        assert cpus, f"job env must report CPUs on node:\n{content}"
+        assert all(int(c) >= 2 for c in cpus), (
+            f"one task with -c 2 needs at least 2 CPUs allocated, got {cpus}"
+        )
+
+
+class TestSrunTaskDefaults:
+    def test_srun_ntasks_defaults_to_one_per_node(self, multi_node_cluster):
+        """Standalone srun -N 2 fans out one task per node without -n."""
+        cluster = multi_node_cluster
+        code, out = cluster.srun_with_exit(
+            ["-N", "2", "bash", "-c", 'echo "host=$(hostname)"']
+        )
+        assert code == 0, f"srun failed (exit {code}):\n{out}"
+
+        hosts = {
+            line.split("host=")[1].strip()
+            for line in out.splitlines()
+            if line.startswith("host=")
+        }
+        assert len(hosts) == 2, f"expected one task on each of 2 hosts, got {hosts}:\n{out}"
+
+    def test_srun_ntasks_per_node_fans_out(self, multi_node_cluster):
+        """srun --ntasks-per-node launches K tasks on every allocated node."""
+        cluster = multi_node_cluster
+        code, out = cluster.srun_with_exit(
+            [
+                "-N", "2",
+                "--ntasks-per-node", "2",
+                "bash", "-c", 'echo "rank=$SPUR_PROCID host=$(hostname)"',
+            ]
+        )
+        assert code == 0, f"srun failed (exit {code}):\n{out}"
+
+        lines = [ln for ln in out.splitlines() if ln.startswith("rank=")]
+        assert len(lines) == 4, f"expected 4 task lines (2 nodes x 2), got:\n{out}"
+
+        ranks = {ln.split("rank=")[1].split()[0] for ln in lines}
+        assert ranks == {"0", "1", "2", "3"}, f"expected ranks 0-3, got {ranks}:\n{out}"

--- a/tests/native_host/e2e/test_task_layout.py
+++ b/tests/native_host/e2e/test_task_layout.py
@@ -11,6 +11,9 @@ a job asks for more nodes than it has tasks to put on them.
 import re
 
 from cluster import parse_job_id, wait_job
+import pytest
+
+pytestmark = pytest.mark.suite_scheduling
 
 
 def _job_field(show_output: str, field: str) -> int:

--- a/tests/native_host/e2e/test_time_limit.py
+++ b/tests/native_host/e2e/test_time_limit.py
@@ -16,6 +16,9 @@ timeouts below allow for the 10s watchdog tick plus the 30s grace period.
 """
 
 from cluster import parse_job_id, wait_job
+import pytest
+
+pytestmark = pytest.mark.suite_scheduling
 
 TIME_LIMIT = "00:00:20"
 # Deadline + watchdog tick + grace period + SIGKILL reap, with slack.

--- a/tests/native_host/e2e/test_topology.py
+++ b/tests/native_host/e2e/test_topology.py
@@ -13,6 +13,8 @@ import pytest
 
 from cluster import job_node_names, parse_job_id, wait_job, wait_job_state
 
+pytestmark = pytest.mark.suite_fabric
+
 
 def switches_for(cluster) -> list[dict]:
     """One leaf switch holding node 0, another holding the rest."""

--- a/tests/native_host/e2e/test_topology.py
+++ b/tests/native_host/e2e/test_topology.py
@@ -13,7 +13,7 @@ import re
 
 import pytest
 
-from cluster import parse_job_id, wait_job, wait_job_state
+from cluster import expand_hostlist, parse_job_id, wait_job, wait_job_state
 
 
 def switches_for(cluster) -> list[dict]:
@@ -40,11 +40,11 @@ def tree_cluster(unstarted_cluster):
     return unstarted_cluster
 
 
-def job_nodelist(cluster, job_id: int) -> str:
+def job_nodes(cluster, job_id: int) -> set[str]:
     out = cluster.scontrol("show", "job", str(job_id))
     match = re.search(r"NodeList=(\S+)", out)
     assert match, f"scontrol reported no NodeList for job {job_id}:\n{out}"
-    return match.group(1)
+    return set(expand_hostlist(match.group(1)))
 
 
 def submit_multinode(cluster, name: str, nodes: int, extra: list[str]) -> int:
@@ -92,11 +92,11 @@ class TestPlacement:
         job_id = submit_multinode(tree_cluster, "topo-pack", 2, ["--topology=tree"])
         try:
             wait_job_state(tree_cluster, job_id, "R", timeout=90)
-            nodelist = job_nodelist(tree_cluster, job_id)
             rack1 = set(tree_cluster.node_names[1:])
-            placed = set(re.split(r"[,\s]+", nodelist))
+            placed = job_nodes(tree_cluster, job_id)
             assert placed <= rack1, (
-                f"a 2-node job must land inside rack1 {sorted(rack1)}, got {nodelist}"
+                f"a 2-node job must land inside rack1 {sorted(rack1)}, "
+                f"got {sorted(placed)}"
             )
         finally:
             tree_cluster.cli_allow_fail(["scancel", str(job_id)])
@@ -105,7 +105,7 @@ class TestPlacement:
         job_id = submit_multinode(tree_cluster, "topo-block", 2, ["--topology=block"])
         try:
             wait_job_state(tree_cluster, job_id, "R", timeout=90)
-            placed = set(re.split(r"[,\s]+", job_nodelist(tree_cluster, job_id)))
+            placed = job_nodes(tree_cluster, job_id)
             assert placed <= set(tree_cluster.node_names[1:]), (
                 f"--topology=block must pack like tree, got {sorted(placed)}"
             )
@@ -119,8 +119,7 @@ class TestPlacement:
         job_id = submit_multinode(tree_cluster, "topo-span", count, ["--topology=tree"])
         try:
             wait_job_state(tree_cluster, job_id, "R", timeout=120)
-            placed = set(re.split(r"[,\s]+", job_nodelist(tree_cluster, job_id)))
-            assert placed == set(tree_cluster.node_names)
+            assert job_nodes(tree_cluster, job_id) == set(tree_cluster.node_names)
         finally:
             tree_cluster.cli_allow_fail(["scancel", str(job_id)])
 
@@ -133,7 +132,7 @@ class TestPlacement:
         )
         try:
             wait_job_state(tree_cluster, job_id, "R", timeout=90)
-            assert target in job_nodelist(tree_cluster, job_id)
+            assert job_nodes(tree_cluster, job_id) == {target}
         finally:
             tree_cluster.cli_allow_fail(["scancel", str(job_id)])
 
@@ -157,7 +156,7 @@ class TestPlacement:
         job_id = submit_multinode(tree_cluster, "topo-optout", 2, [])
         try:
             wait_job_state(tree_cluster, job_id, "R", timeout=90)
-            placed = set(re.split(r"[,\s]+", job_nodelist(tree_cluster, job_id)))
+            placed = job_nodes(tree_cluster, job_id)
             assert len(placed) == 2
             assert placed <= set(tree_cluster.node_names)
         finally:

--- a/tests/native_host/e2e/test_topology.py
+++ b/tests/native_host/e2e/test_topology.py
@@ -9,11 +9,9 @@ multi-node jobs that opt in with `--topology` are reordered; everything else
 must be unaffected, which is what most of these tests pin down.
 """
 
-import re
-
 import pytest
 
-from cluster import expand_hostlist, parse_job_id, wait_job, wait_job_state
+from cluster import job_node_names, parse_job_id, wait_job, wait_job_state
 
 
 def switches_for(cluster) -> list[dict]:
@@ -41,10 +39,7 @@ def tree_cluster(unstarted_cluster):
 
 
 def job_nodes(cluster, job_id: int) -> set[str]:
-    out = cluster.scontrol("show", "job", str(job_id))
-    match = re.search(r"NodeList=(\S+)", out)
-    assert match, f"scontrol reported no NodeList for job {job_id}:\n{out}"
-    return set(expand_hostlist(match.group(1)))
+    return set(job_node_names(cluster, job_id))
 
 
 def submit_multinode(cluster, name: str, nodes: int, extra: list[str]) -> int:

--- a/tests/native_host/e2e/test_topology.py
+++ b/tests/native_host/e2e/test_topology.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for topology-aware placement.
+
+`[topology]` is read once when the scheduler loop starts, so every test here
+brings up a cluster with the config it needs rather than reconfiguring. Only
+multi-node jobs that opt in with `--topology` are reordered; everything else
+must be unaffected, which is what most of these tests pin down.
+"""
+
+import re
+
+import pytest
+
+from cluster import parse_job_id, wait_job, wait_job_state
+
+
+def switches_for(cluster) -> list[dict]:
+    """One leaf switch holding node 0, another holding the rest."""
+    names = cluster.node_names
+    return [
+        {"name": "rack0", "nodes": names[0]},
+        {"name": "rack1", "nodes": ",".join(names[1:])},
+    ]
+
+
+@pytest.fixture
+def tree_cluster(unstarted_cluster):
+    if len(unstarted_cluster.nodes) < 3:
+        pytest.skip(
+            "topology placement needs at least 3 nodes so one leaf switch can "
+            "hold more than one node"
+        )
+    unstarted_cluster.start(
+        config_overrides={
+            "topology": {"plugin": "tree", "switches": switches_for(unstarted_cluster)}
+        }
+    )
+    return unstarted_cluster
+
+
+def job_nodelist(cluster, job_id: int) -> str:
+    out = cluster.scontrol("show", "job", str(job_id))
+    match = re.search(r"NodeList=(\S+)", out)
+    assert match, f"scontrol reported no NodeList for job {job_id}:\n{out}"
+    return match.group(1)
+
+
+def submit_multinode(cluster, name: str, nodes: int, extra: list[str]) -> int:
+    script = cluster.write_file(f"{name}.sh", "#!/bin/bash\nsleep 60\n")
+    job_id = parse_job_id(
+        cluster.sbatch(["-J", name, "-N", str(nodes)] + extra + [script])
+    )
+    assert job_id is not None
+    return job_id
+
+
+class TestTopologyLoading:
+    def test_the_tree_plugin_is_loaded_at_startup(self, tree_cluster):
+        log = tree_cluster.spurctld_log()
+        assert "topology/tree loaded" in log, log[-3000:]
+
+    def test_the_block_plugin_is_loaded_at_startup(self, unstarted_cluster):
+        unstarted_cluster.start(
+            config_overrides={"topology": {"plugin": "block", "block_size": 2}}
+        )
+        log = unstarted_cluster.spurctld_log()
+        assert "topology/block loaded" in log, log[-3000:]
+
+    def test_no_topology_is_loaded_by_default(self, cluster):
+        log = cluster.spurctld_log()
+        assert "topology/" not in log, (
+            f"topology must stay off unless configured:\n{log[-3000:]}"
+        )
+
+    def test_an_unknown_plugin_leaves_the_scheduler_running(self, unstarted_cluster):
+        """A typo in the plugin name falls back to no topology rather than
+        refusing to schedule, so jobs must keep flowing."""
+        unstarted_cluster.start(
+            config_overrides={"topology": {"plugin": "nonesuch"}}
+        )
+        code, out = unstarted_cluster.srun_with_exit(["echo", "TOPO_FALLBACK_OK"])
+        assert code == 0, out
+        assert "TOPO_FALLBACK_OK" in out, out
+
+
+class TestPlacement:
+    def test_a_two_node_job_packs_into_one_switch(self, tree_cluster):
+        """The point of the tree plugin: co-locate a job's nodes behind one
+        leaf so its traffic never crosses the spine."""
+        job_id = submit_multinode(tree_cluster, "topo-pack", 2, ["--topology=tree"])
+        try:
+            wait_job_state(tree_cluster, job_id, "R", timeout=90)
+            nodelist = job_nodelist(tree_cluster, job_id)
+            rack1 = set(tree_cluster.node_names[1:])
+            placed = set(re.split(r"[,\s]+", nodelist))
+            assert placed <= rack1, (
+                f"a 2-node job must land inside rack1 {sorted(rack1)}, got {nodelist}"
+            )
+        finally:
+            tree_cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_the_block_flag_uses_the_same_placement(self, tree_cluster):
+        job_id = submit_multinode(tree_cluster, "topo-block", 2, ["--topology=block"])
+        try:
+            wait_job_state(tree_cluster, job_id, "R", timeout=90)
+            placed = set(re.split(r"[,\s]+", job_nodelist(tree_cluster, job_id)))
+            assert placed <= set(tree_cluster.node_names[1:]), (
+                f"--topology=block must pack like tree, got {sorted(placed)}"
+            )
+        finally:
+            tree_cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_a_job_spanning_switches_still_schedules(self, tree_cluster):
+        """No single leaf is big enough, so the job has to fall back to
+        crossing switches rather than pending forever."""
+        count = len(tree_cluster.node_names)
+        job_id = submit_multinode(tree_cluster, "topo-span", count, ["--topology=tree"])
+        try:
+            wait_job_state(tree_cluster, job_id, "R", timeout=120)
+            placed = set(re.split(r"[,\s]+", job_nodelist(tree_cluster, job_id)))
+            assert placed == set(tree_cluster.node_names)
+        finally:
+            tree_cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_an_explicit_nodelist_still_wins(self, tree_cluster):
+        """Topology reorders candidates; it must not override an operator who
+        named the nodes outright."""
+        target = tree_cluster.node_names[0]
+        job_id = submit_multinode(
+            tree_cluster, "topo-w", 1, ["--topology=tree", "-w", target]
+        )
+        try:
+            wait_job_state(tree_cluster, job_id, "R", timeout=90)
+            assert target in job_nodelist(tree_cluster, job_id)
+        finally:
+            tree_cluster.cli_allow_fail(["scancel", str(job_id)])
+
+    def test_a_single_node_job_is_unaffected(self, tree_cluster):
+        script = tree_cluster.write_file("topo-one.sh", "#!/bin/bash\necho TOPO_ONE_OK\n")
+        out_path = f"{tree_cluster.remote_dir}/topo-one.out"
+        job_id = parse_job_id(
+            tree_cluster.sbatch(
+                ["-J", "topo-one", "-N", "1", "--topology=tree", "-o", out_path, script]
+            )
+        )
+        assert job_id is not None
+        assert wait_job(tree_cluster, job_id, timeout=120) in ("CD", "GONE"), (
+            tree_cluster.debug_job(job_id)
+        )
+        assert "TOPO_ONE_OK" in tree_cluster.read_output_on_any_node(out_path)
+
+    def test_a_job_without_the_flag_still_schedules(self, tree_cluster):
+        """Cluster topology alone must not change placement; the job has to
+        opt in."""
+        job_id = submit_multinode(tree_cluster, "topo-optout", 2, [])
+        try:
+            wait_job_state(tree_cluster, job_id, "R", timeout=90)
+            placed = set(re.split(r"[,\s]+", job_nodelist(tree_cluster, job_id)))
+            assert len(placed) == 2
+            assert placed <= set(tree_cluster.node_names)
+        finally:
+            tree_cluster.cli_allow_fail(["scancel", str(job_id)])
+
+
+class TestConfigTolerance:
+    def test_a_switch_naming_unknown_nodes_is_ignored(self, unstarted_cluster):
+        """A stale switch entry left behind after a node was decommissioned
+        must not take the scheduler down with it."""
+        unstarted_cluster.start(
+            config_overrides={
+                "topology": {
+                    "plugin": "tree",
+                    "switches": [
+                        {"name": "ghost", "nodes": "node[900-999]"},
+                        {"name": "real", "nodes": ",".join(unstarted_cluster.node_names)},
+                    ],
+                }
+            }
+        )
+        code, out = unstarted_cluster.srun_with_exit(["echo", "TOPO_GHOST_OK"])
+        assert code == 0, out
+        assert "TOPO_GHOST_OK" in out, out
+
+    def test_an_unknown_job_topology_value_is_ignored(self, tree_cluster):
+        code, out = tree_cluster.srun_with_exit(["echo", "TOPO_VALUE_OK"])
+        assert code == 0, out
+        script = tree_cluster.write_file("topo-bad.sh", "#!/bin/bash\necho ok\n")
+        job_id = parse_job_id(
+            tree_cluster.sbatch(["-J", "topo-bad", "--topology=nonesuch", script])
+        )
+        assert job_id is not None
+        assert wait_job(tree_cluster, job_id, timeout=120) in ("CD", "GONE"), (
+            tree_cluster.debug_job(job_id)
+        )

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -5,6 +5,8 @@ python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 # Sequential execution (pytest default). Do not use pytest-xdist here.
-addopts = -p no:xdist
+# importlib keys modules by full path; the default prepend mode keys them by
+# basename, which collides once both suites own a same-named module.
+addopts = -p no:xdist --import-mode=importlib
 markers =
     rootful: run the cluster fixture with spurd as root (via sudo)

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -5,8 +5,6 @@ python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 # Sequential execution (pytest default). Do not use pytest-xdist here.
-# importlib keys modules by full path; the default prepend mode keys them by
-# basename, which collides once both suites own a same-named module.
-addopts = -p no:xdist --import-mode=importlib
+addopts = -p no:xdist
 markers =
     rootful: run the cluster fixture with spurd as root (via sudo)

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -8,3 +8,14 @@ python_functions = test_*
 addopts = -p no:xdist
 markers =
     rootful: run the cluster fixture with spurd as root (via sudo)
+    suite_scheduling: native-host suite — partitioning, placement, job control
+    suite_policy: native-host suite — reservations, preemption, qos, licenses
+    suite_api: native-host suite — CLI, REST, FFI, metrics
+    suite_runtime: native-host suite — job runtime, isolation, accounting
+    suite_fabric: native-host suite — multi-node, mesh, topology, GPU
+    suite_ha: native-host suite — raft, failover, MPI, native k0s
+    suite_k8s_core: k8s suite — spurjob basics, failure modes, operator health
+    suite_k8s_spec: k8s suite — spurjob spec surface
+    suite_k8s_quota: k8s suite — quota projection
+    suite_k8s_ha: k8s suite — raft HA
+    suite_k8s_nodes: k8s suite — node watcher (destructive tests skipped)


### PR DESCRIPTION
## Summary

This PR closes a long-standing e2e gap — 65 of the last 120 feat/fix commits shipped without touching `tests/`, and whole subsystems had never had any e2e coverage — then fixes the product bugs that the new coverage exposed, and finally restructures the suite so it runs in parallel. Collected tests go from **218 → 585**.

The commits are ordered so each builds on the last: harness first, then the tests, then the fixes those tests surfaced, then the CI split.

## 1. Harness + coverage expansion (`52bf35e`)

The harness had to grow before the subsystems could be tested:

- **`SpurCluster`** gains `salloc`, `sattach`, `spur exec`, read-only CLI wrappers, `cli_with_env` (submit-side env vars), curl-over-SSH HTTP helpers, plugstack + C-fixture compilation, and per-node controller control so a 3-controller Raft cluster can be driven.
- **k8s fixture** gains `assert_pod_spec`, spec builders, operator restart/log access, and a quota variant.

New coverage for previously untested surfaces:

- **native-host**: scheduling/placement, topology, task layout, SPANK, REST API, metrics, resource limits (cgroups/OOM), FFI (compiled C driver), PTY/attach, licenses, job ownership, images, hetjobs, dispatch resilience, read-side CLI formatting/filtering, submit-time env defaults, burst buffer, WireGuard mesh, and multi-controller Raft HA.
- **k8s**: SpurJob CRD spec→PodSpec propagation, failure modes (OOMKilled, image-pull, restart/orphan cleanup), quota projection, operator health, and node watcher.

Three k8s subsystems turned out to be **unreachable** from the suite rather than merely untested, so the manifests were fixed too: the operator never passed `--enable-quota`, the ClusterRole lacked the quota controller's resources plus `escalate`/`bind`, nothing provided the Postgres that `SlurmAccounting` needs, and `spurctld` exposed neither the REST nor the metrics port.

## 2. Product bugs surfaced by the new coverage

Real defects the suite caught against a live cluster:

- **Burst buffer directives silently dropped** (`6a73ddb`) — `spurd` read `SPUR_BURST_BUFFER` from its own process env instead of the job env, so every `stage_in:`/`stage_out:` was a no-op (a job with `stage_in:exit 7` completed with exit 0). Now read from `cfg.environment`.
- **`scancel` filters always errored** (`6a73ddb`) — `--partition`/`--account` were declared and passed to `get_jobs`, but the "did the caller select anything?" guard only checked job IDs/`--user`/`--name`, so both flags failed with *"no job IDs or filters specified"*. Replaced with a `has_selection()` predicate (unit-tested).
- **`--mem` overruns paged out instead of OOM-killing** (`760ebb5`) — `spurd` set `memory.max` but never capped swap, so a job that outgrew its limit never reached `OUT_OF_MEMORY`. Swap is now capped via a `[cgroup]` section mirroring Slurm's `ConstrainSwapSpace`/`AllowedSwapSpace`, defaulting **off** so deployed clusters keep today's behavior.
- **Multi-node nodelist mis-parsed** (`760ebb5`) — `sattach`/`srun` took the first comma-separated field of the nodelist, yielding `node[1` once the controller compresses an allocation. Both now expand the hostlist first.
- **k8s operator wedged on permanent rejections** (`760ebb5`) — it retried *every* failed submit, so a SpurJob the controller permanently rejected (unknown partition, denied account) sat without status forever. Permanent rejections are now marked `Failed`; only transient codes requeue.
- **Operator backoff was flat, not exponential** (`f7b7a63`) — `error_policy` requeued after a flat 60s despite a comment claiming exponential backoff; kube-rs uses that `Action` verbatim, so the first transient blip cost a full minute of submission latency. Now doubles 1s→60s cap, per-SpurJob, reset on a clean pass (cleanup reconciles take the same path). This is what broke `test_state_survives_leader_failover` in CI.

## 3. Test/harness robustness (`bfdd00b`, `f7b7a63`)

Several failures were the tests' fault, not the product's — they assumed placement or enforcement the environment didn't guarantee:

- Assertions now read the job's own `NodeList` (extracted into shared `job_node_names`/`job_node_indices` helpers) instead of guessing the first N nodes.
- The SPANK failing-hook test searches every agent's log rather than node 0.
- The OOM tests now **preflight** the same cgroup-delegation sequence `spurd` uses and skip (naming the node) on hosts where the memory controller isn't delegated — instead of failing where `--mem` can't be enforced.
- Tests skip rather than fail where the environment lacks `wireguard-tools` or inter-node hostname resolution.

Verified on the 3-node bare-metal cluster: resource limits + topology + placement **39/39** with no skips (so the preflight doesn't mask genuine OOM cases there), and the SPANK fix flips that test from 5/5 failing to 5/5 passing.

**New `e2e-fixtures` CI job** (`f7b7a63`): runs `pytest --setup-plan` over `tests/`, resolving every fixture without starting a cluster. It catches things like a fixture missing its `@pytest.fixture` decorator (which had errored 19 `test_metrics.py` tests at setup) in **under a second** instead of an hour into the E2E run. E2E gates on this workflow's conclusion.

## 4. Parallelizing e2e (`f885805`)

native-host ran as one ~60 min job and k8s as one ~40 min job. Both are now partitioned by pytest markers so CI runs them in parallel:

- **native-host** → six suite matrix jobs (`scheduling`, `policy`, `api`, `runtime`, `fabric`, `ha`), each on its own ephemeral 4-VM cluster. `RUN_DIR`, the VM prefix, and the results artifact are scoped per suite so the jobs never collide on the shared run id.
- **k8s** → five suites (`core`, `spec`, `quota`, `ha`, `nodes`) run concurrently on one bootstrapped cluster, each in its own namespace via `tests/k8s/e2e/run_suites.sh`. Safe because the destructive node tests stay skipped, so no suite mutates shared cluster-scoped `Node`s.
- Every e2e file carries **exactly one** `suite_*` / `suite_k8s_*` marker. A collection guard in each `conftest` plus a parity check in `e2e-fixtures` fail fast if a file has zero or two markers, so a new test can't silently escape a suite. The marker rule and the node-mutation guardrail are documented in `AGENTS.md`.

## Addressing the review feedback

- **CI target failures** — the native-host and k8s failures called out earlier were the placement/enforcement and operator-backoff issues above; they're resolved across `6a73ddb`, `760ebb5`, `bfdd00b`, and `f7b7a63`.
- **e2e time benchmarking** — one caveat on measuring this: E2E runs via `workflow_run`, which GitHub always evaluates from the **default branch**, so the parallel split only takes effect *after* this PR merges. The before number is visible now (native-host ~60 min single job, k8s ~37 min single job); the after (per-suite parallel) numbers will land on the first `main` run and I'll post them here. Target is ≤15 min per suite; if any suite overshoots we rebalance markers, which is a one-line change per file.