### PR TITLE
feat(spur-cli)!: restrict reservation mgmt to root and sudo/wheel users

### DIFF
--- a/crates/spur-cli/src/main.rs
+++ b/crates/spur-cli/src/main.rs
@@ -13,6 +13,7 @@ mod mock_controller;
 mod net;
 mod node;
 mod nodelist;
+mod privilege;
 mod sacct;
 mod sacctmgr;
 mod salloc;

--- a/crates/spur-cli/src/privilege.rs
+++ b/crates/spur-cli/src/privilege.rs
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Local privilege gate for administrative CLI actions.
+//!
+//! This is a client-side guardrail, not a security boundary: the controller
+//! does not authenticate callers, so it only stops ordinary users from running
+//! privileged commands through the CLI. Real enforcement belongs server-side
+//! behind an authenticated identity (future RBAC work).
+
+use anyhow::{bail, Context, Result};
+
+/// Unix groups whose members are treated as privileged, covering the
+/// Debian/Ubuntu (`sudo`) and RHEL/CentOS (`wheel`) conventions.
+const PRIVILEGED_GROUPS: &[&str] = &["sudo", "wheel"];
+
+/// Pure decision core, split from the syscalls so it is unit-testable.
+fn is_privileged(euid: u32, caller_groups: &[String], privileged_groups: &[&str]) -> bool {
+    euid == 0
+        || caller_groups
+            .iter()
+            .any(|g| privileged_groups.contains(&g.as_str()))
+}
+
+/// Resolve the invoking process's group names (supplementary groups plus the
+/// effective gid). Returns `Err` on any lookup failure so callers fail closed.
+fn caller_group_names() -> Result<Vec<String>> {
+    use nix::unistd::{getegid, getgroups, Group};
+
+    let mut gids = getgroups().context("failed to read process groups")?;
+    gids.push(getegid());
+
+    let mut names = Vec::new();
+    for gid in gids {
+        // A gid without a matching group entry cannot be privileged; skip it.
+        if let Some(group) = Group::from_gid(gid).context("failed to resolve group name")? {
+            names.push(group.name);
+        }
+    }
+    Ok(names)
+}
+
+/// Gate a privileged CLI action. Fails closed: any identity/group lookup error
+/// denies the action rather than allowing it.
+pub fn require_privileged(action: &str) -> Result<()> {
+    let euid = nix::unistd::geteuid().as_raw();
+    // Root is always privileged; short-circuit so a group-lookup failure can
+    // never deny root.
+    if euid == 0 {
+        return Ok(());
+    }
+    let groups = caller_group_names()?;
+    if is_privileged(euid, &groups, PRIVILEGED_GROUPS) {
+        return Ok(());
+    }
+    bail!(
+        "insufficient privileges to {action}: requires root or membership in the 'sudo' or 'wheel' group"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PRIV: &[&str] = &["sudo", "wheel"];
+
+    #[test]
+    fn root_is_privileged_regardless_of_groups() {
+        assert!(is_privileged(0, &[], PRIV));
+    }
+
+    #[test]
+    fn sudo_member_is_privileged() {
+        assert!(is_privileged(1000, &["users".into(), "sudo".into()], PRIV));
+    }
+
+    #[test]
+    fn wheel_member_is_privileged() {
+        assert!(is_privileged(1000, &["wheel".into()], PRIV));
+    }
+
+    #[test]
+    fn plain_user_is_denied() {
+        assert!(!is_privileged(
+            1000,
+            &["users".into(), "docker".into()],
+            PRIV
+        ));
+    }
+
+    #[test]
+    fn empty_groups_are_denied() {
+        // Simulates a lookup that resolved no privileged groups.
+        assert!(!is_privileged(1000, &[], PRIV));
+    }
+}

--- a/crates/spur-cli/src/privilege.rs
+++ b/crates/spur-cli/src/privilege.rs
@@ -1,12 +1,10 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Local privilege gate for administrative CLI actions.
-//!
-//! This is a client-side guardrail, not a security boundary: the controller
-//! does not authenticate callers, so it only stops ordinary users from running
-//! privileged commands through the CLI. Real enforcement belongs server-side
-//! behind an authenticated identity (future RBAC work).
+//! Client-side privilege gate for privileged CLI actions; not a security
+//! boundary (the controller doesn't authenticate callers — real enforcement is
+//! future server-side RBAC). Allows root or `sudo`/`wheel` membership, not
+//! proof the caller actually elevated via `sudo`.
 
 use anyhow::{bail, Context, Result};
 

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -510,6 +510,8 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             add_accounts,
             remove_accounts,
         } => {
+            crate::privilege::require_privileged("manage reservations")?;
+
             let channel = spur_client::connect_channel(&args.controller)
                 .await
                 .context("failed to connect to spurctld")?;
@@ -1486,6 +1488,8 @@ async fn create_reservation(
     users: &str,
     flags: &str,
 ) -> Result<()> {
+    crate::privilege::require_privileged("manage reservations")?;
+
     let channel = spur_client::connect_channel(controller)
         .await
         .context("failed to connect to spurctld")?;
@@ -1532,6 +1536,8 @@ async fn create_reservation(
 
 /// Delete a reservation via the controller.
 async fn delete_reservation(controller: &str, name: &str) -> Result<()> {
+    crate::privilege::require_privileged("manage reservations")?;
+
     let channel = spur_client::connect_channel(controller)
         .await
         .context("failed to connect to spurctld")?;

--- a/tests/native_host/e2e/test_reservations.py
+++ b/tests/native_host/e2e/test_reservations.py
@@ -263,12 +263,10 @@ class TestReservations:
 
     def test_reservation_management_requires_privileged_user(self, cluster):
         """Reservation create/update/delete via the CLI is restricted to root or
-        members of the 'sudo'/'wheel' group. An unprivileged caller is denied
-        locally before any RPC is sent. Uses the always-present, deterministically
-        unprivileged 'nobody' account so no user provisioning is required."""
-        # Probe the exact identity under test: `show` is unguarded, so running
-        # it as `nobody` verifies both that `sudo -u nobody` is permitted and
-        # that `nobody` can exec the binary. Skip (not fail) if it cannot.
+        sudo/wheel members. Uses the always-present unprivileged 'nobody'
+        account, so no user provisioning is needed."""
+        # Probe as `nobody` (show is unguarded): confirms sudo -u and binary exec
+        # work for that account; skip rather than fail if not.
         probe = cluster.cli_as_user("nobody", ["scontrol", "show", "reservation"])
         low = probe.lower()
         if (
@@ -281,7 +279,10 @@ class TestReservations:
 
         denied_msg = "requires root or membership"
 
-        # Unprivileged create is denied.
+        # The read path must stay open to everyone (not accidentally gated).
+        assert denied_msg not in low, f"show reservation should be readable by all: {probe}"
+
+        # Unprivileged create is denied (explicit subcommand).
         create_denied = cluster.cli_as_user(
             "nobody",
             [
@@ -294,6 +295,21 @@ class TestReservations:
             ],
         )
         assert denied_msg in create_denied.lower(), f"unexpected: {create_denied}"
+        assert res_name not in cluster.scontrol("show", "reservation")
+
+        # Unprivileged create is denied via the Slurm-inline syntax too.
+        inline_denied = cluster.cli_as_user(
+            "nobody",
+            [
+                "scontrol",
+                "create",
+                f"ReservationName={res_name}",
+                "StartTime=now",
+                "Duration=60",
+                f"Nodes={node}",
+            ],
+        )
+        assert denied_msg in inline_denied.lower(), f"unexpected: {inline_denied}"
         assert res_name not in cluster.scontrol("show", "reservation")
 
         try:
@@ -325,6 +341,13 @@ class TestReservations:
             assert denied_msg in del_denied.lower(), f"unexpected: {del_denied}"
             assert res_name in cluster.scontrol("show", "reservation")
 
+            # Unprivileged delete via the Slurm-inline syntax is denied too.
+            inline_del_denied = cluster.cli_as_user(
+                "nobody", ["scontrol", "delete", f"ReservationName={res_name}"]
+            )
+            assert denied_msg in inline_del_denied.lower(), f"unexpected: {inline_del_denied}"
+            assert res_name in cluster.scontrol("show", "reservation")
+
             # Privileged (root) delete succeeds.
             del_ok = cluster.cli_as_user(
                 "root", ["scontrol", "delete-reservation", res_name]
@@ -332,8 +355,7 @@ class TestReservations:
             assert "deleted" in del_ok.lower(), f"privileged delete failed: {del_ok}"
             assert res_name not in cluster.scontrol("show", "reservation")
         finally:
-            # A leaked reservation fences a node for an hour; clean up on any
-            # mid-test failure (harmless no-op once already deleted).
+            # A leaked reservation fences a node for an hour; best-effort cleanup.
             cluster.cli_as_user("root", ["scontrol", "delete-reservation", res_name])
 
     def test_non_owner_cannot_delete_or_update_reservation(self, cluster):
@@ -352,15 +374,9 @@ class TestReservations:
         ):
             pytest.skip(f"sudo -u unavailable in this environment: {probe.strip()}")
 
-        # The non-owner must be privileged enough to clear the client-side
-        # reservation gate (root or sudo/wheel), or its delete/update is denied
-        # locally before the server ownership check this test targets.
-        groups = set(cluster.nodes[0].exec_allow_fail(f"id -nG {submit_user}").split())
-        if not groups & {"sudo", "wheel"}:
-            pytest.skip(
-                f"non-owner '{submit_user}' is not in sudo/wheel, so the CLI "
-                "privilege gate blocks it before the server ownership check"
-            )
+        # A non-owner is denied by the server ownership check or, if unprivileged,
+        # by the client gate first. Accept both so this never silently skips.
+        denied = ("cannot delete", "cannot modify", "permission", "requires root or membership")
 
         res_name = f"res-owner-{int(time.time())}"
         node = cluster.node_names[0]
@@ -389,7 +405,7 @@ class TestReservations:
             submit_user, ["scontrol", "delete-reservation", res_name]
         )
         assert "deleted" not in del_denied.lower(), f"unexpected delete: {del_denied}"
-        assert "cannot delete" in del_denied.lower() or "permission" in del_denied.lower()
+        assert any(m in del_denied.lower() for m in denied), f"unexpected: {del_denied}"
         assert res_name in cluster.scontrol("show", "reservation")
 
         # Non-owner update must be rejected too.
@@ -397,7 +413,7 @@ class TestReservations:
             submit_user,
             ["scontrol", "update-reservation", f"--name={res_name}", "--duration=120"],
         )
-        assert "cannot modify" in upd_denied.lower() or "permission" in upd_denied.lower()
+        assert any(m in upd_denied.lower() for m in denied), f"unexpected: {upd_denied}"
         assert res_name in cluster.scontrol("show", "reservation")
 
         # Owner (root) can still delete.

--- a/tests/native_host/e2e/test_reservations.py
+++ b/tests/native_host/e2e/test_reservations.py
@@ -14,13 +14,17 @@ class TestReservations:
     def test_create_list_and_delete_reservation(self, cluster):
         res_name = f"res-e2e-{int(time.time())}"
         node = cluster.node_names[0]
-        create_out = cluster.scontrol(
-            "create-reservation",
-            f"--name={res_name}",
-            "--start-time=now",
-            "--duration=60",
-            f"--nodes={node}",
-            "--users=testuser",
+        create_out = cluster.cli_as_user(
+            "root",
+            [
+                "scontrol",
+                "create-reservation",
+                f"--name={res_name}",
+                "--start-time=now",
+                "--duration=60",
+                f"--nodes={node}",
+                "--users=testuser",
+            ],
         )
         assert "created" in create_out.lower()
 
@@ -37,14 +41,19 @@ class TestReservations:
         else:
             other_node = node
             overlap_flags = ["--flags=overlap"]
-        cluster.scontrol(
-            "create-reservation",
-            f"--name={other_name}",
-            "--start-time=now",
-            "--duration=60",
-            f"--nodes={other_node}",
-            *overlap_flags,
+        other_out = cluster.cli_as_user(
+            "root",
+            [
+                "scontrol",
+                "create-reservation",
+                f"--name={other_name}",
+                "--start-time=now",
+                "--duration=60",
+                f"--nodes={other_node}",
+                *overlap_flags,
+            ],
         )
+        assert "created" in other_out.lower()
 
         filtered = cluster.scontrol("show", "reservation", res_name)
         assert res_name in filtered
@@ -57,9 +66,11 @@ class TestReservations:
         assert code != 0
         assert "not found" in out.lower()
 
-        cluster.scontrol("delete-reservation", other_name)
+        cluster.cli_as_user("root", ["scontrol", "delete-reservation", other_name])
 
-        delete_out = cluster.scontrol("delete-reservation", res_name)
+        delete_out = cluster.cli_as_user(
+            "root", ["scontrol", "delete-reservation", res_name]
+        )
         assert "deleted" in delete_out.lower()
 
         show_after = cluster.scontrol("show", "reservation")
@@ -68,14 +79,19 @@ class TestReservations:
     def test_unauthorized_job_blocked_on_reserved_node(self, cluster):
         res_name = f"res-block-{int(time.time())}"
         node = cluster.node_names[0]
-        cluster.scontrol(
-            "create-reservation",
-            f"--name={res_name}",
-            "--start-time=now",
-            "--duration=30",
-            f"--nodes={node}",
-            "--users=resuser",
+        create_out = cluster.cli_as_user(
+            "root",
+            [
+                "scontrol",
+                "create-reservation",
+                f"--name={res_name}",
+                "--start-time=now",
+                "--duration=30",
+                f"--nodes={node}",
+                "--users=resuser",
+            ],
         )
+        assert "created" in create_out.lower()
 
         script = cluster.write_file("res-block.sh", "#!/bin/bash\nsleep 120\n")
         sb = cluster.sbatch(["-N", "1", "-w", node, "-t", "1", script])
@@ -88,14 +104,19 @@ class TestReservations:
         res_name = f"res-auth-{int(time.time())}"
         node = cluster.node_names[0]
         submit_user = cluster.nodes[0].user
-        cluster.scontrol(
-            "create-reservation",
-            f"--name={res_name}",
-            "--start-time=now",
-            "--duration=30",
-            f"--nodes={node}",
-            f"--users={submit_user}",
+        create_out = cluster.cli_as_user(
+            "root",
+            [
+                "scontrol",
+                "create-reservation",
+                f"--name={res_name}",
+                "--start-time=now",
+                "--duration=30",
+                f"--nodes={node}",
+                f"--users={submit_user}",
+            ],
         )
+        assert "created" in create_out.lower()
 
         script = cluster.write_file("res-auth.sh", "#!/bin/bash\necho RES_OK\n")
         out_path = f"{cluster.remote_dir}/res-auth.out"
@@ -125,14 +146,19 @@ class TestReservations:
     def test_hold_on_delete_and_release(self, cluster):
         res_name = f"res-hold-{int(time.time())}"
         node = cluster.node_names[0]
-        cluster.scontrol(
-            "create-reservation",
-            f"--name={res_name}",
-            "--start-time=now",
-            "--duration=60",
-            f"--nodes={node}",
-            "--users=testuser",
+        create_out = cluster.cli_as_user(
+            "root",
+            [
+                "scontrol",
+                "create-reservation",
+                f"--name={res_name}",
+                "--start-time=now",
+                "--duration=60",
+                f"--nodes={node}",
+                "--users=testuser",
+            ],
         )
+        assert "created" in create_out.lower()
 
         script = cluster.write_file("res-hold.sh", "#!/bin/bash\necho HOLD_RELEASE_OK\n")
         out_path = f"{cluster.remote_dir}/res-hold.out"
@@ -154,7 +180,7 @@ class TestReservations:
         assert job_id is not None
         wait_job_state(cluster, job_id, "PD", timeout=30)
 
-        cluster.scontrol("delete-reservation", res_name)
+        cluster.cli_as_user("root", ["scontrol", "delete-reservation", res_name])
 
         wait_job_state(cluster, job_id, "PD", timeout=30)
         held = cluster.squeue(["-j", str(job_id), "-o", "%t %r"])
@@ -171,15 +197,20 @@ class TestReservations:
     def test_no_hold_jobs_delete(self, cluster):
         res_name = f"res-nohold-{int(time.time())}"
         node = cluster.node_names[0]
-        cluster.scontrol(
-            "create-reservation",
-            f"--name={res_name}",
-            "--start-time=now",
-            "--duration=60",
-            f"--nodes={node}",
-            "--users=testuser",
-            "--flags=no_hold_jobs",
+        create_out = cluster.cli_as_user(
+            "root",
+            [
+                "scontrol",
+                "create-reservation",
+                f"--name={res_name}",
+                "--start-time=now",
+                "--duration=60",
+                f"--nodes={node}",
+                "--users=testuser",
+                "--flags=no_hold_jobs",
+            ],
         )
+        assert "created" in create_out.lower()
 
         script = cluster.write_file("res-nohold.sh", "#!/bin/bash\nsleep 120\n")
         sb = cluster.sbatch(
@@ -198,7 +229,7 @@ class TestReservations:
         assert job_id is not None
         wait_job_state(cluster, job_id, "PD", timeout=30)
 
-        cluster.scontrol("delete-reservation", res_name)
+        cluster.cli_as_user("root", ["scontrol", "delete-reservation", res_name])
 
         wait_job_state(cluster, job_id, "PD", timeout=30)
         show = cluster.squeue(["-j", str(job_id), "-o", "%t %r %v"])
@@ -216,7 +247,8 @@ class TestReservations:
         wait_job_state(cluster, job_id, "R", timeout=30)
 
         res_name = f"res-busy-{int(time.time())}"
-        out = cluster.cli_allow_fail(
+        out = cluster.cli_as_user(
+            "root",
             [
                 "scontrol",
                 "create-reservation",
@@ -224,10 +256,85 @@ class TestReservations:
                 "--start-time=now",
                 "--duration=10",
                 f"--nodes={node}",
-            ]
+            ],
         )
         msg = out.lower()
         assert "busy" in msg or "until after reservation start" in msg, f"unexpected: {out}"
+
+    def test_reservation_management_requires_privileged_user(self, cluster):
+        """Reservation create/update/delete via the CLI is restricted to root or
+        members of the 'sudo'/'wheel' group. An unprivileged caller is denied
+        locally before any RPC is sent. Uses the always-present, deterministically
+        unprivileged 'nobody' account so no user provisioning is required."""
+        # Probe the exact identity under test: `show` is unguarded, so running
+        # it as `nobody` verifies both that `sudo -u nobody` is permitted and
+        # that `nobody` can exec the binary. Skip (not fail) if it cannot.
+        probe = cluster.cli_as_user("nobody", ["scontrol", "show", "reservation"])
+        low = probe.lower()
+        if (
+            "sudo" in low and ("password" in low or "not allowed" in low)
+        ) or "permission denied" in low:
+            pytest.skip(f"cannot run CLI as 'nobody' in this environment: {probe.strip()}")
+
+        res_name = f"res-priv-{int(time.time())}"
+        node = cluster.node_names[0]
+
+        denied_msg = "requires root or membership"
+
+        # Unprivileged create is denied.
+        create_denied = cluster.cli_as_user(
+            "nobody",
+            [
+                "scontrol",
+                "create-reservation",
+                f"--name={res_name}",
+                "--start-time=now",
+                "--duration=60",
+                f"--nodes={node}",
+            ],
+        )
+        assert denied_msg in create_denied.lower(), f"unexpected: {create_denied}"
+        assert res_name not in cluster.scontrol("show", "reservation")
+
+        try:
+            # Privileged (root) create succeeds.
+            create_ok = cluster.cli_as_user(
+                "root",
+                [
+                    "scontrol",
+                    "create-reservation",
+                    f"--name={res_name}",
+                    "--start-time=now",
+                    "--duration=60",
+                    f"--nodes={node}",
+                ],
+            )
+            assert "created" in create_ok.lower(), f"create failed: {create_ok}"
+            assert res_name in cluster.scontrol("show", "reservation")
+
+            # Unprivileged update and delete are denied.
+            upd_denied = cluster.cli_as_user(
+                "nobody",
+                ["scontrol", "update-reservation", f"--name={res_name}", "--duration=120"],
+            )
+            assert denied_msg in upd_denied.lower(), f"unexpected: {upd_denied}"
+
+            del_denied = cluster.cli_as_user(
+                "nobody", ["scontrol", "delete-reservation", res_name]
+            )
+            assert denied_msg in del_denied.lower(), f"unexpected: {del_denied}"
+            assert res_name in cluster.scontrol("show", "reservation")
+
+            # Privileged (root) delete succeeds.
+            del_ok = cluster.cli_as_user(
+                "root", ["scontrol", "delete-reservation", res_name]
+            )
+            assert "deleted" in del_ok.lower(), f"privileged delete failed: {del_ok}"
+            assert res_name not in cluster.scontrol("show", "reservation")
+        finally:
+            # A leaked reservation fences a node for an hour; clean up on any
+            # mid-test failure (harmless no-op once already deleted).
+            cluster.cli_as_user("root", ["scontrol", "delete-reservation", res_name])
 
     def test_non_owner_cannot_delete_or_update_reservation(self, cluster):
         """A reservation is owned by its creator; a different user must not be
@@ -244,6 +351,16 @@ class TestReservations:
             "password" in probe.lower() or "not allowed" in probe.lower()
         ):
             pytest.skip(f"sudo -u unavailable in this environment: {probe.strip()}")
+
+        # The non-owner must be privileged enough to clear the client-side
+        # reservation gate (root or sudo/wheel), or its delete/update is denied
+        # locally before the server ownership check this test targets.
+        groups = set(cluster.nodes[0].exec_allow_fail(f"id -nG {submit_user}").split())
+        if not groups & {"sudo", "wheel"}:
+            pytest.skip(
+                f"non-owner '{submit_user}' is not in sudo/wheel, so the CLI "
+                "privilege gate blocks it before the server ownership check"
+            )
 
         res_name = f"res-owner-{int(time.time())}"
         node = cluster.node_names[0]


### PR DESCRIPTION
Reservation create/update/delete via scontrol previously succeeded for any user. Gate these commands behind a local privilege check: allow only effective root (euid 0) or members of the 'sudo'/'wheel' group, denying everyone else before any RPC is sent. Covers both the explicit subcommands and the Slurm-inline "create/delete ReservationName=" paths; "show reservation" stays open. The check fails closed if local identity cannot be resolved.

This is a client-side guardrail, not a security boundary: the controller does not authenticate callers, so server-side enforcement behind an authenticated identity remains the RBAC follow-up.

BREAKING CHANGE: non-privileged users can no longer manage reservations via the CLI; scripts relying on the old permissive behavior will fail.

Tested with cargo clippy (workspace, no warnings), cargo test (all pass, including new privilege unit tests), and new e2e coverage in test_reservations.py exercising the root-allowed / nobody-denied paths.