### PR TITLE
fix(spurctld): return unavailable when accounting startup fails

### DIFF
--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -55,19 +55,35 @@ fn fairshare_to_i32(v: f64) -> Result<i32, Status> {
     Ok(v as i32)
 }
 
-pub(crate) struct AccountingService {
-    pool: PgPool,
+pub(crate) enum AccountingService {
+    Available(PgPool),
+    Unavailable { reason: &'static str },
 }
 
 impl AccountingService {
-    pub(super) fn new(pool: PgPool) -> Self {
-        Self { pool }
+    pub(crate) fn available(pool: PgPool) -> Self {
+        Self::Available(pool)
+    }
+
+    pub(crate) fn unavailable(reason: &'static str) -> Self {
+        Self::Unavailable { reason }
+    }
+
+    fn pool(&self) -> Result<&PgPool, Status> {
+        match self {
+            Self::Available(pool) => Ok(pool),
+            Self::Unavailable { reason } => Err(Status::unavailable(format!(
+                "accounting service is not available ({reason})"
+            ))),
+        }
     }
 }
 
 /// Build a ready-to-register tonic service for embedding in another server.
-pub fn accounting_server(pool: PgPool) -> SlurmAccountingServer<AccountingService> {
-    spur_proto::accounting_server(AccountingService::new(pool))
+pub(crate) fn accounting_server(
+    service: AccountingService,
+) -> SlurmAccountingServer<AccountingService> {
+    spur_proto::accounting_server(service)
 }
 
 #[tonic::async_trait]
@@ -76,6 +92,7 @@ impl SlurmAccounting for AccountingService {
         &self,
         request: Request<RecordJobStartRequest>,
     ) -> Result<Response<()>, Status> {
+        let pool = self.pool()?;
         let req = request.into_inner();
         let start_time = req
             .start_time
@@ -92,8 +109,7 @@ impl SlurmAccounting for AccountingService {
             .map(|r| (r.memory_mb as i64, r.cpus as i32))
             .unwrap_or((0, 1));
 
-        let mut conn = self
-            .pool
+        let mut conn = pool
             .acquire()
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
@@ -122,6 +138,7 @@ impl SlurmAccounting for AccountingService {
         &self,
         request: Request<RecordJobEndRequest>,
     ) -> Result<Response<()>, Status> {
+        let pool = self.pool()?;
         let req = request.into_inner();
         let end_time = req
             .end_time
@@ -138,8 +155,7 @@ impl SlurmAccounting for AccountingService {
             _ => "UNKNOWN",
         };
 
-        let mut conn = self
-            .pool
+        let mut conn = pool
             .acquire()
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
@@ -162,6 +178,7 @@ impl SlurmAccounting for AccountingService {
         &self,
         request: Request<GetJobHistoryRequest>,
     ) -> Result<Response<GetJobHistoryResponse>, Status> {
+        let pool = self.pool()?;
         let req = request.into_inner();
 
         let start_after = req
@@ -196,7 +213,7 @@ impl SlurmAccounting for AccountingService {
         };
 
         let records = db::get_job_history(
-            &self.pool,
+            pool,
             user,
             account,
             start_after,
@@ -270,6 +287,7 @@ impl SlurmAccounting for AccountingService {
         &self,
         request: Request<GetUsageRequest>,
     ) -> Result<Response<GetUsageResponse>, Status> {
+        let pool = self.pool()?;
         let req = request.into_inner();
 
         let since = req
@@ -288,7 +306,7 @@ impl SlurmAccounting for AccountingService {
             Some(req.account.as_str())
         };
 
-        let records = db::get_usage(&self.pool, user, account, since)
+        let records = db::get_usage(pool, user, account, since)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
 
@@ -325,6 +343,7 @@ impl SlurmAccounting for AccountingService {
         &self,
         request: Request<CreateAccountRequest>,
     ) -> Result<Response<()>, Status> {
+        let pool = self.pool()?;
         let req = request.into_inner();
         if let Some(g) = &req.grp_tres {
             validate_tres("grptres", g)?;
@@ -337,7 +356,7 @@ impl SlurmAccounting for AccountingService {
             max_running_jobs: nullable_limit(req.max_running_jobs, "max_running_jobs")?,
             grp_tres: nullable_str(&req.grp_tres),
         };
-        db::upsert_account(&self.pool, &req.name, update)
+        db::upsert_account(pool, &req.name, update)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
         Ok(Response::new(()))
@@ -347,8 +366,9 @@ impl SlurmAccounting for AccountingService {
         &self,
         request: Request<DeleteAccountRequest>,
     ) -> Result<Response<()>, Status> {
+        let pool = self.pool()?;
         let req = request.into_inner();
-        db::delete_account(&self.pool, &req.name)
+        db::delete_account(pool, &req.name)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
         Ok(Response::new(()))
@@ -358,7 +378,8 @@ impl SlurmAccounting for AccountingService {
         &self,
         _request: Request<ListAccountsRequest>,
     ) -> Result<Response<ListAccountsResponse>, Status> {
-        let records = db::list_accounts(&self.pool)
+        let pool = self.pool()?;
+        let records = db::list_accounts(pool)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
 
@@ -379,6 +400,7 @@ impl SlurmAccounting for AccountingService {
     }
 
     async fn add_user(&self, request: Request<AddUserRequest>) -> Result<Response<()>, Status> {
+        let pool = self.pool()?;
         let req = request.into_inner();
         // QOS references are validated against the live DB, not QosCache: a QOS
         // created just now may not have reached the cache's next refresh yet,
@@ -386,7 +408,7 @@ impl SlurmAccounting for AccountingService {
         // check runs only for a field the request actually restated.
         if let Some(dq) = req.default_qos.as_deref() {
             if !dq.is_empty() {
-                let exists = db::qos_exists(&self.pool, dq)
+                let exists = db::qos_exists(pool, dq)
                     .await
                     .map_err(|e| Status::internal(e.to_string()))?;
                 if !exists {
@@ -404,7 +426,7 @@ impl SlurmAccounting for AccountingService {
                     .map(str::trim)
                     .filter(|s| !s.is_empty())
                     .collect();
-                let missing = db::missing_qos(&self.pool, &names)
+                let missing = db::missing_qos(pool, &names)
                     .await
                     .map_err(|e| Status::internal(e.to_string()))?;
                 if let Some(name) = missing.first() {
@@ -449,7 +471,7 @@ impl SlurmAccounting for AccountingService {
             grp_tres: nullable_str(&req.grp_tres),
             max_wall_min: nullable_limit(req.max_wall_minutes, "max_wall_minutes")?,
         };
-        db::add_user(&self.pool, &req.user, &req.account, update)
+        db::add_user(pool, &req.user, &req.account, update)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
         Ok(Response::new(()))
@@ -459,8 +481,9 @@ impl SlurmAccounting for AccountingService {
         &self,
         request: Request<RemoveUserRequest>,
     ) -> Result<Response<()>, Status> {
+        let pool = self.pool()?;
         let req = request.into_inner();
-        let deleted = db::remove_user(&self.pool, &req.user, &req.account)
+        let deleted = db::remove_user(pool, &req.user, &req.account)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
         if deleted == 0 {
@@ -478,6 +501,7 @@ impl SlurmAccounting for AccountingService {
         &self,
         request: Request<ListUsersRequest>,
     ) -> Result<Response<ListUsersResponse>, Status> {
+        let pool = self.pool()?;
         let req = request.into_inner();
         let account = if req.account.is_empty() {
             None
@@ -489,7 +513,7 @@ impl SlurmAccounting for AccountingService {
         } else {
             Some(req.user.as_str())
         };
-        let records = db::list_users(&self.pool, account, user)
+        let records = db::list_users(pool, account, user)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
 
@@ -509,6 +533,7 @@ impl SlurmAccounting for AccountingService {
     }
 
     async fn create_qos(&self, request: Request<CreateQosRequest>) -> Result<Response<()>, Status> {
+        let pool = self.pool()?;
         let req = request.into_inner();
         if let Some(t) = &req.max_tres_per_job {
             validate_tres("maxtresperjob", t)?;
@@ -535,15 +560,16 @@ impl SlurmAccounting for AccountingService {
             grp_tres: nullable_str(&req.grp_tres),
             grp_wall_min: nullable_limit(req.grp_wall_minutes, "grp_wall_minutes")?,
         };
-        db::upsert_qos(&self.pool, &req.name, update)
+        db::upsert_qos(pool, &req.name, update)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
         Ok(Response::new(()))
     }
 
     async fn delete_qos(&self, request: Request<DeleteQosRequest>) -> Result<Response<()>, Status> {
+        let pool = self.pool()?;
         let req = request.into_inner();
-        db::delete_qos(&self.pool, &req.name)
+        db::delete_qos(pool, &req.name)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
         Ok(Response::new(()))
@@ -553,7 +579,8 @@ impl SlurmAccounting for AccountingService {
         &self,
         _request: Request<ListQosRequest>,
     ) -> Result<Response<ListQosResponse>, Status> {
-        let records = db::list_qos(&self.pool)
+        let pool = self.pool()?;
+        let records = db::list_qos(pool)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
 
@@ -582,6 +609,7 @@ impl SlurmAccounting for AccountingService {
         &self,
         request: Request<GetFairshareFactorsRequest>,
     ) -> Result<Response<GetFairshareFactorsResponse>, Status> {
+        let pool = self.pool()?;
         let req = request.into_inner();
         let halflife_days = if req.halflife_days == 0 {
             14
@@ -592,11 +620,11 @@ impl SlurmAccounting for AccountingService {
         let now = Utc::now();
         let since = now - chrono::Duration::days(halflife_days as i64 * 4);
 
-        let usage = db::get_usage(&self.pool, None, None, since)
+        let usage = db::get_usage(pool, None, None, since)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
 
-        let accounts = db::list_accounts(&self.pool)
+        let accounts = db::list_accounts(pool)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
 
@@ -631,6 +659,95 @@ fn datetime_to_proto(dt: DateTime<Utc>) -> prost_types::Timestamp {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn assert_startup_unavailable<T>(result: Result<Response<T>, Status>) {
+        let status = match result {
+            Ok(_) => panic!("accounting RPC unexpectedly succeeded"),
+            Err(status) => status,
+        };
+        assert_eq!(status.code(), tonic::Code::Unavailable);
+        assert_eq!(
+            status.message(),
+            "accounting service is not available (database connection failed at startup)"
+        );
+    }
+
+    #[tokio::test]
+    async fn unavailable_service_rejects_every_accounting_rpc() {
+        let service = AccountingService::unavailable("database connection failed at startup");
+
+        macro_rules! assert_rpc_unavailable {
+            ($method:ident, $request:ty) => {
+                assert_startup_unavailable(
+                    service.$method(Request::new(<$request>::default())).await,
+                );
+            };
+        }
+
+        assert_rpc_unavailable!(record_job_start, RecordJobStartRequest);
+        assert_rpc_unavailable!(record_job_end, RecordJobEndRequest);
+        assert_rpc_unavailable!(get_job_history, GetJobHistoryRequest);
+        assert_rpc_unavailable!(get_usage, GetUsageRequest);
+        assert_rpc_unavailable!(create_account, CreateAccountRequest);
+        assert_rpc_unavailable!(delete_account, DeleteAccountRequest);
+        assert_rpc_unavailable!(list_accounts, ListAccountsRequest);
+        assert_rpc_unavailable!(add_user, AddUserRequest);
+        assert_rpc_unavailable!(remove_user, RemoveUserRequest);
+        assert_rpc_unavailable!(list_users, ListUsersRequest);
+        assert_rpc_unavailable!(create_qos, CreateQosRequest);
+        assert_rpc_unavailable!(delete_qos, DeleteQosRequest);
+        assert_rpc_unavailable!(list_qos, ListQosRequest);
+        assert_rpc_unavailable!(get_fairshare_factors, GetFairshareFactorsRequest);
+    }
+
+    #[tokio::test]
+    async fn unavailable_accounting_server_returns_unavailable_over_grpc() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        let server = tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(accounting_server(AccountingService::unavailable(
+                    "database connection failed at startup",
+                )))
+                .serve_with_incoming(incoming)
+                .await
+                .unwrap();
+        });
+
+        let channel = tonic::transport::Endpoint::from_shared(format!("http://{addr}"))
+            .unwrap()
+            .connect()
+            .await
+            .unwrap();
+        let mut client = spur_proto::accounting_client(channel);
+        let status = client
+            .list_accounts(ListAccountsRequest::default())
+            .await
+            .unwrap_err();
+
+        assert_eq!(status.code(), tonic::Code::Unavailable);
+        assert_eq!(
+            status.message(),
+            "accounting service is not available (database connection failed at startup)"
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn unavailable_service_reports_migration_failure() {
+        let service = AccountingService::unavailable("database migration failed at startup");
+        let status = service
+            .list_accounts(Request::new(ListAccountsRequest::default()))
+            .await
+            .unwrap_err();
+
+        assert_eq!(status.code(), tonic::Code::Unavailable);
+        assert_eq!(
+            status.message(),
+            "accounting service is not available (database migration failed at startup)"
+        );
+    }
 
     #[test]
     fn validate_tres_accepts_empty() {

--- a/crates/spurctld/src/accounting/mod.rs
+++ b/crates/spurctld/src/accounting/mod.rs
@@ -7,7 +7,7 @@ mod grpc;
 mod notifier;
 mod reconcile;
 
-pub use grpc::accounting_server;
+pub(crate) use grpc::{accounting_server, AccountingService};
 pub use notifier::{AccountingNotifier, JobStartRecord};
 pub use reconcile::spawn_loop as spawn_reconcile_loop;
 pub use reconcile::RECONCILE_INTERVAL_SECS;

--- a/crates/spurctld/src/main.rs
+++ b/crates/spurctld/src/main.rs
@@ -178,8 +178,8 @@ async fn main() -> anyhow::Result<()> {
     let sched_stats = Arc::new(SchedStatsCollector::new(config.scheduler.plugin.clone()));
     cluster.set_sched_stats(sched_stats.clone());
 
-    // Build accounting PgPool (best-effort — scheduling works without it)
-    let accounting_pool = if config.accounting.database_url.is_empty() {
+    // Accounting stays best-effort so a database outage does not stop scheduling.
+    let accounting_service = if config.accounting.database_url.is_empty() {
         info!("accounting disabled (database_url not configured)");
         None
     } else {
@@ -191,8 +191,13 @@ async fn main() -> anyhow::Result<()> {
         {
             Ok(pool) => {
                 if let Err(e) = accounting::db::migrate(&pool).await {
-                    tracing::error!(error = %e, "accounting migration failed; disabling accounting");
-                    None
+                    tracing::error!(
+                        error = %e,
+                        "accounting migration failed; accounting service will report unavailable"
+                    );
+                    Some(accounting::AccountingService::unavailable(
+                        "database migration failed at startup",
+                    ))
                 } else {
                     info!("accounting database connected");
                     let notifier = accounting::AccountingNotifier::new(pool.clone());
@@ -221,15 +226,17 @@ async fn main() -> anyhow::Result<()> {
                         config.accounting.fairshare_refresh_secs as u64,
                     );
 
-                    Some(pool)
+                    Some(accounting::AccountingService::available(pool))
                 }
             }
             Err(e) => {
                 tracing::warn!(
                     error = %e,
-                    "failed to connect to accounting database; job history will not be recorded"
+                    "failed to connect to accounting database; accounting service will report unavailable"
                 );
-                None
+                Some(accounting::AccountingService::unavailable(
+                    "database connection failed at startup",
+                ))
             }
         }
     };
@@ -328,7 +335,7 @@ async fn main() -> anyhow::Result<()> {
         raft_handle,
         rpc_stats,
         sched_stats,
-        accounting_pool,
+        accounting_service,
         config.cluster.control_plane_replicas,
     )
     .await?;

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -2394,7 +2394,7 @@ pub async fn serve(
     raft_handle: Arc<RaftHandle>,
     rpc_stats: Arc<RpcStatsCollector>,
     sched_stats: Arc<SchedStatsCollector>,
-    accounting_pool: Option<sqlx::PgPool>,
+    accounting_service: Option<crate::accounting::AccountingService>,
     control_plane_replicas: u32,
 ) -> anyhow::Result<()> {
     let client_addrs: BTreeMap<u64, String> = raft_handle
@@ -2430,8 +2430,8 @@ pub async fn serve(
     let mut builder = tonic::transport::Server::builder().layer(stats_layer);
 
     let mut router = builder.add_service(spur_proto::controller_server(service));
-    if let Some(pool) = accounting_pool {
-        router = router.add_service(crate::accounting::accounting_server(pool));
+    if let Some(service) = accounting_service {
+        router = router.add_service(crate::accounting::accounting_server(service));
     }
 
     router.serve(addr).await?;


### PR DESCRIPTION
Closes #417.

When accounting is configured but PostgreSQL fails to connect or run migrations, `spurctld` currently starts without registering the accounting RPCs. That leaves `sacct` and `sacctmgr` with tonic's generic `UNIMPLEMENTED` response, which is indistinguishable from accounting being intentionally disabled.

This keeps the accounting service registered after a startup failure and returns `UNAVAILABLE` with a short, sanitized reason from every accounting RPC. If no `database_url` is configured, accounting remains disabled as before. Scheduling stays available in either case.

Database recovery is still startup-scoped: after PostgreSQL comes back, `spurctld` must be restarted

## Testing

- Covered all 14 accounting RPCs and the loopback gRPC path
- `cargo test -p spurctld --locked` — 619 passed, 20 PostgreSQL-backed tests ignored
- `cargo clippy -p spurctld --all-targets --locked -- -D warnings`
- Ran `spurctld` locally against an unreachable database and confirmed accounting commands return `UNAVAILABLE` while scheduling and job submission continue to work
- Confirmed that omitting `database_url` preserves the existing `UNIMPLEMENTED` behavior
- Ran formatting, SPDX, and the cross-platform workspace checks available on macOS
