### PR TITLE
fix(spurd): reclaim stranded interactive allocations via heartbeat

### DIFF
--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -562,6 +562,11 @@ impl ClusterManager {
         self.jobs.read().get(&job_id).cloned()
     }
 
+    /// A job's state by ID, without cloning the whole `Job`.
+    pub fn job_state(&self, job_id: JobId) -> Option<JobState> {
+        self.jobs.read().get(&job_id).map(|j| j.state)
+    }
+
     /// Get a job by ID, synthesizing an aggregate record for an array *parent*
     /// id (which has no stored job — Spur stores only per-task jobs) so
     /// `scontrol show job <array_parent>` matches Slurm instead of returning

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -240,8 +240,8 @@ impl ControllerService {
                     node = %node,
                     "agent still holds a terminal job — re-sending cancel to reclaim its allocation"
                 );
-                // Signal 0 = the graceful srun/salloc release path, which drops an
-                // allocation-only entry by id; safe because ids are never reused.
+                // Signal 0 = graceful release: drops an idle allocation, or re-signals
+                // a still-draining process. Safe to repeat because ids are never reused.
                 crate::scheduler_loop::cancel_job_on_nodes(
                     &cluster,
                     job_id,

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -240,8 +240,8 @@ impl ControllerService {
                     node = %node,
                     "agent still holds a terminal job — re-sending cancel to reclaim its allocation"
                 );
-                // Signal 0 = the srun/salloc release path: frees an allocation-only
-                // entry, and its run_attempt guard spares a rare same-id relaunch.
+                // Signal 0 = the graceful srun/salloc release path, which drops an
+                // allocation-only entry by id; safe because ids are never reused.
                 crate::scheduler_loop::cancel_job_on_nodes(
                     &cluster,
                     job_id,
@@ -380,8 +380,10 @@ fn stale_reported_jobs(cluster: &ClusterManager, reported: &[RunningJobStatus]) 
     reported
         .iter()
         .filter_map(|r| {
-            let job = cluster.get_job(r.job_id)?;
-            job.state.is_terminal().then_some(r.job_id)
+            cluster
+                .job_state(r.job_id)?
+                .is_terminal()
+                .then_some(r.job_id)
         })
         .collect()
 }
@@ -3315,10 +3317,12 @@ mod tests {
             );
         };
 
-        // 10: Pending (just submitted, never dispatched). 11: Running. 12: terminal.
+        // 10 Pending, 11 Running, 12 terminal, and the non-Running active states
+        // that must also be spared: 13 Completing, 14 Suspended, 15 Preempted.
         apply(&submit(10, "pending"));
-        apply(&submit(11, "running"));
-        apply(&submit(12, "done"));
+        for id in [11, 12, 13, 14, 15] {
+            apply(&submit(id, "job"));
+        }
 
         let res = spur_core::resource::ResourceAllocations {
             cpus: 1,
@@ -3327,34 +3331,48 @@ mod tests {
         };
         let mut per_node = std::collections::HashMap::new();
         per_node.insert("n1".to_string(), res.clone());
-        apply(&WalOperation::job_start(
-            11,
-            vec!["n1".into()],
-            res.clone(),
-            per_node.clone(),
-        ));
-        apply(&WalOperation::job_start(
-            12,
-            vec!["n1".into()],
-            res,
-            per_node,
-        ));
+        for id in [11, 12, 13, 14, 15] {
+            apply(&WalOperation::job_start(
+                id,
+                vec!["n1".into()],
+                res.clone(),
+                per_node.clone(),
+            ));
+            apply(&WalOperation::job_state_change(
+                id,
+                JobState::Pending,
+                JobState::Running,
+            ));
+        }
         apply(&WalOperation::job_state_change(
-            11,
-            JobState::Pending,
+            12,
             JobState::Running,
-        ));
-        apply(&WalOperation::job_state_change(
-            12,
-            JobState::Pending,
             JobState::Cancelled,
         ));
+        apply(&WalOperation::job_state_change(
+            13,
+            JobState::Running,
+            JobState::Completing,
+        ));
+        apply(&WalOperation::job_state_change(
+            14,
+            JobState::Running,
+            JobState::Suspended,
+        ));
+        apply(&WalOperation::job_state_change(
+            15,
+            JobState::Running,
+            JobState::Preempted,
+        ));
 
-        assert_eq!(cluster.get_job(10).unwrap().state, JobState::Pending);
-        assert_eq!(cluster.get_job(11).unwrap().state, JobState::Running);
-        assert!(cluster.get_job(12).unwrap().state.is_terminal());
+        assert_eq!(cluster.job_state(10), Some(JobState::Pending));
+        assert_eq!(cluster.job_state(11), Some(JobState::Running));
+        assert!(cluster.job_state(12).unwrap().is_terminal());
+        assert_eq!(cluster.job_state(13), Some(JobState::Completing));
+        assert_eq!(cluster.job_state(14), Some(JobState::Suspended));
+        assert_eq!(cluster.job_state(15), Some(JobState::Preempted));
 
-        let reported: Vec<RunningJobStatus> = [10, 11, 12, 999]
+        let reported: Vec<RunningJobStatus> = [10, 11, 12, 13, 14, 15, 999]
             .into_iter()
             .map(|job_id| RunningJobStatus {
                 job_id,
@@ -3366,7 +3384,7 @@ mod tests {
         assert_eq!(
             stale,
             vec![12],
-            "only the terminal job is reclaimed; Pending/Running/unknown are spared"
+            "only the terminal job is reclaimed; Pending/Running/Completing/Suspended/Preempted/unknown are spared"
         );
     }
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -235,13 +235,18 @@ impl ControllerService {
         let node = node.to_string();
         tokio::spawn(async move {
             for job_id in stale {
+                // Re-check: a requeue since the snapshot above would otherwise
+                // send an unguarded cancel into the job's new run.
+                if !is_still_terminal(&cluster, job_id) {
+                    continue;
+                }
                 warn!(
                     job_id,
                     node = %node,
                     "agent still holds a terminal job — re-sending cancel to reclaim its allocation"
                 );
-                // Signal 0 = graceful release. Safe to repeat: the agent no-ops an
-                // unknown id and epoch-gates a requeued one.
+                // Signal 0 = graceful release, no-op on an unknown id. Not
+                // epoch-gated — a requeue racing this send is still possible.
                 crate::scheduler_loop::cancel_job_on_nodes(
                     &cluster,
                     job_id,
@@ -374,17 +379,18 @@ fn is_k0s_admin(cache: &crate::association_cache::AssociationCache, caller: &str
     caller.is_empty() || caller == "root" || cache.is_admin(caller)
 }
 
+/// Whether the controller still considers `job_id` terminal right now — guards
+/// the spawned reclaim loop against a requeue landing after its stale snapshot.
+fn is_still_terminal(cluster: &ClusterManager, job_id: u32) -> bool {
+    cluster.job_state(job_id).is_some_and(|s| s.is_terminal())
+}
+
 /// Reported ids the controller's own record marks terminal. Non-terminal (incl.
 /// Pending mid-dispatch) and unknown ids are spared, so no live job is reclaimed.
 fn stale_reported_jobs(cluster: &ClusterManager, reported: &[RunningJobStatus]) -> Vec<u32> {
     reported
         .iter()
-        .filter_map(|r| {
-            cluster
-                .job_state(r.job_id)?
-                .is_terminal()
-                .then_some(r.job_id)
-        })
+        .filter_map(|r| is_still_terminal(cluster, r.job_id).then_some(r.job_id))
         .collect()
 }
 
@@ -3385,6 +3391,75 @@ mod tests {
             stale,
             vec![12],
             "only the terminal job is reclaimed; Pending/Running/Completing/Suspended/Preempted/unknown are spared"
+        );
+    }
+
+    /// GATE: a job requeued (Timeout -> Pending) between the reclaim snapshot
+    /// and the spawned loop's send must fail the re-check, not just the snapshot.
+    #[tokio::test]
+    async fn is_still_terminal_false_after_requeue_race() {
+        use crate::raft::StateMachineApply;
+        use spur_core::job::{JobSpec, JobState};
+        use spur_core::wal::WalOperation;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let cluster =
+            Arc::new(crate::cluster::ClusterManager::new(test_slurm_config(), dir.path()).unwrap());
+        let apply = |op: &WalOperation| {
+            <crate::cluster::ClusterManager as StateMachineApply>::apply_operation(
+                cluster.as_ref(),
+                op,
+            );
+        };
+
+        apply(&WalOperation::JobSubmit {
+            job_id: 77,
+            spec: Box::new(JobSpec {
+                name: "interactive".into(),
+                user: "alice".into(),
+                num_nodes: 1,
+                num_tasks: 1,
+                cpus_per_task: 1,
+                work_dir: "/tmp".into(),
+                requeue: true,
+                ..Default::default()
+            }),
+        });
+        let res = spur_core::resource::ResourceAllocations {
+            cpus: 1,
+            memory_mb: 0,
+            devices: std::collections::HashMap::new(),
+        };
+        let mut per_node = std::collections::HashMap::new();
+        per_node.insert("n1".to_string(), res.clone());
+        apply(&WalOperation::job_start(
+            77,
+            vec!["n1".into()],
+            res,
+            per_node,
+        ));
+        apply(&WalOperation::job_state_change(
+            77,
+            JobState::Pending,
+            JobState::Running,
+        ));
+        apply(&WalOperation::job_state_change(
+            77,
+            JobState::Running,
+            JobState::Timeout,
+        ));
+        assert!(is_still_terminal(&cluster, 77), "snapshot sees Timeout");
+
+        // Concurrent requeue lands before the reclaim loop's re-check.
+        apply(&WalOperation::job_state_change(
+            77,
+            JobState::Timeout,
+            JobState::Pending,
+        ));
+
+        assert!(
+            !is_still_terminal(&cluster, 77),
+            "re-check must skip a job requeued since the snapshot"
         );
     }
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -224,6 +224,35 @@ impl ControllerService {
         Err(self.not_leader_status())
     }
 
+    /// Re-send a terminal-job cancel to a node still reporting it on heartbeat,
+    /// freeing an allocation whose terminal cancel never landed. Spawned, best-effort.
+    fn reclaim_stale_agent_jobs(&self, node: &str, reported: &[RunningJobStatus]) {
+        let stale = stale_reported_jobs(&self.cluster, reported);
+        if stale.is_empty() {
+            return;
+        }
+        let cluster = self.cluster.clone();
+        let node = node.to_string();
+        tokio::spawn(async move {
+            for job_id in stale {
+                warn!(
+                    job_id,
+                    node = %node,
+                    "agent still holds a terminal job — re-sending cancel to reclaim its allocation"
+                );
+                // Signal 0 = the srun/salloc release path: frees an allocation-only
+                // entry, and its run_attempt guard spares a rare same-id relaunch.
+                crate::scheduler_loop::cancel_job_on_nodes(
+                    &cluster,
+                    job_id,
+                    std::slice::from_ref(&node),
+                    0,
+                )
+                .await;
+            }
+        });
+    }
+
     /// Reads never require the leader (every node applies the committed log),
     /// so forwarding is only an optional freshness hop. Skipping already-
     /// forwarded requests avoids forward loops between non-leaders.
@@ -343,6 +372,18 @@ fn resolve_user_namespace_sa(
 /// Fails closed when accounting is off (cache reports no admins), leaving only root/internal.
 fn is_k0s_admin(cache: &crate::association_cache::AssociationCache, caller: &str) -> bool {
     caller.is_empty() || caller == "root" || cache.is_admin(caller)
+}
+
+/// Reported ids the controller's own record marks terminal. Non-terminal (incl.
+/// Pending mid-dispatch) and unknown ids are spared, so no live job is reclaimed.
+fn stale_reported_jobs(cluster: &ClusterManager, reported: &[RunningJobStatus]) -> Vec<u32> {
+    reported
+        .iter()
+        .filter_map(|r| {
+            let job = cluster.get_job(r.job_id)?;
+            job.state.is_terminal().then_some(r.job_id)
+        })
+        .collect()
 }
 
 #[tonic::async_trait]
@@ -1247,6 +1288,7 @@ impl SlurmController for ControllerService {
             {
                 info!(node = %req.hostname, "learned updated WireGuard mesh key from heartbeat");
             }
+            self.reclaim_stale_agent_jobs(&req.hostname, &req.running_jobs);
             Ok(Response::new(HeartbeatResponse {}))
         } else {
             Err(Status::not_found(format!(
@@ -3240,6 +3282,92 @@ mod tests {
         let status = submit_rpc_status(SubmitError::invalid("partition 'gpu' not found"));
         assert_eq!(status.code(), Code::InvalidArgument);
         assert_eq!(status.message(), "partition 'gpu' not found");
+    }
+
+    /// Only a controller-terminal job is stale; Pending (mid-dispatch), Running,
+    /// and unknown ids are all spared.
+    #[tokio::test]
+    async fn stale_reported_jobs_selects_only_terminal_jobs() {
+        use crate::raft::StateMachineApply;
+        use spur_core::job::{JobSpec, JobState};
+        use spur_core::wal::WalOperation;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let cluster =
+            Arc::new(crate::cluster::ClusterManager::new(test_slurm_config(), dir.path()).unwrap());
+
+        let submit = |job_id: u32, name: &str| WalOperation::JobSubmit {
+            job_id,
+            spec: Box::new(JobSpec {
+                name: name.into(),
+                user: "alice".into(),
+                num_nodes: 1,
+                num_tasks: 1,
+                cpus_per_task: 1,
+                work_dir: "/tmp".into(),
+                ..Default::default()
+            }),
+        };
+        let apply = |op: &WalOperation| {
+            <crate::cluster::ClusterManager as StateMachineApply>::apply_operation(
+                cluster.as_ref(),
+                op,
+            );
+        };
+
+        // 10: Pending (just submitted, never dispatched). 11: Running. 12: terminal.
+        apply(&submit(10, "pending"));
+        apply(&submit(11, "running"));
+        apply(&submit(12, "done"));
+
+        let res = spur_core::resource::ResourceAllocations {
+            cpus: 1,
+            memory_mb: 0,
+            devices: std::collections::HashMap::new(),
+        };
+        let mut per_node = std::collections::HashMap::new();
+        per_node.insert("n1".to_string(), res.clone());
+        apply(&WalOperation::job_start(
+            11,
+            vec!["n1".into()],
+            res.clone(),
+            per_node.clone(),
+        ));
+        apply(&WalOperation::job_start(
+            12,
+            vec!["n1".into()],
+            res,
+            per_node,
+        ));
+        apply(&WalOperation::job_state_change(
+            11,
+            JobState::Pending,
+            JobState::Running,
+        ));
+        apply(&WalOperation::job_state_change(
+            12,
+            JobState::Pending,
+            JobState::Cancelled,
+        ));
+
+        assert_eq!(cluster.get_job(10).unwrap().state, JobState::Pending);
+        assert_eq!(cluster.get_job(11).unwrap().state, JobState::Running);
+        assert!(cluster.get_job(12).unwrap().state.is_terminal());
+
+        let reported: Vec<RunningJobStatus> = [10, 11, 12, 999]
+            .into_iter()
+            .map(|job_id| RunningJobStatus {
+                job_id,
+                ..Default::default()
+            })
+            .collect();
+
+        let stale = stale_reported_jobs(&cluster, &reported);
+        assert_eq!(
+            stale,
+            vec![12],
+            "only the terminal job is reclaimed; Pending/Running/unknown are spared"
+        );
     }
 
     /// GATE: `auth.jwt_key` is captured at startup and must NOT change on

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -240,8 +240,8 @@ impl ControllerService {
                     node = %node,
                     "agent still holds a terminal job — re-sending cancel to reclaim its allocation"
                 );
-                // Signal 0 = graceful release: drops an idle allocation, or re-signals
-                // a still-draining process. Safe to repeat because ids are never reused.
+                // Signal 0 = graceful release. Safe to repeat: the agent no-ops an
+                // unknown id and epoch-gates a requeued one.
                 crate::scheduler_loop::cancel_job_on_nodes(
                     &cluster,
                     job_id,

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -31,7 +31,7 @@ use crate::mpi_plugin::{self, MpiPluginHost, PmixLaunchGuard};
 use crate::pmi::PmiServer;
 use crate::reporter::NodeReporter;
 
-struct TrackedJob {
+pub(crate) struct TrackedJob {
     job: executor::RunningJob,
     rootfs_mode: crate::container::RootfsMode,
     stdout_path: String,
@@ -93,11 +93,19 @@ async fn cleanup_completed_job_mpi(
     }
 }
 
+/// Job ids this node holds, shared with the reporter so heartbeats carry them.
+pub(crate) type RunningJobs = Arc<Mutex<HashMap<u32, TrackedJob>>>;
+
+/// Build an empty running-jobs map to share between the reporter and the agent.
+pub(crate) fn new_running_jobs() -> RunningJobs {
+    Arc::new(Mutex::new(HashMap::new()))
+}
+
 pub struct AgentService {
     pub reporter: Arc<NodeReporter>,
     /// In-memory only: starts empty on every spurd start/restart, regardless
     /// of whether the controller still reports a job Running from before.
-    running: Arc<Mutex<HashMap<u32, TrackedJob>>>,
+    running: RunningJobs,
     allocation: Arc<Mutex<NodeAllocation>>,
     spank: Arc<Option<SpankHost>>,
     pmi_servers: PmiServers,
@@ -127,11 +135,13 @@ impl AgentService {
             &spur_core::config::ClusterConfig::default(),
             memlock,
             MpiConfig::default(),
+            new_running_jobs(),
         )
     }
 
     /// Construct with the `[cluster]` config so this node's K0sAgent honors the operator's k0s
     /// version + install path.
+    #[allow(clippy::too_many_arguments)]
     pub fn with_cluster_config(
         reporter: Arc<NodeReporter>,
         hooks: HooksConfig,
@@ -139,6 +149,7 @@ impl AgentService {
         cluster: &spur_core::config::ClusterConfig,
         memlock: spur_core::config::MemlockLimit,
         mpi: MpiConfig,
+        running: RunningJobs,
     ) -> Self {
         let allocation = NodeAllocation::new(
             hostname::get()
@@ -193,7 +204,7 @@ impl AgentService {
 
         Self {
             reporter,
-            running: Arc::new(Mutex::new(HashMap::new())),
+            running,
             allocation: Arc::new(Mutex::new(allocation)),
             spank: Arc::new(spank),
             pmi_servers: Arc::new(Mutex::new(HashMap::new())),
@@ -2979,6 +2990,7 @@ mod tests {
             std::collections::HashMap::new(),
             String::new(),
             String::new(),
+            new_running_jobs(),
         ))
     }
 
@@ -3443,6 +3455,7 @@ mod tests {
             std::collections::HashMap::new(),
             String::new(),
             "spur0".into(),
+            new_running_jobs(),
         ))
     }
 
@@ -4098,6 +4111,67 @@ mod tests {
             svc.free_gpu_count().await,
             0,
             "committed+tracked allocation must survive reconcile"
+        );
+    }
+
+    // The heartbeat's held-job source must report an allocation-only (srun/salloc)
+    // job so the controller can reconcile it — the strand this fix addresses.
+    #[tokio::test]
+    async fn heartbeat_reports_held_allocation_only_job() {
+        // One shared running map wired into both the reporter (heartbeat source)
+        // and the agent service (owner) — the production wiring from main.rs.
+        let running = new_running_jobs();
+        let reporter = Arc::new(NodeReporter::new(
+            "test-node".into(),
+            "http://localhost:6817".into(),
+            ResourceSet {
+                cpus: 4,
+                memory_mb: 8192,
+                ..Default::default()
+            },
+            spur_net::NodeAddress {
+                ip: "127.0.0.1".into(),
+                hostname: "test-node".into(),
+                port: 6818,
+                source: spur_net::AddressSource::Static,
+            },
+            std::collections::HashMap::new(),
+            String::new(),
+            String::new(),
+            running.clone(),
+        ));
+        let svc = AgentService::with_cluster_config(
+            reporter.clone(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            &spur_core::config::ClusterConfig::default(),
+            spur_core::config::MemlockLimit::Unlimited,
+            MpiConfig::default(),
+            running,
+        );
+
+        assert!(
+            reporter.held_job_ids().is_empty(),
+            "reporter sees no jobs before registration"
+        );
+
+        svc.register_job_allocation(Request::new(RegisterJobAllocationRequest {
+            job_id: 77,
+            cpus: 1,
+            allocated: Some(ResourceAllocations {
+                cpus: 1,
+                memory_mb: 0,
+                devices: std::collections::HashMap::new(),
+            }),
+            ..Default::default()
+        }))
+        .await
+        .expect("register");
+
+        assert_eq!(
+            reporter.held_job_ids(),
+            vec![77],
+            "reporter's heartbeat must observe the agent-registered allocation-only job"
         );
     }
 

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -270,6 +270,10 @@ async fn main() -> anyhow::Result<()> {
     // every register/heartbeat so the controller learns a key that appears/changes after startup.
     let wg_iface = std::env::var("SPUR_WG_INTERFACE").unwrap_or_else(|_| "spur0".into());
 
+    // Shared between the reporter (reads held ids for heartbeats) and the agent
+    // service (owns/mutates it) so the controller can reconcile stale allocations.
+    let running_jobs = agent_server::new_running_jobs();
+
     // Create the node reporter
     let reporter = Arc::new(NodeReporter::new(
         hostname.clone(),
@@ -279,6 +283,7 @@ async fn main() -> anyhow::Result<()> {
         labels,
         args.token.unwrap_or_default(),
         wg_iface,
+        running_jobs.clone(),
     ));
 
     // Register with controller
@@ -309,6 +314,7 @@ async fn main() -> anyhow::Result<()> {
         &cluster_config,
         memlock,
         mpi_config,
+        running_jobs,
     );
 
     // the RPC-driven k0s component owner is idle until the controller sends

--- a/crates/spurd/src/reporter.rs
+++ b/crates/spurd/src/reporter.rs
@@ -18,7 +18,7 @@ pub trait HeldJobs: Send + Sync {
     fn held_job_ids(&self) -> Vec<u32>;
 }
 
-impl<T: Send + Sync> HeldJobs for Mutex<HashMap<u32, T>> {
+impl<T: Send> HeldJobs for Mutex<HashMap<u32, T>> {
     fn held_job_ids(&self) -> Vec<u32> {
         match self.try_lock() {
             Ok(jobs) => jobs.keys().copied().collect(),
@@ -574,5 +574,13 @@ mod tests {
             "node token required"
         )));
         assert!(!should_reregister(&tonic::Status::internal("boom")));
+    }
+
+    #[test]
+    fn held_job_ids_accepts_send_but_not_sync_values() {
+        // Cell is Send but !Sync; this fails to compile if the bound re-tightens to Sync.
+        let map: Mutex<HashMap<u32, std::cell::Cell<u8>>> =
+            Mutex::new(HashMap::from([(7, std::cell::Cell::new(0))]));
+        assert_eq!(map.held_job_ids(), vec![7]);
     }
 }

--- a/crates/spurd/src/reporter.rs
+++ b/crates/spurd/src/reporter.rs
@@ -3,13 +3,29 @@
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
 
 use anyhow::Context;
 use spur_core::resource::{GpuLinkType, GpuResource, ResourceSet};
 use spur_devices::{resolve_link_type, DeviceRegistry, LinkType};
-use spur_proto::proto::{RegisterAgentRequest, ResourceSet as ProtoResourceSet};
+use spur_proto::proto::{RegisterAgentRequest, ResourceSet as ProtoResourceSet, RunningJobStatus};
+use tokio::sync::Mutex;
 use tracing::{debug, info, warn};
+
+/// Source of the job ids this node currently holds. The controller decides from
+/// its own authoritative state whether any reported id is stale.
+pub trait HeldJobs: Send + Sync {
+    fn held_job_ids(&self) -> Vec<u32>;
+}
+
+impl<T: Send + Sync> HeldJobs for Mutex<HashMap<u32, T>> {
+    fn held_job_ids(&self) -> Vec<u32> {
+        match self.try_lock() {
+            Ok(jobs) => jobs.keys().copied().collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+}
 
 /// Discovers and reports node resources to the controller.
 pub struct NodeReporter {
@@ -26,9 +42,13 @@ pub struct NodeReporter {
     /// or changes after startup (late mesh join, `spur0` recreated) reaches the controller.
     pub wg_iface: String,
     node_token: RwLock<String>,
+    /// Job ids this node holds, reported each heartbeat so the controller can
+    /// reclaim allocations it no longer tracks. Shares the agent's running map.
+    held_jobs: Arc<dyn HeldJobs>,
 }
 
 impl NodeReporter {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         hostname: String,
         controller_addr: String,
@@ -37,6 +57,7 @@ impl NodeReporter {
         labels: HashMap<String, String>,
         join_token: String,
         wg_iface: String,
+        held_jobs: Arc<dyn HeldJobs>,
     ) -> Self {
         Self {
             hostname,
@@ -49,6 +70,7 @@ impl NodeReporter {
             join_token,
             wg_iface,
             node_token: RwLock::new(String::new()),
+            held_jobs,
         }
     }
 
@@ -56,6 +78,11 @@ impl NodeReporter {
     /// Read live from the interface so a key that appears or changes after startup is picked up.
     fn wg_pubkey(&self) -> String {
         spur_net::wireguard::interface_public_key(&self.wg_iface).unwrap_or_default()
+    }
+
+    /// Job ids this heartbeat would report, from the shared running map.
+    pub fn held_job_ids(&self) -> Vec<u32> {
+        self.held_jobs.held_job_ids()
     }
 
     /// Register with the controller.
@@ -124,6 +151,14 @@ impl NodeReporter {
             self.cpu_load.store(load as u64, Ordering::Relaxed);
             self.free_memory_mb.store(free_mem, Ordering::Relaxed);
             let current_token = self.node_token.read().unwrap().clone();
+            let running_jobs: Vec<RunningJobStatus> = self
+                .held_job_ids()
+                .into_iter()
+                .map(|job_id| RunningJobStatus {
+                    job_id,
+                    ..Default::default()
+                })
+                .collect();
 
             match spur_client::connect_channel(&self.controller_addr).await {
                 Ok(channel) => {
@@ -133,7 +168,7 @@ impl NodeReporter {
                             hostname: self.hostname.clone(),
                             cpu_load: load,
                             free_memory_mb: free_mem,
-                            running_jobs: vec![],
+                            running_jobs,
                             node_token: current_token,
                             wg_pubkey: self.wg_pubkey(),
                         })


### PR DESCRIPTION
## What this fixes

Fix SPUR-102

An interactive `srun`/`salloc` allocation is tracked on the agent as an *allocation-only* entry with no launched process, so the agent's monitor loop never self-completes it. If the controller loses or forgets that allocation without delivering a terminal cancel/complete RPC — a dropped cancel that isn't retried, a controller restart that drops in-memory state after the job finished, or the interactive client dying abruptly — the node's GPU/CPU/memory stays reserved indefinitely. The node then looks IDLE to the controller yet rejects every new dispatch: an "idle but every submission fails" black hole that today requires a manual `spurd` restart to clear.

This is the allocation-only counterpart to the earlier launching-reservation and completion/eviction strand fixes. Same observable symptom, different root cause: a *committed, live-tracked* allocation the controller no longer knows about, which the agent's own self-heal reconcile deliberately spares (it's a live tracked job).

## Approach

Close the loop the heartbeat already had wiring for. The heartbeat request has always carried a `running_jobs` field that the agent left empty and the controller ignored.

- **Agent** now reports the job ids it currently holds on every heartbeat, sourced directly from its running-jobs map (shared with the reporter, single source of truth — no mirrored bookkeeping).
- **Controller**, on heartbeat, checks each reported id against its *own* authoritative job state. For any id it considers terminal, it re-sends the release to the reporting node, freeing the stranded allocation.

The decision uses the controller's own state, never the agent's self-reported state. It reclaims only jobs it already considers **terminal**, so:

- a `Pending` allocation (the agent registers an allocation *before* the controller persists `start_job`, so a just-dispatched job can legitimately be held while still Pending) is spared;
- `Running`, `Completing`, `Suspended`, and `Preempted` jobs are spared;
- an id the controller has no record of is spared (job ids are monotonic and never reused, so "unknown" means a not-yet-applied assignment, not a forgotten job).

The reclaim reuses the existing graceful release path (the same one `srun`/`salloc` teardown uses): it frees an allocation-only entry cleanly, and its run-epoch guard means that in the rare case a terminal id is reused by a requeue mid-window, the release can't touch the new run's process. The reclaim runs on the reporting node only (never fanned out to other allocated nodes) and is spawned best-effort so the heartbeat response is never delayed.

No proto change, no new persisted (Raft/WAL) type or field, no config change: the controller's own state is already correct; this only re-syncs a lagging agent to it.

## Tests

- Controller: a unit test drives real WAL applies to build Pending / Running / terminal / unknown jobs and asserts the reclaim decision selects only the terminal one.
- Agent: a unit test wires one shared running map into both the reporter and the agent service (the production wiring), registers an allocation-only entry, and asserts the heartbeat source reports it.
- Both tests were confirmed to fail against the unfixed code.

## How it was tested

Validated end-to-end on an isolated 2-node deployment: reproduced the strand (a job made terminal on the controller while the agent kept holding it and its process), confirmed the node showed idle-but-unusable, then confirmed the next heartbeat drove the controller to reclaim it — the held process was killed, the allocation freed, and the node immediately accepted new work. A concurrently-running (non-terminal) job reported on every heartbeat was verified never to be reclaimed.