### PR TITLE
docs: cap code comment length in agent conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ cargo test --locked                                                 # all tests 
 - **IMPORTANT**: Do not add comments that explain *what* the code does. Comments are only for *why* — non-obvious intent, trade-offs, or constraints the code itself cannot convey. Self-explanatory code gets no comments.
 - **IMPORTANT**: Do not reference issue numbers, PR numbers, or task IDs in code comments. That context belongs in git history, not in the source.
 - Do not add comments that narrate the intent of a fix or review feedback (e.g. "changed per review", "moved here to fix X"). The code should stand on its own — review context belongs in the commit message or PR discussion.
+- Keep comments short — 1-3 lines is the norm. Do not write long, multi-line comment blocks unless it is really a must; if an explanation needs a full paragraph, it usually belongs in the commit message or PR description, not the source.
 - **IMPORTANT**: Do not apply band-aid fixes. If a fix would be cleaner with a broader refactor that improves testability or idiomaticness, do the refactor. Explain the reasoning to the user. Maintainability over fast delivery.
 - Do not write tests that simulate a unit's behavior instead of calling the actual unit. Tests must exercise real code.
 - Do not write tests that depend on the test runner's environment. Use explicit fixtures so tests pass identically everywhere.


### PR DESCRIPTION
## Summary
- Adds a rule to the "Do Not" section of `AGENTS.md` discouraging long, multi-line comment blocks.
- 1-3 lines is the norm; paragraph-length explanation usually belongs in the commit message or PR description rather than the source.

## Approach
Complements the existing comment conventions (comments explain *why* not *what*; no issue/PR references; no fix-narration) with an explicit length guideline, since verbose comment blocks have been a recurring pattern in recent merged PRs.

## Recent examples that motivated this
These are inline `//` blocks (not `///`/`//!` API docs, which are legitimately longer):

- **#301** (`expand pending-reason vocabulary`) — several 4-6 line inline blocks in `crates/spurctld/src/cluster.rs`, e.g. the 6-line "License reservation, in priority order…" block (currently around `cluster.rs:1262`) and the "QoS enforcement…" block (around `cluster.rs:1221`). Most of this is rationale that would read better in the PR description.
- **#275** (`job suspend/resume`) — a ~4-line block in `cluster.rs` (around `cluster.rs:3155`) that both runs long *and* opens with "Copilot review: …", narrating review feedback — which the adjacent existing rule already discourages.
- **#318** (`token-based node admission`) and **#348** (`backfill timeline`) — long blocks here are mostly module/item doc comments (`//!`, `///`), which this rule does **not** target; flagging them only to show the sweep considered them and they're fine.

The point isn't to relitigate those PRs — they're merged and reasonable — just to codify the norm so future changes trend shorter.

## Test plan
- [x] Docs-only change; no code affected.