### PR TITLE
feat(spurctld): degrade k0s cluster on provisioning timeout

### DIFF
--- a/crates/spur-cli/src/k8s.rs
+++ b/crates/spur-cli/src/k8s.rs
@@ -247,10 +247,14 @@ async fn cmd_status(controller: &str) -> Result<()> {
         }
     }
     for n in resp.nodes {
-        println!(
+        print!(
             "  {:<24} {:<11} {:<11} enabled={}",
             n.node, n.role, n.component_state, n.enabled
         );
+        if !n.reason.is_empty() {
+            print!("  reason: {}", n.reason);
+        }
+        println!();
     }
     Ok(())
 }

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -737,6 +737,10 @@ pub struct ClusterConfig {
     /// large scratch disk if PVCs will hold much data — the default lives under `/var/lib` (root fs).
     #[serde(default = "default_local_path_dir")]
     pub local_path_dir: String,
+    /// Seconds a cluster may sit in `provisioning` before the reconcile loop marks it `degraded`
+    /// (surfacing which nodes failed). Covers the ~262 MB k0s download plus multi-node join.
+    #[serde(default = "default_provisioning_timeout_secs")]
+    pub provisioning_timeout_secs: u64,
 }
 
 fn default_cluster_distro() -> String {
@@ -769,6 +773,9 @@ fn default_storage_provisioner() -> String {
 fn default_local_path_dir() -> String {
     crate::k0s::DEFAULT_LOCAL_PATH_DIR.into()
 }
+fn default_provisioning_timeout_secs() -> u64 {
+    600
+}
 
 impl Default for ClusterConfig {
     fn default() -> Self {
@@ -785,6 +792,7 @@ impl Default for ClusterConfig {
             cni: default_cni(),
             storage_provisioner: default_storage_provisioner(),
             local_path_dir: default_local_path_dir(),
+            provisioning_timeout_secs: default_provisioning_timeout_secs(),
         }
     }
 }
@@ -1208,6 +1216,13 @@ impl SlurmConfig {
                     value: msg,
                 });
             }
+            if self.cluster.provisioning_timeout_secs == 0 {
+                return Err(ConfigError::InvalidValue {
+                    field: "cluster.provisioning_timeout_secs".into(),
+                    value: "0 (must be > 0; a cluster would degrade before any node could start)"
+                        .into(),
+                });
+            }
             // The mesh CIDR feeds the k0s IPAM (AddressPool) exactly like pod/service, so assert it is
             // a valid IPv4 CIDR in the same pass — otherwise a malformed wg_cidr bypasses validate()
             // and fails every reconcile tick in AddressPool::new, leaving the cluster silently stuck.
@@ -1517,6 +1532,11 @@ cni_mtu = 1400
             "cluster_name=\"t\"\n[cluster]\nenabled=true\ncontrol_plane_replicas=3\n"
         )
         .is_ok());
+        // A zero provisioning timeout would degrade before any node could start; rejected.
+        assert!(SlurmConfig::load_from_str(
+            "cluster_name=\"t\"\n[cluster]\nenabled=true\nprovisioning_timeout_secs=0\n"
+        )
+        .is_err());
         // Unknown storage provisioner is rejected; "none" and "local-path" are accepted.
         assert!(SlurmConfig::load_from_str(
             "cluster_name=\"t\"\n[cluster]\nenabled=true\nstorage_provisioner=\"nfs\"\n"

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -737,10 +737,11 @@ pub struct ClusterConfig {
     /// large scratch disk if PVCs will hold much data — the default lives under `/var/lib` (root fs).
     #[serde(default = "default_local_path_dir")]
     pub local_path_dir: String,
-    /// Seconds a cluster may sit in `provisioning` before the reconcile loop marks it `degraded`
-    /// (surfacing which nodes failed). Covers the ~262 MB k0s download plus multi-node join.
-    #[serde(default = "default_provisioning_timeout_secs")]
-    pub provisioning_timeout_secs: u64,
+    /// Seconds a k8s (k0s) node may stay non-`active` during provisioning before the reconcile
+    /// loop marks the cluster `degraded` (surfacing which nodes failed). Covers the ~262 MB k0s
+    /// download plus multi-node join.
+    #[serde(default = "default_k8s_provisioning_timeout_secs")]
+    pub k8s_provisioning_timeout_secs: u64,
 }
 
 fn default_cluster_distro() -> String {
@@ -773,7 +774,7 @@ fn default_storage_provisioner() -> String {
 fn default_local_path_dir() -> String {
     crate::k0s::DEFAULT_LOCAL_PATH_DIR.into()
 }
-fn default_provisioning_timeout_secs() -> u64 {
+fn default_k8s_provisioning_timeout_secs() -> u64 {
     600
 }
 
@@ -792,7 +793,7 @@ impl Default for ClusterConfig {
             cni: default_cni(),
             storage_provisioner: default_storage_provisioner(),
             local_path_dir: default_local_path_dir(),
-            provisioning_timeout_secs: default_provisioning_timeout_secs(),
+            k8s_provisioning_timeout_secs: default_k8s_provisioning_timeout_secs(),
         }
     }
 }
@@ -1216,9 +1217,9 @@ impl SlurmConfig {
                     value: msg,
                 });
             }
-            if self.cluster.provisioning_timeout_secs == 0 {
+            if self.cluster.k8s_provisioning_timeout_secs == 0 {
                 return Err(ConfigError::InvalidValue {
-                    field: "cluster.provisioning_timeout_secs".into(),
+                    field: "cluster.k8s_provisioning_timeout_secs".into(),
                     value: "0 (must be > 0; a cluster would degrade before any node could start)"
                         .into(),
                 });
@@ -1534,7 +1535,7 @@ cni_mtu = 1400
         .is_ok());
         // A zero provisioning timeout would degrade before any node could start; rejected.
         assert!(SlurmConfig::load_from_str(
-            "cluster_name=\"t\"\n[cluster]\nenabled=true\nprovisioning_timeout_secs=0\n"
+            "cluster_name=\"t\"\n[cluster]\nenabled=true\nk8s_provisioning_timeout_secs=0\n"
         )
         .is_err());
         // Unknown storage provisioner is rejected; "none" and "local-path" are accepted.

--- a/crates/spur-core/src/node.rs
+++ b/crates/spur-core/src/node.rs
@@ -326,6 +326,9 @@ pub struct Node {
     /// per-node pod /24 carved from the cluster pod_cidr.
     #[serde(default)]
     pub k0s_pod_cidr: Option<String>,
+    /// Why this node blocked convergence when the cluster went `degraded` (surfaced in status).
+    #[serde(default)]
+    pub k0s_last_error: Option<String>,
 }
 
 fn default_weight() -> u32 {
@@ -366,6 +369,7 @@ impl Node {
             k0s_role: None,
             k0s_mesh_ip: None,
             k0s_pod_cidr: None,
+            k0s_last_error: None,
         }
     }
 
@@ -432,6 +436,17 @@ mod tests {
         assert!(n.is_k0s_reserved());
         n.k0s_role = None;
         assert!(!n.is_k0s_reserved());
+    }
+
+    #[test]
+    fn a_node_snapshot_without_k0s_last_error_still_deserializes() {
+        // Pre-upgrade snapshots carry no k0s_last_error; replay must load it as absent
+        // rather than failing the whole restore.
+        let node = Node::new("n1".into(), ResourceSet::default());
+        let mut value = serde_json::to_value(&node).expect("serialize node");
+        value.as_object_mut().unwrap().remove("k0s_last_error");
+        let back: Node = serde_json::from_value(value).expect("deserialize node");
+        assert_eq!(back.k0s_last_error, None);
     }
 
     #[test]

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -282,6 +282,10 @@ pub enum WalOperation {
     EvictTerminalJobs {
         job_ids: Vec<JobId>,
     },
+    NodeK0sSetError {
+        name: String,
+        error: Option<String>,
+    },
 }
 
 impl WalOperation {
@@ -802,6 +806,20 @@ mod deregistration_wal_tests {
             serde_json::from_str(&serde_json::to_string(&op).unwrap()).unwrap();
         match back {
             WalOperation::NodeK0sClear { name } => assert_eq!(name, "gpu-node-1"),
+            _ => panic!("wrong variant"),
+        }
+
+        let op = WalOperation::NodeK0sSetError {
+            name: "gpu-node-1".into(),
+            error: Some("not active after 10m".into()),
+        };
+        let back: WalOperation =
+            serde_json::from_str(&serde_json::to_string(&op).unwrap()).unwrap();
+        match back {
+            WalOperation::NodeK0sSetError { name, error } => {
+                assert_eq!(name, "gpu-node-1");
+                assert_eq!(error.as_deref(), Some("not active after 10m"));
+            }
             _ => panic!("wrong variant"),
         }
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -2150,6 +2150,22 @@ impl ClusterManager {
         Ok(())
     }
 
+    /// Record (or clear, with `None`) why a node blocked k0s convergence, replicated via Raft so
+    /// `spur k8s status` can surface it. Errors on an unknown node.
+    pub fn set_node_k0s_error(&self, name: &str, error: Option<String>) -> anyhow::Result<()> {
+        {
+            let nodes = self.nodes.read();
+            if !nodes.contains_key(name) {
+                anyhow::bail!("node {name} not found");
+            }
+        }
+        self.propose(WalOperation::NodeK0sSetError {
+            name: name.to_string(),
+            error,
+        })?;
+        Ok(())
+    }
+
     /// set the cluster-wide k0s phase. A `None`/empty control-plane or `member_nodes` leaves the
     /// persisted value untouched; the `Down` phase clears the member scope + control-plane set.
     pub fn set_k0s_phase(
@@ -4927,6 +4943,12 @@ impl ClusterManager {
                     node.k0s_role = None;
                     node.k0s_mesh_ip = None;
                     node.k0s_pod_cidr = None;
+                    node.k0s_last_error = None;
+                }
+            }
+            WalOperation::NodeK0sSetError { name, error } => {
+                if let Some(node) = nodes.get_mut(name) {
+                    node.k0s_last_error = error.clone();
                 }
             }
             WalOperation::K0sSetPhase {
@@ -12724,6 +12746,7 @@ mod tests {
             cni_mtu: 1450,
             cni: "kuberouter".into(),
             control_plane_node: None,
+            provisioning_timeout: std::time::Duration::from_secs(600),
         };
         crate::cluster_k8s::provision_assignments(&cm, &net, &cm.k0s_state()).unwrap();
         wait_for("both assigned", || {
@@ -12789,14 +12812,105 @@ mod tests {
             cni_mtu: 1450,
             cni: "kuberouter".into(),
             control_plane_node: Some("node-a".into()),
+            provisioning_timeout: std::time::Duration::from_secs(600),
         };
         let mut tokens = std::collections::HashMap::new();
-        crate::cluster_k8s::reconcile_phase(&cm, &net, &cm.k0s_state(), &mut tokens).await;
+        crate::cluster_k8s::reconcile_phase(&cm, &net, &cm.k0s_state(), &mut tokens, false).await;
 
         wait_for("un-roled node assigned by a Ready-phase tick", || {
             cm.get_node("node-a").and_then(|n| n.k0s_role).is_some()
         });
         assert!(cm.get_node("node-a").and_then(|n| n.k0s_mesh_ip).is_some());
+    }
+
+    fn k0s_test_net() -> crate::cluster_k8s::ClusterNetworking {
+        crate::cluster_k8s::ClusterNetworking {
+            mesh_cidr: "10.44.0.0/16".into(),
+            pod_cidr: "10.42.0.0/16".into(),
+            service_cidr: "10.43.0.0/16".into(),
+            cni_mtu: 1450,
+            cni: "kuberouter".into(),
+            control_plane_node: None,
+            provisioning_timeout: std::time::Duration::from_secs(600),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn provisioning_timeout_degrades_records_reason_keeps_roles() {
+        use spur_core::k0s::K0sPhase;
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "node-a", 4, 8000);
+        wait_for("registered", || cm.get_node("node-a").is_some());
+        cm.set_k0s_phase(
+            K0sPhase::Provisioning,
+            Some("node-a".into()),
+            Vec::new(),
+            Vec::new(),
+            false,
+        )
+        .unwrap();
+        wait_for("phase provisioning", || {
+            cm.k0s_state().phase == K0sPhase::Provisioning
+        });
+
+        let net = k0s_test_net();
+        let mut tokens = std::collections::HashMap::new();
+        crate::cluster_k8s::reconcile_phase(&cm, &net, &cm.k0s_state(), &mut tokens, true).await;
+
+        wait_for("degraded", || cm.k0s_state().phase == K0sPhase::Degraded);
+        let node = cm.get_node("node-a").unwrap();
+        // The node kept its role (recoverable retry) and carries a surfaced reason.
+        assert!(node.k0s_role.is_some());
+        assert!(node.k0s_last_error.unwrap().contains("not active"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn provisioning_within_deadline_stays_provisioning() {
+        use spur_core::k0s::K0sPhase;
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "node-a", 4, 8000);
+        wait_for("registered", || cm.get_node("node-a").is_some());
+        cm.set_k0s_phase(
+            K0sPhase::Provisioning,
+            Some("node-a".into()),
+            Vec::new(),
+            Vec::new(),
+            false,
+        )
+        .unwrap();
+        wait_for("phase provisioning", || {
+            cm.k0s_state().phase == K0sPhase::Provisioning
+        });
+
+        let net = k0s_test_net();
+        let mut tokens = std::collections::HashMap::new();
+        crate::cluster_k8s::reconcile_phase(&cm, &net, &cm.k0s_state(), &mut tokens, false).await;
+
+        assert_eq!(cm.k0s_state().phase, K0sPhase::Provisioning);
+        assert!(cm.get_node("node-a").unwrap().k0s_last_error.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn set_node_k0s_error_records_and_clears() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "node-a", 4, 8000);
+        wait_for("registered", || cm.get_node("node-a").is_some());
+
+        cm.set_node_k0s_error("node-a", Some("boom".into()))
+            .unwrap();
+        wait_for("error recorded", || {
+            cm.get_node("node-a").and_then(|n| n.k0s_last_error) == Some("boom".into())
+        });
+
+        cm.set_node_k0s_error("node-a", None).unwrap();
+        wait_for("error cleared", || {
+            cm.get_node("node-a").unwrap().k0s_last_error.is_none()
+        });
+
+        assert!(cm.set_node_k0s_error("ghost", Some("x".into())).is_err());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -12817,6 +12931,7 @@ mod tests {
             cni_mtu: 1450,
             cni: "kuberouter".into(),
             control_plane_node: None,
+            provisioning_timeout: std::time::Duration::from_secs(600),
         };
         crate::cluster_k8s::provision_assignments(&cm, &net, &cm.k0s_state()).unwrap();
         wait_for("both nodes assigned k0s roles", || {
@@ -12868,6 +12983,7 @@ mod tests {
             cni_mtu: 1450,
             cni: "kuberouter".into(),
             control_plane_node: Some("node-a".into()),
+            provisioning_timeout: std::time::Duration::from_secs(600),
         };
         crate::cluster_k8s::provision_assignments(&cm, &net, &cm.k0s_state()).unwrap();
         wait_for("scoped nodes assigned", || {
@@ -12964,6 +13080,7 @@ mod tests {
             cni_mtu: 1450,
             cni: "kuberouter".into(),
             control_plane_node: None,
+            provisioning_timeout: std::time::Duration::from_secs(600),
         };
         crate::cluster_k8s::provision_assignments(&cm, &net, &cm.k0s_state()).unwrap();
         wait_for("all four assigned", || {
@@ -13028,6 +13145,7 @@ mod tests {
             cni_mtu: 1450,
             cni: "kuberouter".into(),
             control_plane_node: None,
+            provisioning_timeout: std::time::Duration::from_secs(600),
         };
         crate::cluster_k8s::provision_assignments(&cm, &net, &cm.k0s_state()).unwrap();
         wait_for("all assigned", || {

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -12,7 +12,7 @@
 use std::collections::{HashMap, HashSet};
 use std::net::Ipv4Addr;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::Context;
 use tracing::{info, warn};
@@ -49,6 +49,9 @@ pub struct ClusterNetworking {
     pub cni: String,
     /// Operator-pinned control-plane node (cluster.control_plane_node), if any.
     pub control_plane_node: Option<String>,
+    /// How long a cluster may stay `provisioning` before the loop marks it `degraded`
+    /// (cluster.provisioning_timeout_secs).
+    pub provisioning_timeout: Duration,
 }
 
 /// Leader-gated k0s reconcile loop. Spawned from `main.rs` when `[cluster].enabled`; it still
@@ -60,13 +63,24 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>, net: Clust
     // Cache of the join token minted per node (worker or secondary control-plane), so we mint once
     // (not every tick) while it joins — re-minting churns k0s server tokens and races the join.
     let mut join_tokens: HashMap<String, String> = HashMap::new();
+    // Leader-local provisioning clock: a leader-flip or restart resets it, so the timeout re-arms
+    // on the new leader rather than tripping instantly off a persisted start time.
+    let mut provisioning_since: Option<Instant> = None;
     loop {
         interval.tick().await;
         if !raft.is_leader() {
             last_mesh.clear(); // forget on leadership loss so a new term re-logs the membership
+            provisioning_since = None;
             continue; // only the leader reconciles
         }
         let state = cluster.k0s_state();
+
+        let timed_out = update_provisioning_clock(
+            state.phase,
+            &mut provisioning_since,
+            Instant::now(),
+            net.provisioning_timeout,
+        );
 
         // Mesh: derive the authoritative full-mesh membership (pubkey + mesh IP + pod /24) from
         // live inventory and push it to every meshed node's agent (ApplyMesh) so a native-routing
@@ -88,8 +102,24 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>, net: Clust
         }
         last_mesh = mesh.nodes.clone();
 
-        reconcile_phase(&cluster, &net, &state, &mut join_tokens).await;
+        reconcile_phase(&cluster, &net, &state, &mut join_tokens, timed_out).await;
     }
+}
+
+/// Advance the leader-local provisioning clock and report whether the deadline passed. Arms on the
+/// first Provisioning observation and resets on any other phase, so re-entry restarts the timer.
+fn update_provisioning_clock(
+    phase: K0sPhase,
+    since: &mut Option<Instant>,
+    now: Instant,
+    timeout: Duration,
+) -> bool {
+    if phase != K0sPhase::Provisioning {
+        *since = None;
+        return false;
+    }
+    let started = *since.get_or_insert(now);
+    now.saturating_duration_since(started) >= timeout
 }
 
 /// Run one reconcile tick for the current phase. Extracted from `run` so it is testable.
@@ -105,6 +135,7 @@ pub(crate) async fn reconcile_phase(
     net: &ClusterNetworking,
     state: &K0sClusterState,
     join_tokens: &mut HashMap<String, String>,
+    timed_out: bool,
 ) {
     match state.phase {
         K0sPhase::Ready | K0sPhase::Provisioning => {
@@ -113,6 +144,11 @@ pub(crate) async fn reconcile_phase(
                 return;
             }
             converge_provisioning(cluster, net, join_tokens).await;
+            // converge may have flipped us to Ready this tick; only degrade a still-provisioning
+            // cluster that has blown its deadline.
+            if timed_out && cluster.k0s_state().phase == K0sPhase::Provisioning {
+                degrade_stuck_cluster(cluster, net, join_tokens).await;
+            }
         }
         K0sPhase::Down => stop_all_components(cluster, state.reset_requested).await,
         K0sPhase::Degraded => warn!("k0s cluster degraded"),
@@ -440,6 +476,7 @@ pub fn node_statuses(cluster: &ClusterManager) -> Vec<ClusterNodeStatus> {
                 role: role_str(role),
                 component_state: "unknown".to_string(),
                 enabled: true,
+                reason: n.k0s_last_error.unwrap_or_default(),
             })
         })
         .collect()
@@ -653,6 +690,7 @@ async fn converge_provisioning(
         }
         if fetch_component_state(cluster, &node.name).await.as_deref() == Some("active") {
             bootstrap_active = true;
+            clear_node_error(cluster, node);
             continue;
         }
         all_active = false;
@@ -676,6 +714,7 @@ async fn converge_provisioning(
         }
         if fetch_component_state(cluster, &node.name).await.as_deref() == Some("active") {
             join_tokens.remove(&node.name); // joined — drop the cached token
+            clear_node_error(cluster, node);
             continue;
         }
         all_active = false;
@@ -720,6 +759,51 @@ async fn converge_provisioning(
             Ok(()) => info!("k0s cluster converged: all components active -> Ready"),
             Err(e) => warn!(error = %e, "failed to mark k0s cluster Ready"),
         }
+    }
+}
+
+/// Drop a node's stale degrade reason once it is healthy again, so status reports honestly on retry.
+/// Guarded so a converged cluster does not churn a WAL write per tick.
+fn clear_node_error(cluster: &ClusterManager, node: &spur_core::node::Node) {
+    if node.k0s_last_error.is_none() {
+        return;
+    }
+    if let Err(e) = cluster.set_node_k0s_error(&node.name, None) {
+        warn!(node = %node.name, error = %e, "failed to clear k0s node error");
+    }
+}
+
+/// Provisioning blew its deadline: record why each non-active node blocked convergence, stop its
+/// half-started unit (non-reset, keeping the role so `spur k8s up` can retry), then mark `degraded`.
+async fn degrade_stuck_cluster(
+    cluster: &ClusterManager,
+    net: &ClusterNetworking,
+    join_tokens: &mut HashMap<String, String>,
+) {
+    let timeout_secs = net.provisioning_timeout.as_secs();
+    for node in cluster.get_nodes() {
+        if node.k0s_role.is_none() {
+            continue;
+        }
+        let state = fetch_component_state(cluster, &node.name).await;
+        if state.as_deref() == Some("active") {
+            clear_node_error(cluster, &node);
+            continue;
+        }
+        let observed = state.as_deref().unwrap_or("unreachable");
+        let reason = format!("not active after {timeout_secs}s (component {observed})");
+        if let Err(e) = cluster.set_node_k0s_error(&node.name, Some(reason)) {
+            warn!(node = %node.name, error = %e, "failed to record k0s node error");
+        }
+        spawn_stop_component(cluster, &node.name, false);
+    }
+    join_tokens.clear();
+    match cluster.set_k0s_phase(K0sPhase::Degraded, None, Vec::new(), Vec::new(), false) {
+        Ok(()) => warn!(
+            timeout_secs,
+            "k0s provisioning timed out -> Degraded; see `spur k8s status` for per-node reasons"
+        ),
+        Err(e) => warn!(error = %e, "failed to mark k0s cluster Degraded"),
     }
 }
 
@@ -875,6 +959,7 @@ pub async fn live_node_statuses(cluster: &ClusterManager) -> Vec<ClusterNodeStat
             role: role_str(role),
             component_state,
             enabled,
+            reason: n.k0s_last_error.unwrap_or_default(),
         });
     }
     out
@@ -883,6 +968,57 @@ pub async fn live_node_statuses(cluster: &ClusterManager) -> Vec<ClusterNodeStat
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn provisioning_clock_arms_then_trips_at_deadline() {
+        let start = Instant::now();
+        let timeout = Duration::from_secs(600);
+        let mut since = None;
+        // First Provisioning observation arms the clock; not yet timed out.
+        assert!(!update_provisioning_clock(
+            K0sPhase::Provisioning,
+            &mut since,
+            start,
+            timeout
+        ));
+        assert!(since.is_some());
+        // Before the deadline: still false. At/after: true.
+        assert!(!update_provisioning_clock(
+            K0sPhase::Provisioning,
+            &mut since,
+            start + Duration::from_secs(599),
+            timeout
+        ));
+        assert!(update_provisioning_clock(
+            K0sPhase::Provisioning,
+            &mut since,
+            start + timeout,
+            timeout
+        ));
+    }
+
+    #[test]
+    fn provisioning_clock_resets_off_provisioning() {
+        let start = Instant::now();
+        let timeout = Duration::from_secs(600);
+        let mut since = Some(start);
+        // A non-Provisioning phase disarms the clock and never reports timed out.
+        assert!(!update_provisioning_clock(
+            K0sPhase::Ready,
+            &mut since,
+            start + timeout,
+            timeout
+        ));
+        assert!(since.is_none());
+        // Re-entering Provisioning re-arms from the new now, not the old start.
+        assert!(!update_provisioning_clock(
+            K0sPhase::Provisioning,
+            &mut since,
+            start + timeout,
+            timeout
+        ));
+        assert_eq!(since, Some(start + timeout));
+    }
 
     #[test]
     fn carve_pod_cidr_from_16() {

--- a/crates/spurctld/src/cluster_k8s.rs
+++ b/crates/spurctld/src/cluster_k8s.rs
@@ -49,8 +49,8 @@ pub struct ClusterNetworking {
     pub cni: String,
     /// Operator-pinned control-plane node (cluster.control_plane_node), if any.
     pub control_plane_node: Option<String>,
-    /// How long a cluster may stay `provisioning` before the loop marks it `degraded`
-    /// (cluster.provisioning_timeout_secs).
+    /// How long a k8s (k0s) node may stay non-`active` during provisioning before the loop
+    /// marks the cluster `degraded` (cluster.k8s_provisioning_timeout_secs).
     pub provisioning_timeout: Duration,
 }
 

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -261,7 +261,7 @@ async fn main() -> anyhow::Result<()> {
             cni: config.cluster.cni.clone(),
             control_plane_node: config.cluster.control_plane_node.clone(),
             provisioning_timeout: std::time::Duration::from_secs(
-                config.cluster.provisioning_timeout_secs,
+                config.cluster.k8s_provisioning_timeout_secs,
             ),
         };
         tokio::spawn(async move {

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -260,6 +260,9 @@ async fn main() -> anyhow::Result<()> {
             cni_mtu: config.cluster.cni_mtu,
             cni: config.cluster.cni.clone(),
             control_plane_node: config.cluster.control_plane_node.clone(),
+            provisioning_timeout: std::time::Duration::from_secs(
+                config.cluster.provisioning_timeout_secs,
+            ),
         };
         tokio::spawn(async move {
             cluster_k8s::run(k8s_cluster, k8s_raft, k8s_net).await;

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -880,6 +880,7 @@ message ClusterNodeStatus {
   string role = 2;             // "controller" | "worker" | "single"
   string component_state = 3;  // systemd active-state: "active" | "inactive" | "failed" | "unknown"
   bool enabled = 4;
+  string reason = 5;           // why this node blocked convergence when degraded; empty otherwise
 }
 
 message ClusterKubeconfigRequest {


### PR DESCRIPTION
## What

A k0s cluster whose node never reaches `active` (unreachable, slow, or a failed k0s download) pinned the whole cluster in `Provisioning` **indefinitely**. The `Degraded` phase existed but no code path ever set it, and `spur k8s status` showed `provisioning` forever with no indication of *why*.

This adds a provisioning timeout: past a configurable deadline, a still-provisioning cluster transitions to `Degraded` with a per-node reason surfaced in `spur k8s status`.

Scopes the **provisioning-timeout → Degraded + cleanup** slice of the gap analysis. Partial-Ready tolerance and online node add/remove are left for follow-ups.

## Approach

- The leader-gated reconcile loop tracks how long the cluster has been `Provisioning` via a leader-local clock. Past `cluster.provisioning_timeout_secs` (default 600), `degrade_stuck_cluster` runs.
- On timeout it records why each non-active node blocked convergence, stops that node's half-started unit **without** `k0s reset` (on-disk state is preserved for diagnosis) while **keeping the role assignment** so `spur k8s up` can retry without re-electing, then marks the cluster `Degraded`.
- The per-node reason is persisted (`Node.k0s_last_error`) via a new append-only WAL op and surfaced through `ClusterNodeStatus.reason` in `spur k8s status`.
- A node's reason is cleared once it reaches `active`, so a subsequent retry reports honestly.

## Key design choices / trade-offs

- **Leader-local timeout clock (not persisted).** A failover or controller restart re-arms the deadline from zero on the new leader rather than tripping instantly off a persisted start time. Trade-off: a cluster mid-provision when leadership flips gets a fresh window.
- **Degraded keeps roles.** A degraded node is intentionally held (role assigned, unit stopped) so a retry can reuse the assignment — it does **not** auto-return to batch scheduling. Recovery is operator-driven (`spur k8s up` to retry, or `spur k8s down` to release). This mirrors the recoverable intent of `Degraded`; the deliberately non-destructive default.
- **Timeout can fire mid-download.** The k0s install/download happens inside the provisioning window, so on very slow links a legitimate bring-up could exceed the deadline. The default (600s) covers the documented download plus join; operators on slow links should raise `provisioning_timeout_secs`. A `0` value is rejected at config validation (it would degrade before any node could start).

## Review fixes applied

A review pass surfaced and this PR fixes: a stale per-node reason that would persist on a recovered cluster (now cleared when a node reaches `active`), a missing config floor allowing `provisioning_timeout_secs = 0`, and a comment/behavior mismatch on the new setter. The provisioning-clock logic was also extracted into a pure, unit-tested helper.

## Testing

- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked` — no warnings; `cargo fmt --all --check` clean.
- Unit tests through the real entry points: timeout → `Degraded` with reason + kept roles; within-deadline stays `Provisioning`; the clock helper arms/trips/resets; the reason setter records/clears/errors-on-unknown-node; a frozen old-payload deser test for the new `Node` field; WAL round-trip for the new op. Each behavioral test was confirmed to fail against the unfixed code.
- Validated on an isolated single-controller deployment on a non-production port: `spurctld` boots with `[cluster]` enabled and the new field, `spur k8s status` renders, and a `0` timeout is rejected at startup. The full real-k0s stuck-node bring-up is left to CI / manual validation.