### PR TITLE
fix(spurctld): filter reservations by name in scontrol show

### DIFF
--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -735,11 +735,21 @@ async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> 
         }
         "reservation" | "reservations" => {
             let resp = client
-                .list_reservations(spur_proto::proto::ListReservationsRequest {})
+                .list_reservations(spur_proto::proto::ListReservationsRequest {
+                    name: name.unwrap_or("").into(),
+                })
                 .await
                 .context("failed to list reservations")?;
 
-            for res in resp.into_inner().reservations {
+            let reservations = resp.into_inner().reservations;
+            if reservations.is_empty() {
+                if let Some(name) = name {
+                    bail!("Reservation {} not found", name);
+                }
+                return Ok(());
+            }
+
+            for res in reservations {
                 println!("ReservationName={}", res.name);
                 println!("   StartTime={}", res.start_time);
                 println!("   EndTime={}", res.end_time);

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -734,6 +734,7 @@ async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> 
             }
         }
         "reservation" | "reservations" => {
+            let name = normalize_show_name(name);
             let resp = client
                 .list_reservations(spur_proto::proto::ListReservationsRequest {
                     name: name.unwrap_or("").into(),
@@ -744,7 +745,7 @@ async fn show(controller: &str, entity: &str, name: Option<&str>) -> Result<()> 
             let reservations = resp.into_inner().reservations;
             if reservations.is_empty() {
                 if let Some(name) = name {
-                    bail!("Reservation {} not found", name);
+                    bail!("Reservation {name} not found");
                 }
                 return Ok(());
             }
@@ -1337,6 +1338,14 @@ async fn update_node(
     Ok(())
 }
 
+/// Normalize a `scontrol show <entity> <name>` filter: trim surrounding
+/// whitespace and treat a blank name as "no filter". Keeping this on the client
+/// side means the request field and the not-found decision use the same value,
+/// so the CLI and the server (which also trims) never disagree.
+fn normalize_show_name(name: Option<&str>) -> Option<&str> {
+    name.map(str::trim).filter(|s| !s.is_empty())
+}
+
 /// Split a comma-separated list into trimmed, non-empty entries.
 fn split_csv(s: &str) -> Vec<String> {
     s.split(',')
@@ -1589,6 +1598,17 @@ mod tests {
 
     fn p(args: &[&str]) -> Vec<String> {
         args.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn normalize_show_name_trims_and_blanks_to_none() {
+        assert_eq!(normalize_show_name(None), None);
+        assert_eq!(normalize_show_name(Some("   ")), None);
+        assert_eq!(
+            normalize_show_name(Some(" rocm_patch ")),
+            Some("rocm_patch")
+        );
+        assert_eq!(normalize_show_name(Some("rocm_patch")), Some("rocm_patch"));
     }
 
     #[test]

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -4435,6 +4435,15 @@ mod tests {
             .reservations;
         assert_eq!(all.len(), 2);
 
+        // A whitespace-only name is trimmed to empty and treated as no filter.
+        let blank = svc
+            .list_reservations(Request::new(ListReservationsRequest { name: "   ".into() }))
+            .await
+            .unwrap()
+            .into_inner()
+            .reservations;
+        assert_eq!(blank.len(), 2);
+
         let none = svc
             .list_reservations(Request::new(ListReservationsRequest {
                 name: "does_not_exist".into(),

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1823,9 +1823,10 @@ impl SlurmController for ControllerService {
         request: Request<ListReservationsRequest>,
     ) -> Result<Response<ListReservationsResponse>, Status> {
         let forward = self.read_should_forward(&request);
+        let req = request.into_inner();
         if let Some(resp) = self
             .forward_read_optional(
-                forward.then(|| request.into_inner()),
+                forward.then(|| req.clone()),
                 "list_reservations",
                 |mut c, r| async move { c.list_reservations(r).await },
             )
@@ -1833,10 +1834,12 @@ impl SlurmController for ControllerService {
         {
             return Ok(resp);
         }
+        let name = req.name.trim();
         let reservations = self.cluster.get_reservations();
         let now = Utc::now();
         let infos: Vec<ReservationInfo> = reservations
             .iter()
+            .filter(|r| name.is_empty() || r.name == name)
             .map(|r| ReservationInfo {
                 name: r.name.clone(),
                 start_time: r.start_time.to_rfc3339(),
@@ -4362,5 +4365,84 @@ mod tests {
             ..Default::default()
         };
         assert!(proto_to_job_spec(spec).is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn list_reservations_filters_by_name() {
+        use spur_core::resource::ResourceSet;
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+
+        for n in ["n1", "n2"] {
+            svc.cluster
+                .register_node(
+                    n.into(),
+                    n.into(),
+                    ResourceSet {
+                        cpus: 4,
+                        memory_mb: 8000,
+                        ..Default::default()
+                    },
+                    "127.0.0.1".into(),
+                    6818,
+                    String::new(),
+                    String::new(),
+                    spur_core::node::NodeSource::NativeHost,
+                    std::collections::HashMap::new(),
+                )
+                .unwrap();
+        }
+        for _ in 0..200 {
+            if svc.cluster.get_node("n1").is_some() && svc.cluster.get_node("n2").is_some() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+
+        for (name, node) in [("rocm_patch", "n1"), ("other_resv", "n2")] {
+            svc.create_reservation(Request::new(CreateReservationRequest {
+                name: name.into(),
+                start_time: "now".into(),
+                duration_minutes: 60,
+                nodes: vec![node.into()],
+                accounts: Vec::new(),
+                users: Vec::new(),
+                flags: Vec::new(),
+                user: String::new(),
+            }))
+            .await
+            .unwrap();
+        }
+
+        let one = svc
+            .list_reservations(Request::new(ListReservationsRequest {
+                name: "rocm_patch".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner()
+            .reservations;
+        assert_eq!(one.len(), 1);
+        assert_eq!(one[0].name, "rocm_patch");
+
+        let all = svc
+            .list_reservations(Request::new(ListReservationsRequest {
+                name: String::new(),
+            }))
+            .await
+            .unwrap()
+            .into_inner()
+            .reservations;
+        assert_eq!(all.len(), 2);
+
+        let none = svc
+            .list_reservations(Request::new(ListReservationsRequest {
+                name: "does_not_exist".into(),
+            }))
+            .await
+            .unwrap()
+            .into_inner()
+            .reservations;
+        assert!(none.is_empty());
     }
 }

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -1363,7 +1363,9 @@ message DeleteReservationRequest {
   string user = 2;             // requesting user; must be the owner (root and trusted internal callers always allowed; legacy reservations with no recorded owner are mutable by anyone)
 }
 
-message ListReservationsRequest { }
+message ListReservationsRequest {
+  string name = 1;  // empty = all
+}
 
 message ListReservationsResponse {
   repeated ReservationInfo reservations = 1;

--- a/tests/native_host/e2e/cluster.py
+++ b/tests/native_host/e2e/cluster.py
@@ -385,6 +385,20 @@ class SpurCluster:
         cmd = f"{self._sudo_prefix()}-u '{run_as}' env {' '.join(inner)}"
         return self.nodes[0].exec_allow_fail(cmd)
 
+    def cli_with_exit(
+        self, args: list[str], controller_addr: str | None = None
+    ) -> tuple[int, str]:
+        """Run a spur CLI command and return (exit_code, combined stdout+stderr)."""
+        cmd_parts = [
+            f"SPUR_CONTROLLER_ADDR='{controller_addr or self.controller_addr}'",
+            f"PATH='{self.bin_dir}':$PATH",
+            f"'{self.bin_dir}/{args[0]}'",
+        ]
+        cmd_parts.extend(f"'{a}'" for a in args[1:])
+        _, stdout, stderr = self.nodes[0].client.exec_command(" ".join(cmd_parts))
+        code = stdout.channel.recv_exit_status()
+        return code, stdout.read().decode() + stderr.read().decode()
+
     def sbatch(self, args: list[str]) -> str:
         return self.cli(["sbatch"] + args)
 

--- a/tests/native_host/e2e/test_reservations.py
+++ b/tests/native_host/e2e/test_reservations.py
@@ -50,6 +50,13 @@ class TestReservations:
         assert res_name in filtered
         assert other_name not in filtered
 
+        # An unknown reservation name is an error, not an empty success.
+        code, out = cluster.cli_with_exit(
+            ["scontrol", "show", "reservation", "no-such-reservation"]
+        )
+        assert code != 0
+        assert "not found" in out.lower()
+
         cluster.scontrol("delete-reservation", other_name)
 
         delete_out = cluster.scontrol("delete-reservation", res_name)

--- a/tests/native_host/e2e/test_reservations.py
+++ b/tests/native_host/e2e/test_reservations.py
@@ -29,6 +29,29 @@ class TestReservations:
         assert node in show_out
         assert "ACTIVE" in show_out or "INACTIVE" in show_out
 
+        # A distinct node avoids overlap; fall back to the overlap flag when the cluster has one node.
+        other_name = f"res-e2e-other-{int(time.time())}"
+        if len(cluster.node_names) >= 2:
+            other_node = cluster.node_names[1]
+            overlap_flags = []
+        else:
+            other_node = node
+            overlap_flags = ["--flags=overlap"]
+        cluster.scontrol(
+            "create-reservation",
+            f"--name={other_name}",
+            "--start-time=now",
+            "--duration=60",
+            f"--nodes={other_node}",
+            *overlap_flags,
+        )
+
+        filtered = cluster.scontrol("show", "reservation", res_name)
+        assert res_name in filtered
+        assert other_name not in filtered
+
+        cluster.scontrol("delete-reservation", other_name)
+
         delete_out = cluster.scontrol("delete-reservation", res_name)
         assert "deleted" in delete_out.lower()
 


### PR DESCRIPTION
## What

`scontrol show reservation <name>` listed every reservation instead of just the named one (SPUR-119).

## Why

The CLI dropped the `name` argument and `ListReservations` had no filter field, so the handler always returned all reservations. This diverged from `scontrol show node`/`show partition`, which filter server-side.

## Approach

- `proto/slurm.proto`: add `string name = 1;` to `ListReservationsRequest` (additive, wire-safe: new tag, no renames/retypes).
- `spurctld` `list_reservations`: filter by name on the controller (`name.is_empty() || r.name == name`), mirroring `get_nodes`/`get_partitions`. Leader-forward path preserved.
- `spur-cli` scontrol: forward the `name` argument; when a name is given but nothing matches, error with `Reservation <name> not found` (exit 1), matching Slurm.

## Tests

- `spurctld` unit test `list_reservations_filters_by_name` exercises the real handler: one match by name, all when empty, none for an unknown name.
- Extended `tests/native_host/e2e/test_reservations.py` to create two reservations and assert the filtered `show` returns only the requested one.

## Validation

- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked`: clean.
- `cargo test --locked`: pass.
- Bare-metal testbed (4 nodes): `show reservation rocm_patch` returns only `rocm_patch`, no-name returns all, unknown name exits 1.