### PR TITLE
fix(spurctld): evict aged terminal jobs to bound controller memory

### DIFF
--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -320,10 +320,19 @@ pub struct ControllerConfig {
     /// the inverse `SchedulerParameters=nohold_on_prolog_fail`.
     #[serde(default = "default_hold_on_prolog_fail")]
     pub hold_on_prolog_fail: bool,
+
+    /// Seconds a terminal job stays in controller memory/snapshots before eviction
+    /// (default 3600); Postgres accounting history is unaffected.
+    #[serde(default = "default_terminal_job_retention_secs")]
+    pub terminal_job_retention_secs: u64,
 }
 
 fn default_max_batch_requeue() -> u32 {
     5
+}
+
+fn default_terminal_job_retention_secs() -> u64 {
+    3600
 }
 
 fn default_hold_on_prolog_fail() -> bool {
@@ -374,6 +383,7 @@ impl Default for ControllerConfig {
             max_batch_requeue: default_max_batch_requeue(),
             max_launch_backoff_secs: default_max_launch_backoff_secs(),
             hold_on_prolog_fail: default_hold_on_prolog_fail(),
+            terminal_job_retention_secs: default_terminal_job_retention_secs(),
         }
     }
 }

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -348,6 +348,10 @@ fn default_max_launch_backoff_secs() -> u64 {
 /// out of chrono's representable range.
 pub const MAX_LAUNCH_BACKOFF_SECS: u64 = 86_400;
 
+/// Upper bound for `terminal_job_retention_secs` (one year). Keeps the eviction
+/// cutoff (`now - retention`) inside chrono's representable range.
+pub const MAX_TERMINAL_JOB_RETENTION_SECS: u64 = 366 * 24 * 60 * 60;
+
 fn default_listen_addr() -> String {
     "[::]:6817".into()
 }
@@ -1156,6 +1160,16 @@ impl SlurmConfig {
                 ),
             });
         }
+        // Bounded so the eviction cutoff `now - retention` stays representable.
+        if self.controller.terminal_job_retention_secs > MAX_TERMINAL_JOB_RETENTION_SECS {
+            return Err(ConfigError::InvalidValue {
+                field: "controller.terminal_job_retention_secs".into(),
+                value: format!(
+                    "{} (must be at most {})",
+                    self.controller.terminal_job_retention_secs, MAX_TERMINAL_JOB_RETENTION_SECS
+                ),
+            });
+        }
         if self.cluster.enabled {
             if self.cluster.distro != "k0s" {
                 return Err(ConfigError::InvalidValue {
@@ -1930,6 +1944,43 @@ max_launch_backoff_secs = 0
         assert!(
             err.to_string().contains("max_launch_backoff_secs"),
             "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn controller_config_rejects_out_of_range_terminal_job_retention_secs() {
+        // Past this bound the eviction cutoff overflows chrono and panics the
+        // controller, so it must be refused at load rather than at first use.
+        let toml = format!(
+            r#"
+cluster_name = "test"
+
+[controller]
+terminal_job_retention_secs = {}
+"#,
+            MAX_TERMINAL_JOB_RETENTION_SECS + 1
+        );
+        let err = SlurmConfig::load_from_str(&toml).unwrap_err();
+        assert!(
+            err.to_string().contains("terminal_job_retention_secs"),
+            "unexpected error: {err}"
+        );
+
+        let ok = format!(
+            r#"
+cluster_name = "test"
+
+[controller]
+terminal_job_retention_secs = {MAX_TERMINAL_JOB_RETENTION_SECS}
+"#
+        );
+        assert_eq!(
+            SlurmConfig::load_from_str(&ok)
+                .unwrap()
+                .controller
+                .terminal_job_retention_secs,
+            MAX_TERMINAL_JOB_RETENTION_SECS,
+            "the bound itself must be accepted"
         );
     }
 

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -321,8 +321,10 @@ pub struct ControllerConfig {
     #[serde(default = "default_hold_on_prolog_fail")]
     pub hold_on_prolog_fail: bool,
 
-    /// Seconds a terminal job stays in controller memory/snapshots before eviction
-    /// (default 3600); Postgres accounting history is unaffected.
+    /// Seconds a terminal job stays in controller memory before eviction (default
+    /// 3600). `sacct` history is unaffected but `scontrol show job` stops finding
+    /// it after the window; runs once per `scheduler.interval_secs` and is floored
+    /// to the accounting reconcile interval so a job's DB row can be repaired first.
     #[serde(default = "default_terminal_job_retention_secs")]
     pub terminal_job_retention_secs: u64,
 }

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -348,8 +348,8 @@ fn default_max_launch_backoff_secs() -> u64 {
 /// out of chrono's representable range.
 pub const MAX_LAUNCH_BACKOFF_SECS: u64 = 86_400;
 
-/// Upper bound for `terminal_job_retention_secs` (one year). Keeps the eviction
-/// cutoff (`now - retention`) inside chrono's representable range.
+/// Upper bound for `terminal_job_retention_secs` (one year). Operational
+/// guardrail: retaining terminal jobs longer defeats the memory bound.
 pub const MAX_TERMINAL_JOB_RETENTION_SECS: u64 = 366 * 24 * 60 * 60;
 
 fn default_listen_addr() -> String {
@@ -1160,7 +1160,7 @@ impl SlurmConfig {
                 ),
             });
         }
-        // Bounded so the eviction cutoff `now - retention` stays representable.
+        // Guardrail: retention beyond the cap defeats the memory bound.
         if self.controller.terminal_job_retention_secs > MAX_TERMINAL_JOB_RETENTION_SECS {
             return Err(ConfigError::InvalidValue {
                 field: "controller.terminal_job_retention_secs".into(),
@@ -1949,8 +1949,8 @@ max_launch_backoff_secs = 0
 
     #[test]
     fn controller_config_rejects_out_of_range_terminal_job_retention_secs() {
-        // Past this bound the eviction cutoff overflows chrono and panics the
-        // controller, so it must be refused at load rather than at first use.
+        // Beyond the guardrail, load must reject up front rather than silently
+        // retaining terminal jobs long enough to defeat the memory bound.
         let toml = format!(
             r#"
 cluster_name = "test"

--- a/crates/spur-core/src/dependency.rs
+++ b/crates/spur-core/src/dependency.rs
@@ -29,6 +29,21 @@ pub enum Dependency {
     Singleton,
 }
 
+impl Dependency {
+    /// The target job id this dependency references, or `None` for `Singleton`
+    /// (which matches on name+user, not a specific id).
+    pub fn target_job_id(&self) -> Option<JobId> {
+        match self {
+            Dependency::After { job_id, .. } => Some(*job_id),
+            Dependency::AfterOk(id)
+            | Dependency::AfterAny(id)
+            | Dependency::AfterNotOk(id)
+            | Dependency::AfterCorr(id) => Some(*id),
+            Dependency::Singleton => None,
+        }
+    }
+}
+
 /// Dependency string parse failure, surfaced at submit time so users get a
 /// clear rejection instead of a silently-deadlocked job.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
@@ -905,5 +920,22 @@ mod tests {
             &|_, _| Vec::new(),
         );
         assert_eq!(result, DependencyResult::Waiting);
+    }
+
+    #[test]
+    fn test_target_job_id_extracts_id_for_id_bearing_deps() {
+        assert_eq!(
+            Dependency::After {
+                job_id: 7,
+                delay_minutes: 5
+            }
+            .target_job_id(),
+            Some(7)
+        );
+        assert_eq!(Dependency::AfterOk(8).target_job_id(), Some(8));
+        assert_eq!(Dependency::AfterAny(9).target_job_id(), Some(9));
+        assert_eq!(Dependency::AfterNotOk(10).target_job_id(), Some(10));
+        assert_eq!(Dependency::AfterCorr(11).target_job_id(), Some(11));
+        assert_eq!(Dependency::Singleton.target_job_id(), None);
     }
 }

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -262,6 +262,12 @@ pub enum WalOperation {
     NodeK0sClear {
         name: String,
     },
+
+    /// Evict terminal jobs whose end_time is older than `before` from the
+    /// in-memory map and snapshots, bounding controller memory.
+    EvictTerminalJobs {
+        before: chrono::DateTime<chrono::Utc>,
+    },
 }
 
 impl WalOperation {
@@ -821,6 +827,22 @@ mod deregistration_wal_tests {
             WalOperation::NodeRemove { name, reason } => {
                 assert_eq!(name, "n0");
                 assert!(reason.is_none());
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    // Frozen on-wire shape; a new field without #[serde(default)] fails here
+    // instead of crashing a controller replaying this entry after upgrade.
+    #[test]
+    fn evict_terminal_jobs_frozen_payload_still_deserializes() {
+        const EVICT: &str = r#"{"EvictTerminalJobs":{"before":"2026-08-06T00:00:00Z"}}"#;
+        let op: WalOperation = serde_json::from_str(EVICT).expect(
+            "frozen EvictTerminalJobs must deserialize; a new field needs #[serde(default)]",
+        );
+        match op {
+            WalOperation::EvictTerminalJobs { before } => {
+                assert_eq!(before.to_rfc3339(), "2026-08-06T00:00:00+00:00");
             }
             _ => panic!("wrong variant"),
         }

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -263,10 +263,10 @@ pub enum WalOperation {
         name: String,
     },
 
-    /// Evict terminal jobs whose end_time is older than `before` from the
-    /// in-memory map and snapshots, bounding controller memory.
+    /// Evict the named terminal jobs to bound controller memory. The leader
+    /// resolves the aged-out set so every replica evicts identically.
     EvictTerminalJobs {
-        before: chrono::DateTime<chrono::Utc>,
+        job_ids: Vec<JobId>,
     },
 }
 
@@ -836,13 +836,13 @@ mod deregistration_wal_tests {
     // instead of crashing a controller replaying this entry after upgrade.
     #[test]
     fn evict_terminal_jobs_frozen_payload_still_deserializes() {
-        const EVICT: &str = r#"{"EvictTerminalJobs":{"before":"2026-08-06T00:00:00Z"}}"#;
+        const EVICT: &str = r#"{"EvictTerminalJobs":{"job_ids":[7,42]}}"#;
         let op: WalOperation = serde_json::from_str(EVICT).expect(
             "frozen EvictTerminalJobs must deserialize; a new field needs #[serde(default)]",
         );
         match op {
-            WalOperation::EvictTerminalJobs { before } => {
-                assert_eq!(before.to_rfc3339(), "2026-08-06T00:00:00+00:00");
+            WalOperation::EvictTerminalJobs { job_ids } => {
+                assert_eq!(job_ids, vec![7, 42]);
             }
             _ => panic!("wrong variant"),
         }

--- a/crates/spurctld/src/accounting/mod.rs
+++ b/crates/spurctld/src/accounting/mod.rs
@@ -10,6 +10,7 @@ mod reconcile;
 pub use grpc::accounting_server;
 pub use notifier::{AccountingNotifier, JobStartRecord};
 pub use reconcile::spawn_loop as spawn_reconcile_loop;
+pub use reconcile::RECONCILE_INTERVAL_SECS;
 
 use std::collections::{HashMap, HashSet};
 

--- a/crates/spurctld/src/accounting/reconcile.rs
+++ b/crates/spurctld/src/accounting/reconcile.rs
@@ -16,6 +16,10 @@ use crate::raft::RaftHandle;
 
 use super::db::{self, AccountingRowState};
 
+/// How often the reconcile pass runs. Terminal-job eviction floors its
+/// effective retention above this so a job's DB row can always be repaired first.
+pub const RECONCILE_INTERVAL_SECS: u64 = 120;
+
 /// Periodically re-issue accounting writes for jobs whose accounting DB
 /// record is missing or stale relative to the in-memory job store. Closes
 /// the gap left by a `notify_job_start`/`notify_job_end` write that

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -4864,7 +4864,7 @@ impl ClusterManager {
                 k0s.reset_requested = *reset_requested;
             }
             WalOperation::EvictTerminalJobs { before } => {
-                let evicted: Vec<JobId> = jobs
+                let evicted: HashSet<JobId> = jobs
                     .iter()
                     .filter(|(_, j)| {
                         j.state.is_terminal() && j.end_time.is_some_and(|t| t < *before)
@@ -4872,9 +4872,7 @@ impl ClusterManager {
                     .map(|(&id, _)| id)
                     .collect();
                 if !evicted.is_empty() {
-                    for id in &evicted {
-                        jobs.remove(id);
-                    }
+                    jobs.retain(|id, _| !evicted.contains(id));
                     self.steps
                         .write()
                         .retain(|_, s| !evicted.contains(&s.job_id));
@@ -6328,6 +6326,25 @@ mod tests {
             spec: Box::new(basic_spec("pending")),
         });
 
+        // A step on each of the terminal (1) and live (2) jobs: eviction must
+        // drop the evicted job's step and keep the live one's.
+        let step = |job_id: JobId| JobStep {
+            job_id,
+            step_id: 0,
+            name: "s".into(),
+            state: StepState::Running,
+            num_tasks: 1,
+            cpus_per_task: 1,
+            resources: scalar_alloc(1, 0),
+            nodes: vec!["node1".into()],
+            distribution: spur_core::step::TaskDistribution::Block,
+            start_time: None,
+            end_time: None,
+            exit_code: None,
+        };
+        cm.steps.write().insert((1, 0), step(1));
+        cm.steps.write().insert((2, 0), step(2));
+
         // A cutoff before the just-set end_time spares even the terminal job.
         cm.apply_operation(&WalOperation::EvictTerminalJobs {
             before: chrono::Utc::now() - chrono::Duration::hours(1),
@@ -6344,6 +6361,40 @@ mod tests {
         assert!(cm.get_job(1).is_none(), "aged terminal job must be evicted");
         assert!(cm.get_job(2).is_some(), "running job must be spared");
         assert!(cm.get_job(3).is_some(), "pending job must be spared");
+        assert!(
+            cm.steps.read().get(&(1, 0)).is_none(),
+            "evicted job's step must be removed"
+        );
+        assert!(
+            cm.steps.read().get(&(2, 0)).is_some(),
+            "live job's step must be kept"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn evict_expired_terminal_jobs_honors_retention_window() {
+        let dir = TempDir::new().unwrap();
+        let mut cfg = test_config();
+        cfg.controller.terminal_job_retention_secs = 0;
+        let cm = test_cluster_with_config(&dir, cfg).await;
+
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("done")),
+        });
+        cm.apply_operation(&WalOperation::JobComplete {
+            job_id: 1,
+            exit_code: 0,
+            state: JobState::Cancelled,
+        });
+
+        // retention 0: end_time is already < now, so the producer proposes and
+        // the job is gone after one pass.
+        cm.evict_expired_terminal_jobs();
+        assert!(
+            cm.get_job(1).is_none(),
+            "with zero retention the terminal job is evicted"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -3303,7 +3303,7 @@ impl ClusterManager {
         }
     }
 
-    /// Evict terminal jobs whose end_time is older than the retention window,
+    /// Evict finished jobs whose end_time is older than the retention window,
     /// bounding controller memory. No-op when nothing has aged out.
     pub fn evict_expired_terminal_jobs(&self) {
         let retention = self.config().controller.terminal_job_retention_secs;
@@ -3312,7 +3312,7 @@ impl ClusterManager {
             .jobs
             .read()
             .iter()
-            .filter(|(_, j)| j.state.is_terminal() && j.end_time.is_some_and(|t| t < before))
+            .filter(|(_, j)| j.state.is_finalized() && j.end_time.is_some_and(|t| t < before))
             .map(|(&id, _)| id)
             .collect();
         if job_ids.is_empty() {
@@ -4868,7 +4868,7 @@ impl ClusterManager {
             WalOperation::EvictTerminalJobs { job_ids } => {
                 let evicted: HashSet<JobId> = job_ids
                     .iter()
-                    .filter(|id| jobs.get(id).is_some_and(|j| j.state.is_terminal()))
+                    .filter(|id| jobs.get(id).is_some_and(|j| j.state.is_finalized()))
                     .copied()
                     .collect();
                 if !evicted.is_empty() {
@@ -6325,6 +6325,20 @@ mod tests {
             job_id: 3,
             spec: Box::new(basic_spec("pending")),
         });
+        // A job stranded in Preempted (a rare requeue-strand): finalized with an
+        // end_time, so it must be reapable even though it isn't is_terminal().
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 4,
+            spec: Box::new(basic_spec("preempted")),
+        });
+        {
+            let mut jobs = cm.jobs.write();
+            let j = jobs.get_mut(&4).unwrap();
+            j.state = JobState::Preempted;
+            j.end_time = Some(chrono::Utc::now());
+        }
+        assert!(!cm.get_job(4).unwrap().state.is_terminal());
+        assert!(cm.get_job(4).unwrap().state.is_finalized());
 
         // A step on each of the terminal (1) and live (2) jobs: eviction must
         // drop the evicted job's step and keep the live one's.
@@ -6345,10 +6359,10 @@ mod tests {
         cm.steps.write().insert((1, 0), step(1));
         cm.steps.write().insert((2, 0), step(2));
 
-        // Apply removes only ids still terminal; live ids 2 and 3 are no-ops
+        // Apply removes only ids still finalized; live ids 2 and 3 are no-ops
         // even when named (a job requeued between propose and apply).
         cm.apply_operation(&WalOperation::EvictTerminalJobs {
-            job_ids: vec![1, 2, 3],
+            job_ids: vec![1, 2, 3, 4],
         });
         assert!(
             cm.get_job(1).is_none(),
@@ -6356,6 +6370,10 @@ mod tests {
         );
         assert!(cm.get_job(2).is_some(), "running job must be spared");
         assert!(cm.get_job(3).is_some(), "pending job must be spared");
+        assert!(
+            cm.get_job(4).is_none(),
+            "named finalized (Preempted) job must be evicted"
+        );
         assert!(
             cm.steps.read().get(&(1, 0)).is_none(),
             "evicted job's step must be removed"

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -3308,6 +3308,8 @@ impl ClusterManager {
     pub fn evict_expired_terminal_jobs(&self) {
         let retention = self.config().controller.terminal_job_retention_secs;
         let before = Utc::now() - chrono::Duration::seconds(retention as i64);
+        // is_finalized is load-bearing, not redundant: end_time survives a
+        // requeue, so a re-dispatched job's stale end_time alone would reap it.
         let job_ids: Vec<JobId> = self
             .jobs
             .read()
@@ -4866,6 +4868,8 @@ impl ClusterManager {
                 k0s.reset_requested = *reset_requested;
             }
             WalOperation::EvictTerminalJobs { job_ids } => {
+                // Re-check finalized: spare an id requeued between propose and
+                // apply. Deterministic — every replica applies in the same order.
                 let evicted: HashSet<JobId> = job_ids
                     .iter()
                     .filter(|id| jobs.get(id).is_some_and(|j| j.state.is_finalized()))
@@ -6384,8 +6388,8 @@ mod tests {
         );
     }
 
-    // The id list, not per-replica end_time, decides eviction: two replicas with
-    // divergent end_times must converge on the same set.
+    // Apply-time state, not per-replica end_time, decides eviction: a replica
+    // where the id requeued before apply spares it; skew never changes the set.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn evict_terminal_jobs_is_replica_deterministic() {
         let dir_a = TempDir::new().unwrap();
@@ -6404,7 +6408,8 @@ mod tests {
                 state: JobState::Cancelled,
             });
         }
-        // Force divergent local end_times across the two replicas.
+        // Divergent local end_times: skew must not change the outcome, since the
+        // apply guard reads state, not end_time.
         cm_a.jobs.write().get_mut(&1).unwrap().end_time =
             Some(chrono::Utc::now() - chrono::Duration::hours(2));
         cm_b.jobs.write().get_mut(&1).unwrap().end_time =
@@ -6413,12 +6418,29 @@ mod tests {
         let entry = WalOperation::EvictTerminalJobs { job_ids: vec![1] };
         cm_a.apply_operation(&entry);
         cm_b.apply_operation(&entry);
-
-        assert!(cm_a.get_job(1).is_none());
-        assert_eq!(
-            cm_a.get_job(1).is_none(),
+        assert!(cm_a.get_job(1).is_none(), "finalized id is evicted");
+        assert!(
             cm_b.get_job(1).is_none(),
-            "both replicas must evict the same set despite end_time skew"
+            "end_time skew must not change the evicted set",
+        );
+
+        // A replica where the id left the finalized set before apply spares it:
+        // the guard is what makes eviction converge with real state, not the id.
+        let dir_c = TempDir::new().unwrap();
+        let cm_c = test_cluster(&dir_c).await;
+        cm_c.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("requeued")),
+        });
+        cm_c.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
+        cm_c.apply_operation(&entry);
+        assert!(
+            cm_c.get_job(1).is_some(),
+            "an id no longer finalized at apply is spared",
         );
     }
 
@@ -6445,6 +6467,27 @@ mod tests {
         assert!(
             cm.get_job(1).is_none(),
             "with zero retention the terminal job is evicted"
+        );
+
+        // A large retention window spares a fresh terminal job: guards against a
+        // producer that proposes everything regardless of age.
+        let dir2 = TempDir::new().unwrap();
+        let mut cfg2 = test_config();
+        cfg2.controller.terminal_job_retention_secs = 86_400;
+        let cm2 = test_cluster_with_config(&dir2, cfg2).await;
+        cm2.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("fresh")),
+        });
+        cm2.apply_operation(&WalOperation::JobComplete {
+            job_id: 1,
+            exit_code: 0,
+            state: JobState::Cancelled,
+        });
+        cm2.evict_expired_terminal_jobs();
+        assert!(
+            cm2.get_job(1).is_some(),
+            "a fresh terminal job within the retention window is spared"
         );
     }
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -3308,15 +3308,17 @@ impl ClusterManager {
     pub fn evict_expired_terminal_jobs(&self) {
         let retention = self.config().controller.terminal_job_retention_secs;
         let before = Utc::now() - chrono::Duration::seconds(retention as i64);
-        let any = self
+        let job_ids: Vec<JobId> = self
             .jobs
             .read()
-            .values()
-            .any(|j| j.state.is_terminal() && j.end_time.is_some_and(|t| t < before));
-        if !any {
+            .iter()
+            .filter(|(_, j)| j.state.is_terminal() && j.end_time.is_some_and(|t| t < before))
+            .map(|(&id, _)| id)
+            .collect();
+        if job_ids.is_empty() {
             return;
         }
-        if let Err(e) = self.propose(WalOperation::EvictTerminalJobs { before }) {
+        if let Err(e) = self.propose(WalOperation::EvictTerminalJobs { job_ids }) {
             warn!(error = %e, "failed to evict expired terminal jobs");
         }
     }
@@ -4863,13 +4865,11 @@ impl ClusterManager {
                 }
                 k0s.reset_requested = *reset_requested;
             }
-            WalOperation::EvictTerminalJobs { before } => {
-                let evicted: HashSet<JobId> = jobs
+            WalOperation::EvictTerminalJobs { job_ids } => {
+                let evicted: HashSet<JobId> = job_ids
                     .iter()
-                    .filter(|(_, j)| {
-                        j.state.is_terminal() && j.end_time.is_some_and(|t| t < *before)
-                    })
-                    .map(|(&id, _)| id)
+                    .filter(|id| jobs.get(id).is_some_and(|j| j.state.is_terminal()))
+                    .copied()
                     .collect();
                 if !evicted.is_empty() {
                     jobs.retain(|id, _| !evicted.contains(id));
@@ -6345,20 +6345,15 @@ mod tests {
         cm.steps.write().insert((1, 0), step(1));
         cm.steps.write().insert((2, 0), step(2));
 
-        // A cutoff before the just-set end_time spares even the terminal job.
+        // Apply removes only ids still terminal; live ids 2 and 3 are no-ops
+        // even when named (a job requeued between propose and apply).
         cm.apply_operation(&WalOperation::EvictTerminalJobs {
-            before: chrono::Utc::now() - chrono::Duration::hours(1),
+            job_ids: vec![1, 2, 3],
         });
         assert!(
-            cm.get_job(1).is_some(),
-            "recent terminal job must be spared"
+            cm.get_job(1).is_none(),
+            "named terminal job must be evicted"
         );
-
-        // A cutoff after it evicts the terminal job only.
-        cm.apply_operation(&WalOperation::EvictTerminalJobs {
-            before: chrono::Utc::now() + chrono::Duration::seconds(1),
-        });
-        assert!(cm.get_job(1).is_none(), "aged terminal job must be evicted");
         assert!(cm.get_job(2).is_some(), "running job must be spared");
         assert!(cm.get_job(3).is_some(), "pending job must be spared");
         assert!(
@@ -6368,6 +6363,44 @@ mod tests {
         assert!(
             cm.steps.read().get(&(2, 0)).is_some(),
             "live job's step must be kept"
+        );
+    }
+
+    // The id list, not per-replica end_time, decides eviction: two replicas with
+    // divergent end_times must converge on the same set.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn evict_terminal_jobs_is_replica_deterministic() {
+        let dir_a = TempDir::new().unwrap();
+        let dir_b = TempDir::new().unwrap();
+        let cm_a = test_cluster(&dir_a).await;
+        let cm_b = test_cluster(&dir_b).await;
+
+        for cm in [&cm_a, &cm_b] {
+            cm.apply_operation(&WalOperation::JobSubmit {
+                job_id: 1,
+                spec: Box::new(basic_spec("done")),
+            });
+            cm.apply_operation(&WalOperation::JobComplete {
+                job_id: 1,
+                exit_code: 0,
+                state: JobState::Cancelled,
+            });
+        }
+        // Force divergent local end_times across the two replicas.
+        cm_a.jobs.write().get_mut(&1).unwrap().end_time =
+            Some(chrono::Utc::now() - chrono::Duration::hours(2));
+        cm_b.jobs.write().get_mut(&1).unwrap().end_time =
+            Some(chrono::Utc::now() + chrono::Duration::hours(2));
+
+        let entry = WalOperation::EvictTerminalJobs { job_ids: vec![1] };
+        cm_a.apply_operation(&entry);
+        cm_b.apply_operation(&entry);
+
+        assert!(cm_a.get_job(1).is_none());
+        assert_eq!(
+            cm_a.get_job(1).is_none(),
+            cm_b.get_job(1).is_none(),
+            "both replicas must evict the same set despite end_time skew"
         );
     }
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -3303,6 +3303,24 @@ impl ClusterManager {
         }
     }
 
+    /// Evict terminal jobs whose end_time is older than the retention window,
+    /// bounding controller memory. No-op when nothing has aged out.
+    pub fn evict_expired_terminal_jobs(&self) {
+        let retention = self.config().controller.terminal_job_retention_secs;
+        let before = Utc::now() - chrono::Duration::seconds(retention as i64);
+        let any = self
+            .jobs
+            .read()
+            .values()
+            .any(|j| j.state.is_terminal() && j.end_time.is_some_and(|t| t < before));
+        if !any {
+            return;
+        }
+        if let Err(e) = self.propose(WalOperation::EvictTerminalJobs { before }) {
+            warn!(error = %e, "failed to evict expired terminal jobs");
+        }
+    }
+
     /// Cancel running jobs whose reservation window has ended (after optional grace).
     pub fn enforce_reservation_end_times(&self) {
         let now = Utc::now();
@@ -4845,6 +4863,23 @@ impl ClusterManager {
                 }
                 k0s.reset_requested = *reset_requested;
             }
+            WalOperation::EvictTerminalJobs { before } => {
+                let evicted: Vec<JobId> = jobs
+                    .iter()
+                    .filter(|(_, j)| {
+                        j.state.is_terminal() && j.end_time.is_some_and(|t| t < *before)
+                    })
+                    .map(|(&id, _)| id)
+                    .collect();
+                if !evicted.is_empty() {
+                    for id in &evicted {
+                        jobs.remove(id);
+                    }
+                    self.steps
+                        .write()
+                        .retain(|_, s| !evicted.contains(&s.job_id));
+                }
+            }
         }
         self.next_job_id.store(next_id, Ordering::Relaxed);
         response
@@ -6259,6 +6294,56 @@ mod tests {
         let node = cm.get_node("node1").unwrap();
         assert_eq!(node.alloc_resources.cpus, 0);
         assert_eq!(node.alloc_resources.memory_mb, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn evict_terminal_jobs_drops_only_aged_terminal_jobs() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("done")),
+        });
+        cm.apply_operation(&WalOperation::JobComplete {
+            job_id: 1,
+            exit_code: 0,
+            state: JobState::Cancelled,
+        });
+        assert!(
+            cm.get_job(1).unwrap().state.is_terminal(),
+            "job 1 is terminal"
+        );
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 2,
+            spec: Box::new(basic_spec("running")),
+        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            2,
+            JobState::Pending,
+            JobState::Running,
+        ));
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 3,
+            spec: Box::new(basic_spec("pending")),
+        });
+
+        // A cutoff before the just-set end_time spares even the terminal job.
+        cm.apply_operation(&WalOperation::EvictTerminalJobs {
+            before: chrono::Utc::now() - chrono::Duration::hours(1),
+        });
+        assert!(
+            cm.get_job(1).is_some(),
+            "recent terminal job must be spared"
+        );
+
+        // A cutoff after it evicts the terminal job only.
+        cm.apply_operation(&WalOperation::EvictTerminalJobs {
+            before: chrono::Utc::now() + chrono::Duration::seconds(1),
+        });
+        assert!(cm.get_job(1).is_none(), "aged terminal job must be evicted");
+        assert!(cm.get_job(2).is_some(), "running job must be spared");
+        assert!(cm.get_job(3).is_some(), "pending job must be spared");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -3306,17 +3306,38 @@ impl ClusterManager {
     /// Evict finished jobs whose end_time is older than the retention window,
     /// bounding controller memory. No-op when nothing has aged out.
     pub fn evict_expired_terminal_jobs(&self) {
-        let retention = self.config().controller.terminal_job_retention_secs;
+        // Floor above the reconcile interval so a job survives at least one
+        // accounting reconcile pass before it can be evicted (retention 0 included).
+        let retention = self
+            .config()
+            .controller
+            .terminal_job_retention_secs
+            .max(crate::accounting::RECONCILE_INTERVAL_SECS);
         let before = Utc::now() - chrono::Duration::seconds(retention as i64);
+        let jobs = self.jobs.read();
+        // Spare a target still referenced by a live job's dependency: dropping it
+        // makes resolve_target_state return None, which cancels/early-releases dependents.
+        let mut referenced: HashSet<JobId> = HashSet::new();
+        for j in jobs.values().filter(|j| !j.state.is_finalized()) {
+            for dep in spur_core::dependency::parse_dependencies(&j.spec.dependency) {
+                if let Some(id) = dep.target_job_id() {
+                    referenced.insert(id);
+                }
+            }
+        }
         // is_finalized is load-bearing, not redundant: end_time survives a
         // requeue, so a re-dispatched job's stale end_time alone would reap it.
-        let job_ids: Vec<JobId> = self
-            .jobs
-            .read()
+        let job_ids: Vec<JobId> = jobs
             .iter()
-            .filter(|(_, j)| j.state.is_finalized() && j.end_time.is_some_and(|t| t < before))
+            .filter(|(id, j)| {
+                j.state.is_finalized()
+                    && j.end_time.is_some_and(|t| t < before)
+                    && !referenced.contains(id)
+                    && j.spec.array_job_id.is_none_or(|p| !referenced.contains(&p))
+            })
             .map(|(&id, _)| id)
             .collect();
+        drop(jobs);
         if job_ids.is_empty() {
             return;
         }
@@ -4919,6 +4940,10 @@ struct ClusterSnapshot {
     /// restored (see restore_from_snapshot).
     #[serde(default)]
     k0s: spur_core::k0s::K0sClusterState,
+    /// Job-id high-water mark. Eviction removes the high-id tail, so restoring
+    /// from survivors alone would reissue used ids; restore takes max(rebuilt, this).
+    #[serde(default)]
+    next_job_id: JobId,
 }
 
 impl ClusterManager {
@@ -4984,6 +5009,7 @@ impl StateMachineApply for ClusterManager {
             tokens: self.tokens.read().values().cloned().collect(),
             burst_buffer_total_gb: *self.burst_buffer_total_gb.read(),
             k0s: self.k0s.read().clone(),
+            next_job_id: self.next_job_id.load(Ordering::Relaxed),
         };
         serde_json::to_vec(&snap).map_err(Into::into)
     }
@@ -4991,7 +5017,9 @@ impl StateMachineApply for ClusterManager {
     fn restore_from_snapshot(&self, data: &[u8]) -> Result<(), anyhow::Error> {
         let snap = serde_json::from_slice::<ClusterSnapshot>(data)?;
 
-        let mut next_id = self.config().controller.first_job_id;
+        // Fold in the persisted high-water mark so evicting the high-id tail
+        // can't lower next_job_id and reissue used ids (absent → 0, harmless).
+        let mut next_id = self.config().controller.first_job_id.max(snap.next_job_id);
         let mut jobs = self.jobs.write();
         jobs.clear();
         for job in snap.jobs {
@@ -6446,29 +6474,6 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn evict_expired_terminal_jobs_honors_retention_window() {
-        let dir = TempDir::new().unwrap();
-        let mut cfg = test_config();
-        cfg.controller.terminal_job_retention_secs = 0;
-        let cm = test_cluster_with_config(&dir, cfg).await;
-
-        cm.apply_operation(&WalOperation::JobSubmit {
-            job_id: 1,
-            spec: Box::new(basic_spec("done")),
-        });
-        cm.apply_operation(&WalOperation::JobComplete {
-            job_id: 1,
-            exit_code: 0,
-            state: JobState::Cancelled,
-        });
-
-        // retention 0: end_time is already < now, so the producer proposes and
-        // the job is gone after one pass.
-        cm.evict_expired_terminal_jobs();
-        assert!(
-            cm.get_job(1).is_none(),
-            "with zero retention the terminal job is evicted"
-        );
-
         // A large retention window spares a fresh terminal job: guards against a
         // producer that proposes everything regardless of age.
         let dir2 = TempDir::new().unwrap();
@@ -6488,6 +6493,154 @@ mod tests {
         assert!(
             cm2.get_job(1).is_some(),
             "a fresh terminal job within the retention window is spared"
+        );
+
+        // An aged job (end_time well past the window) is evicted.
+        cm2.jobs.write().get_mut(&1).unwrap().end_time =
+            Some(chrono::Utc::now() - chrono::Duration::days(2));
+        cm2.evict_expired_terminal_jobs();
+        assert!(
+            cm2.get_job(1).is_none(),
+            "a terminal job older than the retention window is evicted"
+        );
+    }
+
+    // retention below the reconcile interval is floored so a job survives at
+    // least one reconcile pass, else its DB row strands as RUNNING in sacct.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn evict_floors_retention_to_reconcile_interval() {
+        let dir = TempDir::new().unwrap();
+        let mut cfg = test_config();
+        cfg.controller.terminal_job_retention_secs = 0;
+        let cm = test_cluster_with_config(&dir, cfg).await;
+
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("done")),
+        });
+        cm.apply_operation(&WalOperation::JobComplete {
+            job_id: 1,
+            exit_code: 0,
+            state: JobState::Cancelled,
+        });
+
+        // Just completed: within the floored window, so retention 0 does not
+        // evict on the next tick.
+        cm.evict_expired_terminal_jobs();
+        assert!(
+            cm.get_job(1).is_some(),
+            "retention 0 must be floored above the reconcile interval, not evict immediately"
+        );
+
+        // Older than the floor: now evictable.
+        cm.jobs.write().get_mut(&1).unwrap().end_time = Some(
+            chrono::Utc::now()
+                - chrono::Duration::seconds(crate::accounting::RECONCILE_INTERVAL_SECS as i64 + 1),
+        );
+        cm.evict_expired_terminal_jobs();
+        assert!(
+            cm.get_job(1).is_none(),
+            "a job past the floored window is evicted"
+        );
+    }
+
+    // A target referenced by a pending job's dependency must not be evicted:
+    // dropping it would cancel the afterok dependent before its trigger fires.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn evict_spares_jobs_referenced_by_pending_dependency() {
+        let dir = TempDir::new().unwrap();
+        let mut cfg = test_config();
+        cfg.controller.terminal_job_retention_secs = 0;
+        let cm = test_cluster_with_config(&dir, cfg).await;
+
+        // Target runs, completes, and ages out of the window.
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 100,
+            spec: Box::new(basic_spec("target")),
+        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            100,
+            JobState::Pending,
+            JobState::Running,
+        ));
+        cm.apply_operation(&WalOperation::JobComplete {
+            job_id: 100,
+            exit_code: 0,
+            state: JobState::Completed,
+        });
+        cm.jobs.write().get_mut(&100).unwrap().end_time =
+            Some(chrono::Utc::now() - chrono::Duration::days(1));
+
+        // Pending child depends on it (begin-time hold, not a scheduling hold).
+        let mut child = basic_spec("child");
+        child.dependency = vec!["afterok:100".into()];
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 101,
+            spec: Box::new(child),
+        });
+
+        cm.evict_expired_terminal_jobs();
+        assert!(
+            cm.get_job(100).is_some(),
+            "a target referenced by a pending afterok dependent must be spared"
+        );
+
+        // Once the child is gone, the target is evictable.
+        cm.apply_operation(&WalOperation::JobComplete {
+            job_id: 101,
+            exit_code: 0,
+            state: JobState::Cancelled,
+        });
+        cm.jobs.write().get_mut(&101).unwrap().end_time =
+            Some(chrono::Utc::now() - chrono::Duration::days(1));
+        cm.evict_expired_terminal_jobs();
+        assert!(
+            cm.get_job(100).is_none(),
+            "with no live dependent, the aged target is evicted"
+        );
+    }
+
+    // Eviction removes the high-id tail; a snapshot+restore must not lower
+    // next_job_id and reissue a used id (which would clobber the sacct row).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn snapshot_restore_preserves_next_job_id_after_eviction() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        // Allocate ids 1 and 2. id1 survives; the high-id tail (id2) completes
+        // and is evicted, so rebuild-from-survivors alone would yield id1+1.
+        let id1 = cm.next_job_id.fetch_add(1, Ordering::SeqCst);
+        let id2 = cm.next_job_id.fetch_add(1, Ordering::SeqCst);
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: id1,
+            spec: Box::new(basic_spec("survivor")),
+        });
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: id2,
+            spec: Box::new(basic_spec("high")),
+        });
+        cm.apply_operation(&WalOperation::JobComplete {
+            job_id: id2,
+            exit_code: 0,
+            state: JobState::Cancelled,
+        });
+        let next_before = cm.next_job_id.load(Ordering::Relaxed);
+        cm.apply_operation(&WalOperation::EvictTerminalJobs { job_ids: vec![id2] });
+        assert!(cm.get_job(id2).is_none(), "high-id job evicted");
+
+        // Snapshot AFTER eviction: id2's JobSubmit is compacted away, so the map
+        // no longer contains the high id.
+        let snap = cm.snapshot_state().unwrap();
+
+        // Restore into a fresh controller: surviving jobs alone would rebuild
+        // next_job_id below next_before, reissuing id2.
+        let dir2 = TempDir::new().unwrap();
+        let cm2 = test_cluster(&dir2).await;
+        cm2.restore_from_snapshot(&snap).unwrap();
+        assert!(
+            cm2.next_job_id.load(Ordering::Relaxed) >= next_before,
+            "next_job_id must not regress below {next_before} after evicting id {id2} (was {}), id {id1} survives",
+            cm2.next_job_id.load(Ordering::Relaxed)
         );
     }
 
@@ -15205,6 +15358,7 @@ mod tests {
             tokens: Vec::new(),
             burst_buffer_total_gb: 0,
             k0s: spur_core::k0s::K0sClusterState::default(),
+            next_job_id: 0,
         };
         let bytes = serde_json::to_vec(&snap).unwrap();
         cm.restore_from_snapshot(&bytes).unwrap();

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -202,7 +202,7 @@ async fn main() -> anyhow::Result<()> {
                         pool.clone(),
                         cluster.clone(),
                         raft_handle.clone(),
-                        std::time::Duration::from_secs(120),
+                        std::time::Duration::from_secs(accounting::RECONCILE_INTERVAL_SECS),
                     );
 
                     cluster.fairshare_cache().spawn_refresh_loop(

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -125,6 +125,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
         cluster.drive_bb_stage_in();
         cluster.purge_expired_reservations();
         cluster.enforce_reservation_end_times();
+        cluster.evict_expired_terminal_jobs();
 
         // Classify once, apply reasons, and stage only candidates admitted by
         // that classification. Run before the empty-check so reasons stay fresh


### PR DESCRIPTION
## What this fixes

Terminal jobs were retained in the controller's in-memory job map — and in every Raft snapshot — indefinitely. Controller state therefore grew without bound with the total number of jobs ever submitted. On a busy long-running cluster this drives the leader's memory up until it OOMs, and it inflates snapshots past the replication message limit, which in turn stalls Raft log compaction and makes state growth worse.

## Approach

A leader-only maintenance pass (alongside the existing reservation-purge passes in the scheduler loop) evicts finished jobs whose `end_time` is older than a configurable retention window. It does so through a new replicated WAL operation carrying the leader-resolved job ids, so every replica drops the same jobs from its in-memory map and from all subsequent snapshots. Because the snapshot is built from the in-memory map, bounding the map bounds the snapshot.

- New config knob `controller.terminal_job_retention_secs` (default 3600s), validated at load against a one-year upper bound so an out-of-range value cannot overflow the eviction cutoff and panic the controller.
- The eviction set is computed once on the leader and shipped in the WAL op; apply re-checks `is_finalized()` per id so a job requeued between propose and apply is spared. Every replica evicts an identical set — no state divergence from clock skew.
- `is_finalized()` jobs are evicted (terminal, plus a `Preempted` job stranded with an `end_time`); all active states are spared. A job's steps are dropped alongside it.

Accounting history lives in PostgreSQL and is unaffected — a finished job remains visible to `scontrol show job` for the retention window, then ages out of controller memory only (`sacct` history is permanent).

### Correctness guards

- **Dependencies:** a terminal job still referenced by a non-finalized job's dependency is spared, so eviction can't cancel an `afterok`/`afternotok`/`aftercorr` dependent (or early-release an `after`/`afterany` one) by making its target resolve to "unknown".
- **Job-id reuse:** `next_job_id` is persisted in the snapshot and restored as `max(rebuilt-from-survivors, persisted)`, so evicting the high-id tail can't lower the counter and reissue a used id after a snapshot+restart.
- **Accounting reconcile:** effective retention is floored to the accounting reconcile interval, so a job always survives at least one reconcile pass before eviction and can't be stranded as `RUNNING` in `sacct` (this also makes `retention = 0` safe).

## Trade-offs / notes

- The retention default (1 hour) is more generous than Slurm's `MinJobAge` (5 min) to keep post-run inspection convenient; operators can lower it to tighten the memory bound (floored to the reconcile interval).
- A Postgres outage longer than the retention window can still evict a job before its accounting row is durably correct — an operator trade-off, documented on the config field.
- Array-parent views are synthesized from surviving per-task jobs; once all tasks age out, the parent id returns nothing (same as any evicted job).

## Upgrade ordering

`EvictTerminalJobs` is a new WAL variant. Once a leader commits one, an older controller replaying the log can't deserialize it — so upgrade all controllers before this feature emits the op, and do not roll a controller back across this version once an `EvictTerminalJobs` entry has committed.

## Tests

- Apply-path test: an aged terminal job (and a stranded `Preempted` one) is evicted while a recent terminal job, a running job, and a pending job are spared; the evicted job's steps are removed while a live job's steps are kept; a named-but-live id is a no-op.
- Replica-determinism test: divergent per-replica `end_time`s do not change the evicted set (apply reads state, not `end_time`).
- Dependency-sparing test: a target referenced by a begin-held pending `afterok` child is spared until the child finalizes.
- Retention-floor test: `retention = 0` does not evict a just-completed job on the next tick; a job past the floored window is evicted.
- Snapshot-restore test: `next_job_id` does not regress after the high-id tail is evicted.
- Config validation rejects an out-of-range retention value.

## How it was tested

Validated end-to-end on an isolated single-node deployment: a completed job survived past its configured retention (proving the reconcile-interval floor), an unreferenced completed job was evicted once it aged out, and a completed job referenced by a begin-held pending dependent was spared while the dependent stayed `PENDING` (not cancelled). An out-of-range retention value was rejected cleanly at config load rather than panicking at runtime.