### PR TITLE
fix(spurctld): make allocation lifecycle durable and restart-safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3786,6 +3786,7 @@ dependencies = [
  "http-body-util",
  "openraft",
  "parking_lot",
+ "prost",
  "prost-types",
  "serde",
  "serde_json",
@@ -3817,6 +3818,7 @@ dependencies = [
  "libc",
  "libloading",
  "nix",
+ "prost",
  "prost-types",
  "serde",
  "serde_json",
@@ -3835,6 +3837,7 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/spur-cli/src/mock_controller.rs
+++ b/crates/spur-cli/src/mock_controller.rs
@@ -162,6 +162,8 @@ mock_controller_impl! {
         get_sched_stats(()) -> proto::SchedStats;
         register_agent(proto::RegisterAgentRequest) -> proto::RegisterAgentResponse;
         heartbeat(proto::HeartbeatRequest) -> proto::HeartbeatResponse;
+        poll_agent_commands(proto::PollAgentCommandsRequest) -> proto::PollAgentCommandsResponse;
+        acknowledge_agent_command(proto::AcknowledgeAgentCommandRequest) -> ();
         create_token(proto::CreateTokenRequest) -> proto::CreateTokenResponse;
         list_tokens(proto::ListTokensRequest) -> proto::ListTokensResponse;
         revoke_token(proto::RevokeTokenRequest) -> proto::RevokeTokenResponse;

--- a/crates/spur-cli/src/salloc.rs
+++ b/crates/spur-cli/src/salloc.rs
@@ -152,6 +152,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
                     job_id,
                     signal: 2, // SIGINT
                     user: cancel_user,
+                    run_attempt: 0,
                 })
                 .await;
             std::process::exit(130); // Standard SIGINT exit code
@@ -176,6 +177,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
                     job_id,
                     signal: 0,
                     user: whoami::username().unwrap_or_default(),
+                    run_attempt: 0,
                 })
                 .await;
             std::process::exit(1);
@@ -250,6 +252,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
             job_id,
             signal: 0,
             user,
+            run_attempt: 0,
         })
         .await;
 

--- a/crates/spur-cli/src/scancel.rs
+++ b/crates/spur-cli/src/scancel.rs
@@ -87,6 +87,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
                     job_id: *job_id,
                     signal,
                     user: user.clone(),
+                    run_attempt: 0,
                 })
                 .await
             {
@@ -131,6 +132,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
                     job_id: job.job_id,
                     signal,
                     user: user.clone(),
+                    run_attempt: 0,
                 })
                 .await
             {

--- a/crates/spur-cli/src/scontrol.rs
+++ b/crates/spur-cli/src/scontrol.rs
@@ -341,6 +341,7 @@ pub async fn main_with_args(args: Vec<String>) -> Result<()> {
                     job_id,
                     signal: 0,
                     user: whoami::username().unwrap_or_else(|_| "unknown".into()),
+                    run_attempt: 0,
                 })
                 .await
                 .context("requeue failed")?;

--- a/crates/spur-cli/src/sinfo.rs
+++ b/crates/spur-cli/src/sinfo.rs
@@ -522,6 +522,8 @@ mod tests {
         get_sched_stats(()) -> pb::SchedStats;
         register_agent(pb::RegisterAgentRequest) -> pb::RegisterAgentResponse;
         heartbeat(pb::HeartbeatRequest) -> pb::HeartbeatResponse;
+        poll_agent_commands(pb::PollAgentCommandsRequest) -> pb::PollAgentCommandsResponse;
+        acknowledge_agent_command(pb::AcknowledgeAgentCommandRequest) -> ();
         create_token(pb::CreateTokenRequest) -> pb::CreateTokenResponse;
         list_tokens(pb::ListTokensRequest) -> pb::ListTokensResponse;
         revoke_token(pb::RevokeTokenRequest) -> pb::RevokeTokenResponse;

--- a/crates/spur-cli/src/srun.rs
+++ b/crates/spur-cli/src/srun.rs
@@ -620,6 +620,7 @@ fn install_ctrl_c_cancel(
                     job_id,
                     signal: 2,
                     user,
+                    run_attempt: 0,
                 })
                 .await;
             std::process::exit(130);
@@ -776,12 +777,14 @@ async fn release_srun_allocation(
     job_id: u32,
     user: &str,
     exit_code: i32,
+    run_attempt: u32,
 ) {
     if let Err(e) = client
         .complete_job(CompleteJobRequest {
             job_id,
             exit_code,
             user: user.to_string(),
+            run_attempt,
         })
         .await
     {
@@ -794,6 +797,7 @@ async fn release_srun_allocation(
                 job_id,
                 signal: 2,
                 user: user.to_string(),
+                run_attempt,
             })
             .await
         {
@@ -873,6 +877,7 @@ async fn run_standalone_srun(
                 job_id,
                 signal: 0,
                 user: user.clone(),
+                run_attempt: 0,
             })
             .await;
         std::process::exit(result?);
@@ -897,7 +902,7 @@ async fn run_standalone_srun(
             Ok(result) => result.exit_code,
             Err(_) => 1,
         };
-        release_srun_allocation(&mut client, job_id, &user, exit_code).await;
+        release_srun_allocation(&mut client, job_id, &user, exit_code, job.run_attempt).await;
         let result = dispatch_result?;
         let state = if result.exit_code == 0 {
             JobState::JobCompleted

--- a/crates/spur-core/src/allocation.rs
+++ b/crates/spur-core/src/allocation.rs
@@ -1,0 +1,175 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+
+use crate::job::JobId;
+use crate::resource::ResourceAllocations;
+
+/// Stable identity for one job run's allocation on one node.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct AllocationKey {
+    pub job_id: JobId,
+    pub run_attempt: u32,
+    pub node: String,
+}
+
+impl AllocationKey {
+    pub fn new(job_id: JobId, run_attempt: u32, node: impl Into<String>) -> Self {
+        Self {
+            job_id,
+            run_attempt,
+            node: node.into(),
+        }
+    }
+}
+
+/// Controller lifecycle for an exact per-node allocation.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AllocationPhase {
+    #[default]
+    Prepared,
+    Launching,
+    Active,
+    Releasing,
+    Released,
+}
+
+impl AllocationPhase {
+    pub fn is_charged(self) -> bool {
+        self != Self::Released
+    }
+}
+
+/// Durable controller truth for an exact per-node resource owner.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AllocationRecord {
+    pub key: AllocationKey,
+    pub resources: ResourceAllocations,
+    pub phase: AllocationPhase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_boot_id: Option<String>,
+    #[serde(default)]
+    pub last_command_id: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub launch_started_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AgentCommandKind {
+    #[default]
+    Launch,
+    Register,
+    Release,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AgentCommandState {
+    #[default]
+    Pending,
+    Succeeded,
+    Failed,
+}
+
+/// Raft-committed mutation delivered by an agent-initiated poll.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentCommandRecord {
+    pub command_id: u64,
+    pub key: AllocationKey,
+    pub kind: AgentCommandKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(default)]
+    pub payload: Vec<u8>,
+    #[serde(default)]
+    pub signal: i32,
+    #[serde(default)]
+    pub state: AgentCommandState,
+    #[serde(default)]
+    pub agent_session_id: String,
+    #[serde(default)]
+    pub node_boot_id: String,
+    #[serde(default)]
+    pub response_payload: Vec<u8>,
+    #[serde(default)]
+    pub error: String,
+}
+
+impl AgentCommandRecord {
+    pub fn new(
+        command_id: u64,
+        key: AllocationKey,
+        kind: AgentCommandKind,
+        payload: Vec<u8>,
+        signal: i32,
+    ) -> Self {
+        Self {
+            command_id,
+            key,
+            kind,
+            created_at: None,
+            payload,
+            signal,
+            state: AgentCommandState::Pending,
+            agent_session_id: String::new(),
+            node_boot_id: String::new(),
+            response_payload: Vec::new(),
+            error: String::new(),
+        }
+    }
+}
+
+impl AllocationRecord {
+    pub fn new(key: AllocationKey, resources: ResourceAllocations, phase: AllocationPhase) -> Self {
+        Self {
+            key,
+            resources,
+            phase,
+            agent_session_id: None,
+            node_boot_id: None,
+            last_command_id: 0,
+            launch_started_at: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn old_record_without_session_or_command_fields_deserializes() {
+        let frozen = r#"{
+            "key":{"job_id":7,"run_attempt":2,"node":"n1"},
+            "resources":{"cpus":4,"memory_mb":8192,"devices":{}},
+            "phase":"Active"
+        }"#;
+
+        let record: AllocationRecord = serde_json::from_str(frozen).unwrap();
+        assert_eq!(record.key, AllocationKey::new(7, 2, "n1"));
+        assert_eq!(record.phase, AllocationPhase::Active);
+        assert_eq!(record.agent_session_id, None);
+        assert_eq!(record.node_boot_id, None);
+        assert_eq!(record.last_command_id, 0);
+        assert_eq!(record.launch_started_at, None);
+    }
+
+    #[test]
+    fn old_command_without_result_fields_deserializes() {
+        let frozen = r#"{
+            "command_id":11,
+            "key":{"job_id":7,"run_attempt":2,"node":"n1"},
+            "kind":"Release"
+        }"#;
+
+        let command: AgentCommandRecord = serde_json::from_str(frozen).unwrap();
+        assert_eq!(command.command_id, 11);
+        assert_eq!(command.kind, AgentCommandKind::Release);
+        assert_eq!(command.state, AgentCommandState::Pending);
+        assert_eq!(command.created_at, None);
+        assert!(command.payload.is_empty());
+        assert!(command.response_payload.is_empty());
+    }
+}

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -334,7 +334,7 @@ pub struct ControllerConfig {
     pub dispatch_reject_cooldown_secs: u64,
 
     /// Seconds a resource freed by cancel/evict stays excluded from new
-    /// dispatch until the agent confirms release (default 60).
+    /// dispatch, bridging the gap until the kill signal lands (default 60).
     #[serde(default = "default_pending_kill_ttl_secs")]
     pub pending_kill_ttl_secs: u64,
 }

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -332,6 +332,14 @@ pub struct ControllerConfig {
     /// resources-unavailable, so it isn't re-picked every tick (default 30, 0 disables).
     #[serde(default = "default_dispatch_reject_cooldown_secs")]
     pub dispatch_reject_cooldown_secs: u64,
+
+    /// Seconds a resource freed by cancel/evict stays excluded from new
+    /// dispatch on that node until the agent confirms it released the job
+    /// (default 60 — the agent's SIGTERM→5s→SIGKILL escalation plus one
+    /// heartbeat period, with margin). Guards against double-booking a
+    /// resource whose kill RPC was lost.
+    #[serde(default = "default_pending_kill_ttl_secs")]
+    pub pending_kill_ttl_secs: u64,
 }
 
 fn default_max_batch_requeue() -> u32 {
@@ -344,6 +352,10 @@ fn default_terminal_job_retention_secs() -> u64 {
 
 fn default_dispatch_reject_cooldown_secs() -> u64 {
     30
+}
+
+fn default_pending_kill_ttl_secs() -> u64 {
+    60
 }
 
 fn default_hold_on_prolog_fail() -> bool {
@@ -400,6 +412,7 @@ impl Default for ControllerConfig {
             hold_on_prolog_fail: default_hold_on_prolog_fail(),
             terminal_job_retention_secs: default_terminal_job_retention_secs(),
             dispatch_reject_cooldown_secs: default_dispatch_reject_cooldown_secs(),
+            pending_kill_ttl_secs: default_pending_kill_ttl_secs(),
         }
     }
 }
@@ -1210,6 +1223,16 @@ impl SlurmConfig {
                 value: format!(
                     "{} (must be at most {})",
                     self.controller.dispatch_reject_cooldown_secs, MAX_LAUNCH_BACKOFF_SECS
+                ),
+            });
+        }
+        // Same overflow guardrail as dispatch_reject_cooldown_secs above.
+        if self.controller.pending_kill_ttl_secs > MAX_LAUNCH_BACKOFF_SECS {
+            return Err(ConfigError::InvalidValue {
+                field: "controller.pending_kill_ttl_secs".into(),
+                value: format!(
+                    "{} (must be at most {})",
+                    self.controller.pending_kill_ttl_secs, MAX_LAUNCH_BACKOFF_SECS
                 ),
             });
         }

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -332,11 +332,6 @@ pub struct ControllerConfig {
     /// resources-unavailable, so it isn't re-picked every tick (default 30, 0 disables).
     #[serde(default = "default_dispatch_reject_cooldown_secs")]
     pub dispatch_reject_cooldown_secs: u64,
-
-    /// Max seconds a resource freed by cancel/evict stays excluded from new
-    /// dispatch if a heartbeat never confirms the kill landed (default 60).
-    #[serde(default = "default_pending_kill_ttl_secs")]
-    pub pending_kill_ttl_secs: u64,
 }
 
 fn default_max_batch_requeue() -> u32 {
@@ -349,10 +344,6 @@ fn default_terminal_job_retention_secs() -> u64 {
 
 fn default_dispatch_reject_cooldown_secs() -> u64 {
     30
-}
-
-fn default_pending_kill_ttl_secs() -> u64 {
-    60
 }
 
 fn default_hold_on_prolog_fail() -> bool {
@@ -409,7 +400,6 @@ impl Default for ControllerConfig {
             hold_on_prolog_fail: default_hold_on_prolog_fail(),
             terminal_job_retention_secs: default_terminal_job_retention_secs(),
             dispatch_reject_cooldown_secs: default_dispatch_reject_cooldown_secs(),
-            pending_kill_ttl_secs: default_pending_kill_ttl_secs(),
         }
     }
 }
@@ -1220,16 +1210,6 @@ impl SlurmConfig {
                 value: format!(
                     "{} (must be at most {})",
                     self.controller.dispatch_reject_cooldown_secs, MAX_LAUNCH_BACKOFF_SECS
-                ),
-            });
-        }
-        // Same overflow guardrail as dispatch_reject_cooldown_secs above.
-        if self.controller.pending_kill_ttl_secs > MAX_LAUNCH_BACKOFF_SECS {
-            return Err(ConfigError::InvalidValue {
-                field: "controller.pending_kill_ttl_secs".into(),
-                value: format!(
-                    "{} (must be at most {})",
-                    self.controller.pending_kill_ttl_secs, MAX_LAUNCH_BACKOFF_SECS
                 ),
             });
         }

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -333,8 +333,8 @@ pub struct ControllerConfig {
     #[serde(default = "default_dispatch_reject_cooldown_secs")]
     pub dispatch_reject_cooldown_secs: u64,
 
-    /// Seconds a resource freed by cancel/evict stays excluded from new
-    /// dispatch, bridging the gap until the kill signal lands (default 60).
+    /// Max seconds a resource freed by cancel/evict stays excluded from new
+    /// dispatch if a heartbeat never confirms the kill landed (default 60).
     #[serde(default = "default_pending_kill_ttl_secs")]
     pub pending_kill_ttl_secs: u64,
 }

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -327,6 +327,11 @@ pub struct ControllerConfig {
     /// to the accounting reconcile interval so a job's DB row can be repaired first.
     #[serde(default = "default_terminal_job_retention_secs")]
     pub terminal_job_retention_secs: u64,
+
+    /// Seconds a node is skipped for new dispatch after rejecting one as
+    /// resources-unavailable, so it isn't re-picked every tick (default 30, 0 disables).
+    #[serde(default = "default_dispatch_reject_cooldown_secs")]
+    pub dispatch_reject_cooldown_secs: u64,
 }
 
 fn default_max_batch_requeue() -> u32 {
@@ -335,6 +340,10 @@ fn default_max_batch_requeue() -> u32 {
 
 fn default_terminal_job_retention_secs() -> u64 {
     3600
+}
+
+fn default_dispatch_reject_cooldown_secs() -> u64 {
+    30
 }
 
 fn default_hold_on_prolog_fail() -> bool {
@@ -390,6 +399,7 @@ impl Default for ControllerConfig {
             max_launch_backoff_secs: default_max_launch_backoff_secs(),
             hold_on_prolog_fail: default_hold_on_prolog_fail(),
             terminal_job_retention_secs: default_terminal_job_retention_secs(),
+            dispatch_reject_cooldown_secs: default_dispatch_reject_cooldown_secs(),
         }
     }
 }

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -334,10 +334,7 @@ pub struct ControllerConfig {
     pub dispatch_reject_cooldown_secs: u64,
 
     /// Seconds a resource freed by cancel/evict stays excluded from new
-    /// dispatch on that node until the agent confirms it released the job
-    /// (default 60 — the agent's SIGTERM→5s→SIGKILL escalation plus one
-    /// heartbeat period, with margin). Guards against double-booking a
-    /// resource whose kill RPC was lost.
+    /// dispatch until the agent confirms release (default 60).
     #[serde(default = "default_pending_kill_ttl_secs")]
     pub pending_kill_ttl_secs: u64,
 }

--- a/crates/spur-core/src/config.rs
+++ b/crates/spur-core/src/config.rs
@@ -1203,6 +1203,16 @@ impl SlurmConfig {
                 ),
             });
         }
+        // Bounded so `Instant::now() + cooldown` cannot overflow and panic.
+        if self.controller.dispatch_reject_cooldown_secs > MAX_LAUNCH_BACKOFF_SECS {
+            return Err(ConfigError::InvalidValue {
+                field: "controller.dispatch_reject_cooldown_secs".into(),
+                value: format!(
+                    "{} (must be at most {})",
+                    self.controller.dispatch_reject_cooldown_secs, MAX_LAUNCH_BACKOFF_SECS
+                ),
+            });
+        }
         if self.cluster.enabled {
             if self.cluster.distro != "k0s" {
                 return Err(ConfigError::InvalidValue {
@@ -2014,6 +2024,41 @@ terminal_job_retention_secs = {MAX_TERMINAL_JOB_RETENTION_SECS}
                 .terminal_job_retention_secs,
             MAX_TERMINAL_JOB_RETENTION_SECS,
             "the bound itself must be accepted"
+        );
+    }
+
+    #[test]
+    fn controller_config_rejects_out_of_range_dispatch_reject_cooldown_secs() {
+        // Past this bound `Instant::now() + cooldown` overflows and panics, so
+        // it must be refused at load. Zero is valid (disables the cooldown).
+        let toml = format!(
+            r#"
+cluster_name = "test"
+
+[controller]
+dispatch_reject_cooldown_secs = {}
+"#,
+            MAX_LAUNCH_BACKOFF_SECS + 1
+        );
+        let err = SlurmConfig::load_from_str(&toml).unwrap_err();
+        assert!(
+            err.to_string().contains("dispatch_reject_cooldown_secs"),
+            "unexpected error: {err}"
+        );
+
+        let ok = r#"
+cluster_name = "test"
+
+[controller]
+dispatch_reject_cooldown_secs = 0
+"#;
+        assert_eq!(
+            SlurmConfig::load_from_str(ok)
+                .unwrap()
+                .controller
+                .dispatch_reject_cooldown_secs,
+            0,
+            "zero (disabled) must be accepted"
         );
     }
 

--- a/crates/spur-core/src/lib.rs
+++ b/crates/spur-core/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod account_limits;
 pub mod accounting;
 pub mod admission;
+pub mod allocation;
 pub mod array;
 pub mod auth;
 pub mod burst_buffer;

--- a/crates/spur-core/src/node.rs
+++ b/crates/spur-core/src/node.rs
@@ -302,6 +302,14 @@ pub struct Node {
     pub last_busy: Option<DateTime<Utc>>,
     pub agent_start_time: Option<DateTime<Utc>>,
     pub last_heartbeat: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub agent_session_id: String,
+    #[serde(default)]
+    pub node_boot_id: String,
+    #[serde(default = "default_recovery_complete")]
+    pub recovery_complete: bool,
+    #[serde(default)]
+    pub supports_command_polling: bool,
 
     /// Routable comm address for agent gRPC and inter-node TCP (NodeAddr).
     pub address: Option<String>,
@@ -332,6 +340,10 @@ fn default_weight() -> u32 {
     Node::DEFAULT_WEIGHT
 }
 
+fn default_recovery_complete() -> bool {
+    true
+}
+
 impl Node {
     /// Default scheduling weight for a node with no matching `NodeConfig`.
     pub const DEFAULT_WEIGHT: u32 = 1;
@@ -357,6 +369,10 @@ impl Node {
             last_busy: None,
             agent_start_time: None,
             last_heartbeat: None,
+            agent_session_id: String::new(),
+            node_boot_id: String::new(),
+            recovery_complete: true,
+            supports_command_polling: false,
             address: None,
             port: 6818,
             wg_pubkey: None,

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -4,6 +4,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::admission::AdmissionToken;
+use crate::allocation::{AgentCommandRecord, AllocationKey};
 use crate::job::{JobId, JobSpec, JobState, PendingReason};
 use crate::k0s::{K0sPhase, K0sRole};
 use crate::node::{NodeSource, NodeState};
@@ -41,9 +42,68 @@ fn default_job_evict_reason() -> PendingReason {
     PendingReason::JobLaunchFailure
 }
 
+fn default_recovery_complete() -> bool {
+    true
+}
+
 /// All state-mutating operations that get logged to the Raft log.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum WalOperation {
+    AllocationPrepare {
+        job_id: JobId,
+        run_attempt: u32,
+        nodes: Vec<String>,
+        resources: ResourceAllocations,
+        per_node_alloc: HashMap<String, ResourceAllocations>,
+        srun_step_dispatch: bool,
+    },
+    AllocationBeginLaunch {
+        job_id: JobId,
+        run_attempt: u32,
+        command_id: u64,
+        #[serde(default)]
+        created_at: Option<chrono::DateTime<chrono::Utc>>,
+        #[serde(default)]
+        commands: Vec<AgentCommandRecord>,
+    },
+    AllocationActivate {
+        job_id: JobId,
+        run_attempt: u32,
+    },
+    AllocationAbort {
+        job_id: JobId,
+        run_attempt: u32,
+        releasing_nodes: Vec<String>,
+        command_id: u64,
+        #[serde(default)]
+        commands: Vec<AgentCommandRecord>,
+    },
+    AllocationBeginRelease {
+        keys: Vec<AllocationKey>,
+        command_id: u64,
+        #[serde(default)]
+        commands: Vec<AgentCommandRecord>,
+    },
+    AllocationConfirmRelease {
+        key: AllocationKey,
+        command_id: u64,
+        agent_session_id: String,
+        node_boot_id: String,
+    },
+    AgentCommandAcknowledge {
+        command_id: u64,
+        key: AllocationKey,
+        agent_session_id: String,
+        node_boot_id: String,
+        success: bool,
+        #[serde(default)]
+        response_payload: Vec<u8>,
+        #[serde(default)]
+        error: String,
+    },
+    AgentCommandsEnqueue {
+        commands: Vec<AgentCommandRecord>,
+    },
     PendingKillReserve {
         reservations: Vec<PendingKillReservation>,
     },
@@ -106,6 +166,8 @@ pub enum WalOperation {
         node_name: String,
         exit_code: i32,
         signal: i32,
+        #[serde(default)]
+        run_attempt: u32,
     },
     /// The time-limit watchdog signalled a running job for exhausting its wall
     /// clock. Durable so the grace period survives a leadership change and so
@@ -219,6 +281,22 @@ pub enum WalOperation {
         labels: HashMap<String, String>,
         #[serde(default)]
         source: NodeSource,
+        #[serde(default)]
+        agent_session_id: String,
+        #[serde(default)]
+        node_boot_id: String,
+        #[serde(default = "default_recovery_complete")]
+        recovery_complete: bool,
+        #[serde(default)]
+        supports_command_polling: bool,
+    },
+    NodeAgentState {
+        name: String,
+        agent_session_id: String,
+        node_boot_id: String,
+        recovery_complete: bool,
+        #[serde(default)]
+        supports_command_polling: bool,
     },
     NodeUpdate {
         name: String,
@@ -775,6 +853,7 @@ mod tests {
             node_name: "n0".into(),
             exit_code: 0,
             signal: 9,
+            run_attempt: 3,
         };
         let json = serde_json::to_string(&op).unwrap();
         let back: WalOperation = serde_json::from_str(&json).unwrap();
@@ -785,14 +864,27 @@ mod tests {
                 node_name,
                 exit_code,
                 signal,
+                run_attempt,
             } => {
                 assert_eq!(job_id, 1);
                 assert_eq!(node_name, "n0");
                 assert_eq!(exit_code, 0);
                 assert_eq!(signal, 9);
+                assert_eq!(run_attempt, 3);
             }
             _ => panic!("wrong variant"),
         }
+    }
+
+    #[test]
+    fn old_job_node_complete_defaults_to_legacy_attempt() {
+        let frozen =
+            r#"{"JobNodeComplete":{"job_id":1,"node_name":"n0","exit_code":0,"signal":9}}"#;
+        let operation: WalOperation = serde_json::from_str(frozen).unwrap();
+        assert!(matches!(
+            operation,
+            WalOperation::JobNodeComplete { run_attempt: 0, .. }
+        ));
     }
 }
 
@@ -1113,5 +1205,62 @@ mod evict_wal_tests {
             }
             _ => panic!("wrong variant"),
         }
+    }
+}
+
+#[cfg(test)]
+mod allocation_wal_tests {
+    use super::*;
+
+    #[test]
+    fn frozen_allocation_lifecycle_variants_deserialize() {
+        let fixtures = [
+            r#"{"AllocationPrepare":{"job_id":7,"run_attempt":2,"nodes":["n1"],"resources":{"cpus":2,"memory_mb":4096,"devices":{}},"per_node_alloc":{"n1":{"cpus":2,"memory_mb":4096,"devices":{}}},"srun_step_dispatch":false}}"#,
+            r#"{"AllocationBeginLaunch":{"job_id":7,"run_attempt":2,"command_id":11}}"#,
+            r#"{"AllocationActivate":{"job_id":7,"run_attempt":2}}"#,
+            r#"{"AllocationAbort":{"job_id":7,"run_attempt":2,"releasing_nodes":["n1"],"command_id":12}}"#,
+            r#"{"AllocationBeginRelease":{"keys":[{"job_id":7,"run_attempt":2,"node":"n1"}],"command_id":13}}"#,
+            r#"{"AllocationConfirmRelease":{"key":{"job_id":7,"run_attempt":2,"node":"n1"},"command_id":13,"agent_session_id":"s1","node_boot_id":"b1"}}"#,
+            r#"{"AgentCommandAcknowledge":{"command_id":13,"key":{"job_id":7,"run_attempt":2,"node":"n1"},"agent_session_id":"s1","node_boot_id":"b1","success":true}}"#,
+            r#"{"AgentCommandsEnqueue":{"commands":[]}}"#,
+        ];
+
+        for fixture in fixtures {
+            serde_json::from_str::<WalOperation>(fixture).unwrap();
+        }
+    }
+
+    #[test]
+    fn old_launch_and_release_variants_default_to_no_outbox_commands() {
+        let launch: WalOperation = serde_json::from_str(
+            r#"{"AllocationBeginLaunch":{"job_id":7,"run_attempt":2,"command_id":11}}"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            launch,
+            WalOperation::AllocationBeginLaunch { commands, .. } if commands.is_empty()
+        ));
+
+        let release: WalOperation =
+            serde_json::from_str(r#"{"AllocationBeginRelease":{"keys":[],"command_id":12}}"#)
+                .unwrap();
+        assert!(matches!(
+            release,
+            WalOperation::AllocationBeginRelease { commands, .. } if commands.is_empty()
+        ));
+    }
+
+    #[test]
+    fn old_node_register_defaults_to_legacy_recovery_behavior() {
+        let frozen = r#"{"NodeRegister":{"name":"n1","resources":{"cpus":4,"memory_mb":8000,"gpus":[],"generic":{}},"address":"127.0.0.1"}}"#;
+        let operation: WalOperation = serde_json::from_str(frozen).unwrap();
+        assert!(matches!(
+            operation,
+            WalOperation::NodeRegister {
+                recovery_complete: true,
+                supports_command_polling: false,
+                ..
+            }
+        ));
     }
 }

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -17,6 +17,10 @@ fn default_port() -> u16 {
     6818
 }
 
+fn default_job_evict_reason() -> PendingReason {
+    PendingReason::JobLaunchFailure
+}
+
 /// All state-mutating operations that get logged to the Raft log.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum WalOperation {
@@ -138,11 +142,12 @@ pub enum WalOperation {
         at: chrono::DateTime<chrono::Utc>,
     },
     /// Evict a single job to NodeFail: same effect as a node health-check
-    /// failure (frees allocations, feeds the auto-requeue path), but scoped
-    /// to one job instead of every job on a node. Used when a subset of a
-    /// job's assigned nodes never received the launch dispatch.
+    /// failure, but scoped to one job. `reason` drives the requeue path
+    /// (e.g. `JobLaunchFailure` backs off, `NodeDown` retries immediately).
     JobEvict {
         job_id: JobId,
+        #[serde(default = "default_job_evict_reason")]
+        reason: PendingReason,
         /// Human-readable bootstrap failure (shown via scontrol / logs).
         #[serde(default)]
         detail: Option<String>,
@@ -979,13 +984,19 @@ mod evict_wal_tests {
     fn job_evict_op_round_trips() {
         let op = WalOperation::JobEvict {
             job_id: 9,
+            reason: PendingReason::NodeDown,
             detail: Some("PMIx prepare failed".into()),
         };
         let json = serde_json::to_string(&op).unwrap();
         let back: WalOperation = serde_json::from_str(&json).unwrap();
         match back {
-            WalOperation::JobEvict { job_id, detail } => {
+            WalOperation::JobEvict {
+                job_id,
+                reason,
+                detail,
+            } => {
                 assert_eq!(job_id, 9);
+                assert_eq!(reason, PendingReason::NodeDown);
                 assert_eq!(detail.as_deref(), Some("PMIx prepare failed"));
             }
             _ => panic!("wrong variant"),
@@ -1001,6 +1012,24 @@ mod evict_wal_tests {
             WalOperation::JobLaunchFailureDetail { job_id, detail } => {
                 assert_eq!(job_id, 42);
                 assert_eq!(detail, "PMIx prepare failed: n1: connect failed");
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn job_evict_op_deserializes_frozen_pre_reason_and_detail_payload() {
+        let frozen = r#"{"JobEvict":{"job_id":9}}"#;
+        let op: WalOperation = serde_json::from_str(frozen).unwrap();
+        match op {
+            WalOperation::JobEvict {
+                job_id,
+                reason,
+                detail,
+            } => {
+                assert_eq!(job_id, 9);
+                assert_eq!(reason, PendingReason::JobLaunchFailure);
+                assert_eq!(detail, None);
             }
             _ => panic!("wrong variant"),
         }

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -151,6 +151,10 @@ pub enum WalOperation {
         /// Human-readable bootstrap failure (shown via scontrol / logs).
         #[serde(default)]
         detail: Option<String>,
+        /// Caller's observed epoch; 0 (legacy/unfenced) always applies.
+        /// A mismatch at apply time means the job already moved on.
+        #[serde(default)]
+        run_attempt: u32,
     },
     /// Record why a requeued job is back in Pending (survives controller restart).
     JobLaunchFailureDetail {
@@ -986,6 +990,7 @@ mod evict_wal_tests {
             job_id: 9,
             reason: PendingReason::NodeDown,
             detail: Some("PMIx prepare failed".into()),
+            run_attempt: 3,
         };
         let json = serde_json::to_string(&op).unwrap();
         let back: WalOperation = serde_json::from_str(&json).unwrap();
@@ -994,10 +999,12 @@ mod evict_wal_tests {
                 job_id,
                 reason,
                 detail,
+                run_attempt,
             } => {
                 assert_eq!(job_id, 9);
                 assert_eq!(reason, PendingReason::NodeDown);
                 assert_eq!(detail.as_deref(), Some("PMIx prepare failed"));
+                assert_eq!(run_attempt, 3);
             }
             _ => panic!("wrong variant"),
         }
@@ -1026,10 +1033,12 @@ mod evict_wal_tests {
                 job_id,
                 reason,
                 detail,
+                run_attempt,
             } => {
                 assert_eq!(job_id, 9);
                 assert_eq!(reason, PendingReason::JobLaunchFailure);
                 assert_eq!(detail, None);
+                assert_eq!(run_attempt, 0);
             }
             _ => panic!("wrong variant"),
         }

--- a/crates/spur-core/src/wal.rs
+++ b/crates/spur-core/src/wal.rs
@@ -13,6 +13,26 @@ use std::collections::HashMap;
 
 use crate::resource::{ResourceAllocations, ResourceSet};
 
+/// A controller-owned resource hold that remains in force after a cancel or
+/// eviction until the owning node confirms that it no longer holds the job.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingKillReservation {
+    pub job_id: JobId,
+    pub node: String,
+    pub resources: ResourceAllocations,
+    pub attempt: u64,
+    #[serde(default)]
+    pub run_attempt: u32,
+}
+
+/// Identity of a pending-kill hold that a node heartbeat has confirmed released.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingKillRelease {
+    pub job_id: JobId,
+    pub node: String,
+    pub attempt: u64,
+}
+
 fn default_port() -> u16 {
     6818
 }
@@ -24,6 +44,20 @@ fn default_job_evict_reason() -> PendingReason {
 /// All state-mutating operations that get logged to the Raft log.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum WalOperation {
+    PendingKillReserve {
+        reservations: Vec<PendingKillReservation>,
+    },
+    /// Applies a job lifecycle transition and its release holds in one Raft
+    /// entry, so a leader change cannot expose the freed allocation alone.
+    PendingKillTransition {
+        reservations: Vec<PendingKillReservation>,
+        operation: Box<WalOperation>,
+    },
+    /// A heartbeat established that these exact pending-kill holds are gone.
+    PendingKillRelease {
+        releases: Vec<PendingKillRelease>,
+    },
+
     // Job operations
     JobSubmit {
         job_id: JobId,
@@ -118,6 +152,12 @@ pub enum WalOperation {
     JobDispatchBackoff {
         job_id: JobId,
         begin_time: chrono::DateTime<chrono::Utc>,
+    },
+    /// Persist the epoch before dispatching any agent RPC so delayed requests
+    /// from an aborted dispatch cannot target its retry.
+    JobDispatchAttempt {
+        job_id: JobId,
+        run_attempt: u32,
     },
     /// Preempt a running job and requeue it in one atomic step: free its node
     /// allocation, end the prior run for accounting (as PREEMPTED), return it to

--- a/crates/spur-ffi/src/lib.rs
+++ b/crates/spur-ffi/src/lib.rs
@@ -304,6 +304,7 @@ pub extern "C" fn slurm_kill_job(job_id: c_uint, signal: u16, _flags: u16) -> c_
                 job_id,
                 signal: signal as i32,
                 user: String::new(),
+                run_attempt: 0,
             })
             .await
             .ok()?;

--- a/crates/spur-k8s/src/agent.rs
+++ b/crates/spur-k8s/src/agent.rs
@@ -24,14 +24,48 @@ use spur_proto::proto::*;
 
 const NS_LOOKUP_BUDGET: Duration = Duration::from_secs(5);
 
+/// Rejects a term older than the highest seen. 0 (legacy/unset) passes only
+/// before any real term has been observed — once fencing starts, it can't stop.
+struct TermFence(std::sync::atomic::AtomicU64);
+
+impl TermFence {
+    fn new() -> Self {
+        Self(std::sync::atomic::AtomicU64::new(0))
+    }
+
+    fn check(&self, term: u64) -> Result<(), Status> {
+        use std::sync::atomic::Ordering;
+        if term == 0 {
+            return if self.0.load(Ordering::Acquire) == 0 {
+                Ok(())
+            } else {
+                Err(Status::failed_precondition(
+                    "unfenced request rejected after a real controller term was observed",
+                ))
+            };
+        }
+        let prev = self.0.fetch_max(term, Ordering::AcqRel);
+        if term < prev {
+            return Err(Status::failed_precondition(format!(
+                "stale controller term {term} (highest seen {prev}); a newer leader has taken over"
+            )));
+        }
+        Ok(())
+    }
+}
+
 /// Virtual SlurmAgent that creates K8s Pods instead of fork/exec.
 pub struct VirtualAgent {
     client: Client,
+    term_fence: TermFence,
 }
 
 impl VirtualAgent {
     pub fn new(client: Client) -> Self {
-        Self { client }
+        Self {
+            client,
+            term_fence: TermFence::new(),
+        }
     }
 
     /// Look up the namespace of the SpurJob labeled `spur.amd.com/job-id=<id>`.
@@ -93,6 +127,7 @@ impl SlurmAgent for VirtualAgent {
         request: Request<LaunchJobRequest>,
     ) -> Result<Response<LaunchJobResponse>, Status> {
         let req = request.into_inner();
+        self.term_fence.check(req.term)?;
         let job_id = req.job_id;
         let ns = self.resolve_namespace(job_id).await?;
         let target_node = req.target_node.clone();
@@ -484,6 +519,7 @@ impl SlurmAgent for VirtualAgent {
         request: Request<AgentCancelJobRequest>,
     ) -> Result<Response<()>, Status> {
         let req = request.into_inner();
+        self.term_fence.check(req.term)?;
         let job_id = req.job_id;
         let ns = self.resolve_namespace(job_id).await?;
 
@@ -927,6 +963,23 @@ pub fn gpu_request_to_gres(count: u32, gpu_type: Option<&str>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // A demoted leader's stale LaunchJob/CancelJob must be rejected here too,
+    // not just on the native spurd backend.
+    #[test]
+    fn term_fence_rejects_stale_and_a_delayed_unfenced_request() {
+        let fence = TermFence::new();
+        fence
+            .check(0)
+            .expect("legacy zero passes before any term is seen");
+        fence.check(5).expect("first real term is accepted");
+        let err = fence.check(3).expect_err("stale term must be rejected");
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+        assert!(
+            fence.check(0).is_err(),
+            "a delayed unfenced request must not bypass an established term"
+        );
+    }
 
     // --- gpu_request_to_gres ---
 

--- a/crates/spur-k8s/src/agent.rs
+++ b/crates/spur-k8s/src/agent.rs
@@ -129,6 +129,7 @@ impl SlurmAgent for VirtualAgent {
         let req = request.into_inner();
         self.term_fence.check(req.term)?;
         let job_id = req.job_id;
+        let run_attempt = req.run_attempt;
         let ns = self.resolve_namespace(job_id).await?;
         let target_node = req.target_node.clone();
         let peer_nodes = &req.peer_nodes;
@@ -393,6 +394,10 @@ impl SlurmAgent for VirtualAgent {
         // Build labels
         let mut labels = BTreeMap::new();
         labels.insert("spur.amd.com/job-id".to_string(), job_id.to_string());
+        labels.insert(
+            "spur.amd.com/run-attempt".to_string(),
+            run_attempt.to_string(),
+        );
         labels.insert(
             "spur.amd.com/managed-by".to_string(),
             "spur-k8s-operator".to_string(),

--- a/crates/spur-k8s/src/heartbeat.rs
+++ b/crates/spur-k8s/src/heartbeat.rs
@@ -63,6 +63,11 @@ impl HeartbeatManager {
                             running_jobs: vec![],
                             node_token: String::new(),
                             wg_pubkey: String::new(), // virtual agents are not on the mesh
+                            agent_session_id: String::new(),
+                            node_boot_id: String::new(),
+                            allocation_inventory: Vec::new(),
+                            recovery_complete: true,
+                            supports_command_polling: false,
                         };
                         match client.heartbeat(req).await {
                             Ok(_) => debug!(node = %name, "heartbeat sent"),
@@ -102,6 +107,11 @@ mod tests {
             wg_pubkey: String::new(),
             labels: std::collections::HashMap::new(),
             join_token: String::new(),
+            agent_session_id: String::new(),
+            node_boot_id: String::new(),
+            allocation_inventory: Vec::new(),
+            recovery_complete: true,
+            supports_command_polling: false,
         }
     }
 

--- a/crates/spur-k8s/src/job_controller.rs
+++ b/crates/spur-k8s/src/job_controller.rs
@@ -52,7 +52,7 @@ pub struct JobControllerCtx {
     pub client: Client,
     pub ctrl_client: Mutex<SlurmControllerClient<Channel>>,
     /// Track multi-pod completion: job_id → (expected_count, completed_count, any_failed)
-    pub(crate) pod_tracker: Mutex<HashMap<u32, PodTracker>>,
+    pub(crate) pod_tracker: Mutex<HashMap<(u32, u32), PodTracker>>,
 }
 
 pub(crate) struct PodTracker {
@@ -257,6 +257,7 @@ async fn handle_deletion(job: &SpurJob, ctx: &JobControllerCtx) -> Result<Action
                     job_id,
                     signal: 0,
                     user: String::new(),
+                    run_attempt: 0,
                 })
                 .await;
         }
@@ -368,6 +369,11 @@ async fn watch_pods(ctx: Arc<JobControllerCtx>) -> anyhow::Result<()> {
                 Ok(id) => id,
                 Err(_) => continue,
             };
+            let run_attempt = labels
+                .and_then(|labels| labels.get("spur.amd.com/run-attempt"))
+                .and_then(|value| value.parse().ok())
+                .unwrap_or(0);
+            let allocation_key = (job_id, run_attempt);
 
             let phase = pod
                 .status
@@ -417,7 +423,7 @@ async fn watch_pods(ctx: Arc<JobControllerCtx>) -> anyhow::Result<()> {
             // Multi-pod tracking: check if all pods for this job are done.
             let should_report = {
                 let mut tracker = ctx.pod_tracker.lock().await;
-                let entry = tracker.entry(job_id).or_insert_with(|| {
+                let entry = tracker.entry(allocation_key).or_insert_with(|| {
                     // We don't know the expected count here, so we'll report
                     // on first failure or let the pod watcher handle it
                     PodTracker {
@@ -451,20 +457,20 @@ async fn watch_pods(ctx: Arc<JobControllerCtx>) -> anyhow::Result<()> {
                 let final_exit_code = {
                     let tracker = ctx.pod_tracker.lock().await;
                     tracker
-                        .get(&job_id)
+                        .get(&allocation_key)
                         .map(|t| if t.failed { t.exit_code } else { exit_code })
                         .unwrap_or(exit_code)
                 };
 
                 let final_oom = {
                     let tracker = ctx.pod_tracker.lock().await;
-                    tracker.get(&job_id).map(|t| t.oom).unwrap_or(oom)
+                    tracker.get(&allocation_key).map(|t| t.oom).unwrap_or(oom)
                 };
 
                 let final_message = {
                     let tracker = ctx.pod_tracker.lock().await;
                     tracker
-                        .get(&job_id)
+                        .get(&allocation_key)
                         .map(|t| {
                             if t.failed && !t.message.is_empty() {
                                 t.message.clone()
@@ -524,14 +530,15 @@ async fn watch_pods(ctx: Arc<JobControllerCtx>) -> anyhow::Result<()> {
                     drain_node: false,
                     drain_reason: String::new(),
                     reporting_node,
-                    // K8s operator doesn't track run epochs; 0 disables the
-                    // controller-side staleness check for this report.
-                    run_attempt: 0,
+                    run_attempt,
+                    agent_session_id: String::new(),
+                    node_boot_id: String::new(),
+                    node_token: String::new(),
                 };
                 if let Err(e) = ctrl.report_job_status(req).await {
                     error!(job_id, error = %e, "failed to report job status");
                 } else if report_state.is_terminal() {
-                    ctx.pod_tracker.lock().await.remove(&job_id);
+                    ctx.pod_tracker.lock().await.remove(&allocation_key);
                 }
             }
         }

--- a/crates/spur-k8s/src/node_watcher.rs
+++ b/crates/spur-k8s/src/node_watcher.rs
@@ -135,6 +135,11 @@ pub async fn run(
                         wg_pubkey: String::new(),
                         labels: std::collections::HashMap::new(),
                         join_token: String::new(),
+                        agent_session_id: String::new(),
+                        node_boot_id: String::new(),
+                        allocation_inventory: Vec::new(),
+                        recovery_complete: true,
+                        supports_command_polling: false,
                     };
 
                     match ctrl_client.register_agent(req.clone()).await {

--- a/crates/spur-sched/src/cons_tres.rs
+++ b/crates/spur-sched/src/cons_tres.rs
@@ -9,7 +9,7 @@
 use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 
-use spur_core::resource::{GpuResource, ResourceSet};
+use spur_core::resource::{AllocatedDevice, GpuResource, ResourceAllocations, ResourceSet};
 
 /// Why a reservation could not be made. Distinguished so the caller can map
 /// each to the right gRPC status instead of reporting every failure as GPU
@@ -22,6 +22,17 @@ pub enum AllocError {
     /// still mid-launch, not yet committed or released). A second concurrent
     /// launch would double-count resources, so it is rejected.
     DuplicateJob,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct LocalAllocation {
+    pub job_id: u32,
+    pub run_attempt: u32,
+    pub resources: AllocationResult,
+    pub exact_resources: ResourceAllocations,
+    pub last_command_id: u64,
+    pub launching: bool,
+    pub releasing: bool,
 }
 
 /// Per-node resource allocation state.
@@ -48,9 +59,12 @@ pub struct NodeAllocation {
     /// Run epoch of each owner. A job id may be reused after requeue, so a
     /// delayed cleanup must not release a replacement run's allocation.
     owner_attempts: HashMap<u32, u32>,
+    owner_exact_resources: HashMap<u32, ResourceAllocations>,
+    owner_last_command_ids: HashMap<u32, u64>,
     /// Reserved but not yet committed, with reserve time. Reconcile spares
     /// these until they exceed a TTL so a dropped launch can't pin resources.
     launching: HashMap<u32, Instant>,
+    releasing: HashSet<u32>,
 }
 
 impl NodeAllocation {
@@ -66,7 +80,10 @@ impl NodeAllocation {
             gpus: resources.gpus.clone(),
             owners: HashMap::new(),
             owner_attempts: HashMap::new(),
+            owner_exact_resources: HashMap::new(),
+            owner_last_command_ids: HashMap::new(),
             launching: HashMap::new(),
+            releasing: HashSet::new(),
         }
     }
 
@@ -89,6 +106,64 @@ impl NodeAllocation {
             .filter(|(_, &a)| a)
             .filter_map(|(i, _)| self.gpus.get(i).map(|g| g.device_id))
             .collect()
+    }
+
+    pub fn owned_allocations(&self) -> Vec<LocalAllocation> {
+        self.owners
+            .iter()
+            .map(|(&job_id, resources)| LocalAllocation {
+                job_id,
+                run_attempt: self.owner_attempts.get(&job_id).copied().unwrap_or(0),
+                resources: resources.clone(),
+                exact_resources: self
+                    .owner_exact_resources
+                    .get(&job_id)
+                    .cloned()
+                    .unwrap_or_default(),
+                last_command_id: self
+                    .owner_last_command_ids
+                    .get(&job_id)
+                    .copied()
+                    .unwrap_or(0),
+                launching: self.launching.contains_key(&job_id),
+                releasing: self.releasing.contains(&job_id),
+            })
+            .collect()
+    }
+
+    pub fn owns_attempt(&self, job_id: u32, run_attempt: u32) -> bool {
+        self.owners.contains_key(&job_id)
+            && (run_attempt == 0 || self.owner_attempts.get(&job_id) == Some(&run_attempt))
+    }
+
+    pub fn set_exact_resources(
+        &mut self,
+        job_id: u32,
+        run_attempt: u32,
+        resources: ResourceAllocations,
+    ) -> bool {
+        if !self.owns_attempt(job_id, run_attempt) {
+            return false;
+        }
+        self.owner_exact_resources.insert(job_id, resources);
+        true
+    }
+
+    pub fn set_last_command_id(&mut self, job_id: u32, run_attempt: u32, command_id: u64) -> bool {
+        if !self.owns_attempt(job_id, run_attempt) {
+            return false;
+        }
+        self.owner_last_command_ids.insert(job_id, command_id);
+        true
+    }
+
+    pub fn begin_release(&mut self, job_id: u32, run_attempt: u32) -> bool {
+        if !self.owns_attempt(job_id, run_attempt) {
+            return false;
+        }
+        self.launching.remove(&job_id);
+        self.releasing.insert(job_id);
+        true
     }
 
     /// Job ids owning any of `device_ids`, excluding mid-launch owners (a launch
@@ -172,13 +247,9 @@ impl NodeAllocation {
         if self.launching.contains_key(&job_id) {
             return Err(AllocError::DuplicateJob);
         }
-        // A committed reservation still owned here means a prior run's teardown
-        // has not released yet (e.g. a preempted-then-requeued job re-dispatched
-        // under the same id before the agent reaped the killed process). The
-        // controller only re-issues LaunchJob after freeing the job, so this
-        // reservation is stale — supersede it rather than reject, releasing it
-        // first so CPU/memory stay symmetric and the owner entry is not orphaned.
-        self.release_job(job_id);
+        if self.owners.contains_key(&job_id) {
+            return Err(AllocError::DuplicateJob);
+        }
 
         let mut gpu_indices = Vec::with_capacity(gpu_device_ids.len());
         for &id in gpu_device_ids {
@@ -211,8 +282,19 @@ impl NodeAllocation {
             gpu_ids: gpu_device_ids.to_vec(),
             memory_mb,
         };
+        let mut exact_resources = ResourceAllocations::with_scalar(cpus, memory_mb);
+        exact_resources.devices.insert(
+            "gpu".into(),
+            gpu_device_ids
+                .iter()
+                .copied()
+                .map(AllocatedDevice::injectable)
+                .collect(),
+        );
         self.owners.insert(job_id, result.clone());
         self.owner_attempts.insert(job_id, run_attempt);
+        self.owner_exact_resources.insert(job_id, exact_resources);
+        self.owner_last_command_ids.insert(job_id, 0);
         self.launching.insert(job_id, Instant::now());
         Ok(result)
     }
@@ -223,6 +305,7 @@ impl NodeAllocation {
     /// so the caller must not treat the job as backed by an allocation.
     pub fn commit_job(&mut self, job_id: u32) -> bool {
         self.launching.remove(&job_id);
+        self.releasing.remove(&job_id);
         self.owners.contains_key(&job_id)
     }
 
@@ -231,6 +314,8 @@ impl NodeAllocation {
     pub fn release_job(&mut self, job_id: u32) -> bool {
         self.launching.remove(&job_id);
         self.owner_attempts.remove(&job_id);
+        self.owner_exact_resources.remove(&job_id);
+        self.owner_last_command_ids.remove(&job_id);
         let Some(alloc) = self.owners.remove(&job_id) else {
             return false;
         };
@@ -262,6 +347,9 @@ impl NodeAllocation {
             .copied()
             .filter(|id| {
                 if live.contains(id) {
+                    return false;
+                }
+                if self.releasing.contains(id) {
                     return false;
                 }
                 match self.launching.get(id) {
@@ -456,30 +544,20 @@ mod tests {
     }
 
     #[test]
-    fn test_allocate_for_job_supersedes_stale_committed_reservation() {
-        // A committed reservation whose teardown has not released yet (e.g. a
-        // preempted-then-requeued job re-dispatched under the same id before the
-        // agent reaped the killed process) must be superseded, not rejected —
-        // otherwise the legitimate re-launch fails and the job never runs. The
-        // stale reservation is released first, so resources are not double-counted.
+    fn test_allocate_for_job_rejects_committed_owner_until_release() {
         let mut node = make_node(64, 256_000, 0, "");
         node.allocate_for_job(7, 8, 16_000, &[]).unwrap();
-        node.commit_job(7); // prior run committed, then preempted (not released).
+        node.commit_job(7);
         assert_eq!(node.free_cpus(), 56);
 
-        // Re-dispatch under the same id succeeds and does not double-count.
-        let alloc = node
-            .allocate_for_job(7, 8, 16_000, &[])
-            .expect("re-dispatch of a stale committed job id must succeed");
-        assert_eq!(alloc.cpu_ids.len(), 8);
-        assert_eq!(node.free_cpus(), 56);
-        assert_eq!(node.free_memory_mb(), 240_000);
-        // Exactly one owner entry remains, and the fresh reservation is again
-        // treated as in-flight until it commits or releases.
         assert_eq!(
             node.allocate_for_job(7, 8, 16_000, &[]),
             Err(AllocError::DuplicateJob)
         );
+        assert_eq!(node.free_cpus(), 56);
+        assert_eq!(node.free_memory_mb(), 240_000);
+        assert!(node.release_job(7));
+        assert!(node.allocate_for_job(7, 8, 16_000, &[]).is_ok());
     }
 
     #[test]
@@ -538,6 +616,22 @@ mod tests {
         assert!(node.release_job(1));
         assert!(node.release_job(3));
         assert_eq!(node.free_gpus(None), 4);
+    }
+
+    #[test]
+    fn test_reconcile_spares_release_until_controller_acknowledgement() {
+        let mut node = make_node(8, 16000, 0, "");
+        node.allocate_for_job_with_attempt(7, 2, 4000, &[], 3)
+            .unwrap();
+        node.commit_job(7);
+        assert!(node.begin_release(7, 3));
+
+        let reclaimed = node.reconcile(&HashSet::new(), Instant::now(), Duration::ZERO);
+        assert!(reclaimed.is_empty());
+        assert!(node.owns_attempt(7, 3));
+        assert!(node.owned_allocations()[0].releasing);
+        assert!(node.release_job_if_attempt(7, 3));
+        assert_eq!(node.free_cpus(), 8);
     }
 
     #[test]

--- a/crates/spur-sched/src/cons_tres.rs
+++ b/crates/spur-sched/src/cons_tres.rs
@@ -45,6 +45,9 @@ pub struct NodeAllocation {
     /// orphans reconciled. Source of truth; the bitmaps above are a derived
     /// index for fast free-count queries.
     owners: HashMap<u32, AllocationResult>,
+    /// Run epoch of each owner. A job id may be reused after requeue, so a
+    /// delayed cleanup must not release a replacement run's allocation.
+    owner_attempts: HashMap<u32, u32>,
     /// Reserved but not yet committed, with reserve time. Reconcile spares
     /// these until they exceed a TTL so a dropped launch can't pin resources.
     launching: HashMap<u32, Instant>,
@@ -62,6 +65,7 @@ impl NodeAllocation {
             gpu_allocated: vec![false; num_gpus],
             gpus: resources.gpus.clone(),
             owners: HashMap::new(),
+            owner_attempts: HashMap::new(),
             launching: HashMap::new(),
         }
     }
@@ -150,6 +154,19 @@ impl NodeAllocation {
         memory_mb: u64,
         gpu_device_ids: &[u32],
     ) -> Result<AllocationResult, AllocError> {
+        self.allocate_for_job_with_attempt(job_id, cpus, memory_mb, gpu_device_ids, 0)
+    }
+
+    /// Reserve resources for one run epoch of a job. Epoch zero preserves the
+    /// legacy unfenced behavior for controllers that do not send an epoch.
+    pub fn allocate_for_job_with_attempt(
+        &mut self,
+        job_id: u32,
+        cpus: u32,
+        memory_mb: u64,
+        gpu_device_ids: &[u32],
+        run_attempt: u32,
+    ) -> Result<AllocationResult, AllocError> {
         // A launch still in flight (reserved, not yet committed or released) is
         // a genuine concurrent duplicate: a second launch would double-count.
         if self.launching.contains_key(&job_id) {
@@ -195,6 +212,7 @@ impl NodeAllocation {
             memory_mb,
         };
         self.owners.insert(job_id, result.clone());
+        self.owner_attempts.insert(job_id, run_attempt);
         self.launching.insert(job_id, Instant::now());
         Ok(result)
     }
@@ -212,11 +230,21 @@ impl NodeAllocation {
     /// already-released job is a no-op returning false.
     pub fn release_job(&mut self, job_id: u32) -> bool {
         self.launching.remove(&job_id);
+        self.owner_attempts.remove(&job_id);
         let Some(alloc) = self.owners.remove(&job_id) else {
             return false;
         };
         self.release(&alloc);
         true
+    }
+
+    /// Release only when `run_attempt` still owns this job id. Zero is the
+    /// legacy unfenced value and deliberately releases whichever run is held.
+    pub fn release_job_if_attempt(&mut self, job_id: u32, run_attempt: u32) -> bool {
+        if run_attempt != 0 && self.owner_attempts.get(&job_id) != Some(&run_attempt) {
+            return false;
+        }
+        self.release_job(job_id)
     }
 
     /// Release owned allocations whose job is neither live nor launching within

--- a/crates/spurctld/Cargo.toml
+++ b/crates/spurctld/Cargo.toml
@@ -21,6 +21,7 @@ sqlx = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }
 prost-types = { workspace = true }
+prost = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 clap = { workspace = true }

--- a/crates/spurctld/src/accounting/grpc.rs
+++ b/crates/spurctld/src/accounting/grpc.rs
@@ -277,6 +277,7 @@ impl SlurmAccounting for AccountingService {
                 srun_step_dispatch: false,
                 req_gpus: 0,
                 req_gpus_detail: String::new(),
+                run_attempt: 0,
             })
             .collect();
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -514,6 +514,12 @@ impl ClusterManager {
             .retain(|(job_id, n), _| n != node || reported.contains(job_id));
     }
 
+    /// Undo a reservation planted ahead of a cancel/evict that then failed —
+    /// callers pre-reserve before the mutation, so a failure must roll back.
+    pub(crate) fn clear_pending_kill_for_job(&self, job_id: JobId) {
+        self.pending_kill.write().retain(|(id, _), _| *id != job_id);
+    }
+
     /// Per-node resources still held out of new dispatch, pruning any
     /// entry whose TTL has expired.
     pub(crate) fn pending_kill_reservations(&self) -> HashMap<String, ResourceAllocations> {
@@ -6339,6 +6345,23 @@ mod tests {
         let cm0 = Arc::new(ClusterManager::new(cfg, dir.path()).unwrap());
         cm0.note_pending_kill(9, "n1", scalar_alloc(1, 1000));
         assert!(cm0.pending_kill_reservations().is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn clear_pending_kill_for_job_removes_only_that_job() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        cm.note_pending_kill(1, "n1", scalar_alloc(2, 4000));
+        cm.note_pending_kill(2, "n1", scalar_alloc(3, 6000));
+
+        cm.clear_pending_kill_for_job(1);
+
+        let reserved = cm.pending_kill_reservations();
+        assert_eq!(
+            reserved.get("n1").unwrap().cpus,
+            3,
+            "only job 1's reservation must be rolled back"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1138,9 +1138,11 @@ impl ClusterManager {
                 return Ok(NodeCompleteResult::AlreadyTerminal);
             }
             // Drop a report from a superseded run (older epoch); e.g. the
-            // delayed SIGKILL of a preemption-requeued process. Epoch 0 on
-            // either side (legacy) disables the check.
-            if run_attempt != 0 && job.run_attempt != 0 && run_attempt < job.run_attempt {
+            // delayed SIGKILL of a preemption-requeued process. A reported
+            // epoch of 0 is the sentinel for "predates run_attempt fencing"
+            // (an in-flight allocation from before this guard existed, or an
+            // older agent binary) and is trusted rather than treated as stale.
+            if run_attempt != 0 && run_attempt < job.run_attempt {
                 return Ok(NodeCompleteResult::StaleReport);
             }
             if !job.allocated_nodes.iter().any(|n| n == node_name) {
@@ -8108,6 +8110,39 @@ mod tests {
         // Current-epoch report is applied normally.
         cm.node_complete(1, "n1", 0, 9, 2).unwrap();
         assert_eq!(cm.get_job(1).unwrap().state, JobState::Failed);
+    }
+
+    // A reported epoch of 0 is the "predates run_attempt fencing" sentinel
+    // (an in-flight allocation from before the guard existed, or an older
+    // agent binary) and must be trusted even though the job's own epoch has
+    // since advanced — it must not be dropped as a stale report.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn node_complete_trusts_legacy_zero_epoch_report() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("legacy-epoch-job")),
+        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
+        cm.apply_operation(&WalOperation::JobStart {
+            job_id: 1,
+            nodes: vec!["n1".into()],
+            resources: scalar_alloc(6, 12000),
+            per_node_alloc: per_node_for(&["n1"], scalar_alloc(6, 12000)),
+            srun_step_dispatch: false,
+            run_attempt: 2,
+        });
+
+        let res = cm.node_complete(1, "n1", 0, 0, 0).unwrap();
+        assert!(!matches!(res, NodeCompleteResult::StaleReport));
+        assert_eq!(cm.get_job(1).unwrap().state, JobState::Completed);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -488,8 +488,8 @@ impl ClusterManager {
             .retain(|(job_id, n), _| n != node || active_job_ids.contains(job_id));
     }
 
-    /// Reserve `resources` on `node` until the TTL expires. Refreshes the
-    /// TTL if already present.
+    /// Reserve `resources` on `node` until a heartbeat confirms release or
+    /// the TTL expires, whichever comes first. Refreshes the TTL if present.
     pub(crate) fn note_pending_kill(
         &self,
         job_id: JobId,
@@ -504,6 +504,14 @@ impl ClusterManager {
         self.pending_kill
             .write()
             .insert((job_id, node.to_string()), (resources, until));
+    }
+
+    /// Clear `node`'s pending-kill entries for jobs a heartbeat no longer
+    /// reports — real confirmation of release, not just a TTL guess.
+    pub(crate) fn clear_confirmed_pending_kills(&self, node: &str, reported: &HashSet<JobId>) {
+        self.pending_kill
+            .write()
+            .retain(|(job_id, n), _| n != node || reported.contains(job_id));
     }
 
     /// Per-node resources still held out of new dispatch, pruning any

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -964,19 +964,23 @@ impl ClusterManager {
         spur_core::auth::check_job_owner(user, owner, action).map_err(Into::into)
     }
 
+    /// Check without cancelling — callers that pre-reserve resources on the
+    /// expected cancel must check this first, before planting a reservation.
+    pub fn check_cancel_allowed(&self, job_id: JobId, user: &str) -> anyhow::Result<()> {
+        let jobs = self.jobs.read();
+        let job = jobs
+            .get(&job_id)
+            .ok_or_else(|| anyhow::anyhow!("job {} not found", job_id))?;
+        if job.state.is_terminal() {
+            anyhow::bail!("job {} is already {:?}", job_id, job.state);
+        }
+        Self::check_job_owner(user, &job.spec.user, "cancel")
+    }
+
     /// Cancel a job. The requesting `user` must be the job owner, root, or
     /// empty (trusted internal/daemon calls).
     pub fn cancel_job(&self, job_id: JobId, user: &str) -> anyhow::Result<()> {
-        {
-            let jobs = self.jobs.read();
-            let job = jobs
-                .get(&job_id)
-                .ok_or_else(|| anyhow::anyhow!("job {} not found", job_id))?;
-            if job.state.is_terminal() {
-                anyhow::bail!("job {} is already {:?}", job_id, job.state);
-            }
-            Self::check_job_owner(user, &job.spec.user, "cancel")?;
-        }
+        self.check_cancel_allowed(job_id, user)?;
 
         // Use JobComplete (not JobStateChange) so that resource deallocation
         // fires for any allocated nodes. For pending jobs, allocated_nodes is empty

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -3,7 +3,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 
 use chrono::{DateTime, Utc};
@@ -25,7 +25,7 @@ use spur_core::qos::{check_qos_limits, qos_adjusted_priority, QosCheckResult};
 use spur_core::reservation::{self, normalize_node_list, running_jobs_overlap_start, Reservation};
 use spur_core::resource::{ResourceAllocations, ResourceSet};
 use spur_core::step::{JobStep, StepState, STEP_BATCH, STEP_RESERVED_MIN};
-use spur_core::wal::WalOperation;
+use spur_core::wal::{PendingKillRelease, PendingKillReservation, WalOperation};
 use spur_metrics::job::JobMetricsSnapshot;
 use spur_metrics::node::NodeMetricsSnapshot;
 use spur_metrics::partition::PartitionMetricsSnapshot;
@@ -289,9 +289,6 @@ pub enum PreemptOutcome {
     Suspended,
 }
 
-/// Resources, expiry, and owning attempt token for one pending-kill entry.
-type PendingKillEntry = (ResourceAllocations, std::time::Instant, u64);
-
 /// Central cluster state manager.
 ///
 /// Thread-safe via RwLock. The scheduler and gRPC server both access this.
@@ -355,10 +352,10 @@ pub struct ClusterManager {
     /// Consecutive heartbeats a node's report has omitted a job it's bound
     /// to. Leader-local and transient, never persisted.
     phantom_miss_streaks: RwLock<HashMap<(JobId, String), u32>>,
-    /// Resources freed but not yet confirmed released by the agent. The u64
-    /// scopes a rollback to the attempt that planted it, not a concurrent one.
-    pending_kill: RwLock<HashMap<(JobId, String), PendingKillEntry>>,
-    next_pending_kill_attempt: std::sync::atomic::AtomicU64,
+    /// Resources freed but not yet confirmed released by the agent; replicated
+    /// so a leadership change can't make an unconfirmed release schedulable.
+    pending_kill: RwLock<HashMap<(JobId, String), PendingKillReservation>>,
+    next_pending_kill_attempt: AtomicU64,
 }
 
 struct PendingJobClassification {
@@ -421,7 +418,7 @@ impl ClusterManager {
             node_dispatch_cooldowns: RwLock::new(HashMap::new()),
             phantom_miss_streaks: RwLock::new(HashMap::new()),
             pending_kill: RwLock::new(HashMap::new()),
-            next_pending_kill_attempt: std::sync::atomic::AtomicU64::new(1),
+            next_pending_kill_attempt: AtomicU64::new(1),
         };
 
         info!("cluster manager initialized (state will be recovered via Raft)");
@@ -493,15 +490,25 @@ impl ClusterManager {
             .retain(|(job_id, n), _| n != node || active_job_ids.contains(job_id));
     }
 
-    /// New token identifying one reserve-then-mutate attempt, so its rollback
-    /// can't clear a different, concurrent attempt's still-live reservation.
+    /// New token identifying one durable release hold.
     pub(crate) fn new_pending_kill_attempt(&self) -> u64 {
         self.next_pending_kill_attempt
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            .fetch_add(1, Ordering::Relaxed)
     }
 
-    /// Reserve `resources` on `node` under `attempt` until a heartbeat confirms
-    /// release or the TTL expires, whichever comes first.
+    #[cfg(test)]
+    pub(crate) fn reserve_pending_kills(
+        &self,
+        reservations: Vec<PendingKillReservation>,
+    ) -> anyhow::Result<()> {
+        if reservations.is_empty() {
+            return Ok(());
+        }
+        self.propose(WalOperation::PendingKillReserve { reservations })?;
+        Ok(())
+    }
+
+    #[cfg(test)]
     pub(crate) fn note_pending_kill(
         &self,
         job_id: JobId,
@@ -509,43 +516,154 @@ impl ClusterManager {
         resources: ResourceAllocations,
         attempt: u64,
     ) {
-        let ttl = self.config().controller.pending_kill_ttl_secs;
-        if ttl == 0 {
-            return;
+        self.reserve_pending_kills(vec![PendingKillReservation {
+            job_id,
+            node: node.into(),
+            resources,
+            attempt,
+            run_attempt: 0,
+        }])
+        .expect("test pending-kill reservation must commit");
+    }
+
+    pub(crate) fn pending_kills_for_job(&self, job: &Job) -> Vec<PendingKillReservation> {
+        let attempt = self.new_pending_kill_attempt();
+        let node_count = job.allocated_nodes.len().max(1) as u32;
+        job.allocated_nodes
+            .iter()
+            .map(|node| PendingKillReservation {
+                job_id: job.job_id,
+                node: node.clone(),
+                resources: job.per_node_alloc.get(node).cloned().unwrap_or_else(|| {
+                    job.allocated_resources.as_ref().map_or_else(
+                        ResourceAllocations::default,
+                        |total| {
+                            ResourceAllocations::with_scalar(
+                                total.cpus / node_count,
+                                total.memory_mb / node_count as u64,
+                            )
+                        },
+                    )
+                }),
+                attempt,
+                run_attempt: job.run_attempt,
+            })
+            .collect()
+    }
+
+    pub(crate) fn reserve_pending_dispatch(
+        &self,
+        job_id: JobId,
+        nodes: &[String],
+        per_node_alloc: &HashMap<String, ResourceAllocations>,
+        run_attempt: u32,
+    ) -> anyhow::Result<()> {
+        let attempt = self.new_pending_kill_attempt();
+        let reservations = nodes
+            .iter()
+            .filter_map(|node| {
+                per_node_alloc
+                    .get(node)
+                    .cloned()
+                    .map(|resources| PendingKillReservation {
+                        job_id,
+                        node: node.clone(),
+                        resources,
+                        attempt,
+                        run_attempt,
+                    })
+            })
+            .collect();
+        self.propose(WalOperation::PendingKillReserve { reservations })?;
+        Ok(())
+    }
+
+    pub fn begin_dispatch_attempt(&self, job_id: JobId) -> anyhow::Result<u32> {
+        let attempt = self
+            .jobs
+            .read()
+            .get(&job_id)
+            .ok_or_else(|| anyhow::anyhow!("job {} not found", job_id))
+            .and_then(|job| {
+                if job.state != JobState::Pending {
+                    anyhow::bail!("job {} is not pending", job_id);
+                }
+                Ok(job.run_attempt.saturating_add(1))
+            })?;
+        self.propose(WalOperation::JobDispatchAttempt {
+            job_id,
+            run_attempt: attempt,
+        })?;
+        Ok(attempt)
+    }
+
+    fn pending_kills_for_jobs(&self, jobs: &[Job]) -> Vec<PendingKillReservation> {
+        jobs.iter()
+            .flat_map(|job| self.pending_kills_for_job(job))
+            .collect()
+    }
+
+    pub(crate) fn propose_with_pending_kills(
+        &self,
+        reservations: Vec<PendingKillReservation>,
+        operation: WalOperation,
+    ) -> anyhow::Result<ClientResponse> {
+        if reservations.is_empty() {
+            return self.propose(operation);
         }
-        let until = std::time::Instant::now() + std::time::Duration::from_secs(ttl);
-        self.pending_kill
-            .write()
-            .insert((job_id, node.to_string()), (resources, until, attempt));
+        self.propose(WalOperation::PendingKillTransition {
+            reservations,
+            operation: Box::new(operation),
+        })
     }
 
-    /// Clear `node`'s pending-kill entries for jobs a heartbeat no longer
-    /// reports — real confirmation of release, not just a TTL guess.
-    pub(crate) fn clear_confirmed_pending_kills(&self, node: &str, reported: &HashSet<JobId>) {
-        self.pending_kill
-            .write()
-            .retain(|(job_id, n), _| n != node || reported.contains(job_id));
+    /// Replicate the release confirmations established by one heartbeat.
+    pub(crate) fn clear_confirmed_pending_kills(
+        &self,
+        node: &str,
+        reported: &HashSet<JobId>,
+    ) -> anyhow::Result<()> {
+        let releases: Vec<PendingKillRelease> = self
+            .pending_kill
+            .read()
+            .values()
+            .filter(|hold| hold.node == node && !reported.contains(&hold.job_id))
+            .map(|hold| PendingKillRelease {
+                job_id: hold.job_id,
+                node: hold.node.clone(),
+                attempt: hold.attempt,
+            })
+            .collect();
+        if releases.is_empty() {
+            return Ok(());
+        }
+        self.propose(WalOperation::PendingKillRelease { releases })?;
+        Ok(())
     }
 
-    /// Undo `attempt`'s own reservation after its cancel/evict failed — never
-    /// a concurrent attempt's still-live one on the same job.
-    pub(crate) fn clear_pending_kill_for_job(&self, job_id: JobId, attempt: u64) {
-        self.pending_kill
-            .write()
-            .retain(|(id, _), (_, _, a)| *id != job_id || *a != attempt);
-    }
-
-    /// Per-node resources still held out of new dispatch, pruning any
-    /// entry whose TTL has expired.
+    /// Per-node resources still held out of new dispatch.
     pub(crate) fn pending_kill_reservations(&self) -> HashMap<String, ResourceAllocations> {
-        let now = std::time::Instant::now();
-        let mut pending = self.pending_kill.write();
-        pending.retain(|_, (_, until, _)| *until > now);
         let mut by_node: HashMap<String, ResourceAllocations> = HashMap::new();
-        for ((_, node), (resources, _, _)) in pending.iter() {
-            by_node.entry(node.clone()).or_default().add(resources);
+        for hold in self.pending_kill.read().values() {
+            by_node
+                .entry(hold.node.clone())
+                .or_default()
+                .add(&hold.resources);
         }
         by_node
+    }
+
+    pub(crate) fn has_pending_kill(&self, job_id: JobId, node: &str) -> bool {
+        self.pending_kill
+            .read()
+            .contains_key(&(job_id, node.to_string()))
+    }
+
+    pub(crate) fn pending_kill_run_attempt(&self, job_id: JobId, node: &str) -> Option<u32> {
+        self.pending_kill
+            .read()
+            .get(&(job_id, node.to_string()))
+            .map(|hold| hold.run_attempt)
     }
 
     /// Submit a new job. If it has an array spec, expand into individual tasks.
@@ -1003,15 +1121,7 @@ impl ClusterManager {
     pub fn cancel_job(&self, job_id: JobId, user: &str) -> anyhow::Result<()> {
         self.check_cancel_allowed(job_id, user)?;
 
-        // Use JobComplete (not JobStateChange) so that resource deallocation
-        // fires for any allocated nodes. For pending jobs, allocated_nodes is empty
-        // so the deallocation loop is a no-op.
-        let resp = self.propose(WalOperation::JobComplete {
-            job_id,
-            exit_code: -1,
-            state: JobState::Cancelled,
-        })?;
-        self.run_all_finalized_side_effects(&resp);
+        self.complete_job_after_cancel(job_id, -1, JobState::Cancelled)?;
 
         info!(job_id, "job cancelled");
         Ok(())
@@ -1055,13 +1165,14 @@ impl ClusterManager {
         } else {
             JobState::Failed
         };
-        self.complete_job(job_id, exit_code, state).map_err(|e| {
-            warn!(job_id, error = %e, "finish_srun_job: complete_job failed");
-            SrunCompleteError::Internal {
-                job_id,
-                message: e.to_string(),
-            }
-        })?;
+        self.complete_job_after_cancel(job_id, exit_code, state)
+            .map_err(|e| {
+                warn!(job_id, error = %e, "finish_srun_job: complete_job failed");
+                SrunCompleteError::Internal {
+                    job_id,
+                    message: e.to_string(),
+                }
+            })?;
         Ok(job)
     }
 
@@ -1151,8 +1262,7 @@ impl ClusterManager {
             old_state = job.state;
             spec_for_notify = job.spec.clone();
             submit_time_for_notify = job.submit_time;
-            // Next run epoch (first dispatch = 1), threaded to the agents.
-            run_attempt = job.run_attempt.saturating_add(1);
+            run_attempt = job.run_attempt.max(1);
             if job.state != JobState::Pending {
                 anyhow::bail!("job {} cannot start from state {:?}", job_id, job.state);
             }
@@ -1288,11 +1398,31 @@ impl ClusterManager {
     }
 
     /// Complete a job (controller-initiated or force-finish from COMPLETING timeout).
+    #[cfg(test)]
     pub fn complete_job(
         &self,
         job_id: JobId,
         exit_code: i32,
         state: JobState,
+    ) -> anyhow::Result<()> {
+        self.complete_job_inner(job_id, exit_code, state, false)
+    }
+
+    pub fn complete_job_after_cancel(
+        &self,
+        job_id: JobId,
+        exit_code: i32,
+        state: JobState,
+    ) -> anyhow::Result<()> {
+        self.complete_job_inner(job_id, exit_code, state, true)
+    }
+
+    fn complete_job_inner(
+        &self,
+        job_id: JobId,
+        exit_code: i32,
+        state: JobState,
+        hold_until_heartbeat: bool,
     ) -> anyhow::Result<()> {
         // A time-limit expiry has to win over the caller's outcome here, not
         // just in the per-node completion path. The marker is only ever set on
@@ -1302,7 +1432,7 @@ impl ClusterManager {
         // expiry that would otherwise be reported as an ordinary failure and
         // skip the Timeout requeue. Cancelled (user cancel, preemption) and an
         // already-correct Timeout pass through untouched.
-        let state = {
+        let (state, holds) = {
             let jobs = self.jobs.read();
             let job = jobs
                 .get(&job_id)
@@ -1310,22 +1440,31 @@ impl ClusterManager {
             if job.state.is_terminal() {
                 anyhow::bail!("invalid transition from {:?} to {:?}", job.state, state);
             }
-            if job.time_limit_signaled_at.is_some()
+            let state = if job.time_limit_signaled_at.is_some()
                 && matches!(state, JobState::Failed | JobState::Completed)
             {
                 JobState::Timeout
             } else {
                 state
-            }
+            };
+            let holds = if hold_until_heartbeat {
+                self.pending_kills_for_job(job)
+            } else {
+                Vec::new()
+            };
+            (state, holds)
         };
 
         // propose() handles: state transition, exit_code, end_time,
         // resource deallocation, step completion, license return
-        let resp = self.propose(WalOperation::JobComplete {
-            job_id,
-            exit_code,
-            state,
-        })?;
+        let resp = self.propose_with_pending_kills(
+            holds,
+            WalOperation::JobComplete {
+                job_id,
+                exit_code,
+                state,
+            },
+        )?;
         self.run_all_finalized_side_effects(&resp);
 
         debug!(job_id, exit_code, "job completed");
@@ -1346,7 +1485,7 @@ impl ClusterManager {
     /// controller-side state change; the caller dispatches the signal named by
     /// the returned `PreemptOutcome`. `Off` is rejected.
     pub fn preempt_job(&self, job_id: JobId, mode: PreemptMode) -> anyhow::Result<PreemptOutcome> {
-        {
+        let job = {
             let jobs = self.jobs.read();
             let job = jobs
                 .get(&job_id)
@@ -1354,7 +1493,8 @@ impl ClusterManager {
             if job.state != JobState::Running {
                 anyhow::bail!("job {} is not running (state {:?})", job_id, job.state);
             }
-        }
+            job.clone()
+        };
 
         match mode {
             PreemptMode::Off => anyhow::bail!("preemption disabled for job {}", job_id),
@@ -1364,7 +1504,7 @@ impl ClusterManager {
                 Ok(PreemptOutcome::Suspended)
             }
             PreemptMode::Cancel => {
-                self.complete_job(job_id, -1, JobState::Cancelled)?;
+                self.complete_job_after_cancel(job_id, -1, JobState::Cancelled)?;
                 info!(job_id, "job preempted (cancel)");
                 Ok(PreemptOutcome::Killed)
             }
@@ -1389,7 +1529,10 @@ impl ClusterManager {
                     .get(&job_id)
                     .and_then(|j| j.spec.begin_time)
                     .map_or(hold, |user_begin| user_begin.max(hold));
-                let resp = self.propose(WalOperation::JobPreemptRequeue { job_id, begin_time })?;
+                let resp = self.propose_with_pending_kills(
+                    self.pending_kills_for_job(&job),
+                    WalOperation::JobPreemptRequeue { job_id, begin_time },
+                )?;
                 self.run_all_finalized_side_effects(&resp);
                 info!(job_id, hold_secs, "job preempted (requeue)");
                 Ok(PreemptOutcome::Killed)
@@ -1582,13 +1725,7 @@ impl ClusterManager {
             (job.state, self.launch_backoff_until(job))
         };
 
-        // transition to Failed via JobComplete so node resources,
-        // licenses, and steps are properly cleaned up.
-        self.propose(WalOperation::JobComplete {
-            job_id,
-            exit_code: -1,
-            state: JobState::Failed,
-        })?;
+        self.complete_job_after_cancel(job_id, -1, JobState::Failed)?;
 
         if hold {
             self.propose(WalOperation::job_state_change_held_pending_desc(
@@ -1680,7 +1817,7 @@ impl ClusterManager {
         run_attempt: u32,
         detail: Option<String>,
     ) -> anyhow::Result<Vec<JobFinalized>> {
-        {
+        let job = {
             let jobs = self.jobs.read();
             let job = jobs
                 .get(&job_id)
@@ -1688,13 +1825,17 @@ impl ClusterManager {
             if job.state.is_terminal() {
                 return Ok(Vec::new());
             }
-        }
-        let resp = self.propose(WalOperation::JobEvict {
-            job_id,
-            reason,
-            detail,
-            run_attempt,
-        })?;
+            job.clone()
+        };
+        let resp = self.propose_with_pending_kills(
+            self.pending_kills_for_job(&job),
+            WalOperation::JobEvict {
+                job_id,
+                reason,
+                detail,
+                run_attempt,
+            },
+        )?;
         self.run_all_finalized_side_effects(&resp);
         Ok(resp.jobs_finalized)
     }
@@ -1995,11 +2136,7 @@ impl ClusterManager {
         };
 
         if state == JobState::Running {
-            self.propose(WalOperation::JobComplete {
-                job_id,
-                exit_code: -1,
-                state: JobState::Failed,
-            })?;
+            self.complete_job_after_cancel(job_id, -1, JobState::Failed)?;
             state = JobState::Failed;
         }
 
@@ -2220,14 +2357,22 @@ impl ClusterManager {
         // locked so auto-recovery won't override the operator's intent.
         // Resuming to Idle clears the lock.
         let admin_locked = effective_state.is_admin_hold();
+        let holds = if effective_state == NodeState::Down {
+            self.pending_kills_for_jobs(&self.active_jobs_on_node(name))
+        } else {
+            Vec::new()
+        };
 
-        self.propose(WalOperation::NodeStateChange {
-            name: name.to_string(),
-            old_state,
-            new_state: effective_state,
-            reason,
-            admin_locked,
-        })?;
+        self.propose_with_pending_kills(
+            holds,
+            WalOperation::NodeStateChange {
+                name: name.to_string(),
+                old_state,
+                new_state: effective_state,
+                reason,
+                admin_locked,
+            },
+        )?;
         info!(node = %name, old = ?old_state, new = ?effective_state, "node state updated");
         Ok(())
     }
@@ -2340,13 +2485,16 @@ impl ClusterManager {
                     admin_locked,
                 } => {
                     warn!(node = %name, "node marked DOWN (heartbeat timeout)");
-                    match self.propose(WalOperation::NodeStateChange {
-                        name: name.clone(),
-                        old_state,
-                        new_state: NodeState::Down,
-                        reason: Some("Not responding".into()),
-                        admin_locked,
-                    }) {
+                    match self.propose_with_pending_kills(
+                        self.pending_kills_for_jobs(&self.active_jobs_on_node(&name)),
+                        WalOperation::NodeStateChange {
+                            name: name.clone(),
+                            old_state,
+                            new_state: NodeState::Down,
+                            reason: Some("Not responding".into()),
+                            admin_locked,
+                        },
+                    ) {
                         Ok(resp) => {
                             self.run_all_finalized_side_effects(&resp);
                             evicted.extend(resp.jobs_finalized);
@@ -2450,10 +2598,13 @@ impl ClusterManager {
             }
         }
 
-        let resp = self.propose(WalOperation::NodeRemove {
-            name: name.to_string(),
-            reason,
-        })?;
+        let resp = self.propose_with_pending_kills(
+            self.pending_kills_for_jobs(&self.active_jobs_on_node(name)),
+            WalOperation::NodeRemove {
+                name: name.to_string(),
+                reason,
+            },
+        )?;
         self.run_all_finalized_side_effects(&resp);
         Ok(resp.jobs_finalized)
     }
@@ -3522,7 +3673,7 @@ impl ClusterManager {
     }
 
     /// Cancel running jobs whose reservation window has ended (after optional grace).
-    pub fn enforce_reservation_end_times(&self) {
+    pub fn enforce_reservation_end_times(&self) -> Vec<Job> {
         let now = Utc::now();
         let grace = chrono::Duration::minutes(self.config().scheduler.resv_overrun_minutes as i64);
         let reservations: std::collections::HashMap<String, Reservation> = self
@@ -3530,7 +3681,7 @@ impl ClusterManager {
             .into_iter()
             .map(|r| (r.name.clone(), r))
             .collect();
-        let to_cancel: Vec<JobId> = self
+        let to_cancel: Vec<Job> = self
             .jobs
             .read()
             .values()
@@ -3544,17 +3695,21 @@ impl ClusterManager {
                 let res_name = job.spec.reservation.as_ref()?;
                 let res = reservations.get(res_name)?;
                 if now > res.end_time + grace {
-                    Some(job.job_id)
+                    Some(job.clone())
                 } else {
                     None
                 }
             })
             .collect();
-        for job_id in to_cancel {
-            if let Err(e) = self.complete_job(job_id, -1, JobState::Cancelled) {
-                warn!(job_id, error = %e, "failed to cancel job after reservation ended");
+        let mut cancelled = Vec::new();
+        for job in to_cancel {
+            if let Err(e) = self.complete_job_after_cancel(job.job_id, -1, JobState::Cancelled) {
+                warn!(job_id = job.job_id, error = %e, "failed to cancel job after reservation ended");
+            } else {
+                cancelled.push(job);
             }
         }
+        cancelled
     }
 
     fn validate_reservation_job_overlap(
@@ -4166,9 +4321,29 @@ impl ClusterManager {
         }
     }
 
+    fn apply_pending_kill_reservations(&self, reservations: &[PendingKillReservation]) {
+        let mut pending = self.pending_kill.write();
+        for hold in reservations {
+            // Raft applies are strictly ordered, so the newest reservation for a
+            // key is always the accurate one — never keep a stale prior attempt.
+            pending.insert((hold.job_id, hold.node.clone()), hold.clone());
+            self.next_pending_kill_attempt
+                .fetch_max(hold.attempt.saturating_add(1), Ordering::Relaxed);
+        }
+    }
+
     /// Apply a WalOperation to in-memory state.
     /// Called by Raft's `apply_to_state_machine` on commit.
     fn apply_operation(&self, op: &WalOperation) -> ClientResponse {
+        if let WalOperation::PendingKillTransition {
+            reservations,
+            operation,
+        } = op
+        {
+            self.apply_pending_kill_reservations(reservations);
+            return self.apply_operation(operation);
+        }
+
         let mut response = ClientResponse::default();
         let mut jobs = self.jobs.write();
         let mut nodes = self.nodes.write();
@@ -4176,6 +4351,22 @@ impl ClusterManager {
         let timestamp = Utc::now();
 
         match op {
+            WalOperation::PendingKillReserve { reservations } => {
+                self.apply_pending_kill_reservations(reservations);
+            }
+            WalOperation::PendingKillTransition { .. } => unreachable!("handled before locking"),
+            WalOperation::PendingKillRelease { releases } => {
+                let mut pending = self.pending_kill.write();
+                for release in releases {
+                    let key = (release.job_id, release.node.clone());
+                    if pending
+                        .get(&key)
+                        .is_some_and(|hold| hold.attempt == release.attempt)
+                    {
+                        pending.remove(&key);
+                    }
+                }
+            }
             WalOperation::JobSubmit { job_id, spec } => {
                 let mut job = Job::new(*job_id, (**spec).clone());
                 if let Some(het_group) = spec.het_group {
@@ -4247,6 +4438,16 @@ impl ClusterManager {
                 Self::reset_job_for_requeue(job);
                 job.spec.begin_time = Some(*begin_time);
                 job.set_pending_reason(PendingReason::JobLaunchFailure);
+            }
+            WalOperation::JobDispatchAttempt {
+                job_id,
+                run_attempt,
+            } => {
+                if let Some(job) = jobs.get_mut(job_id) {
+                    if job.state == JobState::Pending && *run_attempt > job.run_attempt {
+                        job.run_attempt = *run_attempt;
+                    }
+                }
             }
             WalOperation::JobPreemptRequeue { job_id, begin_time } => {
                 // Only a running job is preempted; on replay the job is already
@@ -4389,7 +4590,9 @@ impl ClusterManager {
                     job.per_node_alloc = per_node_alloc.clone();
                     job.set_pending_reason(PendingReason::None);
                     job.srun_step_dispatch = *srun_step_dispatch;
-                    job.run_attempt = *run_attempt;
+                    // Monotonic like JobDispatchAttempt's write: never let a
+                    // stale-snapshot start regress the epoch backward.
+                    job.run_attempt = job.run_attempt.max(*run_attempt);
                     job.launch_failure_detail = None;
                 }
                 let node_count = node_names.len().max(1) as u32;
@@ -4840,6 +5043,9 @@ impl ClusterManager {
                     }
                 }
                 nodes.remove(name);
+                // The node will never heartbeat again to confirm release, so any
+                // hold on it — including ones just planted above — must go now.
+                self.pending_kill.write().retain(|(_, n), _| n != name);
                 info!(
                     node = %name,
                     reason = reason.as_deref().unwrap_or(""),
@@ -5134,6 +5340,12 @@ impl ClusterManager {
 struct ClusterSnapshot {
     jobs: Vec<Job>,
     nodes: Vec<Node>,
+    /// Holds are part of the controller's allocation truth until the node
+    /// confirms release, including after a leader change or snapshot install.
+    #[serde(default)]
+    pending_kills: Vec<PendingKillReservation>,
+    #[serde(default)]
+    next_pending_kill_attempt: u64,
     reservations: Vec<Reservation>,
     /// The leader's authoritative partition table. `None` = pre-partition-support
     /// snapshot (field absent) → restore falls back to the config baseline.
@@ -5220,6 +5432,8 @@ impl StateMachineApply for ClusterManager {
         let snap = ClusterSnapshot {
             jobs: self.jobs.read().values().cloned().collect(),
             nodes: self.nodes.read().values().cloned().collect(),
+            pending_kills: self.pending_kill.read().values().cloned().collect(),
+            next_pending_kill_attempt: self.next_pending_kill_attempt.load(Ordering::Relaxed),
             reservations: self.reservations.read().clone(),
             partitions: Some(self.partitions.read().clone()),
             deleted_partition_names: self.deleted_partition_names.read().clone(),
@@ -5251,6 +5465,19 @@ impl StateMachineApply for ClusterManager {
         for node in snap.nodes {
             nodes.insert(node.name.clone(), node);
         }
+
+        let next_pending_attempt = snap
+            .pending_kills
+            .iter()
+            .map(|hold| hold.attempt.saturating_add(1))
+            .fold(snap.next_pending_kill_attempt.max(1), u64::max);
+        *self.pending_kill.write() = snap
+            .pending_kills
+            .into_iter()
+            .map(|hold| ((hold.job_id, hold.node.clone()), hold))
+            .collect();
+        self.next_pending_kill_attempt
+            .store(next_pending_attempt, Ordering::Relaxed);
 
         *self.reservations.write() = snap.reservations;
 
@@ -6276,6 +6503,40 @@ mod tests {
         assert!(cm0.nodes_on_dispatch_cooldown().is_empty());
     }
 
+    // JobStart's write must be monotonic like JobDispatchAttempt's, or a
+    // stale-snapshot start could regress the epoch backward.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn job_start_does_not_regress_run_attempt_below_a_later_dispatch_attempt() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("epoch-monotonic")),
+        });
+        cm.apply_operation(&WalOperation::JobDispatchAttempt {
+            job_id: 1,
+            run_attempt: 5,
+        });
+
+        // A stale JobStart snapshot from before the bump above must not win.
+        cm.apply_operation(&WalOperation::JobStart {
+            job_id: 1,
+            nodes: vec!["n1".into()],
+            resources: scalar_alloc(6, 12000),
+            per_node_alloc: per_node_for(&["n1"], scalar_alloc(6, 12000)),
+            srun_step_dispatch: false,
+            run_attempt: 3,
+        });
+
+        assert_eq!(
+            cm.get_job(1).unwrap().run_attempt,
+            5,
+            "JobStart must not regress run_attempt below a later dispatch attempt"
+        );
+    }
+
     // Only the Nth consecutive miss crosses the threshold; a report resets it.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn phantom_miss_streak_crosses_threshold_only_after_consecutive_misses() {
@@ -6322,7 +6583,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn pending_kill_reservations_aggregate_prune_and_respect_disable() {
+    async fn pending_kill_reservations_aggregate() {
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
 
@@ -6338,39 +6599,23 @@ mod tests {
             "multiple pending kills on the same node sum"
         );
         assert_eq!(reserved.get("n2").unwrap().cpus, 1);
-
-        // A past instant is pruned on read, so an expired entry clears.
-        cm.pending_kill.write().insert(
-            (1, "n1".into()),
-            (
-                scalar_alloc(2, 4000),
-                std::time::Instant::now() - std::time::Duration::from_secs(1),
-                101,
-            ),
-        );
-        let reserved = cm.pending_kill_reservations();
-        assert_eq!(
-            reserved.get("n1").unwrap().cpus,
-            3,
-            "the expired entry no longer contributes, the live one still does"
-        );
-
-        // Disabled (0s): note_pending_kill is a no-op.
-        let mut cfg = test_config();
-        cfg.controller.pending_kill_ttl_secs = 0;
-        let cm0 = Arc::new(ClusterManager::new(cfg, dir.path()).unwrap());
-        cm0.note_pending_kill(9, "n1", scalar_alloc(1, 1000), 201);
-        assert!(cm0.pending_kill_reservations().is_empty());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn clear_pending_kill_for_job_removes_only_that_job() {
+    async fn pending_kill_release_removes_only_the_confirmed_attempt() {
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         cm.note_pending_kill(1, "n1", scalar_alloc(2, 4000), 101);
         cm.note_pending_kill(2, "n1", scalar_alloc(3, 6000), 102);
 
-        cm.clear_pending_kill_for_job(1, 101);
+        cm.propose(WalOperation::PendingKillRelease {
+            releases: vec![PendingKillRelease {
+                job_id: 1,
+                node: "n1".into(),
+                attempt: 101,
+            }],
+        })
+        .unwrap();
 
         let reserved = cm.pending_kill_reservations();
         assert_eq!(
@@ -6380,19 +6625,27 @@ mod tests {
         );
     }
 
-    // A losing cancel's rollback must not clear a concurrent, still-live
-    // reservation planted for the same job by a winning cancel attempt.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn clear_pending_kill_for_job_spares_a_concurrent_attempts_reservation() {
+    async fn pending_kill_release_spares_a_newer_attempt() {
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
-        cm.note_pending_kill(1, "n1", scalar_alloc(2, 4000), 101);
-        // A second, winning attempt for the same job refreshes the entry
-        // under a new attempt token.
-        cm.note_pending_kill(1, "n1", scalar_alloc(2, 4000), 102);
+        cm.reserve_pending_kills(vec![PendingKillReservation {
+            job_id: 1,
+            node: "n1".into(),
+            resources: scalar_alloc(2, 4000),
+            attempt: 102,
+            run_attempt: 0,
+        }])
+        .unwrap();
 
-        // The losing (first) attempt's rollback must not touch it.
-        cm.clear_pending_kill_for_job(1, 101);
+        cm.propose(WalOperation::PendingKillRelease {
+            releases: vec![PendingKillRelease {
+                job_id: 1,
+                node: "n1".into(),
+                attempt: 101,
+            }],
+        })
+        .unwrap();
 
         assert_eq!(
             cm.pending_kill_reservations().get("n1").unwrap().cpus,
@@ -6401,8 +6654,88 @@ mod tests {
         );
     }
 
+    // A second reservation for an already-held key (e.g. redispatch to the
+    // same node) must replace it, not keep the stale attempt forever.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn note_pending_kill_for_job_falls_back_to_an_even_split_without_per_node_alloc() {
+    async fn pending_kill_reserve_overwrites_a_stale_entry_on_the_same_key() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        cm.reserve_pending_kills(vec![PendingKillReservation {
+            job_id: 1,
+            node: "n1".into(),
+            resources: scalar_alloc(2, 4000),
+            attempt: 101,
+            run_attempt: 5,
+        }])
+        .unwrap();
+
+        cm.reserve_pending_kills(vec![PendingKillReservation {
+            job_id: 1,
+            node: "n1".into(),
+            resources: scalar_alloc(4, 8000),
+            attempt: 205,
+            run_attempt: 6,
+        }])
+        .unwrap();
+
+        assert_eq!(
+            cm.pending_kill_reservations().get("n1").unwrap().cpus,
+            4,
+            "the newer reservation's resources must replace the stale entry"
+        );
+        assert_eq!(
+            cm.pending_kill_run_attempt(1, "n1"),
+            Some(6),
+            "the newer reservation's run_attempt must replace the stale entry"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pending_kill_survives_snapshot_restore() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        cm.reserve_pending_kills(vec![PendingKillReservation {
+            job_id: 9,
+            node: "n1".into(),
+            resources: scalar_alloc(2, 4000),
+            attempt: 101,
+            run_attempt: 0,
+        }])
+        .unwrap();
+
+        let snapshot = cm.snapshot_state().unwrap();
+        let restored_dir = TempDir::new().unwrap();
+        let restored = test_cluster(&restored_dir).await;
+        restored.restore_from_snapshot(&snapshot).unwrap();
+
+        assert_eq!(
+            restored.pending_kill_reservations()["n1"].cpus,
+            2,
+            "a new leader must retain an unconfirmed release hold"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn old_snapshot_without_pending_kills_restores() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        let mut snapshot: serde_json::Value =
+            serde_json::from_slice(&cm.snapshot_state().unwrap()).unwrap();
+        let object = snapshot.as_object_mut().unwrap();
+        object.remove("pending_kills");
+        object.remove("next_pending_kill_attempt");
+
+        let restored_dir = TempDir::new().unwrap();
+        let restored = test_cluster(&restored_dir).await;
+        restored
+            .restore_from_snapshot(&serde_json::to_vec(&snapshot).unwrap())
+            .unwrap();
+
+        assert!(restored.pending_kill_reservations().is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pending_kills_for_job_falls_back_to_an_even_split_without_per_node_alloc() {
         // A job replayed from a pre-per_node_alloc WAL entry has an empty map;
         // the reservation must still protect its real allocation, not zero.
         let dir = TempDir::new().unwrap();
@@ -6410,7 +6743,8 @@ mod tests {
         let mut job = make_running_job(1, &["n1", "n2"], 2);
         job.per_node_alloc.clear();
 
-        crate::server::note_pending_kill_for_job(&cm, &job);
+        cm.reserve_pending_kills(cm.pending_kills_for_job(&job))
+            .unwrap();
 
         let reserved = cm.pending_kill_reservations();
         assert_eq!(reserved.get("n1").unwrap().cpus, 2);
@@ -8456,6 +8790,13 @@ mod tests {
         assert_eq!(job.state, JobState::Cancelled);
         assert_eq!(job.exit_code, Some(-1));
         assert!(job.node_completions.is_empty());
+        let pending = cm.pending_kill_reservations();
+        for name in ["n1", "n2", "n3"] {
+            assert_eq!(
+                pending[name].cpus, 2,
+                "node {name} must remain held until its heartbeat confirms release"
+            );
+        }
         for name in ["n1", "n2", "n3"] {
             assert_eq!(
                 cm.get_node(name).unwrap().alloc_resources.cpus,
@@ -15860,6 +16201,8 @@ mod tests {
         let snap = ClusterSnapshot {
             jobs: Vec::new(),
             nodes: vec![stale],
+            pending_kills: Vec::new(),
+            next_pending_kill_attempt: 1,
             reservations: Vec::new(),
             partitions: None,
             deleted_partition_names: HashSet::new(),
@@ -16050,6 +16393,49 @@ mod tests {
         assert_eq!(resp.jobs_finalized[0].state, JobState::NodeFail);
         assert_eq!(cm.get_job(id).unwrap().state, JobState::NodeFail);
         assert!(cm.get_node("n1").is_none());
+    }
+
+    // A removed node will never heartbeat again to confirm release, so any
+    // pending-kill hold on it — pre-existing or freshly planted — must go too.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn node_remove_clears_its_pending_kill_holds() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        register_node(&cm, "n1", 4, 8000);
+        register_node(&cm, "n2", 4, 8000);
+        cm.reserve_pending_kills(vec![PendingKillReservation {
+            job_id: 1,
+            node: "n1".into(),
+            resources: scalar_alloc(2, 4000),
+            attempt: 101,
+            run_attempt: 1,
+        }])
+        .unwrap();
+        cm.reserve_pending_kills(vec![PendingKillReservation {
+            job_id: 2,
+            node: "n2".into(),
+            resources: scalar_alloc(1, 1000),
+            attempt: 102,
+            run_attempt: 1,
+        }])
+        .unwrap();
+
+        cm.apply_operation(&WalOperation::NodeRemove {
+            name: "n1".into(),
+            reason: None,
+        });
+
+        let reserved = cm.pending_kill_reservations();
+        assert!(
+            !reserved.contains_key("n1"),
+            "the removed node's hold must not linger forever"
+        );
+        assert_eq!(
+            reserved.get("n2").unwrap().cpus,
+            1,
+            "another node's hold must be untouched"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -354,6 +354,11 @@ pub struct ClusterManager {
     /// still considers allocated there. Leader-local and transient, never
     /// persisted; reset to zero (removed) as soon as a report includes the job.
     phantom_miss_streaks: RwLock<HashMap<(JobId, String), u32>>,
+    /// Resources still counted free in `Node.alloc_resources` (the job's
+    /// terminal transition already committed) but not yet confirmed released
+    /// by the agent — kept out of new dispatch until confirmed or the entry
+    /// expires. Leader-local and transient, never persisted.
+    pending_kill: RwLock<HashMap<(JobId, String), (ResourceAllocations, std::time::Instant)>>,
 }
 
 struct PendingJobClassification {
@@ -415,6 +420,7 @@ impl ClusterManager {
             sched_stats: OnceLock::new(),
             node_dispatch_cooldowns: RwLock::new(HashMap::new()),
             phantom_miss_streaks: RwLock::new(HashMap::new()),
+            pending_kill: RwLock::new(HashMap::new()),
         };
 
         info!("cluster manager initialized (state will be recovered via Raft)");
@@ -477,6 +483,39 @@ impl ClusterManager {
         self.phantom_miss_streaks
             .write()
             .remove(&(job_id, node.to_string()));
+    }
+
+    /// Record that `job_id`'s hold on `node` was just released in controller
+    /// state (cancel/evict) but not yet confirmed by the agent, so new
+    /// dispatch avoids `resources` there until it expires. Refreshes the TTL
+    /// if already present (e.g. a re-sent kill).
+    pub(crate) fn note_pending_kill(
+        &self,
+        job_id: JobId,
+        node: &str,
+        resources: ResourceAllocations,
+    ) {
+        let ttl = self.config().controller.pending_kill_ttl_secs;
+        if ttl == 0 {
+            return;
+        }
+        let until = std::time::Instant::now() + std::time::Duration::from_secs(ttl);
+        self.pending_kill
+            .write()
+            .insert((job_id, node.to_string()), (resources, until));
+    }
+
+    /// Per-node resources still held out of new dispatch pending kill
+    /// confirmation, pruning any entry whose TTL has expired.
+    pub(crate) fn pending_kill_reservations(&self) -> HashMap<String, ResourceAllocations> {
+        let now = std::time::Instant::now();
+        let mut pending = self.pending_kill.write();
+        pending.retain(|_, (_, until)| *until > now);
+        let mut by_node: HashMap<String, ResourceAllocations> = HashMap::new();
+        for ((_, node), (resources, _)) in pending.iter() {
+            by_node.entry(node.clone()).or_default().add(resources);
+        }
+        by_node
     }
 
     /// Submit a new job. If it has an array spec, expand into individual tasks.
@@ -3845,6 +3884,16 @@ impl ClusterManager {
         *self.raft.write() = Some(raft);
     }
 
+    /// Current Raft term, used as a fencing generation on outgoing agent RPCs.
+    /// 0 before Raft is wired up (never actually dispatches at that point).
+    pub fn current_term(&self) -> u64 {
+        self.raft
+            .read()
+            .as_ref()
+            .map(|r| r.metrics().borrow().current_term)
+            .unwrap_or(0)
+    }
+
     pub fn set_accounting(&self, notifier: AccountingNotifier) {
         *self.accounting.write() = Some(notifier);
     }
@@ -6234,6 +6283,47 @@ mod tests {
             !cm.note_node_omitted_job(1, "n1"),
             "streak must restart from zero after a report reset it"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn pending_kill_reservations_aggregate_prune_and_respect_disable() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+
+        assert!(cm.pending_kill_reservations().is_empty());
+        cm.note_pending_kill(1, "n1", scalar_alloc(2, 4000));
+        cm.note_pending_kill(2, "n1", scalar_alloc(3, 6000));
+        cm.note_pending_kill(3, "n2", scalar_alloc(1, 1000));
+
+        let reserved = cm.pending_kill_reservations();
+        assert_eq!(
+            reserved.get("n1").unwrap().cpus,
+            5,
+            "multiple pending kills on the same node sum"
+        );
+        assert_eq!(reserved.get("n2").unwrap().cpus, 1);
+
+        // A past instant is pruned on read, so an expired entry clears.
+        cm.pending_kill.write().insert(
+            (1, "n1".into()),
+            (
+                scalar_alloc(2, 4000),
+                std::time::Instant::now() - std::time::Duration::from_secs(1),
+            ),
+        );
+        let reserved = cm.pending_kill_reservations();
+        assert_eq!(
+            reserved.get("n1").unwrap().cpus,
+            3,
+            "the expired entry no longer contributes, the live one still does"
+        );
+
+        // Disabled (0s): note_pending_kill is a no-op.
+        let mut cfg = test_config();
+        cfg.controller.pending_kill_ttl_secs = 0;
+        let cm0 = Arc::new(ClusterManager::new(cfg, dir.path()).unwrap());
+        cm0.note_pending_kill(9, "n1", scalar_alloc(1, 1000));
+        assert!(cm0.pending_kill_reservations().is_empty());
     }
 
     /// Consumer-driven: `maybe_requeue` must honor the new `max_batch_requeue`

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -342,6 +342,9 @@ pub struct ClusterManager {
     /// Wake signal for the scheduler loop.
     pub(crate) scheduler_notify: Arc<Notify>,
     sched_stats: OnceLock<Arc<SchedStatsCollector>>,
+    /// Nodes skipped for new dispatch until the given instant after a
+    /// resources-unavailable reject. Leader-local and transient, never persisted.
+    node_dispatch_cooldowns: RwLock<HashMap<String, std::time::Instant>>,
 }
 
 struct PendingJobClassification {
@@ -401,6 +404,7 @@ impl ClusterManager {
             association_cache,
             scheduler_notify: Arc::new(Notify::new()),
             sched_stats: OnceLock::new(),
+            node_dispatch_cooldowns: RwLock::new(HashMap::new()),
         };
 
         info!("cluster manager initialized (state will be recovered via Raft)");
@@ -413,6 +417,27 @@ impl ClusterManager {
     /// from their point of view.
     pub fn config(&self) -> Arc<SlurmConfig> {
         self.config.read().clone()
+    }
+
+    /// Skip a node for new dispatch for the configured cooldown after it rejected
+    /// one as resources-unavailable, so the scheduler stops re-picking it each tick.
+    pub fn cool_down_node(&self, name: &str) {
+        let secs = self.config().controller.dispatch_reject_cooldown_secs;
+        if secs == 0 {
+            return;
+        }
+        let until = std::time::Instant::now() + std::time::Duration::from_secs(secs);
+        self.node_dispatch_cooldowns
+            .write()
+            .insert(name.to_string(), until);
+    }
+
+    /// Names still within their dispatch cooldown, pruning any that have expired.
+    pub fn nodes_on_dispatch_cooldown(&self) -> HashSet<String> {
+        let now = std::time::Instant::now();
+        let mut cooldowns = self.node_dispatch_cooldowns.write();
+        cooldowns.retain(|_, &mut until| until > now);
+        cooldowns.keys().cloned().collect()
     }
 
     /// Submit a new job. If it has an array spec, expand into individual tasks.
@@ -6071,6 +6096,31 @@ mod tests {
             .expect("single-node raft did not self-elect within 5s");
         cm.set_raft(handle.raft);
         (cm, conf_path)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dispatch_cooldown_marks_then_expires_and_respects_disable() {
+        let dir = TempDir::new().unwrap();
+
+        // Enabled (default 30s): a cooled node is reported until it expires.
+        let cm = Arc::new(ClusterManager::new(test_config(), dir.path()).unwrap());
+        assert!(cm.nodes_on_dispatch_cooldown().is_empty());
+        cm.cool_down_node("worker1");
+        assert!(cm.nodes_on_dispatch_cooldown().contains("worker1"));
+
+        // A past instant is pruned on read, so an expired cooldown clears.
+        cm.node_dispatch_cooldowns.write().insert(
+            "worker1".into(),
+            std::time::Instant::now() - std::time::Duration::from_secs(1),
+        );
+        assert!(!cm.nodes_on_dispatch_cooldown().contains("worker1"));
+
+        // Disabled (0s): cool_down_node is a no-op.
+        let mut cfg = test_config();
+        cfg.controller.dispatch_reject_cooldown_secs = 0;
+        let cm0 = Arc::new(ClusterManager::new(cfg, dir.path()).unwrap());
+        cm0.cool_down_node("worker1");
+        assert!(cm0.nodes_on_dispatch_cooldown().is_empty());
     }
 
     /// Consumer-driven: `maybe_requeue` must honor the new `max_batch_requeue`

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -289,6 +289,9 @@ pub enum PreemptOutcome {
     Suspended,
 }
 
+/// Resources, expiry, and owning attempt token for one pending-kill entry.
+type PendingKillEntry = (ResourceAllocations, std::time::Instant, u64);
+
 /// Central cluster state manager.
 ///
 /// Thread-safe via RwLock. The scheduler and gRPC server both access this.
@@ -352,9 +355,10 @@ pub struct ClusterManager {
     /// Consecutive heartbeats a node's report has omitted a job it's bound
     /// to. Leader-local and transient, never persisted.
     phantom_miss_streaks: RwLock<HashMap<(JobId, String), u32>>,
-    /// Resources freed in controller state but not yet confirmed released by
-    /// the agent. Leader-local and transient, never persisted.
-    pending_kill: RwLock<HashMap<(JobId, String), (ResourceAllocations, std::time::Instant)>>,
+    /// Resources freed but not yet confirmed released by the agent. The u64
+    /// scopes a rollback to the attempt that planted it, not a concurrent one.
+    pending_kill: RwLock<HashMap<(JobId, String), PendingKillEntry>>,
+    next_pending_kill_attempt: std::sync::atomic::AtomicU64,
 }
 
 struct PendingJobClassification {
@@ -417,6 +421,7 @@ impl ClusterManager {
             node_dispatch_cooldowns: RwLock::new(HashMap::new()),
             phantom_miss_streaks: RwLock::new(HashMap::new()),
             pending_kill: RwLock::new(HashMap::new()),
+            next_pending_kill_attempt: std::sync::atomic::AtomicU64::new(1),
         };
 
         info!("cluster manager initialized (state will be recovered via Raft)");
@@ -488,13 +493,21 @@ impl ClusterManager {
             .retain(|(job_id, n), _| n != node || active_job_ids.contains(job_id));
     }
 
-    /// Reserve `resources` on `node` until a heartbeat confirms release or
-    /// the TTL expires, whichever comes first. Refreshes the TTL if present.
+    /// New token identifying one reserve-then-mutate attempt, so its rollback
+    /// can't clear a different, concurrent attempt's still-live reservation.
+    pub(crate) fn new_pending_kill_attempt(&self) -> u64 {
+        self.next_pending_kill_attempt
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Reserve `resources` on `node` under `attempt` until a heartbeat confirms
+    /// release or the TTL expires, whichever comes first.
     pub(crate) fn note_pending_kill(
         &self,
         job_id: JobId,
         node: &str,
         resources: ResourceAllocations,
+        attempt: u64,
     ) {
         let ttl = self.config().controller.pending_kill_ttl_secs;
         if ttl == 0 {
@@ -503,7 +516,7 @@ impl ClusterManager {
         let until = std::time::Instant::now() + std::time::Duration::from_secs(ttl);
         self.pending_kill
             .write()
-            .insert((job_id, node.to_string()), (resources, until));
+            .insert((job_id, node.to_string()), (resources, until, attempt));
     }
 
     /// Clear `node`'s pending-kill entries for jobs a heartbeat no longer
@@ -514,10 +527,12 @@ impl ClusterManager {
             .retain(|(job_id, n), _| n != node || reported.contains(job_id));
     }
 
-    /// Undo a reservation planted ahead of a cancel/evict that then failed —
-    /// callers pre-reserve before the mutation, so a failure must roll back.
-    pub(crate) fn clear_pending_kill_for_job(&self, job_id: JobId) {
-        self.pending_kill.write().retain(|(id, _), _| *id != job_id);
+    /// Undo `attempt`'s own reservation after its cancel/evict failed — never
+    /// a concurrent attempt's still-live one on the same job.
+    pub(crate) fn clear_pending_kill_for_job(&self, job_id: JobId, attempt: u64) {
+        self.pending_kill
+            .write()
+            .retain(|(id, _), (_, _, a)| *id != job_id || *a != attempt);
     }
 
     /// Per-node resources still held out of new dispatch, pruning any
@@ -525,9 +540,9 @@ impl ClusterManager {
     pub(crate) fn pending_kill_reservations(&self) -> HashMap<String, ResourceAllocations> {
         let now = std::time::Instant::now();
         let mut pending = self.pending_kill.write();
-        pending.retain(|_, (_, until)| *until > now);
+        pending.retain(|_, (_, until, _)| *until > now);
         let mut by_node: HashMap<String, ResourceAllocations> = HashMap::new();
-        for ((_, node), (resources, _)) in pending.iter() {
+        for ((_, node), (resources, _, _)) in pending.iter() {
             by_node.entry(node.clone()).or_default().add(resources);
         }
         by_node
@@ -6312,9 +6327,9 @@ mod tests {
         let cm = test_cluster(&dir).await;
 
         assert!(cm.pending_kill_reservations().is_empty());
-        cm.note_pending_kill(1, "n1", scalar_alloc(2, 4000));
-        cm.note_pending_kill(2, "n1", scalar_alloc(3, 6000));
-        cm.note_pending_kill(3, "n2", scalar_alloc(1, 1000));
+        cm.note_pending_kill(1, "n1", scalar_alloc(2, 4000), 101);
+        cm.note_pending_kill(2, "n1", scalar_alloc(3, 6000), 102);
+        cm.note_pending_kill(3, "n2", scalar_alloc(1, 1000), 103);
 
         let reserved = cm.pending_kill_reservations();
         assert_eq!(
@@ -6330,6 +6345,7 @@ mod tests {
             (
                 scalar_alloc(2, 4000),
                 std::time::Instant::now() - std::time::Duration::from_secs(1),
+                101,
             ),
         );
         let reserved = cm.pending_kill_reservations();
@@ -6343,7 +6359,7 @@ mod tests {
         let mut cfg = test_config();
         cfg.controller.pending_kill_ttl_secs = 0;
         let cm0 = Arc::new(ClusterManager::new(cfg, dir.path()).unwrap());
-        cm0.note_pending_kill(9, "n1", scalar_alloc(1, 1000));
+        cm0.note_pending_kill(9, "n1", scalar_alloc(1, 1000), 201);
         assert!(cm0.pending_kill_reservations().is_empty());
     }
 
@@ -6351,16 +6367,37 @@ mod tests {
     async fn clear_pending_kill_for_job_removes_only_that_job() {
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
-        cm.note_pending_kill(1, "n1", scalar_alloc(2, 4000));
-        cm.note_pending_kill(2, "n1", scalar_alloc(3, 6000));
+        cm.note_pending_kill(1, "n1", scalar_alloc(2, 4000), 101);
+        cm.note_pending_kill(2, "n1", scalar_alloc(3, 6000), 102);
 
-        cm.clear_pending_kill_for_job(1);
+        cm.clear_pending_kill_for_job(1, 101);
 
         let reserved = cm.pending_kill_reservations();
         assert_eq!(
             reserved.get("n1").unwrap().cpus,
             3,
             "only job 1's reservation must be rolled back"
+        );
+    }
+
+    // A losing cancel's rollback must not clear a concurrent, still-live
+    // reservation planted for the same job by a winning cancel attempt.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn clear_pending_kill_for_job_spares_a_concurrent_attempts_reservation() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        cm.note_pending_kill(1, "n1", scalar_alloc(2, 4000), 101);
+        // A second, winning attempt for the same job refreshes the entry
+        // under a new attempt token.
+        cm.note_pending_kill(1, "n1", scalar_alloc(2, 4000), 102);
+
+        // The losing (first) attempt's rollback must not touch it.
+        cm.clear_pending_kill_for_job(1, 101);
+
+        assert_eq!(
+            cm.pending_kill_reservations().get("n1").unwrap().cpus,
+            2,
+            "the winning attempt's reservation must survive the loser's rollback"
         );
     }
 

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -488,8 +488,8 @@ impl ClusterManager {
             .retain(|(job_id, n), _| n != node || active_job_ids.contains(job_id));
     }
 
-    /// Reserve `resources` on `node` until the agent confirms `job_id`'s
-    /// release or the TTL expires. Refreshes the TTL if already present.
+    /// Reserve `resources` on `node` until the TTL expires. Refreshes the
+    /// TTL if already present.
     pub(crate) fn note_pending_kill(
         &self,
         job_id: JobId,
@@ -506,8 +506,8 @@ impl ClusterManager {
             .insert((job_id, node.to_string()), (resources, until));
     }
 
-    /// Per-node resources still held out of new dispatch pending kill
-    /// confirmation, pruning any entry whose TTL has expired.
+    /// Per-node resources still held out of new dispatch, pruning any
+    /// entry whose TTL has expired.
     pub(crate) fn pending_kill_reservations(&self) -> HashMap<String, ResourceAllocations> {
         let now = std::time::Instant::now();
         let mut pending = self.pending_kill.write();
@@ -1629,20 +1629,22 @@ impl ClusterManager {
         job.spec.begin_time.map_or(hold, |user| user.max(hold))
     }
 
-    /// Evict a single job to NodeFail. Only updates controller state —
-    /// callers must also cancel on its nodes and complete its steps.
+    /// Evict a single job to NodeFail; an empty result means it wasn't.
+    /// Only updates controller state — callers cancel on nodes/complete steps.
     pub fn evict_job(
         &self,
         job_id: JobId,
         reason: PendingReason,
+        run_attempt: u32,
     ) -> anyhow::Result<Vec<JobFinalized>> {
-        self.evict_job_with_detail(job_id, reason, None)
+        self.evict_job_with_detail(job_id, reason, run_attempt, None)
     }
 
     pub fn evict_job_with_detail(
         &self,
         job_id: JobId,
         reason: PendingReason,
+        run_attempt: u32,
         detail: Option<String>,
     ) -> anyhow::Result<Vec<JobFinalized>> {
         {
@@ -1658,6 +1660,7 @@ impl ClusterManager {
             job_id,
             reason,
             detail,
+            run_attempt,
         })?;
         self.run_all_finalized_side_effects(&resp);
         Ok(resp.jobs_finalized)
@@ -4044,8 +4047,12 @@ impl ClusterManager {
         nodes: &mut HashMap<String, Node>,
         timestamp: chrono::DateTime<Utc>,
         reason: PendingReason,
+        run_attempt: u32,
     ) -> Option<JobFinalized> {
         let job = jobs.get_mut(&job_id)?;
+        if run_attempt != 0 && run_attempt != job.run_attempt {
+            return None;
+        }
 
         if let Some(since) = job.suspended_at.take() {
             job.suspended_secs += (timestamp - since).num_seconds().max(0);
@@ -4119,7 +4126,7 @@ impl ClusterManager {
 
         for jid in affected {
             if let Some(fin) =
-                Self::evict_job_locked(jid, jobs, nodes, timestamp, PendingReason::NodeDown)
+                Self::evict_job_locked(jid, jobs, nodes, timestamp, PendingReason::NodeDown, 0)
             {
                 response.jobs_finalized.push(fin);
             }
@@ -4313,17 +4320,19 @@ impl ClusterManager {
                 job_id,
                 reason,
                 detail,
+                run_attempt,
             } => {
-                if let Some(job) = jobs.get_mut(job_id) {
-                    job.launch_failure_detail = detail.clone();
-                }
                 if let Some(fin) = Self::evict_job_locked(
                     *job_id,
                     &mut jobs,
                     &mut nodes,
                     timestamp,
                     reason.clone(),
+                    *run_attempt,
                 ) {
+                    if let Some(job) = jobs.get_mut(job_id) {
+                        job.launch_failure_detail = detail.clone();
+                    }
                     response.jobs_finalized.push(fin);
                 }
             }
@@ -6318,6 +6327,22 @@ mod tests {
         let cm0 = Arc::new(ClusterManager::new(cfg, dir.path()).unwrap());
         cm0.note_pending_kill(9, "n1", scalar_alloc(1, 1000));
         assert!(cm0.pending_kill_reservations().is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn note_pending_kill_for_job_falls_back_to_an_even_split_without_per_node_alloc() {
+        // A job replayed from a pre-per_node_alloc WAL entry has an empty map;
+        // the reservation must still protect its real allocation, not zero.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        let mut job = make_running_job(1, &["n1", "n2"], 2);
+        job.per_node_alloc.clear();
+
+        crate::server::note_pending_kill_for_job(&cm, &job);
+
+        let reserved = cm.pending_kill_reservations();
+        assert_eq!(reserved.get("n1").unwrap().cpus, 2);
+        assert_eq!(reserved.get("n2").unwrap().cpus, 2);
     }
 
     /// Consumer-driven: `maybe_requeue` must honor the new `max_batch_requeue`
@@ -11394,7 +11419,7 @@ mod tests {
         .unwrap();
         settle(&cm, job_id, JobState::Running);
 
-        cm.evict_job(job_id, PendingReason::JobLaunchFailure)
+        cm.evict_job(job_id, PendingReason::JobLaunchFailure, 0)
             .unwrap();
         settle(&cm, job_id, JobState::Pending);
 
@@ -13972,7 +13997,8 @@ mod tests {
         settle(&cm, id, JobState::Running);
 
         // n1's dispatch succeeded, n2's never reached the agent.
-        cm.evict_job(id, PendingReason::JobLaunchFailure).unwrap();
+        cm.evict_job(id, PendingReason::JobLaunchFailure, 0)
+            .unwrap();
         settle(&cm, id, JobState::NodeFail);
 
         let job = cm.get_job(id).unwrap();
@@ -13995,6 +14021,23 @@ mod tests {
                 "allocation on {name} must be freed on eviction"
             );
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn evict_job_returns_empty_for_a_job_that_never_started() {
+        // A Pending job can't reach NodeFail; must report empty like a terminal job.
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        let spec = basic_spec("evict-never-started");
+        let id = submit_and_wait(&cm, spec);
+        assert_eq!(cm.get_job(id).unwrap().state, JobState::Pending);
+
+        let finalized = cm.evict_job(id, PendingReason::NodeDown, 0).unwrap();
+        assert!(
+            finalized.is_empty(),
+            "evicting a job that can't reach NodeFail must no-op"
+        );
+        assert_eq!(cm.get_job(id).unwrap().state, JobState::Pending);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -14053,7 +14096,7 @@ mod tests {
              leaving only B's 3 cpus"
         );
 
-        cm.evict_job(job_a, PendingReason::NodeDown).unwrap();
+        cm.evict_job(job_a, PendingReason::NodeDown, 0).unwrap();
         settle(&cm, job_a, JobState::NodeFail);
 
         assert_eq!(
@@ -16104,6 +16147,40 @@ mod tests {
     }
 
     #[test]
+    fn evict_job_locked_rejects_stale_run_attempt() {
+        let mut jobs = HashMap::new();
+        let mut nodes = HashMap::new();
+        let mut job = make_running_job(1, &["n1"], 2);
+        job.run_attempt = 5;
+        jobs.insert(1, job);
+        nodes.insert("n1".into(), make_test_node("n1", 4, 2));
+
+        let result = ClusterManager::evict_job_locked(
+            1,
+            &mut jobs,
+            &mut nodes,
+            Utc::now(),
+            PendingReason::NodeDown,
+            3,
+        );
+        assert!(
+            result.is_none(),
+            "eviction targeting a superseded run must no-op"
+        );
+        assert_eq!(jobs[&1].state, JobState::Running, "job must be untouched");
+
+        let result = ClusterManager::evict_job_locked(
+            1,
+            &mut jobs,
+            &mut nodes,
+            Utc::now(),
+            PendingReason::NodeDown,
+            5,
+        );
+        assert!(result.is_some(), "a matching run_attempt must still evict");
+    }
+
+    #[test]
     fn evict_job_returns_none_for_missing_job() {
         let mut jobs = HashMap::new();
         let mut nodes = HashMap::new();
@@ -16113,6 +16190,7 @@ mod tests {
             &mut nodes,
             Utc::now(),
             PendingReason::NodeDown,
+            0,
         );
         assert!(result.is_none());
     }
@@ -16130,6 +16208,7 @@ mod tests {
             &mut nodes,
             Utc::now(),
             PendingReason::NodeDown,
+            0,
         )
         .unwrap();
         assert_eq!(fin.job_id, 1);
@@ -16157,6 +16236,7 @@ mod tests {
             &mut nodes,
             Utc::now(),
             PendingReason::NodeDown,
+            0,
         );
 
         assert_eq!(nodes["n1"].alloc_resources.cpus, 0);
@@ -16178,6 +16258,7 @@ mod tests {
             &mut nodes,
             Utc::now(),
             PendingReason::NodeDown,
+            0,
         );
         assert!(result.is_none());
     }
@@ -16200,6 +16281,7 @@ mod tests {
             &mut nodes,
             Utc::now(),
             PendingReason::NodeDown,
+            0,
         );
 
         let job = &jobs[&1];
@@ -16222,6 +16304,7 @@ mod tests {
             &mut nodes,
             Utc::now(),
             PendingReason::NodeDown,
+            0,
         )
         .unwrap();
         assert_eq!(fin.state, JobState::NodeFail);
@@ -16244,6 +16327,7 @@ mod tests {
             &mut nodes,
             Utc::now(),
             PendingReason::NodeDown,
+            0,
         );
 
         assert_eq!(nodes["n1"].state, NodeState::Drain);

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -179,6 +179,11 @@ pub struct SubmitOutcome {
 /// oversized batch scripts.
 const MAX_JOB_SPEC_SIZE: usize = 4 * 1024 * 1024;
 
+/// Consecutive heartbeats a node's report must omit a job the controller
+/// believes is allocated there before the binding is treated as a phantom
+/// and evicted, guarding against a single suspicious heartbeat.
+const PHANTOM_MISS_THRESHOLD: u32 = 2;
+
 /// A `std::io::Write` that only tallies byte counts and discards the data. Used
 /// to measure a value's serialized size without allocating the serialized bytes.
 #[derive(Default)]
@@ -345,6 +350,10 @@ pub struct ClusterManager {
     /// Nodes skipped for new dispatch until the given instant after a
     /// resources-unavailable reject. Leader-local and transient, never persisted.
     node_dispatch_cooldowns: RwLock<HashMap<String, std::time::Instant>>,
+    /// Consecutive heartbeats a node's report has omitted a job the controller
+    /// still considers allocated there. Leader-local and transient, never
+    /// persisted; reset to zero (removed) as soon as a report includes the job.
+    phantom_miss_streaks: RwLock<HashMap<(JobId, String), u32>>,
 }
 
 struct PendingJobClassification {
@@ -405,6 +414,7 @@ impl ClusterManager {
             scheduler_notify: Arc::new(Notify::new()),
             sched_stats: OnceLock::new(),
             node_dispatch_cooldowns: RwLock::new(HashMap::new()),
+            phantom_miss_streaks: RwLock::new(HashMap::new()),
         };
 
         info!("cluster manager initialized (state will be recovered via Raft)");
@@ -438,6 +448,35 @@ impl ClusterManager {
         let mut cooldowns = self.node_dispatch_cooldowns.write();
         cooldowns.retain(|_, &mut until| until > now);
         cooldowns.keys().cloned().collect()
+    }
+
+    /// Active (non-terminal) jobs the controller currently believes are
+    /// allocated on `node`, for reconciling against what the node reports.
+    pub(crate) fn active_jobs_on_node(&self, node: &str) -> Vec<Job> {
+        self.jobs
+            .read()
+            .values()
+            .filter(|j| !j.state.is_terminal() && j.allocated_nodes.iter().any(|n| n == node))
+            .cloned()
+            .collect()
+    }
+
+    /// Record that `node`'s heartbeat omitted `job_id`, returning whether the
+    /// consecutive-miss streak has crossed [`PHANTOM_MISS_THRESHOLD`]. Call
+    /// [`Self::note_node_reported_job`] instead once a report includes the job.
+    pub(crate) fn note_node_omitted_job(&self, job_id: JobId, node: &str) -> bool {
+        let mut streaks = self.phantom_miss_streaks.write();
+        let count = streaks.entry((job_id, node.to_string())).or_insert(0);
+        *count += 1;
+        *count >= PHANTOM_MISS_THRESHOLD
+    }
+
+    /// Clear any miss-streak for `job_id` on `node` — its heartbeat report
+    /// included the job again, or the job/binding no longer needs tracking.
+    pub(crate) fn note_node_reported_job(&self, job_id: JobId, node: &str) {
+        self.phantom_miss_streaks
+            .write()
+            .remove(&(job_id, node.to_string()));
     }
 
     /// Submit a new job. If it has an array spec, expand into individual tasks.
@@ -1562,15 +1601,14 @@ impl ClusterManager {
     /// nodes is responsible for sending the cancel RPC once eviction
     /// succeeds.
     ///
-    /// No longer called from `scheduler_loop`: batch dispatch is now
-    /// confirmed on every assigned node *before* a job is allowed to become
-    /// Running (see `confirm_dispatch_on_nodes`), so a job can no longer
-    /// reach Running with only some of its nodes actually launched — this
-    /// function's original trigger. Kept as a public primitive, with its
-    /// back-off/requeue contract still exercised directly by this module's
-    /// tests, for any other caller that needs to evict an already-Running
-    /// job (e.g. a future admin-initiated NodeFail).
-    #[allow(dead_code)]
+    /// No longer called from `scheduler_loop`'s original dispatch-confirmation
+    /// trigger: batch dispatch is now confirmed on every assigned node
+    /// *before* a job is allowed to become Running, so a job can no longer
+    /// reach Running with only some of its nodes actually launched. Now used
+    /// by the heartbeat reconciler to fail a job whose binding to a node has
+    /// gone silent (see `reconcile_reported_allocations` in `server.rs`) —
+    /// callers must also cancel on the job's still-allocated nodes afterward,
+    /// since this only updates controller state.
     pub fn evict_job(&self, job_id: JobId) -> anyhow::Result<()> {
         self.evict_job_with_detail(job_id, None)
     }
@@ -6149,6 +6187,53 @@ mod tests {
         let cm0 = Arc::new(ClusterManager::new(cfg, dir.path()).unwrap());
         cm0.cool_down_node("worker1");
         assert!(cm0.nodes_on_dispatch_cooldown().is_empty());
+    }
+
+    // The D1 "phantom" building blocks: a node omitting a job it's bound to
+    // must accumulate misses and only cross PHANTOM_MISS_THRESHOLD on the
+    // Nth consecutive miss; any report that includes the job resets it.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn phantom_miss_streak_crosses_threshold_only_after_consecutive_misses() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("phantom-job")),
+        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
+        cm.apply_operation(&WalOperation::JobStart {
+            job_id: 1,
+            nodes: vec!["n1".into()],
+            resources: scalar_alloc(6, 12000),
+            per_node_alloc: per_node_for(&["n1"], scalar_alloc(6, 12000)),
+            srun_step_dispatch: false,
+            run_attempt: 1,
+        });
+
+        let bound = cm.active_jobs_on_node("n1");
+        assert_eq!(bound.len(), 1, "job 1 is bound to n1");
+
+        assert!(
+            !cm.note_node_omitted_job(1, "n1"),
+            "first miss must not cross the threshold"
+        );
+        assert!(
+            cm.note_node_omitted_job(1, "n1"),
+            "second consecutive miss crosses PHANTOM_MISS_THRESHOLD"
+        );
+
+        // A report that includes the job resets the streak.
+        cm.note_node_reported_job(1, "n1");
+        assert!(
+            !cm.note_node_omitted_job(1, "n1"),
+            "streak must restart from zero after a report reset it"
+        );
     }
 
     /// Consumer-driven: `maybe_requeue` must honor the new `max_batch_requeue`

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1786,6 +1786,18 @@ impl ClusterManager {
         self.nodes.read().values().cloned().collect()
     }
 
+    /// Nodes eligible for new placement this tick: all nodes minus those within
+    /// a dispatch cooldown after a resources-unavailable reject.
+    pub fn schedulable_nodes(&self) -> Vec<Node> {
+        let cooling = self.nodes_on_dispatch_cooldown();
+        self.nodes
+            .read()
+            .values()
+            .filter(|n| !cooling.contains(&n.name))
+            .cloned()
+            .collect()
+    }
+
     /// Get a node by name.
     pub fn get_node(&self, name: &str) -> Option<Node> {
         self.nodes.read().get(name).cloned()
@@ -6103,10 +6115,20 @@ mod tests {
         let dir = TempDir::new().unwrap();
 
         // Enabled (default 30s): a cooled node is reported until it expires.
-        let cm = Arc::new(ClusterManager::new(test_config(), dir.path()).unwrap());
+        let cm = test_cluster_with_config(&dir, test_config()).await;
+        register_node(&cm, "worker1", 8, 16000);
+        register_node(&cm, "worker2", 8, 16000);
         assert!(cm.nodes_on_dispatch_cooldown().is_empty());
         cm.cool_down_node("worker1");
         assert!(cm.nodes_on_dispatch_cooldown().contains("worker1"));
+
+        // The scheduler's node view excludes the cooled node, keeps the other.
+        let names: HashSet<String> = cm.schedulable_nodes().into_iter().map(|n| n.name).collect();
+        assert!(
+            !names.contains("worker1"),
+            "cooled node excluded from scheduling"
+        );
+        assert!(names.contains("worker2"), "healthy node still schedulable");
 
         // A past instant is pruned on read, so an expired cooldown clears.
         cm.node_dispatch_cooldowns.write().insert(
@@ -6114,6 +6136,10 @@ mod tests {
             std::time::Instant::now() - std::time::Duration::from_secs(1),
         );
         assert!(!cm.nodes_on_dispatch_cooldown().contains("worker1"));
+        assert!(
+            cm.schedulable_nodes().iter().any(|n| n.name == "worker1"),
+            "expired cooldown makes the node schedulable again"
+        );
 
         // Disabled (0s): cool_down_node is a no-op.
         let mut cfg = test_config();

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -179,9 +179,8 @@ pub struct SubmitOutcome {
 /// oversized batch scripts.
 const MAX_JOB_SPEC_SIZE: usize = 4 * 1024 * 1024;
 
-/// Consecutive heartbeats a node's report must omit a job the controller
-/// believes is allocated there before the binding is treated as a phantom
-/// and evicted, guarding against a single suspicious heartbeat.
+/// Consecutive heartbeat omissions before a binding is treated as a phantom
+/// and evicted — guards against a single suspicious heartbeat.
 const PHANTOM_MISS_THRESHOLD: u32 = 2;
 
 /// A `std::io::Write` that only tallies byte counts and discards the data. Used
@@ -350,14 +349,11 @@ pub struct ClusterManager {
     /// Nodes skipped for new dispatch until the given instant after a
     /// resources-unavailable reject. Leader-local and transient, never persisted.
     node_dispatch_cooldowns: RwLock<HashMap<String, std::time::Instant>>,
-    /// Consecutive heartbeats a node's report has omitted a job the controller
-    /// still considers allocated there. Leader-local and transient, never
-    /// persisted; reset to zero (removed) as soon as a report includes the job.
+    /// Consecutive heartbeats a node's report has omitted a job it's bound
+    /// to. Leader-local and transient, never persisted.
     phantom_miss_streaks: RwLock<HashMap<(JobId, String), u32>>,
-    /// Resources still counted free in `Node.alloc_resources` (the job's
-    /// terminal transition already committed) but not yet confirmed released
-    /// by the agent — kept out of new dispatch until confirmed or the entry
-    /// expires. Leader-local and transient, never persisted.
+    /// Resources freed in controller state but not yet confirmed released by
+    /// the agent. Leader-local and transient, never persisted.
     pending_kill: RwLock<HashMap<(JobId, String), (ResourceAllocations, std::time::Instant)>>,
 }
 
@@ -468,8 +464,7 @@ impl ClusterManager {
     }
 
     /// Record that `node`'s heartbeat omitted `job_id`, returning whether the
-    /// consecutive-miss streak has crossed [`PHANTOM_MISS_THRESHOLD`]. Call
-    /// [`Self::note_node_reported_job`] instead once a report includes the job.
+    /// miss streak has crossed [`PHANTOM_MISS_THRESHOLD`].
     pub(crate) fn note_node_omitted_job(&self, job_id: JobId, node: &str) -> bool {
         let mut streaks = self.phantom_miss_streaks.write();
         let count = streaks.entry((job_id, node.to_string())).or_insert(0);
@@ -485,20 +480,16 @@ impl ClusterManager {
             .remove(&(job_id, node.to_string()));
     }
 
-    /// Remove `node`'s miss-streak entries for jobs no longer in
-    /// `active_job_ids` — a job can leave the active set by a path other than
-    /// a later heartbeat re-reporting it (completed, cancelled, evicted),
-    /// which `note_node_reported_job` alone would never observe.
+    /// Remove `node`'s miss-streak entries for jobs no longer active there
+    /// (completed, cancelled, evicted by another path).
     pub(crate) fn prune_phantom_streaks_not_in(&self, node: &str, active_job_ids: &HashSet<JobId>) {
         self.phantom_miss_streaks
             .write()
             .retain(|(job_id, n), _| n != node || active_job_ids.contains(job_id));
     }
 
-    /// Record that `job_id`'s hold on `node` was just released in controller
-    /// state (cancel/evict) but not yet confirmed by the agent, so new
-    /// dispatch avoids `resources` there until it expires. Refreshes the TTL
-    /// if already present (e.g. a re-sent kill).
+    /// Reserve `resources` on `node` until the agent confirms `job_id`'s
+    /// release or the TTL expires. Refreshes the TTL if already present.
     pub(crate) fn note_pending_kill(
         &self,
         job_id: JobId,
@@ -1225,11 +1216,8 @@ impl ClusterManager {
             if job.state.is_terminal() {
                 return Ok(NodeCompleteResult::AlreadyTerminal);
             }
-            // Drop a report from a superseded run (older epoch); e.g. the
-            // delayed SIGKILL of a preemption-requeued process. A reported
-            // epoch of 0 is the sentinel for "predates run_attempt fencing"
-            // (an in-flight allocation from before this guard existed, or an
-            // older agent binary) and is trusted rather than treated as stale.
+            // Drop a report from a superseded run (older epoch). Reported
+            // epoch 0 predates fencing (legacy job or agent) and is trusted.
             if run_attempt != 0 && run_attempt < job.run_attempt {
                 return Ok(NodeCompleteResult::StaleReport);
             }
@@ -1641,24 +1629,8 @@ impl ClusterManager {
         job.spec.begin_time.map_or(hold, |user| user.max(hold))
     }
 
-    /// Evict a running job to NodeFail: frees allocations and feeds the
-    /// existing auto-requeue path in `notify_job_finished`, same as the
-    /// health-check path (`evict_jobs_on_node`) that runs when an entire
-    /// node goes Down, but scoped to a single job. Unlike the health-check
-    /// path, this does not by itself cancel the job on nodes that *did*
-    /// launch it — a caller evicting a job with launched-but-unconfirmed
-    /// nodes is responsible for sending the cancel RPC once eviction
-    /// succeeds.
-    ///
-    /// No longer called from `scheduler_loop`'s original dispatch-confirmation
-    /// trigger: batch dispatch is now confirmed on every assigned node
-    /// *before* a job is allowed to become Running, so a job can no longer
-    /// reach Running with only some of its nodes actually launched. Now used
-    /// by the heartbeat reconciler to fail a job whose binding to a node has
-    /// gone silent (see `reconcile_reported_allocations` in `server.rs`) —
-    /// callers must also cancel on the job's still-allocated nodes and
-    /// complete its steps (`complete_evicted_steps`) afterward, since this
-    /// only updates controller state.
+    /// Evict a single job to NodeFail. Only updates controller state —
+    /// callers must also cancel on its nodes and complete its steps.
     pub fn evict_job(&self, job_id: JobId) -> anyhow::Result<Vec<JobFinalized>> {
         self.evict_job_with_detail(job_id, None)
     }
@@ -6249,9 +6221,7 @@ mod tests {
         assert!(cm0.nodes_on_dispatch_cooldown().is_empty());
     }
 
-    // The D1 "phantom" building blocks: a node omitting a job it's bound to
-    // must accumulate misses and only cross PHANTOM_MISS_THRESHOLD on the
-    // Nth consecutive miss; any report that includes the job resets it.
+    // Only the Nth consecutive miss crosses the threshold; a report resets it.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn phantom_miss_streak_crosses_threshold_only_after_consecutive_misses() {
         let dir = TempDir::new().unwrap();
@@ -8298,10 +8268,7 @@ mod tests {
         assert_eq!(cm.get_job(1).unwrap().state, JobState::Failed);
     }
 
-    // A reported epoch of 0 is the "predates run_attempt fencing" sentinel
-    // (an in-flight allocation from before the guard existed, or an older
-    // agent binary) and must be trusted even though the job's own epoch has
-    // since advanced — it must not be dropped as a stale report.
+    // Reported epoch 0 (legacy sentinel) must be trusted, not dropped as stale.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn node_complete_trusts_legacy_zero_epoch_report() {
         let dir = TempDir::new().unwrap();

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -13,6 +13,10 @@ use tracing::{debug, info, warn};
 
 use spur_core::account_limits::{check_account_limits, AccountCheckResult};
 use spur_core::accounting::{Qos, TresRecord, TresType};
+use spur_core::allocation::{
+    AgentCommandKind, AgentCommandRecord, AgentCommandState, AllocationKey, AllocationPhase,
+    AllocationRecord,
+};
 use spur_core::burst_buffer::BbStageState;
 use spur_core::config::SlurmConfig;
 use spur_core::job::{
@@ -25,7 +29,9 @@ use spur_core::qos::{check_qos_limits, qos_adjusted_priority, QosCheckResult};
 use spur_core::reservation::{self, normalize_node_list, running_jobs_overlap_start, Reservation};
 use spur_core::resource::{ResourceAllocations, ResourceSet};
 use spur_core::step::{JobStep, StepState, STEP_BATCH, STEP_RESERVED_MIN};
-use spur_core::wal::{PendingKillRelease, PendingKillReservation, WalOperation};
+#[cfg(test)]
+use spur_core::wal::PendingKillRelease;
+use spur_core::wal::{PendingKillReservation, WalOperation};
 use spur_metrics::job::JobMetricsSnapshot;
 use spur_metrics::node::NodeMetricsSnapshot;
 use spur_metrics::partition::PartitionMetricsSnapshot;
@@ -43,6 +49,7 @@ use crate::sched_stats::SchedStatsCollector;
 /// the next node. Byte-exact with the `state_desc` Slurm sets in the same case,
 /// so operator runbooks and log greps written against Slurm keep working.
 pub const LAUNCH_FAILURE_HELD_DESC: &str = "launch failed requeued held";
+pub(crate) const AGENT_COMMAND_ACK_TIMEOUT_SECS: u64 = 30;
 
 /// Seconds to defer a job by after its `requeue_count`-th launch failure,
 /// doubling per attempt from the same base the preemption requeue uses.
@@ -109,9 +116,23 @@ pub enum SrunCompleteError {
     NotFound(JobId),
     NotSrunJob(JobId),
     NotStepDispatch(JobId),
-    AlreadyTerminal { job_id: JobId, state: JobState },
-    NotOwner { job_id: JobId, user: String },
-    Internal { job_id: JobId, message: String },
+    StaleRun {
+        job_id: JobId,
+        expected: u32,
+        actual: u32,
+    },
+    AlreadyTerminal {
+        job_id: JobId,
+        state: JobState,
+    },
+    NotOwner {
+        job_id: JobId,
+        user: String,
+    },
+    Internal {
+        job_id: JobId,
+        message: String,
+    },
 }
 
 impl std::fmt::Display for SrunCompleteError {
@@ -125,6 +146,14 @@ impl std::fmt::Display for SrunCompleteError {
                     "job {id} does not use native step dispatch (CompleteJob is not valid)"
                 )
             }
+            Self::StaleRun {
+                job_id,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "job {job_id} run attempt {expected} was superseded by attempt {actual}"
+            ),
             Self::AlreadyTerminal { job_id, state } => {
                 write!(f, "job {job_id} is already {state:?}")
             }
@@ -178,10 +207,6 @@ pub struct SubmitOutcome {
 /// be bypassed by a field the check forgot to sum. Mirrors Slurm, which rejects
 /// oversized batch scripts.
 const MAX_JOB_SPEC_SIZE: usize = 4 * 1024 * 1024;
-
-/// Consecutive heartbeat omissions before a binding is treated as a phantom
-/// and evicted — guards against a single suspicious heartbeat.
-const PHANTOM_MISS_THRESHOLD: u32 = 2;
 
 /// A `std::io::Write` that only tallies byte counts and discards the data. Used
 /// to measure a value's serialized size without allocating the serialized bytes.
@@ -349,13 +374,10 @@ pub struct ClusterManager {
     /// Nodes skipped for new dispatch until the given instant after a
     /// resources-unavailable reject. Leader-local and transient, never persisted.
     node_dispatch_cooldowns: RwLock<HashMap<String, std::time::Instant>>,
-    /// Consecutive heartbeats a node's report has omitted a job it's bound
-    /// to. Leader-local and transient, never persisted.
-    phantom_miss_streaks: RwLock<HashMap<(JobId, String), u32>>,
-    /// Resources freed but not yet confirmed released by the agent; replicated
-    /// so a leadership change can't make an unconfirmed release schedulable.
-    pending_kill: RwLock<HashMap<(JobId, String), PendingKillReservation>>,
-    next_pending_kill_attempt: AtomicU64,
+    allocations: RwLock<HashMap<AllocationKey, AllocationRecord>>,
+    agent_commands: RwLock<HashMap<u64, AgentCommandRecord>>,
+    agent_command_notify: Notify,
+    next_agent_command_id: AtomicU64,
 }
 
 struct PendingJobClassification {
@@ -416,9 +438,10 @@ impl ClusterManager {
             scheduler_notify: Arc::new(Notify::new()),
             sched_stats: OnceLock::new(),
             node_dispatch_cooldowns: RwLock::new(HashMap::new()),
-            phantom_miss_streaks: RwLock::new(HashMap::new()),
-            pending_kill: RwLock::new(HashMap::new()),
-            next_pending_kill_attempt: AtomicU64::new(1),
+            allocations: RwLock::new(HashMap::new()),
+            agent_commands: RwLock::new(HashMap::new()),
+            agent_command_notify: Notify::new(),
+            next_agent_command_id: AtomicU64::new(1),
         };
 
         info!("cluster manager initialized (state will be recovered via Raft)");
@@ -465,35 +488,9 @@ impl ClusterManager {
             .collect()
     }
 
-    /// Record that `node`'s heartbeat omitted `job_id`, returning whether the
-    /// miss streak has crossed [`PHANTOM_MISS_THRESHOLD`].
-    pub(crate) fn note_node_omitted_job(&self, job_id: JobId, node: &str) -> bool {
-        let mut streaks = self.phantom_miss_streaks.write();
-        let count = streaks.entry((job_id, node.to_string())).or_insert(0);
-        *count += 1;
-        *count >= PHANTOM_MISS_THRESHOLD
-    }
-
-    /// Clear any miss-streak for `job_id` on `node` — its heartbeat report
-    /// included the job again, or the job/binding no longer needs tracking.
-    pub(crate) fn note_node_reported_job(&self, job_id: JobId, node: &str) {
-        self.phantom_miss_streaks
-            .write()
-            .remove(&(job_id, node.to_string()));
-    }
-
-    /// Remove `node`'s miss-streak entries for jobs no longer active there
-    /// (completed, cancelled, evicted by another path).
-    pub(crate) fn prune_phantom_streaks_not_in(&self, node: &str, active_job_ids: &HashSet<JobId>) {
-        self.phantom_miss_streaks
-            .write()
-            .retain(|(job_id, n), _| n != node || active_job_ids.contains(job_id));
-    }
-
     /// New token identifying one durable release hold.
     pub(crate) fn new_pending_kill_attempt(&self) -> u64 {
-        self.next_pending_kill_attempt
-            .fetch_add(1, Ordering::Relaxed)
+        self.next_agent_command_id.fetch_add(1, Ordering::Relaxed)
     }
 
     #[cfg(test)]
@@ -527,10 +524,10 @@ impl ClusterManager {
     }
 
     pub(crate) fn pending_kills_for_job(&self, job: &Job) -> Vec<PendingKillReservation> {
-        let attempt = self.new_pending_kill_attempt();
         let node_count = job.allocated_nodes.len().max(1) as u32;
         job.allocated_nodes
             .iter()
+            .filter(|node| !job.node_completions.contains_key(*node))
             .map(|node| PendingKillReservation {
                 job_id: job.job_id,
                 node: node.clone(),
@@ -545,56 +542,43 @@ impl ClusterManager {
                         },
                     )
                 }),
-                attempt,
+                attempt: self.new_pending_kill_attempt(),
                 run_attempt: job.run_attempt,
             })
             .collect()
     }
 
-    pub(crate) fn reserve_pending_dispatch(
+    pub(crate) fn abort_dispatch(
         &self,
         job_id: JobId,
-        nodes: &[String],
-        per_node_alloc: &HashMap<String, ResourceAllocations>,
         run_attempt: u32,
+        cleanup_nodes: &[String],
     ) -> anyhow::Result<()> {
-        let attempt = self.new_pending_kill_attempt();
-        let reservations = nodes
+        let commands: Vec<_> = cleanup_nodes
             .iter()
-            .filter_map(|node| {
-                per_node_alloc
-                    .get(node)
-                    .cloned()
-                    .map(|resources| PendingKillReservation {
-                        job_id,
-                        node: node.clone(),
-                        resources,
-                        attempt,
-                        run_attempt,
-                    })
+            .map(|node| {
+                AgentCommandRecord::new(
+                    self.new_pending_kill_attempt(),
+                    AllocationKey::new(job_id, run_attempt, node.clone()),
+                    AgentCommandKind::Release,
+                    Vec::new(),
+                    9,
+                )
             })
             .collect();
-        self.propose(WalOperation::PendingKillReserve { reservations })?;
-        Ok(())
-    }
-
-    pub fn begin_dispatch_attempt(&self, job_id: JobId) -> anyhow::Result<u32> {
-        let attempt = self
-            .jobs
-            .read()
-            .get(&job_id)
-            .ok_or_else(|| anyhow::anyhow!("job {} not found", job_id))
-            .and_then(|job| {
-                if job.state != JobState::Pending {
-                    anyhow::bail!("job {} is not pending", job_id);
-                }
-                Ok(job.run_attempt.saturating_add(1))
-            })?;
-        self.propose(WalOperation::JobDispatchAttempt {
+        let command_id = commands
+            .iter()
+            .map(|command| command.command_id)
+            .max()
+            .unwrap_or_else(|| self.new_pending_kill_attempt());
+        self.propose(WalOperation::AllocationAbort {
             job_id,
-            run_attempt: attempt,
+            run_attempt,
+            releasing_nodes: cleanup_nodes.to_vec(),
+            command_id,
+            commands,
         })?;
-        Ok(attempt)
+        Ok(())
     }
 
     fn pending_kills_for_jobs(&self, jobs: &[Job]) -> Vec<PendingKillReservation> {
@@ -617,53 +601,41 @@ impl ClusterManager {
         })
     }
 
-    /// Replicate the release confirmations established by one heartbeat.
-    pub(crate) fn clear_confirmed_pending_kills(
-        &self,
-        node: &str,
-        reported: &HashSet<JobId>,
-    ) -> anyhow::Result<()> {
-        let releases: Vec<PendingKillRelease> = self
-            .pending_kill
-            .read()
-            .values()
-            .filter(|hold| hold.node == node && !reported.contains(&hold.job_id))
-            .map(|hold| PendingKillRelease {
-                job_id: hold.job_id,
-                node: hold.node.clone(),
-                attempt: hold.attempt,
-            })
-            .collect();
-        if releases.is_empty() {
-            return Ok(());
-        }
-        self.propose(WalOperation::PendingKillRelease { releases })?;
-        Ok(())
-    }
-
     /// Per-node resources still held out of new dispatch.
+    #[cfg(test)]
     pub(crate) fn pending_kill_reservations(&self) -> HashMap<String, ResourceAllocations> {
         let mut by_node: HashMap<String, ResourceAllocations> = HashMap::new();
-        for hold in self.pending_kill.read().values() {
+        for record in self.allocations.read().values() {
+            if record.phase != AllocationPhase::Releasing {
+                continue;
+            }
             by_node
-                .entry(hold.node.clone())
+                .entry(record.key.node.clone())
                 .or_default()
-                .add(&hold.resources);
+                .add(&record.resources);
         }
         by_node
     }
 
     pub(crate) fn has_pending_kill(&self, job_id: JobId, node: &str) -> bool {
-        self.pending_kill
-            .read()
-            .contains_key(&(job_id, node.to_string()))
+        self.allocations.read().values().any(|record| {
+            record.phase == AllocationPhase::Releasing
+                && record.key.job_id == job_id
+                && record.key.node == node
+        })
     }
 
     pub(crate) fn pending_kill_run_attempt(&self, job_id: JobId, node: &str) -> Option<u32> {
-        self.pending_kill
+        self.allocations
             .read()
-            .get(&(job_id, node.to_string()))
-            .map(|hold| hold.run_attempt)
+            .values()
+            .filter(|record| {
+                record.phase == AllocationPhase::Releasing
+                    && record.key.job_id == job_id
+                    && record.key.node == node
+            })
+            .map(|record| record.key.run_attempt)
+            .max()
     }
 
     /// Submit a new job. If it has an array spec, expand into individual tasks.
@@ -1133,6 +1105,7 @@ impl ClusterManager {
         job_id: JobId,
         exit_code: i32,
         user: &str,
+        run_attempt: u32,
     ) -> Result<Job, SrunCompleteError> {
         let job = {
             let jobs = self.jobs.read();
@@ -1149,6 +1122,13 @@ impl ClusterManager {
                 return Err(SrunCompleteError::AlreadyTerminal {
                     job_id,
                     state: job.state,
+                });
+            }
+            if run_attempt != 0 && run_attempt != job.run_attempt {
+                return Err(SrunCompleteError::StaleRun {
+                    job_id,
+                    expected: run_attempt,
+                    actual: job.run_attempt,
                 });
             }
             Self::check_job_owner(user, &job.spec.user, "complete").map_err(|_| {
@@ -1221,6 +1201,336 @@ impl ClusterManager {
     /// Start a job on specific nodes.
     /// Transition a pending job to Running and record its allocation. Returns
     /// the run epoch assigned to this dispatch (threaded into the launch RPC).
+    pub(crate) fn prepare_dispatch(
+        &self,
+        job_id: JobId,
+        node_names: Vec<String>,
+        resources: ResourceAllocations,
+        per_node_alloc: HashMap<String, ResourceAllocations>,
+        srun_step_dispatch: bool,
+    ) -> anyhow::Result<u32> {
+        for name in &node_names {
+            if !per_node_alloc.contains_key(name) {
+                anyhow::bail!(
+                    "job {}: per_node_alloc missing entry for node '{}'",
+                    job_id,
+                    name
+                );
+            }
+        }
+
+        let run_attempt = {
+            let jobs = self.jobs.read();
+            let job = jobs
+                .get(&job_id)
+                .ok_or_else(|| anyhow::anyhow!("job {} not found", job_id))?;
+            if job.state != JobState::Pending {
+                anyhow::bail!("job {} cannot prepare from state {:?}", job_id, job.state);
+            }
+            job.run_attempt.saturating_add(1)
+        };
+
+        let blocked_node = self
+            .allocations
+            .read()
+            .values()
+            .find(|record| {
+                record.phase.is_charged()
+                    && record.key.job_id == job_id
+                    && record.key.run_attempt != run_attempt
+                    && node_names.contains(&record.key.node)
+            })
+            .map(|record| record.key.clone());
+        if let Some(record) = blocked_node {
+            anyhow::bail!(
+                "job {} attempt {} still owns resources on node {}",
+                job_id,
+                record.run_attempt,
+                record.node
+            );
+        }
+
+        if self.allocations.read().values().any(|record| {
+            record.key.job_id == job_id
+                && record.phase.is_charged()
+                && record.phase != AllocationPhase::Releasing
+        }) {
+            anyhow::bail!("job {job_id} still has an in-flight dispatch");
+        }
+
+        self.propose(WalOperation::AllocationPrepare {
+            job_id,
+            run_attempt,
+            nodes: node_names,
+            resources,
+            per_node_alloc,
+            srun_step_dispatch,
+        })?;
+        Ok(run_attempt)
+    }
+
+    pub(crate) fn begin_allocation_launch(
+        &self,
+        job_id: JobId,
+        run_attempt: u32,
+    ) -> anyhow::Result<u64> {
+        let command_id = self.next_agent_command_id.fetch_add(1, Ordering::Relaxed);
+        self.propose(WalOperation::AllocationBeginLaunch {
+            job_id,
+            run_attempt,
+            command_id,
+            created_at: Some(Utc::now()),
+            commands: Vec::new(),
+        })?;
+        Ok(command_id)
+    }
+
+    pub(crate) fn recover_incomplete_dispatches(&self) {
+        let pending: Vec<_> = self
+            .jobs
+            .read()
+            .values()
+            .filter(|job| job.state == JobState::Pending)
+            .cloned()
+            .collect();
+        for job in pending {
+            let records: Vec<_> = self
+                .allocations
+                .read()
+                .values()
+                .filter(|record| {
+                    record.key.job_id == job.job_id
+                        && record.key.run_attempt == job.run_attempt
+                        && record.phase.is_charged()
+                        && record.phase != AllocationPhase::Releasing
+                })
+                .cloned()
+                .collect();
+            if records.is_empty() {
+                continue;
+            }
+            if records
+                .iter()
+                .all(|record| record.phase == AllocationPhase::Prepared)
+            {
+                if let Err(error) = self.abort_dispatch(job.job_id, job.run_attempt, &[]) {
+                    warn!(job_id = job.job_id, error = %error, "failed to roll back prepared dispatch");
+                }
+                continue;
+            }
+            if records
+                .iter()
+                .all(|record| record.phase == AllocationPhase::Active)
+            {
+                let Some(resources) = job.allocated_resources.clone() else {
+                    continue;
+                };
+                if let Err(error) = self.start_job_impl(
+                    job.job_id,
+                    job.allocated_nodes.clone(),
+                    resources,
+                    job.per_node_alloc.clone(),
+                    job.srun_step_dispatch,
+                ) {
+                    warn!(job_id = job.job_id, error = %error, "failed to activate acknowledged dispatch");
+                }
+                continue;
+            }
+
+            let now = Utc::now();
+            let commands = self.agent_commands.read();
+            let command_failed = records.iter().any(|record| {
+                commands
+                    .get(&record.last_command_id)
+                    .is_some_and(|command| command.state == AgentCommandState::Failed)
+            });
+            let command_expired = records.iter().any(|record| {
+                let command = commands.get(&record.last_command_id);
+                let deadline = command
+                    .filter(|command| command.state == AgentCommandState::Pending)
+                    .and_then(|command| command.created_at)
+                    .or(record.launch_started_at);
+                deadline.is_some_and(|created_at| {
+                    now.signed_duration_since(created_at)
+                        >= chrono::Duration::seconds(AGENT_COMMAND_ACK_TIMEOUT_SECS as i64)
+                }) || (command.is_none() && deadline.is_none())
+            });
+            drop(commands);
+            if !command_failed && !command_expired {
+                continue;
+            }
+            if let Err(error) =
+                self.abort_dispatch(job.job_id, job.run_attempt, &job.allocated_nodes)
+            {
+                warn!(job_id = job.job_id, error = %error, "failed to clean up rejected dispatch");
+                continue;
+            }
+            if let Err(error) = self.backoff_pending_job_after_dispatch_failure(job.job_id) {
+                warn!(job_id = job.job_id, error = %error, "failed to back off rejected dispatch");
+            }
+        }
+    }
+
+    pub(crate) fn begin_allocation_launch_commands(
+        &self,
+        job_id: JobId,
+        run_attempt: u32,
+        commands: Vec<(AllocationKey, AgentCommandKind, Vec<u8>)>,
+    ) -> anyhow::Result<Vec<AgentCommandRecord>> {
+        if commands.is_empty() {
+            anyhow::bail!("job {job_id}: launch command set is empty");
+        }
+        let created_at = Utc::now();
+        let commands: Vec<_> = commands
+            .into_iter()
+            .map(|(key, kind, payload)| {
+                let command_id = self.next_agent_command_id.fetch_add(1, Ordering::Relaxed);
+                let mut command = AgentCommandRecord::new(command_id, key, kind, payload, 0);
+                command.created_at = Some(created_at);
+                command
+            })
+            .collect();
+        let command_id = commands
+            .iter()
+            .map(|command| command.command_id)
+            .max()
+            .unwrap_or(0);
+        self.propose(WalOperation::AllocationBeginLaunch {
+            job_id,
+            run_attempt,
+            command_id,
+            created_at: Some(created_at),
+            commands: commands.clone(),
+        })?;
+        Ok(commands)
+    }
+
+    pub(crate) fn node_supports_command_polling(&self, name: &str) -> bool {
+        self.nodes
+            .read()
+            .get(name)
+            .is_some_and(|node| node.supports_command_polling)
+    }
+
+    pub(crate) fn agent_session_matches(
+        &self,
+        name: &str,
+        agent_session_id: &str,
+        node_boot_id: &str,
+    ) -> bool {
+        self.nodes.read().get(name).is_some_and(|node| {
+            node.agent_session_id == agent_session_id && node.node_boot_id == node_boot_id
+        })
+    }
+
+    pub(crate) fn pending_agent_commands(
+        &self,
+        node: &str,
+        agent_session_id: &str,
+        node_boot_id: &str,
+    ) -> anyhow::Result<Vec<AgentCommandRecord>> {
+        let nodes = self.nodes.read();
+        let registered = nodes
+            .get(node)
+            .ok_or_else(|| anyhow::anyhow!("node {node} is not registered"))?;
+        if registered.agent_session_id != agent_session_id
+            || registered.node_boot_id != node_boot_id
+        {
+            anyhow::bail!("agent session does not match the registered node");
+        }
+        let recovery_complete = registered.recovery_complete;
+        drop(nodes);
+
+        let mut commands: Vec<_> = self
+            .agent_commands
+            .read()
+            .values()
+            .filter(|command| {
+                command.key.node == node
+                    && command.state == AgentCommandState::Pending
+                    && (recovery_complete || command.kind == AgentCommandKind::Release)
+            })
+            .cloned()
+            .collect();
+        commands.sort_by_key(|command| command.command_id);
+        Ok(commands)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn acknowledge_agent_command(
+        &self,
+        command_id: u64,
+        key: AllocationKey,
+        agent_session_id: String,
+        node_boot_id: String,
+        success: bool,
+        response_payload: Vec<u8>,
+        error: String,
+    ) -> anyhow::Result<()> {
+        self.propose(WalOperation::AgentCommandAcknowledge {
+            command_id,
+            key,
+            agent_session_id,
+            node_boot_id,
+            success,
+            response_payload,
+            error,
+        })?;
+        Ok(())
+    }
+
+    pub(crate) fn agent_commands(&self, command_ids: &[u64]) -> Vec<AgentCommandRecord> {
+        let commands = self.agent_commands.read();
+        command_ids
+            .iter()
+            .filter_map(|id| commands.get(id).cloned())
+            .collect()
+    }
+
+    pub(crate) async fn wait_for_agent_command_update(&self) {
+        self.agent_command_notify.notified().await;
+    }
+
+    pub(crate) fn allocation_records_on_node(&self, node: &str) -> Vec<AllocationRecord> {
+        self.allocations
+            .read()
+            .values()
+            .filter(|record| record.key.node == node && record.phase.is_charged())
+            .cloned()
+            .collect()
+    }
+
+    pub(crate) fn enqueue_recovery_releases(&self, keys: Vec<AllocationKey>) -> anyhow::Result<()> {
+        let existing: HashSet<_> = self
+            .agent_commands
+            .read()
+            .values()
+            .filter(|command| {
+                command.kind == AgentCommandKind::Release
+                    && command.state == AgentCommandState::Pending
+            })
+            .map(|command| command.key.clone())
+            .collect();
+        let commands: Vec<_> = keys
+            .into_iter()
+            .filter(|key| !existing.contains(key))
+            .map(|key| {
+                AgentCommandRecord::new(
+                    self.next_agent_command_id.fetch_add(1, Ordering::Relaxed),
+                    key,
+                    AgentCommandKind::Release,
+                    Vec::new(),
+                    9,
+                )
+            })
+            .collect();
+        if commands.is_empty() {
+            return Ok(());
+        }
+        self.propose(WalOperation::AgentCommandsEnqueue { commands })?;
+        Ok(())
+    }
+
     pub fn start_job(
         &self,
         job_id: JobId,
@@ -1239,47 +1549,43 @@ impl ClusterManager {
         per_node_alloc: std::collections::HashMap<String, ResourceAllocations>,
         srun_step_dispatch: bool,
     ) -> anyhow::Result<u32> {
-        for name in &node_names {
-            if !per_node_alloc.contains_key(name) {
-                anyhow::bail!(
-                    "job {}: per_node_alloc missing entry for node '{}'",
-                    job_id,
-                    name
-                );
-            }
-        }
-
-        // Validate job exists and can transition
-        let old_state;
         let spec_for_notify;
         let submit_time_for_notify;
-        let run_attempt;
+        let mut run_attempt;
         {
             let jobs = self.jobs.read();
             let job = jobs
                 .get(&job_id)
                 .ok_or_else(|| anyhow::anyhow!("job {} not found", job_id))?;
-            old_state = job.state;
             spec_for_notify = job.spec.clone();
             submit_time_for_notify = job.submit_time;
-            run_attempt = job.run_attempt.max(1);
+            run_attempt = job.run_attempt;
             if job.state != JobState::Pending {
                 anyhow::bail!("job {} cannot start from state {:?}", job_id, job.state);
             }
         }
 
-        // propose() handles: state transition, resource allocation, license subtraction
-        self.propose(WalOperation::job_state_change(
+        let phase = self
+            .allocations
+            .read()
+            .values()
+            .find(|record| record.key.job_id == job_id && record.key.run_attempt == run_attempt)
+            .map(|record| record.phase);
+        if phase.is_none() {
+            run_attempt = self.prepare_dispatch(
+                job_id,
+                node_names.clone(),
+                resources.clone(),
+                per_node_alloc.clone(),
+                srun_step_dispatch,
+            )?;
+            self.begin_allocation_launch(job_id, run_attempt)?;
+        } else if phase == Some(AllocationPhase::Prepared) {
+            self.begin_allocation_launch(job_id, run_attempt)?;
+        }
+
+        self.propose(WalOperation::AllocationActivate {
             job_id,
-            old_state,
-            JobState::Running,
-        ))?;
-        self.propose(WalOperation::JobStart {
-            job_id,
-            nodes: node_names.clone(),
-            resources: resources.clone(),
-            per_node_alloc: per_node_alloc.clone(),
-            srun_step_dispatch,
             run_attempt,
         })?;
 
@@ -1359,9 +1665,9 @@ impl ClusterManager {
             if job.state.is_terminal() {
                 return Ok(NodeCompleteResult::AlreadyTerminal);
             }
-            // Drop a report from a superseded run (older epoch). Reported
-            // epoch 0 predates fencing (legacy job or agent) and is trusted.
-            if run_attempt != 0 && run_attempt < job.run_attempt {
+            // Epoch 0 predates fencing (legacy job or agent) and is trusted.
+            // Every fenced report must identify the allocation exactly.
+            if run_attempt != 0 && run_attempt != job.run_attempt {
                 return Ok(NodeCompleteResult::StaleReport);
             }
             if !job.allocated_nodes.iter().any(|n| n == node_name) {
@@ -1378,6 +1684,7 @@ impl ClusterManager {
                 node_name: node_name.to_string(),
                 exit_code,
                 signal,
+                run_attempt,
             })
             .map_err(|source| NodeCompleteError::RaftPropose { source })?;
 
@@ -1842,6 +2149,7 @@ impl ClusterManager {
 
     /// Register a node agent.
     #[allow(clippy::too_many_arguments)]
+    #[cfg(test)]
     pub fn register_node(
         &self,
         name: String,
@@ -1854,6 +2162,40 @@ impl ClusterManager {
         source: NodeSource,
         labels: HashMap<String, String>,
     ) -> anyhow::Result<()> {
+        self.register_node_with_session(
+            name,
+            hostname,
+            resources,
+            address,
+            port,
+            wg_pubkey,
+            version,
+            source,
+            labels,
+            String::new(),
+            String::new(),
+            true,
+            false,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn register_node_with_session(
+        &self,
+        name: String,
+        hostname: String,
+        resources: ResourceSet,
+        address: String,
+        port: u16,
+        wg_pubkey: String,
+        version: String,
+        source: NodeSource,
+        labels: HashMap<String, String>,
+        agent_session_id: String,
+        node_boot_id: String,
+        recovery_complete: bool,
+        supports_command_polling: bool,
+    ) -> anyhow::Result<()> {
         let hostname = if hostname.is_empty() {
             name.clone()
         } else {
@@ -1863,6 +2205,16 @@ impl ClusterManager {
             let nodes = self.nodes.read();
             evaluate_registration(nodes.get(&name), &resources)
         };
+
+        if !agent_session_id.is_empty() && !matches!(&action, RegistrationAction::Register) {
+            self.propose(WalOperation::NodeAgentState {
+                name: name.clone(),
+                agent_session_id: agent_session_id.clone(),
+                node_boot_id: node_boot_id.clone(),
+                recovery_complete,
+                supports_command_polling,
+            })?;
+        }
 
         match action {
             RegistrationAction::Skip => {
@@ -1924,6 +2276,10 @@ impl ClusterManager {
                     version,
                     labels,
                     source: source.clone(),
+                    agent_session_id,
+                    node_boot_id,
+                    recovery_complete,
+                    supports_command_polling,
                 })?;
                 if let Some(node) = self.nodes.write().get_mut(&name) {
                     node.source = source;
@@ -1932,6 +2288,32 @@ impl ClusterManager {
                 info!(node = %name, "node registered");
             }
         }
+        Ok(())
+    }
+
+    pub(crate) fn update_agent_recovery(
+        &self,
+        name: &str,
+        agent_session_id: &str,
+        node_boot_id: &str,
+        recovery_complete: bool,
+        supports_command_polling: bool,
+    ) -> anyhow::Result<()> {
+        if self.nodes.read().get(name).is_some_and(|node| {
+            node.agent_session_id == agent_session_id
+                && node.node_boot_id == node_boot_id
+                && node.recovery_complete == recovery_complete
+                && node.supports_command_polling == supports_command_polling
+        }) {
+            return Ok(());
+        }
+        self.propose(WalOperation::NodeAgentState {
+            name: name.into(),
+            agent_session_id: agent_session_id.into(),
+            node_boot_id: node_boot_id.into(),
+            recovery_complete,
+            supports_command_polling,
+        })?;
         Ok(())
     }
 
@@ -2041,7 +2423,7 @@ impl ClusterManager {
         self.nodes
             .read()
             .values()
-            .filter(|n| !cooling.contains(&n.name))
+            .filter(|n| n.recovery_complete && !cooling.contains(&n.name))
             .cloned()
             .collect()
     }
@@ -4223,16 +4605,11 @@ impl ClusterManager {
         Self::clear_run_state_for_requeue(job);
     }
 
-    /// Evict a single job by ID: transition to NodeFail, then free its
-    /// allocations on every node it spans. Transition is validated first
-    /// so allocations are never freed for a job that can't be evicted.
-    /// Nodes that already reported completion via `JobNodeComplete` (which
-    /// frees a node's slice as it arrives, ahead of the whole job finishing)
-    /// are skipped so their resources aren't subtracted twice.
+    /// Evict a single job by ID. Allocation records are updated by the caller
+    /// after the job transition succeeds.
     fn evict_job_locked(
         job_id: JobId,
         jobs: &mut HashMap<JobId, Job>,
-        nodes: &mut HashMap<String, Node>,
         timestamp: chrono::DateTime<Utc>,
         reason: PendingReason,
         run_attempt: u32,
@@ -4252,38 +4629,7 @@ impl ClusterManager {
         job.exit_code = Some(-1);
         job.end_time = Some(timestamp);
         job.set_pending_reason(reason);
-        let already_deallocated: Vec<String> = job.node_completions.keys().cloned().collect();
         job.node_completions.clear();
-
-        let alloc_nodes = job.allocated_nodes.clone();
-        if let Some(ref total) = job.allocated_resources {
-            let node_count = alloc_nodes.len().max(1) as u32;
-            for alloc_node in &alloc_nodes {
-                if already_deallocated.iter().any(|n| n == alloc_node) {
-                    continue;
-                }
-                if let Some(node) = nodes.get_mut(alloc_node) {
-                    let slice = job
-                        .per_node_alloc
-                        .get(alloc_node)
-                        .cloned()
-                        .unwrap_or_else(|| {
-                            ResourceAllocations::with_scalar(
-                                total.cpus / node_count,
-                                total.memory_mb / node_count as u64,
-                            )
-                        });
-                    node.alloc_resources.subtract(&slice);
-                    node.update_state_from_alloc();
-                    if node.state == NodeState::Draining
-                        && node.alloc_resources.cpus == 0
-                        && !node.alloc_resources.has_devices()
-                    {
-                        node.state = NodeState::Drain;
-                    }
-                }
-            }
-        }
 
         Some(JobFinalized {
             job_id,
@@ -4292,12 +4638,11 @@ impl ClusterManager {
         })
     }
 
-    /// Fail all running/completing/suspended jobs on a node, releasing
-    /// allocations on **every** node each job spans.
+    /// Fail all running/completing/suspended jobs on a node. The caller updates
+    /// the allocation ledger for every node each job spans.
     fn evict_jobs_on_node(
         node_name: &str,
         jobs: &mut HashMap<JobId, Job>,
-        nodes: &mut HashMap<String, Node>,
         timestamp: chrono::DateTime<Utc>,
         response: &mut ClientResponse,
     ) {
@@ -4314,21 +4659,128 @@ impl ClusterManager {
 
         for jid in affected {
             if let Some(fin) =
-                Self::evict_job_locked(jid, jobs, nodes, timestamp, PendingReason::NodeDown, 0)
+                Self::evict_job_locked(jid, jobs, timestamp, PendingReason::NodeDown, 0)
             {
                 response.jobs_finalized.push(fin);
             }
         }
     }
 
+    fn apply_job_complete_operation(
+        &self,
+        job_id: JobId,
+        exit_code: i32,
+        state: JobState,
+        reservations: &[PendingKillReservation],
+    ) -> ClientResponse {
+        let timestamp = Utc::now();
+        let mut response = ClientResponse::default();
+        let mut jobs = self.jobs.write();
+        let mut nodes = self.nodes.write();
+        let completion_attempt;
+
+        if let Some(job) = jobs.get_mut(&job_id) {
+            if job.state.is_finalized()
+                && !(job.state == JobState::Preempted && state == JobState::Cancelled)
+            {
+                return ClientResponse::default();
+            }
+            if let Err(e) = job.transition(state) {
+                warn!(
+                    job_id,
+                    error = %e,
+                    "invalid state transition in WAL apply"
+                );
+                return ClientResponse::default();
+            }
+            if state.is_terminal() {
+                response.jobs_finalized.push(JobFinalized {
+                    job_id,
+                    state,
+                    exit_code,
+                });
+            }
+            job.exit_code = Some(exit_code);
+            job.end_time = Some(timestamp);
+            if state == JobState::Timeout {
+                job.set_pending_reason(PendingReason::TimeLimit);
+            }
+            if let Some(since) = job.suspended_at.take() {
+                job.suspended_secs += (timestamp - since).num_seconds().max(0);
+            }
+            completion_attempt = job.run_attempt;
+            job.node_completions.clear();
+        } else {
+            return ClientResponse::default();
+        }
+
+        let reservations: Vec<_> = reservations
+            .iter()
+            .filter(|reservation| {
+                reservation.job_id == job_id && reservation.run_attempt == completion_attempt
+            })
+            .cloned()
+            .collect();
+        let held_keys: HashSet<_> = reservations
+            .iter()
+            .map(|reservation| {
+                AllocationKey::new(
+                    reservation.job_id,
+                    reservation.run_attempt,
+                    reservation.node.clone(),
+                )
+            })
+            .collect();
+        {
+            let mut allocations = self.allocations.write();
+            for record in allocations.values_mut().filter(|record| {
+                record.key.job_id == job_id && record.key.run_attempt == completion_attempt
+            }) {
+                if !held_keys.contains(&record.key) {
+                    record.phase = AllocationPhase::Released;
+                }
+            }
+        }
+        self.apply_pending_kill_reservations(&reservations);
+        {
+            let allocations = self.allocations.read();
+            Self::rebuild_node_resource_projection(&mut nodes, &allocations);
+        }
+
+        drop(jobs);
+        drop(nodes);
+        self.complete_job_steps(&job_id, exit_code, timestamp);
+        response
+    }
+
     fn apply_pending_kill_reservations(&self, reservations: &[PendingKillReservation]) {
-        let mut pending = self.pending_kill.write();
+        let mut allocations = self.allocations.write();
+        let mut commands = self.agent_commands.write();
         for hold in reservations {
-            // Raft applies are strictly ordered, so the newest reservation for a
-            // key is always the accurate one — never keep a stale prior attempt.
-            pending.insert((hold.job_id, hold.node.clone()), hold.clone());
-            self.next_pending_kill_attempt
+            let key = AllocationKey::new(hold.job_id, hold.run_attempt, hold.node.clone());
+            let mut record = AllocationRecord::new(
+                key.clone(),
+                hold.resources.clone(),
+                AllocationPhase::Releasing,
+            );
+            record.last_command_id = hold.attempt;
+            allocations.insert(key, record);
+            if hold.attempt > 0 {
+                commands.entry(hold.attempt).or_insert_with(|| {
+                    AgentCommandRecord::new(
+                        hold.attempt,
+                        AllocationKey::new(hold.job_id, hold.run_attempt, hold.node.clone()),
+                        AgentCommandKind::Release,
+                        Vec::new(),
+                        0,
+                    )
+                });
+            }
+            self.next_agent_command_id
                 .fetch_max(hold.attempt.saturating_add(1), Ordering::Relaxed);
+        }
+        if !reservations.is_empty() {
+            self.agent_command_notify.notify_waiters();
         }
     }
 
@@ -4340,8 +4792,51 @@ impl ClusterManager {
             operation,
         } = op
         {
-            self.apply_pending_kill_reservations(reservations);
-            return self.apply_operation(operation);
+            if let WalOperation::JobComplete {
+                job_id,
+                exit_code,
+                state,
+            } = operation.as_ref()
+            {
+                return self.apply_job_complete_operation(
+                    *job_id,
+                    *exit_code,
+                    *state,
+                    reservations,
+                );
+            }
+            let response = self.apply_operation(operation);
+            let finalized: HashSet<_> = response
+                .jobs_finalized
+                .iter()
+                .map(|job| job.job_id)
+                .collect();
+            let removed_node = match operation.as_ref() {
+                WalOperation::NodeRemove { name, .. } => Some(name.as_str()),
+                _ => None,
+            };
+            let reservations: Vec<_> = reservations
+                .iter()
+                .filter(|reservation| {
+                    finalized.contains(&reservation.job_id)
+                        && removed_node != Some(reservation.node.as_str())
+                })
+                .cloned()
+                .collect();
+            self.apply_pending_kill_reservations(&reservations);
+            let mut nodes = self.nodes.write();
+            let allocations = self.allocations.read();
+            Self::rebuild_node_resource_projection(&mut nodes, &allocations);
+            return response;
+        }
+
+        if let WalOperation::JobComplete {
+            job_id,
+            exit_code,
+            state,
+        } = op
+        {
+            return self.apply_job_complete_operation(*job_id, *exit_code, *state, &[]);
         }
 
         let mut response = ClientResponse::default();
@@ -4351,21 +4846,347 @@ impl ClusterManager {
         let timestamp = Utc::now();
 
         match op {
+            WalOperation::AllocationPrepare {
+                job_id,
+                run_attempt,
+                nodes: node_names,
+                resources,
+                per_node_alloc,
+                srun_step_dispatch,
+            } => {
+                let Some(job) = jobs.get_mut(job_id) else {
+                    return ClientResponse::default();
+                };
+                if job.state != JobState::Pending || *run_attempt < job.run_attempt {
+                    return ClientResponse::default();
+                }
+                job.run_attempt = *run_attempt;
+                job.allocated_nodes = node_names.clone();
+                job.allocated_resources = Some(resources.clone());
+                job.per_node_alloc = per_node_alloc.clone();
+                job.srun_step_dispatch = *srun_step_dispatch;
+
+                let mut allocations = self.allocations.write();
+                allocations.retain(|_, record| {
+                    record.key.job_id != *job_id || record.phase != AllocationPhase::Released
+                });
+                for node in node_names {
+                    let Some(slice) = per_node_alloc.get(node) else {
+                        warn!(job_id = *job_id, node = %node, "prepared allocation has no resource slice");
+                        continue;
+                    };
+                    let key = AllocationKey::new(*job_id, *run_attempt, node.clone());
+                    allocations.entry(key.clone()).or_insert_with(|| {
+                        AllocationRecord::new(key, slice.clone(), AllocationPhase::Prepared)
+                    });
+                }
+                Self::rebuild_node_resource_projection(&mut nodes, &allocations);
+            }
+            WalOperation::AllocationBeginLaunch {
+                job_id,
+                run_attempt,
+                command_id,
+                created_at,
+                commands,
+            } => {
+                let mut allocations = self.allocations.write();
+                for record in allocations.values_mut().filter(|record| {
+                    record.key.job_id == *job_id && record.key.run_attempt == *run_attempt
+                }) {
+                    if record.phase == AllocationPhase::Prepared {
+                        record.phase = AllocationPhase::Launching;
+                        record.launch_started_at = *created_at;
+                    }
+                    if record.phase == AllocationPhase::Launching {
+                        let node_command =
+                            commands.iter().find(|command| command.key == record.key);
+                        if record.launch_started_at.is_none() {
+                            record.launch_started_at =
+                                node_command.and_then(|command| command.created_at);
+                        }
+                        let node_command = node_command
+                            .map(|command| command.command_id)
+                            .unwrap_or(*command_id);
+                        record.last_command_id = record.last_command_id.max(node_command);
+                    }
+                }
+                self.agent_commands.write().extend(
+                    commands
+                        .iter()
+                        .cloned()
+                        .map(|command| (command.command_id, command)),
+                );
+                if !commands.is_empty() {
+                    self.agent_command_notify.notify_waiters();
+                }
+                self.next_agent_command_id
+                    .fetch_max(command_id.saturating_add(1), Ordering::Relaxed);
+                Self::rebuild_node_resource_projection(&mut nodes, &allocations);
+            }
+            WalOperation::AllocationActivate {
+                job_id,
+                run_attempt,
+            } => {
+                let Some(job) = jobs.get_mut(job_id) else {
+                    return ClientResponse::default();
+                };
+                if job.run_attempt != *run_attempt || job.state != JobState::Pending {
+                    return ClientResponse::default();
+                }
+                let mut allocations = self.allocations.write();
+                let all_launching = job.allocated_nodes.iter().all(|node| {
+                    allocations
+                        .get(&AllocationKey::new(*job_id, *run_attempt, node.clone()))
+                        .is_some_and(|record| {
+                            matches!(
+                                record.phase,
+                                AllocationPhase::Launching | AllocationPhase::Active
+                            )
+                        })
+                });
+                if !all_launching {
+                    warn!(
+                        job_id = *job_id,
+                        run_attempt, "activation missing a launched allocation"
+                    );
+                    return ClientResponse::default();
+                }
+                if job.apply_transition(JobState::Running).is_err() {
+                    return ClientResponse::default();
+                }
+                job.start_time = Some(timestamp);
+                job.set_pending_reason(PendingReason::None);
+                for record in allocations.values_mut().filter(|record| {
+                    record.key.job_id == *job_id && record.key.run_attempt == *run_attempt
+                }) {
+                    record.phase = AllocationPhase::Active;
+                }
+                self.agent_commands.write().retain(|_, command| {
+                    command.key.job_id != *job_id
+                        || command.key.run_attempt != *run_attempt
+                        || command.kind == AgentCommandKind::Release
+                });
+                Self::rebuild_node_resource_projection(&mut nodes, &allocations);
+            }
+            WalOperation::AllocationAbort {
+                job_id,
+                run_attempt,
+                releasing_nodes,
+                command_id,
+                commands,
+            } => {
+                let releasing: HashSet<&str> = releasing_nodes.iter().map(String::as_str).collect();
+                let mut allocations = self.allocations.write();
+                for record in allocations.values_mut().filter(|record| {
+                    record.key.job_id == *job_id && record.key.run_attempt == *run_attempt
+                }) {
+                    if releasing.contains(record.key.node.as_str()) {
+                        record.phase = AllocationPhase::Releasing;
+                        record.last_command_id = commands
+                            .iter()
+                            .find(|command| command.key == record.key)
+                            .map(|command| command.command_id)
+                            .unwrap_or(*command_id);
+                    } else {
+                        record.phase = AllocationPhase::Released;
+                    }
+                }
+                self.agent_commands.write().extend(
+                    commands
+                        .iter()
+                        .cloned()
+                        .map(|command| (command.command_id, command)),
+                );
+                if !commands.is_empty() {
+                    self.agent_command_notify.notify_waiters();
+                }
+                self.agent_commands.write().retain(|_, command| {
+                    command.key.job_id != *job_id
+                        || command.key.run_attempt != *run_attempt
+                        || command.kind == AgentCommandKind::Release
+                });
+                if let Some(job) = jobs.get_mut(job_id) {
+                    if job.state == JobState::Pending && job.run_attempt == *run_attempt {
+                        job.allocated_nodes.clear();
+                        job.allocated_resources = None;
+                        job.per_node_alloc.clear();
+                    }
+                }
+                self.next_agent_command_id
+                    .fetch_max(command_id.saturating_add(1), Ordering::Relaxed);
+                Self::rebuild_node_resource_projection(&mut nodes, &allocations);
+            }
+            WalOperation::AllocationBeginRelease {
+                keys,
+                command_id,
+                commands,
+            } => {
+                let mut allocations = self.allocations.write();
+                for key in keys {
+                    if let Some(record) = allocations.get_mut(key) {
+                        if record.phase != AllocationPhase::Released {
+                            record.phase = AllocationPhase::Releasing;
+                            record.last_command_id = commands
+                                .iter()
+                                .find(|command| command.key == *key)
+                                .map(|command| command.command_id)
+                                .unwrap_or(*command_id);
+                        }
+                    }
+                }
+                self.agent_commands.write().extend(
+                    commands
+                        .iter()
+                        .cloned()
+                        .map(|command| (command.command_id, command)),
+                );
+                if !commands.is_empty() {
+                    self.agent_command_notify.notify_waiters();
+                }
+                self.next_agent_command_id
+                    .fetch_max(command_id.saturating_add(1), Ordering::Relaxed);
+                Self::rebuild_node_resource_projection(&mut nodes, &allocations);
+            }
+            WalOperation::AllocationConfirmRelease {
+                key,
+                command_id,
+                agent_session_id,
+                node_boot_id,
+            } => {
+                let mut allocations = self.allocations.write();
+                if let Some(record) = allocations.get_mut(key) {
+                    if record.phase == AllocationPhase::Releasing
+                        && record.last_command_id == *command_id
+                    {
+                        record.phase = AllocationPhase::Released;
+                        record.agent_session_id = Some(agent_session_id.clone());
+                        record.node_boot_id = Some(node_boot_id.clone());
+                    }
+                }
+                Self::rebuild_node_resource_projection(&mut nodes, &allocations);
+            }
+            WalOperation::AgentCommandAcknowledge {
+                command_id,
+                key,
+                agent_session_id,
+                node_boot_id,
+                success,
+                response_payload,
+                error,
+            } => {
+                let session_matches = nodes.get(&key.node).is_some_and(|node| {
+                    node.agent_session_id == *agent_session_id && node.node_boot_id == *node_boot_id
+                });
+                if !session_matches {
+                    warn!(
+                        command_id,
+                        node = %key.node,
+                        "ignoring acknowledgement from an unregistered agent session"
+                    );
+                    return ClientResponse::default();
+                }
+
+                let kind = {
+                    let mut commands = self.agent_commands.write();
+                    let Some(command) = commands.get_mut(command_id) else {
+                        return ClientResponse::default();
+                    };
+                    if command.key != *key || command.state != AgentCommandState::Pending {
+                        return ClientResponse::default();
+                    }
+                    command.state = if *success {
+                        AgentCommandState::Succeeded
+                    } else {
+                        AgentCommandState::Failed
+                    };
+                    command.agent_session_id = agent_session_id.clone();
+                    command.node_boot_id = node_boot_id.clone();
+                    command.response_payload = response_payload.clone();
+                    command.error = error.clone();
+                    command.kind
+                };
+
+                if *success {
+                    let mut allocations = self.allocations.write();
+                    if let Some(record) = allocations.get_mut(key) {
+                        if record.last_command_id == *command_id {
+                            match kind {
+                                AgentCommandKind::Launch | AgentCommandKind::Register
+                                    if record.phase == AllocationPhase::Launching =>
+                                {
+                                    record.phase = AllocationPhase::Active;
+                                    record.agent_session_id = Some(agent_session_id.clone());
+                                    record.node_boot_id = Some(node_boot_id.clone());
+                                }
+                                AgentCommandKind::Release
+                                    if record.phase == AllocationPhase::Releasing =>
+                                {
+                                    record.phase = AllocationPhase::Released;
+                                    record.agent_session_id = Some(agent_session_id.clone());
+                                    record.node_boot_id = Some(node_boot_id.clone());
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                    Self::rebuild_node_resource_projection(&mut nodes, &allocations);
+                }
+                if *success && kind == AgentCommandKind::Release {
+                    self.agent_commands.write().remove(command_id);
+                }
+                self.agent_command_notify.notify_waiters();
+            }
+            WalOperation::AgentCommandsEnqueue { commands } => {
+                let mut allocations = self.allocations.write();
+                for command in commands {
+                    if let Some(record) = allocations.get_mut(&command.key) {
+                        if record.phase != AllocationPhase::Released {
+                            record.phase = AllocationPhase::Releasing;
+                            record.last_command_id = command.command_id;
+                        }
+                    }
+                    self.next_agent_command_id
+                        .fetch_max(command.command_id.saturating_add(1), Ordering::Relaxed);
+                }
+                let replacement_keys: HashSet<_> =
+                    commands.iter().map(|command| command.key.clone()).collect();
+                let mut outbox = self.agent_commands.write();
+                outbox.retain(|_, command| {
+                    command.kind != AgentCommandKind::Release
+                        || command.state != AgentCommandState::Failed
+                        || !replacement_keys.contains(&command.key)
+                });
+                outbox.extend(
+                    commands
+                        .iter()
+                        .cloned()
+                        .map(|command| (command.command_id, command)),
+                );
+                drop(outbox);
+                if !commands.is_empty() {
+                    self.agent_command_notify.notify_waiters();
+                }
+                Self::rebuild_node_resource_projection(&mut nodes, &allocations);
+            }
             WalOperation::PendingKillReserve { reservations } => {
                 self.apply_pending_kill_reservations(reservations);
+                let allocations = self.allocations.read();
+                Self::rebuild_node_resource_projection(&mut nodes, &allocations);
             }
             WalOperation::PendingKillTransition { .. } => unreachable!("handled before locking"),
             WalOperation::PendingKillRelease { releases } => {
-                let mut pending = self.pending_kill.write();
+                let mut allocations = self.allocations.write();
                 for release in releases {
-                    let key = (release.job_id, release.node.clone());
-                    if pending
-                        .get(&key)
-                        .is_some_and(|hold| hold.attempt == release.attempt)
-                    {
-                        pending.remove(&key);
+                    for record in allocations.values_mut() {
+                        if record.key.job_id == release.job_id
+                            && record.key.node == release.node
+                            && record.last_command_id == release.attempt
+                        {
+                            record.phase = AllocationPhase::Released;
+                        }
                     }
                 }
+                Self::rebuild_node_resource_projection(&mut nodes, &allocations);
             }
             WalOperation::JobSubmit { job_id, spec } => {
                 let mut job = Job::new(*job_id, (**spec).clone());
@@ -4452,9 +5273,7 @@ impl ClusterManager {
             WalOperation::JobPreemptRequeue { job_id, begin_time } => {
                 // Only a running job is preempted; on replay the job is already
                 // Pending, so this is a NoOp (no re-dealloc, no double requeue).
-                let freed_nodes;
-                let allocated_resources;
-                let per_node_map;
+                let preempt_attempt;
                 {
                     let Some(job) = jobs.get_mut(job_id) else {
                         return ClientResponse::default();
@@ -4474,9 +5293,7 @@ impl ClusterManager {
                     if let Some(since) = job.suspended_at.take() {
                         job.suspended_secs += (timestamp - since).num_seconds().max(0);
                     }
-                    freed_nodes = job.allocated_nodes.clone();
-                    allocated_resources = job.allocated_resources.clone();
-                    per_node_map = job.per_node_alloc.clone();
+                    preempt_attempt = job.run_attempt;
                     job.node_completions.clear();
 
                     if let Err(e) = job.transition(JobState::Pending) {
@@ -4487,27 +5304,16 @@ impl ClusterManager {
                     job.spec.begin_time = Some(*begin_time);
                     job.set_pending_reason(PendingReason::BeginTime);
                 }
-                if let Some(ref total) = allocated_resources {
-                    let node_count = freed_nodes.len().max(1) as u32;
-                    for name in &freed_nodes {
-                        if let Some(node) = nodes.get_mut(name) {
-                            let slice = per_node_map.get(name).cloned().unwrap_or_else(|| {
-                                warn!(job_id = *job_id, node = %name, "per_node_alloc missing at preempt deallocation, using scalar fallback");
-                                ResourceAllocations::with_scalar(
-                                    total.cpus / node_count,
-                                    total.memory_mb / node_count as u64,
-                                )
-                            });
-                            node.alloc_resources.subtract(&slice);
-                            node.update_state_from_alloc();
-                            if node.state == NodeState::Draining
-                                && node.alloc_resources.cpus == 0
-                                && !node.alloc_resources.has_devices()
-                            {
-                                node.state = NodeState::Drain;
-                            }
-                        }
+                {
+                    let mut allocations = self.allocations.write();
+                    for record in allocations.values_mut().filter(|record| {
+                        record.key.job_id == *job_id
+                            && record.key.run_attempt == preempt_attempt
+                            && record.phase != AllocationPhase::Released
+                    }) {
+                        record.phase = AllocationPhase::Releasing;
                     }
+                    Self::rebuild_node_resource_projection(&mut nodes, &allocations);
                 }
                 drop(jobs);
                 drop(nodes);
@@ -4556,10 +5362,10 @@ impl ClusterManager {
                 detail,
                 run_attempt,
             } => {
+                let current_attempt = jobs.get(job_id).map(|job| job.run_attempt);
                 if let Some(fin) = Self::evict_job_locked(
                     *job_id,
                     &mut jobs,
-                    &mut nodes,
                     timestamp,
                     reason.clone(),
                     *run_attempt,
@@ -4568,6 +5374,17 @@ impl ClusterManager {
                         job.launch_failure_detail = detail.clone();
                     }
                     response.jobs_finalized.push(fin);
+                    if let Some(current_attempt) = current_attempt {
+                        let mut allocations = self.allocations.write();
+                        for record in allocations.values_mut().filter(|record| {
+                            record.key.job_id == *job_id
+                                && record.key.run_attempt == current_attempt
+                                && record.phase != AllocationPhase::Released
+                        }) {
+                            record.phase = AllocationPhase::Releasing;
+                        }
+                        Self::rebuild_node_resource_projection(&mut nodes, &allocations);
+                    }
                 }
             }
             WalOperation::JobLaunchFailureDetail { job_id, detail } => {
@@ -4583,6 +5400,10 @@ impl ClusterManager {
                 srun_step_dispatch,
                 run_attempt,
             } => {
+                let actual_attempt = jobs
+                    .get(job_id)
+                    .map(|job| job.run_attempt.max(*run_attempt))
+                    .unwrap_or(*run_attempt);
                 if let Some(job) = jobs.get_mut(job_id) {
                     job.start_time = Some(timestamp);
                     job.allocated_nodes = node_names.clone();
@@ -4596,19 +5417,21 @@ impl ClusterManager {
                     job.launch_failure_detail = None;
                 }
                 let node_count = node_names.len().max(1) as u32;
+                let mut allocations = self.allocations.write();
                 for name in node_names {
-                    if let Some(node) = nodes.get_mut(name) {
-                        let slice = per_node_alloc.get(name).cloned().unwrap_or_else(|| {
-                            warn!(job_id = *job_id, node = %name, "per_node_alloc missing at allocation, using scalar fallback");
-                            ResourceAllocations::with_scalar(
-                                resources.cpus / node_count,
-                                resources.memory_mb / node_count as u64,
-                            )
-                        });
-                        node.alloc_resources.add(&slice);
-                        node.update_state_from_alloc();
-                    }
+                    let slice = per_node_alloc.get(name).cloned().unwrap_or_else(|| {
+                        ResourceAllocations::with_scalar(
+                            resources.cpus / node_count,
+                            resources.memory_mb / node_count as u64,
+                        )
+                    });
+                    let key = AllocationKey::new(*job_id, actual_attempt, name.clone());
+                    allocations.insert(
+                        key.clone(),
+                        AllocationRecord::new(key, slice, AllocationPhase::Active),
+                    );
                 }
+                Self::rebuild_node_resource_projection(&mut nodes, &allocations);
                 // Licenses are not mutated here: usage is derived on demand from
                 // running jobs (see available_licenses()), so the config total is
                 // authoritative and cannot drift.
@@ -4618,7 +5441,9 @@ impl ClusterManager {
                 node_name,
                 exit_code,
                 signal,
+                run_attempt,
             } => {
+                let completion_attempt;
                 let finalized = {
                     let Some(job) = jobs.get_mut(job_id) else {
                         return ClientResponse::default();
@@ -4628,8 +5453,11 @@ impl ClusterManager {
                     if !job.state.is_active() {
                         return ClientResponse::default();
                     }
+                    if *run_attempt != 0 && *run_attempt != job.run_attempt {
+                        return ClientResponse::default();
+                    }
+                    completion_attempt = job.run_attempt;
 
-                    let already_reported = job.node_completions.contains_key(node_name);
                     job.node_completions.insert(
                         node_name.clone(),
                         spur_core::job::NodeCompletion {
@@ -4637,29 +5465,6 @@ impl ClusterManager {
                             signal: *signal,
                         },
                     );
-
-                    if let Some(ref total) = job.allocated_resources {
-                        if !already_reported {
-                            let node_count = job.allocated_nodes.len().max(1) as u32;
-                            if let Some(node) = nodes.get_mut(node_name) {
-                                let slice = job.per_node_alloc.get(node_name).cloned().unwrap_or_else(|| {
-                                    warn!(job_id = *job_id, node = %node_name, "per_node_alloc missing at node deallocation, using scalar fallback");
-                                    ResourceAllocations::with_scalar(
-                                        total.cpus / node_count,
-                                        total.memory_mb / node_count as u64,
-                                    )
-                                });
-                                node.alloc_resources.subtract(&slice);
-                                node.update_state_from_alloc();
-                                if node.state == NodeState::Draining
-                                    && node.alloc_resources.cpus == 0
-                                    && !node.alloc_resources.has_devices()
-                                {
-                                    node.state = NodeState::Drain;
-                                }
-                            }
-                        }
-                    }
 
                     // Suspended jobs route through Completing too, so an
                     // out-of-band task death finalizes instead of stranding.
@@ -4714,6 +5519,15 @@ impl ClusterManager {
                     }
                 };
 
+                {
+                    let key = AllocationKey::new(*job_id, completion_attempt, node_name.clone());
+                    let mut allocations = self.allocations.write();
+                    if let Some(record) = allocations.get_mut(&key) {
+                        record.phase = AllocationPhase::Released;
+                    }
+                    Self::rebuild_node_resource_projection(&mut nodes, &allocations);
+                }
+
                 if let Some((final_state, final_exit)) = finalized {
                     drop(jobs);
                     drop(nodes);
@@ -4738,91 +5552,7 @@ impl ClusterManager {
                     }
                 }
             }
-            WalOperation::JobComplete {
-                job_id,
-                exit_code,
-                state,
-            } => {
-                let freed_nodes;
-                let allocated_resources;
-                let already_deallocated;
-                if let Some(job) = jobs.get_mut(job_id) {
-                    // is_finalized (incl. Preempted): a stale/replayed complete
-                    // is a silent no-op, not a rejected-transition warning.
-                    // Preempted is finalized for the ended run but may still cancel.
-                    if job.state.is_finalized()
-                        && !(job.state == JobState::Preempted && *state == JobState::Cancelled)
-                    {
-                        return ClientResponse::default();
-                    }
-                    if let Err(e) = job.transition(*state) {
-                        warn!(
-                            job_id = *job_id,
-                            error = %e,
-                            "invalid state transition in WAL apply"
-                        );
-                        return ClientResponse::default();
-                    }
-                    if state.is_terminal() {
-                        response.jobs_finalized.push(JobFinalized {
-                            job_id: *job_id,
-                            state: *state,
-                            exit_code: *exit_code,
-                        });
-                    }
-                    job.exit_code = Some(*exit_code);
-                    job.end_time = Some(timestamp);
-                    // Derived from the replicated entry, so every replica reports
-                    // the same reason for a job the watchdog had to force-kill.
-                    if *state == JobState::Timeout {
-                        job.set_pending_reason(PendingReason::TimeLimit);
-                    }
-                    // Suspended -> terminal: fold the final suspended interval in
-                    // and clear suspended_at so it never lingers on a terminal job.
-                    if let Some(since) = job.suspended_at.take() {
-                        job.suspended_secs += (timestamp - since).num_seconds().max(0);
-                    }
-                    freed_nodes = job.allocated_nodes.clone();
-                    allocated_resources = job.allocated_resources.clone();
-                    already_deallocated = job.node_completions.keys().cloned().collect::<Vec<_>>();
-                    job.node_completions.clear();
-                } else {
-                    return ClientResponse::default();
-                }
-                // Deallocate node resources not already freed during COMPLETING
-                let per_node_map = jobs
-                    .get(job_id)
-                    .map(|j| j.per_node_alloc.clone())
-                    .unwrap_or_default();
-                if let Some(ref total) = allocated_resources {
-                    let node_count = freed_nodes.len().max(1) as u32;
-                    for name in &freed_nodes {
-                        if already_deallocated.iter().any(|n| n == name) {
-                            continue;
-                        }
-                        if let Some(node) = nodes.get_mut(name) {
-                            let slice = per_node_map.get(name).cloned().unwrap_or_else(|| {
-                                warn!(job_id = *job_id, node = %name, "per_node_alloc missing at deallocation, using scalar fallback");
-                                ResourceAllocations::with_scalar(
-                                    total.cpus / node_count,
-                                    total.memory_mb / node_count as u64,
-                                )
-                            });
-                            node.alloc_resources.subtract(&slice);
-                            node.update_state_from_alloc();
-                            if node.state == NodeState::Draining
-                                && node.alloc_resources.cpus == 0
-                                && !node.alloc_resources.has_devices()
-                            {
-                                node.state = NodeState::Drain;
-                            }
-                        }
-                    }
-                }
-                drop(jobs);
-                drop(nodes);
-                self.complete_job_steps(job_id, *exit_code, timestamp);
-            }
+            WalOperation::JobComplete { .. } => unreachable!("handled before locking"),
             WalOperation::JobStepComplete {
                 job_id,
                 step_id,
@@ -4909,6 +5639,10 @@ impl ClusterManager {
                 version,
                 labels,
                 source,
+                agent_session_id,
+                node_boot_id,
+                recovery_complete,
+                supports_command_polling,
             } => {
                 let mut node = Node::new(name.clone(), resources.clone());
                 node.hostname = if hostname.is_empty() {
@@ -4929,11 +5663,20 @@ impl ClusterManager {
                     node.version = Some(version.clone());
                 }
                 node.source = spur_core::node::resolve_wal_node_source(source, version, labels);
+                node.agent_session_id = agent_session_id.clone();
+                node.node_boot_id = node_boot_id.clone();
+                node.recovery_complete = *recovery_complete;
+                node.supports_command_polling = *supports_command_polling;
                 node.last_heartbeat = Some(Utc::now());
-                node.state = node
-                    .state
-                    .transition(&NodeEvent::Register, false)
-                    .unwrap_or(NodeState::Idle);
+                if *recovery_complete {
+                    node.state = node
+                        .state
+                        .transition(&NodeEvent::Register, false)
+                        .unwrap_or(NodeState::Idle);
+                } else {
+                    node.state = NodeState::Unknown;
+                    node.state_reason = Some("agent recovery in progress".into());
+                }
 
                 // Assign partitions: match by hostlist OR label selector (union)
                 drop(nodes);
@@ -4956,6 +5699,39 @@ impl ClusterManager {
                 nodes.insert(name.clone(), node);
                 self.next_job_id.store(next_id, Ordering::Relaxed);
                 return ClientResponse::default();
+            }
+            WalOperation::NodeAgentState {
+                name,
+                agent_session_id,
+                node_boot_id,
+                recovery_complete,
+                supports_command_polling,
+            } => {
+                if let Some(node) = nodes.get_mut(name) {
+                    node.agent_session_id = agent_session_id.clone();
+                    node.node_boot_id = node_boot_id.clone();
+                    node.recovery_complete = *recovery_complete;
+                    node.supports_command_polling = *supports_command_polling;
+                    if *recovery_complete {
+                        if node.admin_locked {
+                            node.state = if node.alloc_resources.cpus > 0
+                                || node.alloc_resources.has_devices()
+                            {
+                                NodeState::Draining
+                            } else {
+                                NodeState::Drain
+                            };
+                        } else {
+                            node.state_reason = None;
+                            node.update_state_from_alloc();
+                        }
+                    } else {
+                        node.state = NodeState::Unknown;
+                        if !node.admin_locked {
+                            node.state_reason = Some("agent recovery in progress".into());
+                        }
+                    }
+                }
             }
             WalOperation::NodeUpdate {
                 name,
@@ -5000,7 +5776,20 @@ impl ClusterManager {
                     node.admin_locked = *admin_locked;
                 }
                 if *new_state == NodeState::Down {
-                    Self::evict_jobs_on_node(name, &mut jobs, &mut nodes, timestamp, &mut response);
+                    Self::evict_jobs_on_node(name, &mut jobs, timestamp, &mut response);
+                    let evicted: HashSet<_> = response
+                        .jobs_finalized
+                        .iter()
+                        .map(|job| job.job_id)
+                        .collect();
+                    let mut allocations = self.allocations.write();
+                    for record in allocations.values_mut().filter(|record| {
+                        evicted.contains(&record.key.job_id)
+                            && record.phase != AllocationPhase::Released
+                    }) {
+                        record.phase = AllocationPhase::Releasing;
+                    }
+                    Self::rebuild_node_resource_projection(&mut nodes, &allocations);
                 }
             }
             WalOperation::NodeLabelsUpdate { name, set, remove } => {
@@ -5032,7 +5821,23 @@ impl ClusterManager {
                 }
             }
             WalOperation::NodeRemove { name, reason } => {
-                Self::evict_jobs_on_node(name, &mut jobs, &mut nodes, timestamp, &mut response);
+                Self::evict_jobs_on_node(name, &mut jobs, timestamp, &mut response);
+                let evicted: HashSet<_> = response
+                    .jobs_finalized
+                    .iter()
+                    .map(|job| job.job_id)
+                    .collect();
+                {
+                    let mut allocations = self.allocations.write();
+                    for record in allocations.values_mut().filter(|record| {
+                        evicted.contains(&record.key.job_id)
+                            && record.phase != AllocationPhase::Released
+                    }) {
+                        record.phase = AllocationPhase::Releasing;
+                    }
+                    allocations.retain(|key, _| key.node != *name);
+                    Self::rebuild_node_resource_projection(&mut nodes, &allocations);
+                }
                 if let Some(node) = nodes.get(name) {
                     if node.alloc_resources.cpus > 0 || node.alloc_resources.has_devices() {
                         warn!(
@@ -5043,9 +5848,9 @@ impl ClusterManager {
                     }
                 }
                 nodes.remove(name);
-                // The node will never heartbeat again to confirm release, so any
-                // hold on it — including ones just planted above — must go now.
-                self.pending_kill.write().retain(|(_, n), _| n != name);
+                self.agent_commands
+                    .write()
+                    .retain(|_, command| command.key.node != *name);
                 info!(
                     node = %name,
                     reason = reason.as_deref().unwrap_or(""),
@@ -5326,6 +6131,16 @@ impl ClusterManager {
                     self.steps
                         .write()
                         .retain(|_, s| !evicted.contains(&s.job_id));
+                    let mut allocations = self.allocations.write();
+                    allocations.retain(|_, record| {
+                        !evicted.contains(&record.key.job_id)
+                            || record.phase != AllocationPhase::Released
+                    });
+                    self.agent_commands.write().retain(|_, command| {
+                        !evicted.contains(&command.key.job_id)
+                            || allocations.contains_key(&command.key)
+                    });
+                    Self::rebuild_node_resource_projection(&mut nodes, &allocations);
                 }
             }
         }
@@ -5340,8 +6155,13 @@ impl ClusterManager {
 struct ClusterSnapshot {
     jobs: Vec<Job>,
     nodes: Vec<Node>,
-    /// Holds are part of the controller's allocation truth until the node
-    /// confirms release, including after a leader change or snapshot install.
+    #[serde(default)]
+    allocations: Option<Vec<AllocationRecord>>,
+    #[serde(default)]
+    next_agent_command_id: u64,
+    #[serde(default)]
+    agent_commands: Vec<AgentCommandRecord>,
+    /// Kept as an upgrade bridge for snapshots produced before allocation records.
     #[serde(default)]
     pending_kills: Vec<PendingKillReservation>,
     #[serde(default)]
@@ -5421,6 +6241,88 @@ impl ClusterManager {
             self.apply_node_config_policy(node);
         }
     }
+
+    fn legacy_allocation_records(
+        jobs: &HashMap<JobId, Job>,
+        pending_kills: &[PendingKillReservation],
+    ) -> HashMap<AllocationKey, AllocationRecord> {
+        let mut allocations = HashMap::new();
+        for job in jobs.values() {
+            let default_phase = match job.state {
+                JobState::Running | JobState::Suspended => AllocationPhase::Active,
+                JobState::Completing => AllocationPhase::Releasing,
+                _ => continue,
+            };
+            let node_count = job.allocated_nodes.len().max(1) as u32;
+            for node in &job.allocated_nodes {
+                let resources = job.per_node_alloc.get(node).cloned().unwrap_or_else(|| {
+                    job.allocated_resources.as_ref().map_or_else(
+                        ResourceAllocations::default,
+                        |total| {
+                            ResourceAllocations::with_scalar(
+                                total.cpus / node_count,
+                                total.memory_mb / node_count as u64,
+                            )
+                        },
+                    )
+                });
+                let phase = if job.node_completions.contains_key(node) {
+                    AllocationPhase::Released
+                } else {
+                    default_phase
+                };
+                let key = AllocationKey::new(job.job_id, job.run_attempt, node.clone());
+                allocations.insert(key.clone(), AllocationRecord::new(key, resources, phase));
+            }
+        }
+
+        for hold in pending_kills {
+            let key = AllocationKey::new(hold.job_id, hold.run_attempt, hold.node.clone());
+            let mut record = AllocationRecord::new(
+                key.clone(),
+                hold.resources.clone(),
+                AllocationPhase::Releasing,
+            );
+            record.last_command_id = hold.attempt;
+            allocations.insert(key, record);
+        }
+        allocations
+    }
+
+    fn rebuild_node_resource_projection(
+        nodes: &mut HashMap<String, Node>,
+        allocations: &HashMap<AllocationKey, AllocationRecord>,
+    ) {
+        for node in nodes.values_mut() {
+            node.alloc_resources = ResourceAllocations::default();
+        }
+        for record in allocations
+            .values()
+            .filter(|record| record.phase.is_charged())
+        {
+            if let Some(node) = nodes.get_mut(&record.key.node) {
+                node.alloc_resources.add(&record.resources);
+            }
+        }
+        for node in nodes.values_mut() {
+            if node.state == NodeState::Draining
+                && node.alloc_resources.cpus == 0
+                && !node.alloc_resources.has_devices()
+            {
+                node.state = NodeState::Drain;
+            } else if matches!(
+                node.state,
+                NodeState::Idle | NodeState::Allocated | NodeState::Mixed
+            ) {
+                node.update_state_from_alloc();
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn allocation_records(&self) -> HashMap<AllocationKey, AllocationRecord> {
+        self.allocations.read().clone()
+    }
 }
 
 impl StateMachineApply for ClusterManager {
@@ -5432,8 +6334,30 @@ impl StateMachineApply for ClusterManager {
         let snap = ClusterSnapshot {
             jobs: self.jobs.read().values().cloned().collect(),
             nodes: self.nodes.read().values().cloned().collect(),
-            pending_kills: self.pending_kill.read().values().cloned().collect(),
-            next_pending_kill_attempt: self.next_pending_kill_attempt.load(Ordering::Relaxed),
+            allocations: Some(self.allocations.read().values().cloned().collect()),
+            next_agent_command_id: self.next_agent_command_id.load(Ordering::Relaxed),
+            agent_commands: self.agent_commands.read().values().cloned().collect(),
+            pending_kills: self
+                .allocations
+                .read()
+                .values()
+                .filter(|record| {
+                    matches!(
+                        record.phase,
+                        AllocationPhase::Prepared
+                            | AllocationPhase::Launching
+                            | AllocationPhase::Releasing
+                    )
+                })
+                .map(|record| PendingKillReservation {
+                    job_id: record.key.job_id,
+                    node: record.key.node.clone(),
+                    resources: record.resources.clone(),
+                    attempt: record.last_command_id,
+                    run_attempt: record.key.run_attempt,
+                })
+                .collect(),
+            next_pending_kill_attempt: self.next_agent_command_id.load(Ordering::Relaxed),
             reservations: self.reservations.read().clone(),
             partitions: Some(self.partitions.read().clone()),
             deleted_partition_names: self.deleted_partition_names.read().clone(),
@@ -5448,7 +6372,7 @@ impl StateMachineApply for ClusterManager {
     }
 
     fn restore_from_snapshot(&self, data: &[u8]) -> Result<(), anyhow::Error> {
-        let snap = serde_json::from_slice::<ClusterSnapshot>(data)?;
+        let mut snap = serde_json::from_slice::<ClusterSnapshot>(data)?;
 
         // Fold in the persisted high-water mark so evicting the high-id tail
         // can't lower next_job_id and reissue used ids (absent → 0, harmless).
@@ -5466,18 +6390,37 @@ impl StateMachineApply for ClusterManager {
             nodes.insert(node.name.clone(), node);
         }
 
-        let next_pending_attempt = snap
-            .pending_kills
-            .iter()
-            .map(|hold| hold.attempt.saturating_add(1))
-            .fold(snap.next_pending_kill_attempt.max(1), u64::max);
-        *self.pending_kill.write() = snap
-            .pending_kills
+        let allocations = match snap.allocations.take() {
+            Some(records) => records
+                .into_iter()
+                .map(|record| (record.key.clone(), record))
+                .collect(),
+            None => Self::legacy_allocation_records(&jobs, &snap.pending_kills),
+        };
+        let agent_commands: HashMap<_, _> = snap
+            .agent_commands
             .into_iter()
-            .map(|hold| ((hold.job_id, hold.node.clone()), hold))
+            .map(|command| (command.command_id, command))
             .collect();
-        self.next_pending_kill_attempt
-            .store(next_pending_attempt, Ordering::Relaxed);
+        let next_command_id = allocations
+            .values()
+            .map(|record| record.last_command_id.saturating_add(1))
+            .chain(
+                agent_commands
+                    .keys()
+                    .map(|command_id| command_id.saturating_add(1)),
+            )
+            .fold(
+                snap.next_agent_command_id
+                    .max(snap.next_pending_kill_attempt)
+                    .max(1),
+                u64::max,
+            );
+        Self::rebuild_node_resource_projection(&mut nodes, &allocations);
+        *self.allocations.write() = allocations;
+        *self.agent_commands.write() = agent_commands;
+        self.next_agent_command_id
+            .store(next_command_id, Ordering::Relaxed);
 
         *self.reservations.write() = snap.reservations;
 
@@ -6537,51 +7480,6 @@ mod tests {
         );
     }
 
-    // Only the Nth consecutive miss crosses the threshold; a report resets it.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn phantom_miss_streak_crosses_threshold_only_after_consecutive_misses() {
-        let dir = TempDir::new().unwrap();
-        let cm = test_cluster(&dir).await;
-        register_node(&cm, "n1", 8, 16000);
-
-        cm.apply_operation(&WalOperation::JobSubmit {
-            job_id: 1,
-            spec: Box::new(basic_spec("phantom-job")),
-        });
-        cm.apply_operation(&WalOperation::job_state_change(
-            1,
-            JobState::Pending,
-            JobState::Running,
-        ));
-        cm.apply_operation(&WalOperation::JobStart {
-            job_id: 1,
-            nodes: vec!["n1".into()],
-            resources: scalar_alloc(6, 12000),
-            per_node_alloc: per_node_for(&["n1"], scalar_alloc(6, 12000)),
-            srun_step_dispatch: false,
-            run_attempt: 1,
-        });
-
-        let bound = cm.active_jobs_on_node("n1");
-        assert_eq!(bound.len(), 1, "job 1 is bound to n1");
-
-        assert!(
-            !cm.note_node_omitted_job(1, "n1"),
-            "first miss must not cross the threshold"
-        );
-        assert!(
-            cm.note_node_omitted_job(1, "n1"),
-            "second consecutive miss crosses PHANTOM_MISS_THRESHOLD"
-        );
-
-        // A report that includes the job resets the streak.
-        cm.note_node_reported_job(1, "n1");
-        assert!(
-            !cm.note_node_omitted_job(1, "n1"),
-            "streak must restart from zero after a report reset it"
-        );
-    }
-
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn pending_kill_reservations_aggregate() {
         let dir = TempDir::new().unwrap();
@@ -6654,10 +7552,9 @@ mod tests {
         );
     }
 
-    // A second reservation for an already-held key (e.g. redispatch to the
-    // same node) must replace it, not keep the stale attempt forever.
+    // Different run attempts are independent owners even when job and node match.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn pending_kill_reserve_overwrites_a_stale_entry_on_the_same_key() {
+    async fn pending_kill_reserve_keeps_distinct_run_attempts() {
         let dir = TempDir::new().unwrap();
         let cm = test_cluster(&dir).await;
         cm.reserve_pending_kills(vec![PendingKillReservation {
@@ -6680,8 +7577,8 @@ mod tests {
 
         assert_eq!(
             cm.pending_kill_reservations().get("n1").unwrap().cpus,
-            4,
-            "the newer reservation's resources must replace the stale entry"
+            6,
+            "both attempts remain charged until each cleanup is acknowledged"
         );
         assert_eq!(
             cm.pending_kill_run_attempt(1, "n1"),
@@ -6732,6 +7629,325 @@ mod tests {
             .unwrap();
 
         assert!(restored.pending_kill_reservations().is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn prepare_charges_exact_resources_before_launch_and_activate_is_atomic() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("durable-prepare")),
+        });
+
+        let resources = scalar_alloc(4, 8000);
+        let attempt = cm
+            .prepare_dispatch(
+                1,
+                vec!["n1".into()],
+                resources.clone(),
+                per_node_for(&["n1"], resources.clone()),
+                false,
+            )
+            .unwrap();
+
+        let prepared = cm.get_job(1).unwrap();
+        assert_eq!(prepared.state, JobState::Pending);
+        assert_eq!(prepared.run_attempt, attempt);
+        assert_eq!(prepared.allocated_nodes, vec!["n1"]);
+        assert_eq!(cm.get_node("n1").unwrap().alloc_resources, resources);
+        let key = AllocationKey::new(1, attempt, "n1");
+        assert_eq!(
+            cm.allocation_records()[&key].phase,
+            AllocationPhase::Prepared
+        );
+
+        cm.begin_allocation_launch(1, attempt).unwrap();
+        assert_eq!(
+            cm.allocation_records()[&key].phase,
+            AllocationPhase::Launching
+        );
+        cm.start_job(
+            1,
+            vec!["n1".into()],
+            scalar_alloc(4, 8000),
+            per_node_for(&["n1"], scalar_alloc(4, 8000)),
+        )
+        .unwrap();
+
+        assert_eq!(cm.get_job(1).unwrap().state, JobState::Running);
+        assert_eq!(cm.allocation_records()[&key].phase, AllocationPhase::Active);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn polled_commands_require_the_registered_session_and_explicit_release_ack() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        cm.register_node_with_session(
+            "n1".into(),
+            "n1".into(),
+            ResourceSet {
+                cpus: 8,
+                memory_mb: 16000,
+                ..Default::default()
+            },
+            "127.0.0.1".into(),
+            6818,
+            String::new(),
+            String::new(),
+            NodeSource::NativeHost,
+            HashMap::new(),
+            "session-1".into(),
+            "boot-1".into(),
+            true,
+            true,
+        )
+        .unwrap();
+        wait_for("session-aware node registration", || {
+            cm.get_node("n1")
+                .is_some_and(|node| node.agent_session_id == "session-1")
+        });
+        let job_id = submit_and_wait(&cm, basic_spec("polled-command"));
+        let resources = scalar_alloc(2, 4000);
+        let attempt = cm
+            .prepare_dispatch(
+                job_id,
+                vec!["n1".into()],
+                resources.clone(),
+                per_node_for(&["n1"], resources.clone()),
+                false,
+            )
+            .unwrap();
+        let key = AllocationKey::new(job_id, attempt, "n1");
+        let commands = cm
+            .begin_allocation_launch_commands(
+                job_id,
+                attempt,
+                vec![(key.clone(), AgentCommandKind::Launch, vec![1, 2, 3])],
+            )
+            .unwrap();
+        let command_id = commands[0].command_id;
+        assert_eq!(
+            cm.pending_agent_commands("n1", "session-1", "boot-1")
+                .unwrap()
+                .len(),
+            1
+        );
+
+        cm.acknowledge_agent_command(
+            command_id,
+            key.clone(),
+            "wrong-session".into(),
+            "boot-1".into(),
+            true,
+            Vec::new(),
+            String::new(),
+        )
+        .unwrap();
+        assert_eq!(
+            cm.agent_commands(&[command_id])[0].state,
+            AgentCommandState::Pending
+        );
+
+        cm.acknowledge_agent_command(
+            command_id,
+            key.clone(),
+            "session-1".into(),
+            "boot-1".into(),
+            true,
+            Vec::new(),
+            String::new(),
+        )
+        .unwrap();
+        wait_for("launch acknowledgement", || {
+            cm.allocation_records()
+                .get(&key)
+                .is_some_and(|record| record.phase == AllocationPhase::Active)
+        });
+        assert_eq!(cm.get_job(job_id).unwrap().state, JobState::Pending);
+        cm.start_job(
+            job_id,
+            vec!["n1".into()],
+            resources.clone(),
+            per_node_for(&["n1"], resources),
+        )
+        .unwrap();
+        assert_eq!(cm.get_job(job_id).unwrap().state, JobState::Running);
+
+        cm.cancel_job(job_id, "testuser").unwrap();
+        settle(&cm, job_id, JobState::Cancelled);
+        assert_eq!(cm.get_node("n1").unwrap().alloc_resources.cpus, 2);
+        let release = cm
+            .pending_agent_commands("n1", "session-1", "boot-1")
+            .unwrap()
+            .into_iter()
+            .find(|command| command.kind == AgentCommandKind::Release)
+            .unwrap();
+        cm.acknowledge_agent_command(
+            release.command_id,
+            release.key,
+            "session-1".into(),
+            "boot-1".into(),
+            true,
+            Vec::new(),
+            String::new(),
+        )
+        .unwrap();
+        wait_for("release acknowledgement", || {
+            cm.get_node("n1").unwrap().alloc_resources.cpus == 0
+        });
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn incomplete_dispatch_recovery_redelivers_then_aborts_after_durable_deadline() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+        let job_id = submit_and_wait(&cm, basic_spec("launch-recovery"));
+        let resources = scalar_alloc(2, 4000);
+        let attempt = cm
+            .prepare_dispatch(
+                job_id,
+                vec!["n1".into()],
+                resources.clone(),
+                per_node_for(&["n1"], resources),
+                false,
+            )
+            .unwrap();
+        let key = AllocationKey::new(job_id, attempt, "n1");
+        let launch = cm
+            .begin_allocation_launch_commands(
+                job_id,
+                attempt,
+                vec![(key.clone(), AgentCommandKind::Launch, Vec::new())],
+            )
+            .unwrap()
+            .remove(0);
+
+        cm.recover_incomplete_dispatches();
+        assert_eq!(
+            cm.allocation_records()[&key].phase,
+            AllocationPhase::Launching
+        );
+        assert_eq!(
+            cm.agent_commands(&[launch.command_id])[0].state,
+            AgentCommandState::Pending
+        );
+
+        cm.agent_commands
+            .write()
+            .get_mut(&launch.command_id)
+            .unwrap()
+            .created_at =
+            Some(Utc::now() - chrono::Duration::seconds(AGENT_COMMAND_ACK_TIMEOUT_SECS as i64 + 1));
+        cm.recover_incomplete_dispatches();
+
+        assert_eq!(
+            cm.allocation_records()[&key].phase,
+            AllocationPhase::Releasing
+        );
+        assert!(cm.agent_commands(&[launch.command_id]).is_empty());
+        assert!(cm
+            .agent_commands
+            .read()
+            .values()
+            .any(|command| command.key == key
+                && command.kind == AgentCommandKind::Release
+                && command.state == AgentCommandState::Pending));
+        assert_eq!(cm.get_job(job_id).unwrap().state, JobState::Pending);
+        assert_eq!(cm.get_node("n1").unwrap().alloc_resources.cpus, 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn incomplete_legacy_dispatch_aborts_after_durable_deadline() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+        let job_id = submit_and_wait(&cm, basic_spec("legacy-launch-recovery"));
+        let resources = scalar_alloc(2, 4000);
+        let attempt = cm
+            .prepare_dispatch(
+                job_id,
+                vec!["n1".into()],
+                resources.clone(),
+                per_node_for(&["n1"], resources),
+                false,
+            )
+            .unwrap();
+        let key = AllocationKey::new(job_id, attempt, "n1");
+        let command_id = cm.begin_allocation_launch(job_id, attempt).unwrap();
+        assert!(cm.agent_commands(&[command_id]).is_empty());
+        cm.allocations
+            .write()
+            .get_mut(&key)
+            .unwrap()
+            .launch_started_at =
+            Some(Utc::now() - chrono::Duration::seconds(AGENT_COMMAND_ACK_TIMEOUT_SECS as i64 + 1));
+
+        cm.recover_incomplete_dispatches();
+
+        assert_eq!(
+            cm.allocation_records()[&key].phase,
+            AllocationPhase::Releasing
+        );
+        assert!(cm
+            .agent_commands
+            .read()
+            .values()
+            .any(|command| command.key == key
+                && command.kind == AgentCommandKind::Release
+                && command.state == AgentCommandState::Pending));
+        assert_eq!(cm.get_job(job_id).unwrap().state, JobState::Pending);
+        assert_eq!(cm.get_node("n1").unwrap().alloc_resources.cpus, 2);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn snapshot_without_allocation_records_migrates_job_and_release_holds() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 8, 16000);
+        cm.apply_operation(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(basic_spec("legacy-snapshot")),
+        });
+        cm.apply_operation(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
+        cm.apply_operation(&WalOperation::JobStart {
+            job_id: 1,
+            nodes: vec!["n1".into()],
+            resources: scalar_alloc(2, 4000),
+            per_node_alloc: per_node_for(&["n1"], scalar_alloc(2, 4000)),
+            srun_step_dispatch: false,
+            run_attempt: 3,
+        });
+        cm.note_pending_kill(9, "n1", scalar_alloc(1, 1000), 77);
+
+        let mut snapshot: serde_json::Value =
+            serde_json::from_slice(&cm.snapshot_state().unwrap()).unwrap();
+        let object = snapshot.as_object_mut().unwrap();
+        object.remove("allocations");
+        object.remove("next_agent_command_id");
+
+        let restored_dir = TempDir::new().unwrap();
+        let restored = test_cluster(&restored_dir).await;
+        restored
+            .restore_from_snapshot(&serde_json::to_vec(&snapshot).unwrap())
+            .unwrap();
+
+        let records = restored.allocation_records();
+        assert_eq!(
+            records[&AllocationKey::new(1, 3, "n1")].phase,
+            AllocationPhase::Active
+        );
+        assert_eq!(
+            records[&AllocationKey::new(9, 0, "n1")].phase,
+            AllocationPhase::Releasing
+        );
+        assert_eq!(restored.get_node("n1").unwrap().alloc_resources.cpus, 3);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -6938,6 +8154,40 @@ mod tests {
         });
     }
 
+    fn acknowledge_all_releases(cm: &ClusterManager) {
+        let releasing: Vec<_> = cm
+            .allocation_records()
+            .into_values()
+            .filter(|record| {
+                record.phase == AllocationPhase::Releasing && record.last_command_id > 0
+            })
+            .collect();
+        let mut acknowledged = Vec::new();
+        for record in &releasing {
+            let Some(node) = cm.get_node(&record.key.node) else {
+                continue;
+            };
+            cm.acknowledge_agent_command(
+                record.last_command_id,
+                record.key.clone(),
+                node.agent_session_id,
+                node.node_boot_id,
+                true,
+                Vec::new(),
+                String::new(),
+            )
+            .unwrap();
+            acknowledged.push(record.key.clone());
+        }
+        wait_for("release acknowledgements applied", || {
+            acknowledged.iter().all(|key| {
+                cm.allocation_records()
+                    .get(key)
+                    .is_some_and(|current| current.phase == AllocationPhase::Released)
+            })
+        });
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn apply_job_submit() {
         let dir = TempDir::new().unwrap();
@@ -7124,6 +8374,46 @@ mod tests {
         cm.steps.write().insert((1, 0), step(1));
         cm.steps.write().insert((2, 0), step(2));
 
+        let released_key = AllocationKey::new(1, 1, "node1");
+        let live_key = AllocationKey::new(2, 1, "node1");
+        let releasing_key = AllocationKey::new(4, 1, "node1");
+        cm.allocations.write().extend([
+            (
+                released_key.clone(),
+                AllocationRecord::new(
+                    released_key.clone(),
+                    scalar_alloc(1, 0),
+                    AllocationPhase::Released,
+                ),
+            ),
+            (
+                live_key.clone(),
+                AllocationRecord::new(
+                    live_key.clone(),
+                    scalar_alloc(1, 0),
+                    AllocationPhase::Active,
+                ),
+            ),
+            (
+                releasing_key.clone(),
+                AllocationRecord::new(
+                    releasing_key.clone(),
+                    scalar_alloc(1, 0),
+                    AllocationPhase::Releasing,
+                ),
+            ),
+        ]);
+        cm.agent_commands.write().insert(
+            44,
+            AgentCommandRecord::new(
+                44,
+                releasing_key.clone(),
+                AgentCommandKind::Release,
+                Vec::new(),
+                9,
+            ),
+        );
+
         // Apply removes only ids still finalized; live ids 2 and 3 are no-ops
         // even when named (a job requeued between propose and apply).
         cm.apply_operation(&WalOperation::EvictTerminalJobs {
@@ -7147,6 +8437,11 @@ mod tests {
             cm.steps.read().get(&(2, 0)).is_some(),
             "live job's step must be kept"
         );
+        let allocations = cm.allocation_records();
+        assert!(!allocations.contains_key(&released_key));
+        assert!(allocations.contains_key(&live_key));
+        assert!(allocations.contains_key(&releasing_key));
+        assert!(cm.agent_commands.read().contains_key(&44));
     }
 
     // Apply-time state, not per-replica end_time, decides eviction: a replica
@@ -7670,6 +8965,10 @@ mod tests {
             version: "1.0".into(),
             labels: HashMap::new(),
             source: NodeSource::default(),
+            agent_session_id: String::new(),
+            node_boot_id: String::new(),
+            recovery_complete: true,
+            supports_command_polling: false,
         });
 
         let node = cm.get_node("gpu-node").unwrap();
@@ -8027,6 +9326,7 @@ mod tests {
             node_name: "worker1".into(),
             exit_code: 0,
             signal: 0,
+            run_attempt: 0,
         });
 
         let job = cm.get_job(1).unwrap();
@@ -8068,6 +9368,7 @@ mod tests {
             node_name: "worker1".into(),
             exit_code: 0,
             signal: spur_core::job::OOM_SIGNAL_FLAG | 9,
+            run_attempt: 0,
         });
 
         let job = cm.get_job(1).unwrap();
@@ -8110,6 +9411,7 @@ mod tests {
             node_name: "n1".into(),
             exit_code: 0,
             signal: 0,
+            run_attempt: 0,
         });
         let job = cm.get_job(1).unwrap();
         assert_eq!(job.state, JobState::Completing);
@@ -8122,6 +9424,7 @@ mod tests {
             node_name: "n2".into(),
             exit_code: 0,
             signal: 0,
+            run_attempt: 0,
         });
         assert_eq!(cm.get_job(1).unwrap().state, JobState::Completing);
 
@@ -8130,6 +9433,7 @@ mod tests {
             node_name: "n3".into(),
             exit_code: 42,
             signal: 0,
+            run_attempt: 0,
         });
 
         let job = cm.get_job(1).unwrap();
@@ -8198,6 +9502,7 @@ mod tests {
             node_name: "n1".into(),
             exit_code: 2,
             signal: 0,
+            run_attempt: 0,
         });
         let job = cm.get_job(1).unwrap();
         assert_eq!(job.state, JobState::Failed);
@@ -8265,6 +9570,7 @@ mod tests {
             node_name: "n1".into(),
             exit_code: 0,
             signal: 0,
+            run_attempt: 0,
         });
         assert!(r1.jobs_finalized.is_empty());
         assert_eq!(cm.get_job(1).unwrap().state, JobState::Completing);
@@ -8274,6 +9580,7 @@ mod tests {
             node_name: "n2".into(),
             exit_code: 0,
             signal: 0,
+            run_attempt: 0,
         });
         let f = r2
             .jobs_finalized
@@ -8410,6 +9717,7 @@ mod tests {
             node_name: "n1".into(),
             exit_code: 0,
             signal: 0,
+            run_attempt: 0,
         });
 
         let result = cm.node_complete(1, "n2", 0, 0, 0).unwrap();
@@ -8674,8 +9982,8 @@ mod tests {
         assert_eq!(job.pending_reason, PendingReason::NonZeroExitCode);
     }
 
-    // A completion report from a superseded run (older epoch) must be dropped,
-    // not fail the re-dispatched run. Reproduces the preempt-requeue race.
+    // A completion report for any other fenced epoch must be dropped, not fail
+    // the current run. Reproduces the preempt-requeue race.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn node_complete_drops_stale_run_report() {
         let dir = TempDir::new().unwrap();
@@ -8701,11 +10009,28 @@ mod tests {
             run_attempt: 2,
         });
 
+        cm.apply_operation(&WalOperation::JobNodeComplete {
+            job_id: 1,
+            node_name: "n1".into(),
+            exit_code: 0,
+            signal: 9,
+            run_attempt: 1,
+        });
+        assert_eq!(cm.get_job(1).unwrap().state, JobState::Running);
+        assert_eq!(
+            cm.allocation_records()[&AllocationKey::new(1, 2, "n1")].phase,
+            AllocationPhase::Active
+        );
+
         // Stale SIGKILL report from epoch 1 must be ignored.
         let res = cm.node_complete(1, "n1", 0, 9, 1).unwrap();
         assert!(matches!(res, NodeCompleteResult::StaleReport));
         let job = cm.get_job(1).unwrap();
         assert_eq!(job.state, JobState::Running);
+
+        let res = cm.node_complete(1, "n1", 0, 9, 3).unwrap();
+        assert!(matches!(res, NodeCompleteResult::StaleReport));
+        assert_eq!(cm.get_job(1).unwrap().state, JobState::Running);
 
         // Current-epoch report is applied normally.
         cm.node_complete(1, "n1", 0, 9, 2).unwrap();
@@ -8775,6 +10100,7 @@ mod tests {
             node_name: "n1".into(),
             exit_code: 0,
             signal: 0,
+            run_attempt: 0,
         });
 
         let job = cm.get_job(1).unwrap();
@@ -8791,17 +10117,23 @@ mod tests {
         assert_eq!(job.exit_code, Some(-1));
         assert!(job.node_completions.is_empty());
         let pending = cm.pending_kill_reservations();
-        for name in ["n1", "n2", "n3"] {
+        assert!(!pending.contains_key("n1"));
+        for name in ["n2", "n3"] {
             assert_eq!(
                 pending[name].cpus, 2,
-                "node {name} must remain held until its heartbeat confirms release"
+                "node {name} must remain held until cleanup is acknowledged"
             );
         }
+        assert_eq!(cm.get_node("n1").unwrap().alloc_resources.cpus, 0);
+        for name in ["n2", "n3"] {
+            assert_eq!(cm.get_node(name).unwrap().alloc_resources.cpus, 2);
+        }
+        acknowledge_all_releases(&cm);
         for name in ["n1", "n2", "n3"] {
             assert_eq!(
                 cm.get_node(name).unwrap().alloc_resources.cpus,
                 0,
-                "node {name} should be deallocated after cancel"
+                "node {name} should be deallocated after cleanup acknowledgement"
             );
         }
 
@@ -8810,6 +10142,7 @@ mod tests {
             node_name: "n2".into(),
             exit_code: 0,
             signal: 0,
+            run_attempt: 0,
         });
 
         let job = cm.get_job(1).unwrap();
@@ -8848,6 +10181,7 @@ mod tests {
             node_name: "n1".into(),
             exit_code: 0,
             signal: 0,
+            run_attempt: 0,
         });
 
         cm.cancel_job(1, "testuser").unwrap();
@@ -9019,7 +10353,9 @@ mod tests {
         let job = cm.get_job(job_id).unwrap();
         assert_eq!(job.state, JobState::Pending);
         assert!(job.allocated_nodes.is_empty());
-        assert_eq!(cm.node_metrics().alloc_cpus, 0, "nodes must be freed");
+        assert_eq!(cm.node_metrics().alloc_cpus, 2, "cleanup remains charged");
+        acknowledge_all_releases(&cm);
+        assert_eq!(cm.node_metrics().alloc_cpus, 0);
 
         // The requeue must carry a future begin_time hold so the scheduler
         // cannot re-dispatch the job into its own in-flight preemption cancel,
@@ -9158,7 +10494,9 @@ mod tests {
 
         let job = cm.get_job(job_id).unwrap();
         assert!(job.allocated_nodes.is_empty());
-        assert_eq!(cm.node_metrics().alloc_cpus, 0, "nodes must be freed");
+        assert_eq!(cm.node_metrics().alloc_cpus, 2, "cleanup remains charged");
+        acknowledge_all_releases(&cm);
+        assert_eq!(cm.node_metrics().alloc_cpus, 0);
         assert_eq!(job.requeue_count, 1);
         assert_eq!(
             job.pending_reason,
@@ -9571,6 +10909,8 @@ mod tests {
 
         let job = cm.get_job(job_id).unwrap();
         assert_eq!(job.state, JobState::Cancelled);
+        assert_eq!(cm.node_metrics().alloc_cpus, 2);
+        acknowledge_all_releases(&cm);
         assert_eq!(cm.node_metrics().alloc_cpus, 0);
     }
 
@@ -9743,7 +11083,7 @@ mod tests {
         // One op finalizes the prior run as PREEMPTED (drives accounting) ...
         assert_eq!(resp.jobs_finalized.len(), 1);
         assert_eq!(resp.jobs_finalized[0].state, JobState::Preempted);
-        // ... and the job is Pending-with-hold with nodes freed.
+        // ... and the job is Pending-with-hold while cleanup stays charged.
         let job = cm.get_job(1).unwrap();
         assert_eq!(job.state, JobState::Pending);
         assert_eq!(job.spec.begin_time, Some(begin_time));
@@ -9751,7 +11091,7 @@ mod tests {
         assert_eq!(job.preempt_requeue_count, 1);
         assert_eq!(job.requeue_count, 0);
         assert!(job.allocated_nodes.is_empty());
-        assert_eq!(cm.get_node("worker1").unwrap().alloc_resources.cpus, 0);
+        assert_eq!(cm.get_node("worker1").unwrap().alloc_resources.cpus, 2);
 
         // Replay the identical entry: job is already Pending -> NoOp.
         let replay = cm.apply_operation(&WalOperation::JobPreemptRequeue {
@@ -9772,7 +11112,7 @@ mod tests {
             job.preempt_requeue_count, 1,
             "replayed preempt-requeue must not double-count"
         );
-        assert_eq!(cm.get_node("worker1").unwrap().alloc_resources.cpus, 0);
+        assert_eq!(cm.get_node("worker1").unwrap().alloc_resources.cpus, 2);
     }
 
     /// Drive a job to RUNNING on `node` then finalize it as PREEMPTED via the
@@ -9805,6 +11145,7 @@ mod tests {
             node_name: "worker1".into(),
             exit_code: 0,
             signal: 0,
+            run_attempt: 0,
         });
         assert!(
             resp.jobs_finalized.is_empty(),
@@ -13139,9 +14480,12 @@ mod tests {
         settle(&cm, job_id, JobState::Cancelled);
 
         let node = cm.get_node("worker1").unwrap();
+        assert_eq!(node.alloc_resources.cpus, 2, "cleanup remains charged");
+        acknowledge_all_releases(&cm);
+        let node = cm.get_node("worker1").unwrap();
         assert_eq!(
             node.alloc_resources.cpus, 0,
-            "resources must be freed after cancel"
+            "resources must be freed after cleanup acknowledgement"
         );
     }
 
@@ -14374,9 +15718,12 @@ mod tests {
         );
 
         let node = cm.get_node("n1").unwrap();
+        assert_eq!(node.alloc_resources.cpus, 2, "cleanup remains charged");
+        acknowledge_all_releases(&cm);
+        let node = cm.get_node("n1").unwrap();
         assert_eq!(
             node.alloc_resources.cpus, 0,
-            "node CPUs must be freed after requeue"
+            "node CPUs must be freed after cleanup acknowledgement"
         );
         assert!(
             !node.alloc_resources.has_devices(),
@@ -14429,9 +15776,14 @@ mod tests {
 
         for name in ["n1", "n2"] {
             let node = cm.get_node(name).unwrap();
+            assert_eq!(node.alloc_resources.cpus, 2, "cleanup remains charged");
+        }
+        acknowledge_all_releases(&cm);
+        for name in ["n1", "n2"] {
+            let node = cm.get_node(name).unwrap();
             assert_eq!(
                 node.alloc_resources.cpus, 0,
-                "allocation on {name} must be freed on eviction"
+                "allocation on {name} must be freed after acknowledgement"
             );
         }
     }
@@ -14500,6 +15852,7 @@ mod tests {
             node_name: "n1".into(),
             exit_code: 0,
             signal: 0,
+            run_attempt: 0,
         });
         settle(&cm, job_a, JobState::Completing);
         assert_eq!(
@@ -14520,8 +15873,14 @@ mod tests {
         );
         assert_eq!(
             cm.get_node("n2").unwrap().alloc_resources.cpus,
+            2,
+            "n2's cleanup must remain charged until acknowledgement"
+        );
+        acknowledge_all_releases(&cm);
+        assert_eq!(
+            cm.get_node("n2").unwrap().alloc_resources.cpus,
             0,
-            "n2's slice must still be freed by the eviction"
+            "n2's slice must be freed after acknowledgement"
         );
     }
 
@@ -16029,6 +17388,10 @@ mod tests {
             version: String::new(),
             labels: HashMap::new(),
             source: spur_core::node::NodeSource::NativeHost,
+            agent_session_id: String::new(),
+            node_boot_id: String::new(),
+            recovery_complete: true,
+            supports_command_polling: false,
         });
 
         assert_eq!(
@@ -16068,6 +17431,10 @@ mod tests {
             version: String::new(),
             labels: HashMap::new(),
             source: NodeSource::default(),
+            agent_session_id: String::new(),
+            node_boot_id: String::new(),
+            recovery_complete: true,
+            supports_command_polling: false,
         });
 
         let node = cm.get_node("gpu-node").unwrap();
@@ -16115,6 +17482,10 @@ mod tests {
             version: String::new(),
             labels: HashMap::from([("gpu".into(), "mi300x".into())]),
             source: NodeSource::default(),
+            agent_session_id: String::new(),
+            node_boot_id: String::new(),
+            recovery_complete: true,
+            supports_command_polling: false,
         });
 
         let node = cm.get_node("gpu-node").unwrap();
@@ -16162,6 +17533,10 @@ mod tests {
             version: String::new(),
             labels: HashMap::from([("gpu".into(), "mi250".into())]),
             source: NodeSource::default(),
+            agent_session_id: String::new(),
+            node_boot_id: String::new(),
+            recovery_complete: true,
+            supports_command_polling: false,
         });
 
         let node = cm.get_node("cpu-node").unwrap();
@@ -16201,6 +17576,9 @@ mod tests {
         let snap = ClusterSnapshot {
             jobs: Vec::new(),
             nodes: vec![stale],
+            allocations: Some(Vec::new()),
+            next_agent_command_id: 1,
+            agent_commands: Vec::new(),
             pending_kills: Vec::new(),
             next_pending_kill_attempt: 1,
             reservations: Vec::new(),
@@ -16340,7 +17718,10 @@ mod tests {
 
         let node = cm.get_node("n1").unwrap();
         assert_eq!(node.state, NodeState::Down);
-        assert_eq!(node.alloc_resources.cpus, 0);
+        assert_eq!(node.alloc_resources.cpus, 1);
+        assert!(cm.allocation_records().values().any(|record| {
+            record.key.job_id == id && record.phase == AllocationPhase::Releasing
+        }));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -16499,6 +17880,10 @@ mod tests {
         wait_for("n1 removed", || cm.get_node("n1").is_none());
 
         assert_eq!(cm.get_job(id).unwrap().state, JobState::NodeFail);
+        assert!(
+            cm.allocation_records().keys().all(|key| key.node != "n1"),
+            "a removed node cannot acknowledge a retained allocation"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -16528,11 +17913,18 @@ mod tests {
         assert_eq!(evicted.len(), 1);
         assert_eq!(evicted[0].job_id, id);
         assert_eq!(cm.get_job(id).unwrap().state, JobState::NodeFail);
+        assert!(
+            cm.allocation_records().keys().all(|key| key.node != "n1"),
+            "the removed node must not retain an undeliverable release"
+        );
 
+        let n2 = cm.get_node("n2").unwrap();
+        assert_eq!(n2.alloc_resources.cpus, 1);
+        acknowledge_all_releases(&cm);
         let n2 = cm.get_node("n2").unwrap();
         assert_eq!(
             n2.alloc_resources.cpus, 0,
-            "peer node n2 must have allocations freed"
+            "peer node n2 must be freed after cleanup acknowledgement"
         );
         assert_eq!(n2.alloc_resources.memory_mb, 0);
     }
@@ -16557,6 +17949,7 @@ mod tests {
             node_name: "n1".into(),
             exit_code: 0,
             signal: 0,
+            run_attempt: 0,
         });
 
         let node = cm.get_node("n1").unwrap();
@@ -16607,45 +18000,69 @@ mod tests {
     #[test]
     fn evict_job_locked_rejects_stale_run_attempt() {
         let mut jobs = HashMap::new();
-        let mut nodes = HashMap::new();
         let mut job = make_running_job(1, &["n1"], 2);
         job.run_attempt = 5;
         jobs.insert(1, job);
-        nodes.insert("n1".into(), make_test_node("n1", 4, 2));
 
-        let result = ClusterManager::evict_job_locked(
-            1,
-            &mut jobs,
-            &mut nodes,
-            Utc::now(),
-            PendingReason::NodeDown,
-            3,
-        );
+        let result =
+            ClusterManager::evict_job_locked(1, &mut jobs, Utc::now(), PendingReason::NodeDown, 3);
         assert!(
             result.is_none(),
             "eviction targeting a superseded run must no-op"
         );
         assert_eq!(jobs[&1].state, JobState::Running, "job must be untouched");
 
-        let result = ClusterManager::evict_job_locked(
-            1,
-            &mut jobs,
-            &mut nodes,
-            Utc::now(),
-            PendingReason::NodeDown,
-            5,
-        );
+        let result =
+            ClusterManager::evict_job_locked(1, &mut jobs, Utc::now(), PendingReason::NodeDown, 5);
         assert!(result.is_some(), "a matching run_attempt must still evict");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stale_eviction_does_not_install_release_holds_for_the_current_run() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 4, 8000);
+        let job_id = submit_and_wait(&cm, basic_spec("stale-eviction"));
+        let resources = scalar_alloc(2, 4000);
+        let attempt = cm
+            .start_job(
+                job_id,
+                vec!["n1".into()],
+                resources.clone(),
+                per_node_for(&["n1"], resources.clone()),
+            )
+            .unwrap();
+        let key = AllocationKey::new(job_id, attempt, "n1");
+        let hold = PendingKillReservation {
+            job_id,
+            node: "n1".into(),
+            resources,
+            attempt: cm.new_pending_kill_attempt(),
+            run_attempt: attempt,
+        };
+
+        let response = cm.apply_operation(&WalOperation::PendingKillTransition {
+            reservations: vec![hold],
+            operation: Box::new(WalOperation::JobEvict {
+                job_id,
+                reason: PendingReason::NodeDown,
+                detail: None,
+                run_attempt: attempt + 1,
+            }),
+        });
+
+        assert!(response.jobs_finalized.is_empty());
+        assert_eq!(cm.get_job(job_id).unwrap().state, JobState::Running);
+        assert_eq!(cm.allocation_records()[&key].phase, AllocationPhase::Active);
+        assert!(cm.pending_kill_reservations().is_empty());
     }
 
     #[test]
     fn evict_job_returns_none_for_missing_job() {
         let mut jobs = HashMap::new();
-        let mut nodes = HashMap::new();
         let result = ClusterManager::evict_job_locked(
             999,
             &mut jobs,
-            &mut nodes,
             Utc::now(),
             PendingReason::NodeDown,
             0,
@@ -16656,19 +18073,11 @@ mod tests {
     #[test]
     fn evict_job_transitions_running_to_nodefail() {
         let mut jobs = HashMap::new();
-        let mut nodes = HashMap::new();
         jobs.insert(1, make_running_job(1, &["n1"], 2));
-        nodes.insert("n1".into(), make_test_node("n1", 4, 2));
 
-        let fin = ClusterManager::evict_job_locked(
-            1,
-            &mut jobs,
-            &mut nodes,
-            Utc::now(),
-            PendingReason::NodeDown,
-            0,
-        )
-        .unwrap();
+        let fin =
+            ClusterManager::evict_job_locked(1, &mut jobs, Utc::now(), PendingReason::NodeDown, 0)
+                .unwrap();
         assert_eq!(fin.job_id, 1);
         assert_eq!(fin.state, JobState::NodeFail);
         assert_eq!(fin.exit_code, -1);
@@ -16681,66 +18090,42 @@ mod tests {
     }
 
     #[test]
-    fn evict_job_frees_allocations_on_all_nodes() {
+    fn evict_job_locked_does_not_mutate_resource_projection() {
         let mut jobs = HashMap::new();
-        let mut nodes = HashMap::new();
+        let mut nodes: HashMap<String, Node> = HashMap::new();
         jobs.insert(1, make_running_job(1, &["n1", "n2"], 2));
         nodes.insert("n1".into(), make_test_node("n1", 4, 2));
         nodes.insert("n2".into(), make_test_node("n2", 4, 2));
 
-        ClusterManager::evict_job_locked(
-            1,
-            &mut jobs,
-            &mut nodes,
-            Utc::now(),
-            PendingReason::NodeDown,
-            0,
-        );
+        ClusterManager::evict_job_locked(1, &mut jobs, Utc::now(), PendingReason::NodeDown, 0);
 
-        assert_eq!(nodes["n1"].alloc_resources.cpus, 0);
-        assert_eq!(nodes["n2"].alloc_resources.cpus, 0);
+        assert_eq!(nodes["n1"].alloc_resources.cpus, 2);
+        assert_eq!(nodes["n2"].alloc_resources.cpus, 2);
     }
 
     #[test]
     fn evict_job_returns_none_for_terminal_job() {
         let mut jobs = HashMap::new();
-        let mut nodes = HashMap::new();
         let mut job = make_running_job(1, &["n1"], 2);
         job.state = JobState::Completed;
         jobs.insert(1, job);
-        nodes.insert("n1".into(), make_test_node("n1", 4, 2));
 
-        let result = ClusterManager::evict_job_locked(
-            1,
-            &mut jobs,
-            &mut nodes,
-            Utc::now(),
-            PendingReason::NodeDown,
-            0,
-        );
+        let result =
+            ClusterManager::evict_job_locked(1, &mut jobs, Utc::now(), PendingReason::NodeDown, 0);
         assert!(result.is_none());
     }
 
     #[test]
     fn evict_job_finalizes_suspended_time() {
         let mut jobs = HashMap::new();
-        let mut nodes = HashMap::new();
         let suspended_at = Utc::now() - chrono::Duration::seconds(30);
         let mut job = make_running_job(1, &["n1"], 2);
         job.state = JobState::Suspended;
         job.suspended_at = Some(suspended_at);
         job.suspended_secs = 10;
         jobs.insert(1, job);
-        nodes.insert("n1".into(), make_test_node("n1", 4, 2));
 
-        ClusterManager::evict_job_locked(
-            1,
-            &mut jobs,
-            &mut nodes,
-            Utc::now(),
-            PendingReason::NodeDown,
-            0,
-        );
+        ClusterManager::evict_job_locked(1, &mut jobs, Utc::now(), PendingReason::NodeDown, 0);
 
         let job = &jobs[&1];
         assert!(job.suspended_at.is_none());
@@ -16750,45 +18135,32 @@ mod tests {
     #[test]
     fn evict_job_transitions_completing_to_nodefail() {
         let mut jobs = HashMap::new();
-        let mut nodes = HashMap::new();
+        let mut nodes: HashMap<String, Node> = HashMap::new();
         let mut job = make_running_job(1, &["n1"], 2);
         job.state = JobState::Completing;
         jobs.insert(1, job);
         nodes.insert("n1".into(), make_test_node("n1", 4, 2));
 
-        let fin = ClusterManager::evict_job_locked(
-            1,
-            &mut jobs,
-            &mut nodes,
-            Utc::now(),
-            PendingReason::NodeDown,
-            0,
-        )
-        .unwrap();
+        let fin =
+            ClusterManager::evict_job_locked(1, &mut jobs, Utc::now(), PendingReason::NodeDown, 0)
+                .unwrap();
         assert_eq!(fin.state, JobState::NodeFail);
         assert_eq!(jobs[&1].state, JobState::NodeFail);
-        assert_eq!(nodes["n1"].alloc_resources.cpus, 0);
+        assert_eq!(nodes["n1"].alloc_resources.cpus, 2);
     }
 
     #[test]
-    fn evict_job_transitions_draining_node_to_drain() {
+    fn evict_job_locked_does_not_change_draining_node_state() {
         let mut jobs = HashMap::new();
-        let mut nodes = HashMap::new();
+        let mut nodes: HashMap<String, Node> = HashMap::new();
         jobs.insert(1, make_running_job(1, &["n1"], 2));
         let mut node = make_test_node("n1", 4, 2);
         node.state = NodeState::Draining;
         nodes.insert("n1".into(), node);
 
-        ClusterManager::evict_job_locked(
-            1,
-            &mut jobs,
-            &mut nodes,
-            Utc::now(),
-            PendingReason::NodeDown,
-            0,
-        );
+        ClusterManager::evict_job_locked(1, &mut jobs, Utc::now(), PendingReason::NodeDown, 0);
 
-        assert_eq!(nodes["n1"].state, NodeState::Drain);
+        assert_eq!(nodes["n1"].state, NodeState::Draining);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -16799,10 +18171,32 @@ mod tests {
         let id = submit_and_wait(&cm, srun_spec("srun-alloc"));
         start_srun_job_on(&cm, id, "n1");
 
-        let returned = cm.finish_srun_job(id, 0, "testuser").unwrap();
+        let returned = cm.finish_srun_job(id, 0, "testuser", 0).unwrap();
         assert_eq!(returned.job_id, id);
         settle(&cm, id, JobState::Completed);
         assert_eq!(cm.get_job(id).unwrap().exit_code, Some(0));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn finish_srun_job_rejects_a_superseded_run_attempt() {
+        let dir = TempDir::new().unwrap();
+        let cm = test_cluster(&dir).await;
+        register_node(&cm, "n1", 4, 8000);
+        let id = submit_and_wait(&cm, srun_spec("srun-stale-complete"));
+        start_srun_job_on(&cm, id, "n1");
+        let current_attempt = cm.get_job(id).unwrap().run_attempt;
+
+        assert!(matches!(
+            cm.finish_srun_job(id, 0, "testuser", current_attempt.saturating_add(1)),
+            Err(SrunCompleteError::StaleRun {
+                job_id,
+                expected,
+                actual,
+            }) if job_id == id
+                && expected == current_attempt.saturating_add(1)
+                && actual == current_attempt
+        ));
+        assert_eq!(cm.get_job(id).unwrap().state, JobState::Running);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -16814,7 +18208,7 @@ mod tests {
         start_job_on(&cm, id, "n1");
 
         assert!(matches!(
-            cm.finish_srun_job(id, 0, "testuser"),
+            cm.finish_srun_job(id, 0, "testuser", 0),
             Err(SrunCompleteError::NotSrunJob(j)) if j == id
         ));
     }
@@ -16826,11 +18220,11 @@ mod tests {
         register_node(&cm, "n1", 4, 8000);
         let id = submit_and_wait(&cm, srun_spec("srun-done"));
         start_srun_job_on(&cm, id, "n1");
-        cm.finish_srun_job(id, 0, "testuser").unwrap();
+        cm.finish_srun_job(id, 0, "testuser", 0).unwrap();
         settle(&cm, id, JobState::Completed);
 
         assert!(matches!(
-            cm.finish_srun_job(id, 0, "testuser"),
+            cm.finish_srun_job(id, 0, "testuser", 0),
             Err(SrunCompleteError::AlreadyTerminal {
                 job_id,
                 state: JobState::Completed,
@@ -16847,7 +18241,7 @@ mod tests {
         start_srun_job_on(&cm, id, "n1");
 
         assert!(matches!(
-            cm.finish_srun_job(id, 0, "otheruser"),
+            cm.finish_srun_job(id, 0, "otheruser", 0),
             Err(SrunCompleteError::NotOwner { job_id, user }) if job_id == id && user == "otheruser"
         ));
     }
@@ -16861,7 +18255,7 @@ mod tests {
         start_job_on(&cm, id, "n1");
 
         assert!(matches!(
-            cm.finish_srun_job(id, 0, "testuser"),
+            cm.finish_srun_job(id, 0, "testuser", 0),
             Err(SrunCompleteError::NotStepDispatch(j)) if j == id
         ));
     }
@@ -16872,7 +18266,7 @@ mod tests {
         let cm = test_cluster(&dir).await;
 
         assert!(matches!(
-            cm.finish_srun_job(999, 0, "testuser"),
+            cm.finish_srun_job(999, 0, "testuser", 0),
             Err(SrunCompleteError::NotFound(999))
         ));
     }

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -485,6 +485,16 @@ impl ClusterManager {
             .remove(&(job_id, node.to_string()));
     }
 
+    /// Remove `node`'s miss-streak entries for jobs no longer in
+    /// `active_job_ids` — a job can leave the active set by a path other than
+    /// a later heartbeat re-reporting it (completed, cancelled, evicted),
+    /// which `note_node_reported_job` alone would never observe.
+    pub(crate) fn prune_phantom_streaks_not_in(&self, node: &str, active_job_ids: &HashSet<JobId>) {
+        self.phantom_miss_streaks
+            .write()
+            .retain(|(job_id, n), _| n != node || active_job_ids.contains(job_id));
+    }
+
     /// Record that `job_id`'s hold on `node` was just released in controller
     /// state (cancel/evict) but not yet confirmed by the agent, so new
     /// dispatch avoids `resources` there until it expires. Refreshes the TTL
@@ -1646,9 +1656,10 @@ impl ClusterManager {
     /// reach Running with only some of its nodes actually launched. Now used
     /// by the heartbeat reconciler to fail a job whose binding to a node has
     /// gone silent (see `reconcile_reported_allocations` in `server.rs`) —
-    /// callers must also cancel on the job's still-allocated nodes afterward,
-    /// since this only updates controller state.
-    pub fn evict_job(&self, job_id: JobId) -> anyhow::Result<()> {
+    /// callers must also cancel on the job's still-allocated nodes and
+    /// complete its steps (`complete_evicted_steps`) afterward, since this
+    /// only updates controller state.
+    pub fn evict_job(&self, job_id: JobId) -> anyhow::Result<Vec<JobFinalized>> {
         self.evict_job_with_detail(job_id, None)
     }
 
@@ -1656,19 +1667,19 @@ impl ClusterManager {
         &self,
         job_id: JobId,
         detail: Option<String>,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Vec<JobFinalized>> {
         {
             let jobs = self.jobs.read();
             let job = jobs
                 .get(&job_id)
                 .ok_or_else(|| anyhow::anyhow!("job {} not found", job_id))?;
             if job.state.is_terminal() {
-                return Ok(());
+                return Ok(Vec::new());
             }
         }
         let resp = self.propose(WalOperation::JobEvict { job_id, detail })?;
         self.run_all_finalized_side_effects(&resp);
-        Ok(())
+        Ok(resp.jobs_finalized.clone())
     }
 
     /// Register a node agent.

--- a/crates/spurctld/src/cluster.rs
+++ b/crates/spurctld/src/cluster.rs
@@ -1631,13 +1631,18 @@ impl ClusterManager {
 
     /// Evict a single job to NodeFail. Only updates controller state —
     /// callers must also cancel on its nodes and complete its steps.
-    pub fn evict_job(&self, job_id: JobId) -> anyhow::Result<Vec<JobFinalized>> {
-        self.evict_job_with_detail(job_id, None)
+    pub fn evict_job(
+        &self,
+        job_id: JobId,
+        reason: PendingReason,
+    ) -> anyhow::Result<Vec<JobFinalized>> {
+        self.evict_job_with_detail(job_id, reason, None)
     }
 
     pub fn evict_job_with_detail(
         &self,
         job_id: JobId,
+        reason: PendingReason,
         detail: Option<String>,
     ) -> anyhow::Result<Vec<JobFinalized>> {
         {
@@ -1649,9 +1654,13 @@ impl ClusterManager {
                 return Ok(Vec::new());
             }
         }
-        let resp = self.propose(WalOperation::JobEvict { job_id, detail })?;
+        let resp = self.propose(WalOperation::JobEvict {
+            job_id,
+            reason,
+            detail,
+        })?;
         self.run_all_finalized_side_effects(&resp);
-        Ok(resp.jobs_finalized.clone())
+        Ok(resp.jobs_finalized)
     }
 
     /// Register a node agent.
@@ -4300,7 +4309,11 @@ impl ClusterManager {
                     }
                 }
             }
-            WalOperation::JobEvict { job_id, detail } => {
+            WalOperation::JobEvict {
+                job_id,
+                reason,
+                detail,
+            } => {
                 if let Some(job) = jobs.get_mut(job_id) {
                     job.launch_failure_detail = detail.clone();
                 }
@@ -4309,7 +4322,7 @@ impl ClusterManager {
                     &mut jobs,
                     &mut nodes,
                     timestamp,
-                    PendingReason::JobLaunchFailure,
+                    reason.clone(),
                 ) {
                     response.jobs_finalized.push(fin);
                 }
@@ -11381,7 +11394,8 @@ mod tests {
         .unwrap();
         settle(&cm, job_id, JobState::Running);
 
-        cm.evict_job(job_id).unwrap();
+        cm.evict_job(job_id, PendingReason::JobLaunchFailure)
+            .unwrap();
         settle(&cm, job_id, JobState::Pending);
 
         let job = cm.get_job(job_id).unwrap();
@@ -13958,7 +13972,7 @@ mod tests {
         settle(&cm, id, JobState::Running);
 
         // n1's dispatch succeeded, n2's never reached the agent.
-        cm.evict_job(id).unwrap();
+        cm.evict_job(id, PendingReason::JobLaunchFailure).unwrap();
         settle(&cm, id, JobState::NodeFail);
 
         let job = cm.get_job(id).unwrap();
@@ -14039,7 +14053,7 @@ mod tests {
              leaving only B's 3 cpus"
         );
 
-        cm.evict_job(job_a).unwrap();
+        cm.evict_job(job_a, PendingReason::NodeDown).unwrap();
         settle(&cm, job_a, JobState::NodeFail);
 
         assert_eq!(

--- a/crates/spurctld/src/rest/handlers.rs
+++ b/crates/spurctld/src/rest/handlers.rs
@@ -147,6 +147,12 @@ pub async fn cancel_job(
 
     let job = state.cluster.get_job(job_id);
 
+    // Reserve before the free lands, so the scheduler never sees a window
+    // where the resources look free but the agent hasn't been told yet.
+    if let Some(job) = &job {
+        crate::server::note_pending_kill_for_job(&state.cluster, job);
+    }
+
     state
         .cluster
         .cancel_job(job_id, "")

--- a/crates/spurctld/src/rest/handlers.rs
+++ b/crates/spurctld/src/rest/handlers.rs
@@ -154,12 +154,14 @@ pub async fn cancel_job(
 
     // Reserve before the free lands (the check above already gated this
     // on the job being live).
-    if let Some(job) = &job {
-        crate::server::note_pending_kill_for_job(&state.cluster, job);
-    }
+    let attempt = job
+        .as_ref()
+        .map(|job| crate::server::note_pending_kill_for_job(&state.cluster, job));
 
     if let Err(e) = state.cluster.cancel_job(job_id, "") {
-        state.cluster.clear_pending_kill_for_job(job_id);
+        if let Some(attempt) = attempt {
+            state.cluster.clear_pending_kill_for_job(job_id, attempt);
+        }
         return Err(error_response(&format!("cancel failed: {e}")));
     }
 

--- a/crates/spurctld/src/rest/handlers.rs
+++ b/crates/spurctld/src/rest/handlers.rs
@@ -158,10 +158,10 @@ pub async fn cancel_job(
         crate::server::note_pending_kill_for_job(&state.cluster, job);
     }
 
-    state
-        .cluster
-        .cancel_job(job_id, "")
-        .map_err(|e| error_response(&format!("cancel failed: {e}")))?;
+    if let Err(e) = state.cluster.cancel_job(job_id, "") {
+        state.cluster.clear_pending_kill_for_job(job_id);
+        return Err(error_response(&format!("cancel failed: {e}")));
+    }
 
     if let Some(job) = job {
         let cluster = state.cluster.clone();

--- a/crates/spurctld/src/rest/handlers.rs
+++ b/crates/spurctld/src/rest/handlers.rs
@@ -145,10 +145,15 @@ pub async fn cancel_job(
         return Err(unavailable_response("not the Raft leader"));
     }
 
+    state
+        .cluster
+        .check_cancel_allowed(job_id, "")
+        .map_err(|e| error_response(&format!("cancel failed: {e}")))?;
+
     let job = state.cluster.get_job(job_id);
 
-    // Reserve before the free lands, so the scheduler never sees a window
-    // where the resources look free but the agent hasn't been told yet.
+    // Reserve before the free lands (the check above already gated this
+    // on the job being live).
     if let Some(job) = &job {
         crate::server::note_pending_kill_for_job(&state.cluster, job);
     }

--- a/crates/spurctld/src/rest/handlers.rs
+++ b/crates/spurctld/src/rest/handlers.rs
@@ -152,16 +152,7 @@ pub async fn cancel_job(
 
     let job = state.cluster.get_job(job_id);
 
-    // Reserve before the free lands (the check above already gated this
-    // on the job being live).
-    let attempt = job
-        .as_ref()
-        .map(|job| crate::server::note_pending_kill_for_job(&state.cluster, job));
-
     if let Err(e) = state.cluster.cancel_job(job_id, "") {
-        if let Some(attempt) = attempt {
-            state.cluster.clear_pending_kill_for_job(job_id, attempt);
-        }
         return Err(error_response(&format!("cancel failed: {e}")));
     }
 

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -142,10 +142,12 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
         // drive_bb_stage_in() is the controller-side seam only.
         cluster.drive_bb_stage_in();
         cluster.purge_expired_reservations();
-        cluster.enforce_reservation_end_times();
+        for job in cluster.enforce_reservation_end_times() {
+            send_cancel_to_agents(&cluster, &job, 0).await;
+        }
         cluster.evict_expired_terminal_jobs();
 
-        // Pruned on every read so an idle cluster doesn't accumulate expired entries.
+        // Held out of scheduling until a heartbeat confirms release.
         let pending_kill = cluster.pending_kill_reservations();
 
         // Classify once, apply reasons, and stage only candidates admitted by
@@ -328,10 +330,15 @@ async fn process_assignment(
         }
     }
 
+    let dispatch_attempt = match cluster.begin_dispatch_attempt(job_id) {
+        Ok(attempt) => attempt,
+        Err(e) => {
+            debug!(job_id, error = %e, "job left Pending before dispatch");
+            return false;
+        }
+    };
+
     if spec.srun_job && srun_step_dispatch {
-        // Same one-shot read as the batch path below: this iteration is the
-        // only place that can advance a Pending job's run_attempt.
-        let prospective_run_attempt = job.run_attempt.saturating_add(1);
         match register_allocation_on_nodes(
             cluster.clone(),
             job_id,
@@ -339,25 +346,37 @@ async fn process_assignment(
             &spec,
             per_node_allocs.clone(),
             allocated_nodelist.clone(),
-            prospective_run_attempt,
+            dispatch_attempt,
         )
         .await
         {
             AllocationRegisterOutcome::AllFailed => {
+                if let Err(e) = cluster.reserve_pending_dispatch(
+                    job_id,
+                    &dispatch_nodes,
+                    &per_node_allocs,
+                    dispatch_attempt,
+                ) {
+                    error!(job_id, error = %e, "failed to reserve failed registration cleanup");
+                    return false;
+                }
+                cancel_job_on_nodes(&cluster, job_id, &dispatch_nodes, 9, dispatch_attempt).await;
                 if let Err(e) = cluster.requeue_job(job_id) {
                     error!(job_id, error = %e, "failed to requeue after registration failure");
                 }
                 return false;
             }
             AllocationRegisterOutcome::PartialFailed { succeeded_nodes } => {
-                cancel_job_on_nodes(
-                    &cluster,
+                if let Err(e) = cluster.reserve_pending_dispatch(
                     job_id,
                     &succeeded_nodes,
-                    9,
-                    prospective_run_attempt,
-                )
-                .await;
+                    &per_node_allocs,
+                    dispatch_attempt,
+                ) {
+                    error!(job_id, error = %e, "failed to reserve partial registration cleanup");
+                    return false;
+                }
+                cancel_job_on_nodes(&cluster, job_id, &succeeded_nodes, 9, dispatch_attempt).await;
                 if let Err(e) = cluster.requeue_job(job_id) {
                     error!(job_id, error = %e, "failed to requeue after partial registration");
                 }
@@ -372,7 +391,9 @@ async fn process_assignment(
     // LaunchJob dispatch below, which — unlike the old fire-and-forget
     // spawn — now runs (and is awaited) *before* the job is allowed to
     // become visibly Running.
-    let peer_addrs: Vec<String> = {
+    let peer_addrs: Vec<String> = if srun_step_dispatch {
+        Vec::new()
+    } else {
         let mut addrs = Vec::with_capacity(all_nodes.len());
         for name in &all_nodes {
             let Some(n) = cluster.get_node(name) else {
@@ -429,13 +450,6 @@ async fn process_assignment(
     };
 
     if let Some(dspec) = dispatch_spec {
-        // The run epoch start_job_impl is about to persist for this
-        // dispatch. Safe to read ahead of that call: this iteration is
-        // the only place that can advance a Pending job's run_attempt,
-        // and nothing here yields back to another iteration for the
-        // same job in between.
-        let prospective_run_attempt = job.run_attempt.saturating_add(1);
-
         match confirm_dispatch_on_nodes(
             cluster.clone(),
             job_id,
@@ -445,7 +459,7 @@ async fn process_assignment(
             per_node_allocs.clone(),
             allocated_nodelist.clone(),
             tasks_per_node,
-            prospective_run_attempt,
+            dispatch_attempt,
             task_fanout,
         )
         .await
@@ -480,14 +494,16 @@ async fn process_assignment(
         // start_job failure here (e.g. the job was cancelled out from
         // under us between assignment and this point) doesn't leave
         // orphans.
-        cancel_job_on_nodes(
-            &cluster,
+        if let Err(hold_err) = cluster.reserve_pending_dispatch(
             job_id,
             &dispatch_nodes,
-            0,
-            job.run_attempt.saturating_add(1),
-        )
-        .await;
+            &per_node_allocs,
+            dispatch_attempt,
+        ) {
+            error!(job_id, error = %hold_err, "failed to reserve failed-dispatch cleanup");
+            return false;
+        }
+        cancel_job_on_nodes(&cluster, job_id, &dispatch_nodes, 0, dispatch_attempt).await;
         debug!(
             job_id = assignment.job_id,
             error = %e,
@@ -652,11 +668,6 @@ pub(crate) async fn try_preempt(
                 mode = ?mode,
                 "preempting lower-priority job"
             );
-            // Reserve before the free lands whenever this mode will kill, so the
-            // scheduler never sees a window where resources look free early.
-            if matches!(mode, PreemptMode::Cancel | PreemptMode::Requeue) {
-                crate::server::note_pending_kill_for_job(cluster, candidate);
-            }
             match cluster.preempt_job(candidate.job_id, mode) {
                 Ok(PreemptOutcome::Killed) => {
                     // Signal 0 = graceful cancel (SIGTERM then SIGKILL).
@@ -1639,10 +1650,14 @@ async fn confirm_dispatch_on_nodes(
     };
     let _ = cluster.set_job_launch_failure_detail(job_id, confirmation_detail.clone());
 
-    // Stop whatever DID launch before the job settles anywhere: a node that
-    // never confirmed will never report completion, and letting it keep
-    // running while the job as a whole is aborted back to Pending would
-    // orphan it.
+    // Stop whatever DID launch (only succeeded_nodes hold anything) before the
+    // job settles back to Pending, or the launched process would be orphaned.
+    if let Err(e) =
+        cluster.reserve_pending_dispatch(job_id, &succeeded_nodes, &per_node_allocs, run_attempt)
+    {
+        error!(job_id, error = %e, "failed to reserve aborted dispatch cleanup");
+        return DispatchConfirmOutcome::Aborted;
+    }
     cancel_job_on_nodes(&cluster, job_id, &succeeded_nodes, 9, run_attempt).await;
 
     // Drain before deciding the job's fate, so the failing node is already out
@@ -1778,10 +1793,8 @@ async fn enforce_time_limits(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>
                 "grace period expired — force-killing job"
             );
 
-            // Reserve before the free, so the scheduler never sees the gap
-            // where resources look free but the agent hasn't been told.
-            crate::server::note_pending_kill_for_job(&cluster, job);
-            if let Err(e) = cluster.complete_job(job.job_id, -1, spur_core::job::JobState::Timeout)
+            if let Err(e) =
+                cluster.complete_job_after_cancel(job.job_id, -1, spur_core::job::JobState::Timeout)
             {
                 warn!(job_id = job.job_id, error = %e, "failed to mark job as timed out");
                 continue;
@@ -1871,7 +1884,7 @@ async fn force_finish_completing_job(cluster: &Arc<ClusterManager>, job: &spur_c
         "completing timeout expired — force-finishing job"
     );
 
-    if let Err(e) = cluster.complete_job(job.job_id, exit_code, state) {
+    if let Err(e) = cluster.complete_job_after_cancel(job.job_id, exit_code, state) {
         warn!(
             job_id = job.job_id,
             error = %e,
@@ -4460,6 +4473,54 @@ mod tests {
             assert!(
                 cm.nodes_on_dispatch_cooldown().contains("n1"),
                 "a resources-unavailable reject on the srun registration path must cool the node too"
+            );
+        }
+
+        // A partial registration failure must report only the nodes that
+        // actually succeeded, so cleanup never touches a node that has nothing.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn partial_registration_failure_reports_only_succeeded_nodes() {
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+
+            let (good_addr, _) = spawn_mock_agent().await;
+            let bad_addr = spawn_mock_agent_rejecting_registration().await;
+            register_node_at(&cm, "n1", good_addr);
+            register_node_at(&cm, "n2", bad_addr);
+
+            let mut spec = batch_spec("srun-partial-fail", 2);
+            spec.srun_job = true;
+            let job_id = submit_and_wait(&cm, spec.clone());
+
+            let per_node_allocs = HashMap::from([
+                ("n1".into(), ResourceAllocations::with_scalar(4, 8000)),
+                ("n2".into(), ResourceAllocations::with_scalar(4, 8000)),
+            ]);
+            let outcome = register_allocation_on_nodes(
+                cm.clone(),
+                job_id,
+                vec!["n1".into(), "n2".into()],
+                &spec,
+                per_node_allocs.clone(),
+                "n1,n2".into(),
+                0,
+            )
+            .await;
+            let AllocationRegisterOutcome::PartialFailed { succeeded_nodes } = outcome else {
+                panic!("expected PartialFailed");
+            };
+            assert_eq!(succeeded_nodes, vec!["n1".to_string()]);
+
+            cm.reserve_pending_dispatch(job_id, &succeeded_nodes, &per_node_allocs, 0)
+                .unwrap();
+            let reserved = cm.pending_kill_reservations();
+            assert!(
+                reserved.contains_key("n1"),
+                "the node that actually registered must be held"
+            );
+            assert!(
+                !reserved.contains_key("n2"),
+                "a node that never registered anything must not be held"
             );
         }
 

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -39,6 +39,23 @@ fn node_comm_http_url(node: &Node) -> Option<String> {
     Some(spur_net::format_comm_http_url(host, node.port))
 }
 
+/// Inflate each node's `alloc_resources` by any pending-kill amount for it, so
+/// the scheduler doesn't place a new job on a resource whose prior occupant's
+/// kill hasn't been confirmed released yet.
+fn apply_pending_kill_reservations(
+    nodes: &mut [Node],
+    pending_kill: &std::collections::HashMap<String, spur_core::resource::ResourceAllocations>,
+) {
+    if pending_kill.is_empty() {
+        return;
+    }
+    for node in nodes {
+        if let Some(resources) = pending_kill.get(&node.name) {
+            node.alloc_resources.add(resources);
+        }
+    }
+}
+
 /// Spawn the time-limit enforcement watchdog and power manager alongside the scheduler loop.
 pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
     let enforcer_cluster = cluster.clone();
@@ -138,7 +155,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
         }
         let hit_depth_limit = pending.len() > max_jobs;
 
-        let nodes = cluster.schedulable_nodes();
+        let mut nodes = cluster.schedulable_nodes();
         let partitions = cluster.get_partitions();
         let reservations = cluster.get_reservations();
 
@@ -146,6 +163,11 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
             debug!("no nodes registered, skipping scheduling cycle");
             continue;
         }
+
+        // Keep a resource excluded from placement until the agent confirms it
+        // released a cancelled/evicted job, even though the controller's own
+        // alloc_resources already counts it free — a kill RPC can be lost.
+        apply_pending_kill_reservations(&mut nodes, &cluster.pending_kill_reservations());
 
         let cycle_start = Instant::now();
 
@@ -841,6 +863,7 @@ struct AgentDispatchParams<'a> {
     allocated: &'a spur_core::resource::ResourceAllocations,
     allocated_nodelist: &'a str,
     run_attempt: u32,
+    term: u64,
     pmix_tmpdir: &'a str,
     /// See `LaunchJobRequest.task_fanout` in slurm.proto: true only for a
     /// standalone `srun` request routed through this batch dispatch path
@@ -1030,6 +1053,7 @@ async fn dispatch_to_agent(
             pmix_plan,
             task_fanout: params.task_fanout,
             pmix_prepared: params.pmix_prepared,
+            term: params.term,
         })
         .await
         .map_err(|s| match s.code() {
@@ -1107,6 +1131,7 @@ struct AllocationRegisterParams {
     allocated: spur_core::resource::ResourceAllocations,
     work_dir: String,
     run_attempt: u32,
+    term: u64,
 }
 
 /// Register a srun-only allocation on a node agent without launching a batch process.
@@ -1139,6 +1164,7 @@ async fn register_allocation_to_agent(
             work_dir: params.work_dir.clone(),
             user: params.user.clone(),
             run_attempt: params.run_attempt,
+            term: params.term,
         })
         .await?;
 
@@ -1165,6 +1191,7 @@ async fn register_allocation_on_nodes(
     let mut failures = 0u32;
     let mut succeeded_nodes: Vec<String> = Vec::new();
     let total = dispatch_nodes.len() as u32;
+    let term = cluster.current_term();
 
     let mut set = tokio::task::JoinSet::new();
     for node_name in &dispatch_nodes {
@@ -1205,6 +1232,7 @@ async fn register_allocation_on_nodes(
             allocated_nodelist: allocated_nodelist.clone(),
             allocated,
             work_dir: spec.work_dir.clone(),
+            term,
             run_attempt,
         };
         set.spawn(async move {
@@ -1355,6 +1383,7 @@ async fn confirm_dispatch_on_nodes(
     let modex_connect_timeout_secs = cluster.config().mpi.modex_connect_timeout_secs;
     let modex_fence_timeout_secs = cluster.config().mpi.modex_fence_timeout_secs;
     let modex_verify_timeout_secs = cluster.config().mpi.modex_verify_timeout_secs;
+    let term = cluster.current_term();
 
     let needs_pmix_prepare = batch_dispatched_multi_node_pmix(
         spec.mpi.as_deref(),
@@ -1512,6 +1541,7 @@ async fn confirm_dispatch_on_nodes(
                     allocated: &allocated,
                     allocated_nodelist: &allocated_nodelist,
                     run_attempt,
+                    term,
                     pmix_tmpdir: &pmix_tmpdir,
                     task_fanout,
                     modex_connect_timeout_secs,
@@ -1925,8 +1955,9 @@ pub async fn send_cancel_to_nodes(
     node_names: &[String],
     signal: i32,
 ) {
+    let term = cluster.current_term();
     for agent_addr in cancel_agent_addrs(cluster, job_id, node_names) {
-        tokio::spawn(cancel_one_agent(agent_addr, job_id, signal));
+        tokio::spawn(cancel_one_agent(agent_addr, job_id, signal, term));
     }
 }
 
@@ -1940,9 +1971,10 @@ pub async fn cancel_job_on_nodes(
     node_names: &[String],
     signal: i32,
 ) {
+    let term = cluster.current_term();
     let mut set = tokio::task::JoinSet::new();
     for agent_addr in cancel_agent_addrs(cluster, job_id, node_names) {
-        set.spawn(cancel_one_agent(agent_addr, job_id, signal));
+        set.spawn(cancel_one_agent(agent_addr, job_id, signal, term));
     }
     while set.join_next().await.is_some() {}
 }
@@ -2060,7 +2092,12 @@ fn cancel_agent_addrs(
 /// Deliver one CancelJob RPC, bounded by `CANCEL_RPC_TIMEOUT`. Errors and
 /// timeouts are logged, never propagated: a cancel is best-effort cleanup and
 /// must not block the caller past the timeout.
-async fn cancel_one_agent(agent_addr: String, job_id: spur_core::job::JobId, signal: i32) {
+async fn cancel_one_agent(
+    agent_addr: String,
+    job_id: spur_core::job::JobId,
+    signal: i32,
+    term: u64,
+) {
     let attempt = async {
         match SlurmAgentClient::connect(agent_addr.clone())
             .await
@@ -2070,7 +2107,11 @@ async fn cancel_one_agent(agent_addr: String, job_id: spur_core::job::JobId, sig
             }) {
             Ok(mut client) => {
                 if let Err(e) = client
-                    .cancel_job(AgentCancelJobRequest { job_id, signal })
+                    .cancel_job(AgentCancelJobRequest {
+                        job_id,
+                        signal,
+                        term,
+                    })
                     .await
                 {
                     warn!(
@@ -4306,6 +4347,37 @@ mod tests {
             assert!(
                 cm.nodes_on_dispatch_cooldown().contains("n1"),
                 "a resources-unavailable reject must put the node on cooldown"
+            );
+        }
+
+        // A node with a pending-kill reservation must not look free to the
+        // scheduler even though `alloc_resources` itself already shows it as
+        // free — the whole point of the confirm-before-free gate.
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn pending_kill_reservation_inflates_node_alloc_resources() {
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+            register_node_at(&cm, "n1", unreachable_addr().await);
+            register_node_at(&cm, "n2", unreachable_addr().await);
+
+            let mut nodes: Vec<_> = ["n1", "n2"]
+                .iter()
+                .map(|n| cm.get_node(n).unwrap())
+                .collect();
+            assert_eq!(nodes[0].alloc_resources.cpus, 0);
+
+            let mut pending_kill = std::collections::HashMap::new();
+            pending_kill.insert("n1".to_string(), ResourceAllocations::with_scalar(2, 4000));
+
+            apply_pending_kill_reservations(&mut nodes, &pending_kill);
+
+            assert_eq!(
+                nodes[0].alloc_resources.cpus, 2,
+                "n1 inflated by its pending-kill reservation"
+            );
+            assert_eq!(
+                nodes[1].alloc_resources.cpus, 0,
+                "n2 has no pending-kill entry, untouched"
             );
         }
     }

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -138,7 +138,12 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
         }
         let hit_depth_limit = pending.len() > max_jobs;
 
-        let nodes = cluster.get_nodes();
+        let cooling = cluster.nodes_on_dispatch_cooldown();
+        let nodes: Vec<spur_core::node::Node> = cluster
+            .get_nodes()
+            .into_iter()
+            .filter(|n| !cooling.contains(&n.name))
+            .collect();
         let partitions = cluster.get_partitions();
         let reservations = cluster.get_reservations();
 
@@ -862,6 +867,9 @@ enum DispatchError {
     /// own context, so the same failure recurs everywhere: Slurm drains the node
     /// and holds the job instead of retrying it onto the next one.
     PrologFailed(String),
+    /// The agent rejected the dispatch because the controller-allocated resources
+    /// are already in use locally — the controller's view of this node is stale.
+    ResourcesUnavailable,
     Other(anyhow::Error),
 }
 
@@ -869,6 +877,9 @@ impl std::fmt::Display for DispatchError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::PrologFailed(reason) => write!(f, "agent rejected job: {reason}"),
+            Self::ResourcesUnavailable => {
+                write!(f, "agent rejected job: allocated resources unavailable")
+            }
             Self::Other(e) => write!(f, "{e:#}"),
         }
     }
@@ -1021,7 +1032,11 @@ async fn dispatch_to_agent(
             task_fanout: params.task_fanout,
             pmix_prepared: params.pmix_prepared,
         })
-        .await?;
+        .await
+        .map_err(|s| match s.code() {
+            tonic::Code::ResourceExhausted => DispatchError::ResourcesUnavailable,
+            _ => DispatchError::Other(s.into()),
+        })?;
 
     let inner = response.into_inner();
     if !inner.success {
@@ -1519,8 +1534,12 @@ async fn confirm_dispatch_on_nodes(
             Ok((node_name, _, Err(e))) => {
                 error!(job_id, node = %node_name, error = %e, "dispatch confirmation failed");
                 failures += 1;
-                if let DispatchError::PrologFailed(reason) = e {
-                    prolog_failed.push((node_name, reason));
+                match e {
+                    DispatchError::PrologFailed(reason) => {
+                        prolog_failed.push((node_name, reason));
+                    }
+                    DispatchError::ResourcesUnavailable => cluster.cool_down_node(&node_name),
+                    DispatchError::Other(_) => {}
                 }
             }
             Err(e) => {
@@ -2492,6 +2511,9 @@ mod tests {
             release_pmix_calls: Arc<AtomicU32>,
             reject_launch_as: Option<spur_proto::proto::LaunchFailureKind>,
             launch_delay: Duration,
+            /// launch_job returns a ResourceExhausted status, standing in for a
+            /// node whose local allocation table already holds the GPUs.
+            reject_resources: bool,
             /// Records each `LaunchJobRequest.task_fanout` this agent receives,
             /// so tests can assert on it without a real spurd behind the RPC.
             fanout_calls: Option<Arc<std::sync::Mutex<Vec<bool>>>>,
@@ -2511,6 +2533,11 @@ mod tests {
             {
                 if !self.launch_delay.is_zero() {
                     tokio::time::sleep(self.launch_delay).await;
+                }
+                if self.reject_resources {
+                    return Err(tonic::Status::resource_exhausted(
+                        "controller-allocated GPUs unavailable on this node",
+                    ));
                 }
                 if let Some(kind) = self.reject_launch_as {
                     return Ok(tonic::Response::new(spur_proto::proto::LaunchJobResponse {
@@ -2744,6 +2771,7 @@ mod tests {
                 release_pmix_calls: release_pmix_calls.clone(),
                 reject_launch_as,
                 launch_delay,
+                reject_resources: false,
                 fanout_calls: capture.then(|| fanout_calls.clone()),
             };
             tokio::spawn(async move {
@@ -2755,6 +2783,28 @@ mod tests {
                     .await;
             });
             (addr, cancel_calls, release_pmix_calls, fanout_calls)
+        }
+
+        /// Mock agent whose launch_job always rejects with ResourceExhausted.
+        async fn spawn_mock_agent_rejecting_resources() -> std::net::SocketAddr {
+            let incoming = TcpIncoming::bind("127.0.0.1:0".parse().unwrap()).unwrap();
+            let addr = incoming.local_addr().unwrap();
+            let agent = MockAgent {
+                cancel_calls: Arc::new(AtomicU32::new(0)),
+                reject_launch_as: None,
+                launch_delay: Duration::ZERO,
+                reject_resources: true,
+                fanout_calls: None,
+            };
+            tokio::spawn(async move {
+                let _ = Server::builder()
+                    .add_service(
+                        spur_proto::proto::slurm_agent_server::SlurmAgentServer::new(agent),
+                    )
+                    .serve_with_incoming(incoming)
+                    .await;
+            });
+            addr
         }
 
         /// Reserve a localhost port with nothing listening on it, so a
@@ -4234,6 +4284,25 @@ mod tests {
                 cm.get_job(job_id).unwrap().state,
                 JobState::Cancelled,
                 "the job must stay exactly as the earlier, real cancel left it"
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn resources_unavailable_reject_cools_down_the_node() {
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+
+            let addr = spawn_mock_agent_rejecting_resources().await;
+            register_node_at(&cm, "n1", addr);
+
+            let job_id = submit_and_wait(&cm, batch_spec("resource-reject", 1));
+
+            assert!(cm.nodes_on_dispatch_cooldown().is_empty());
+            let outcome = confirm_dispatch_pending_job(&cm, job_id, &["n1"]).await;
+            assert!(matches!(outcome, DispatchConfirmOutcome::Aborted));
+            assert!(
+                cm.nodes_on_dispatch_cooldown().contains("n1"),
+                "a resources-unavailable reject must put the node on cooldown"
             );
         }
     }

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -640,6 +640,7 @@ pub(crate) async fn try_preempt(
             );
             match cluster.preempt_job(candidate.job_id, mode) {
                 Ok(PreemptOutcome::Killed) => {
+                    crate::server::note_pending_kill_for_job(cluster, candidate);
                     // Signal 0 = graceful cancel (SIGTERM then SIGKILL).
                     send_cancel_to_agents(cluster, candidate, 0).await;
                 }
@@ -1138,7 +1139,7 @@ struct AllocationRegisterParams {
 async fn register_allocation_to_agent(
     agent_addr: &str,
     params: &AllocationRegisterParams,
-) -> anyhow::Result<()> {
+) -> Result<(), DispatchError> {
     let mut client = SlurmAgentClient::connect(agent_addr.to_string())
         .await?
         .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
@@ -1166,7 +1167,11 @@ async fn register_allocation_to_agent(
             run_attempt: params.run_attempt,
             term: params.term,
         })
-        .await?;
+        .await
+        .map_err(|s| match s.code() {
+            tonic::Code::ResourceExhausted => DispatchError::ResourcesUnavailable,
+            _ => DispatchError::Other(s.into()),
+        })?;
 
     info!(
         job_id = params.job_id,
@@ -1254,6 +1259,9 @@ async fn register_allocation_on_nodes(
                     error = %e,
                     "allocation registration on agent failed"
                 );
+                if matches!(e, DispatchError::ResourcesUnavailable) {
+                    cluster.cool_down_node(&node_name);
+                }
                 failures += 1;
             }
             Err(e) => {
@@ -1758,6 +1766,7 @@ async fn enforce_time_limits(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>
                 continue;
             }
 
+            crate::server::note_pending_kill_for_job(&cluster, job);
             send_cancel_to_agents(&cluster, job, 9).await; // SIGKILL
         }
     }
@@ -2153,6 +2162,7 @@ pub async fn send_suspend_to_agents(
     job: &spur_core::job::Job,
     resume: bool,
 ) {
+    let term = cluster.current_term();
     for node_name in &job.allocated_nodes {
         let node_info = cluster.get_node(node_name);
         let agent_addr = match node_info {
@@ -2180,7 +2190,11 @@ pub async fn send_suspend_to_agents(
                 }) {
                 Ok(mut client) => {
                     if let Err(e) = client
-                        .suspend_job(AgentSuspendJobRequest { job_id, resume })
+                        .suspend_job(AgentSuspendJobRequest {
+                            job_id,
+                            resume,
+                            term,
+                        })
                         .await
                     {
                         warn!(job_id, resume, agent = %agent_addr, error = %e, "SuspendJob RPC failed");
@@ -2558,6 +2572,9 @@ mod tests {
             /// launch_job returns a ResourceExhausted status, standing in for a
             /// node whose local allocation table already holds the GPUs.
             reject_resources: bool,
+            /// register_job_allocation returns a ResourceExhausted status,
+            /// the srun/salloc equivalent of `reject_resources`.
+            reject_registration: bool,
             /// Records each `LaunchJobRequest.task_fanout` this agent receives,
             /// so tests can assert on it without a real spurd behind the RPC.
             fanout_calls: Option<Arc<std::sync::Mutex<Vec<bool>>>>,
@@ -2685,6 +2702,11 @@ mod tests {
                 tonic::Response<spur_proto::proto::RegisterJobAllocationResponse>,
                 tonic::Status,
             > {
+                if self.reject_registration {
+                    return Err(tonic::Status::resource_exhausted(
+                        "controller-allocated resources unavailable on this node",
+                    ));
+                }
                 Ok(tonic::Response::new(Default::default()))
             }
 
@@ -2816,6 +2838,7 @@ mod tests {
                 reject_launch_as,
                 launch_delay,
                 reject_resources: false,
+                reject_registration: false,
                 fanout_calls: capture.then(|| fanout_calls.clone()),
             };
             tokio::spawn(async move {
@@ -2838,6 +2861,30 @@ mod tests {
                 reject_launch_as: None,
                 launch_delay: Duration::ZERO,
                 reject_resources: true,
+                reject_registration: false,
+                fanout_calls: None,
+            };
+            tokio::spawn(async move {
+                let _ = Server::builder()
+                    .add_service(
+                        spur_proto::proto::slurm_agent_server::SlurmAgentServer::new(agent),
+                    )
+                    .serve_with_incoming(incoming)
+                    .await;
+            });
+            addr
+        }
+
+        /// Mock agent whose register_job_allocation always rejects with ResourceExhausted.
+        async fn spawn_mock_agent_rejecting_registration() -> std::net::SocketAddr {
+            let incoming = TcpIncoming::bind("127.0.0.1:0".parse().unwrap()).unwrap();
+            let addr = incoming.local_addr().unwrap();
+            let agent = MockAgent {
+                cancel_calls: Arc::new(AtomicU32::new(0)),
+                reject_launch_as: None,
+                launch_delay: Duration::ZERO,
+                reject_resources: false,
+                reject_registration: true,
                 fanout_calls: None,
             };
             tokio::spawn(async move {
@@ -4347,6 +4394,36 @@ mod tests {
             assert!(
                 cm.nodes_on_dispatch_cooldown().contains("n1"),
                 "a resources-unavailable reject must put the node on cooldown"
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn interactive_registration_resources_unavailable_cools_down_the_node() {
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+
+            let addr = spawn_mock_agent_rejecting_registration().await;
+            register_node_at(&cm, "n1", addr);
+
+            let mut spec = batch_spec("srun-resource-reject", 1);
+            spec.srun_job = true;
+            let job_id = submit_and_wait(&cm, spec.clone());
+
+            assert!(cm.nodes_on_dispatch_cooldown().is_empty());
+            let outcome = register_allocation_on_nodes(
+                cm.clone(),
+                job_id,
+                vec!["n1".into()],
+                &spec,
+                HashMap::from([("n1".into(), ResourceAllocations::with_scalar(4, 8000))]),
+                "n1".into(),
+                0,
+            )
+            .await;
+            assert!(matches!(outcome, AllocationRegisterOutcome::AllFailed));
+            assert!(
+                cm.nodes_on_dispatch_cooldown().contains("n1"),
+                "a resources-unavailable reject on the srun registration path must cool the node too"
             );
         }
 

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -138,12 +138,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
         }
         let hit_depth_limit = pending.len() > max_jobs;
 
-        let cooling = cluster.nodes_on_dispatch_cooldown();
-        let nodes: Vec<spur_core::node::Node> = cluster
-            .get_nodes()
-            .into_iter()
-            .filter(|n| !cooling.contains(&n.name))
-            .collect();
+        let nodes = cluster.schedulable_nodes();
         let partitions = cluster.get_partitions();
         let reservations = cluster.get_reservations();
 

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -350,7 +350,14 @@ async fn process_assignment(
                 return false;
             }
             AllocationRegisterOutcome::PartialFailed { succeeded_nodes } => {
-                cancel_job_on_nodes(&cluster, job_id, &succeeded_nodes, 9).await;
+                cancel_job_on_nodes(
+                    &cluster,
+                    job_id,
+                    &succeeded_nodes,
+                    9,
+                    prospective_run_attempt,
+                )
+                .await;
                 if let Err(e) = cluster.requeue_job(job_id) {
                     error!(job_id, error = %e, "failed to requeue after partial registration");
                 }
@@ -473,7 +480,14 @@ async fn process_assignment(
         // start_job failure here (e.g. the job was cancelled out from
         // under us between assignment and this point) doesn't leave
         // orphans.
-        cancel_job_on_nodes(&cluster, job_id, &dispatch_nodes, 0).await;
+        cancel_job_on_nodes(
+            &cluster,
+            job_id,
+            &dispatch_nodes,
+            0,
+            job.run_attempt.saturating_add(1),
+        )
+        .await;
         debug!(
             job_id = assignment.job_id,
             error = %e,
@@ -1629,7 +1643,7 @@ async fn confirm_dispatch_on_nodes(
     // never confirmed will never report completion, and letting it keep
     // running while the job as a whole is aborted back to Pending would
     // orphan it.
-    cancel_job_on_nodes(&cluster, job_id, &succeeded_nodes, 9).await;
+    cancel_job_on_nodes(&cluster, job_id, &succeeded_nodes, 9, run_attempt).await;
 
     // Drain before deciding the job's fate, so the failing node is already out
     // of the candidate set on the next scheduling attempt. The drain is issued
@@ -1847,7 +1861,7 @@ async fn force_finish_completing_job(cluster: &Arc<ClusterManager>, job: &spur_c
     }
 
     if !missing.is_empty() {
-        cancel_job_on_nodes(cluster, job.job_id, &missing, 9).await;
+        cancel_job_on_nodes(cluster, job.job_id, &missing, 9, job.run_attempt).await;
     }
 
     info!(
@@ -1952,27 +1966,34 @@ pub async fn send_cancel_to_agents(
     job: &spur_core::job::Job,
     signal: i32,
 ) {
-    send_cancel_to_nodes(cluster, job.job_id, &job.allocated_nodes, signal).await;
+    send_cancel_to_nodes(
+        cluster,
+        job.job_id,
+        &job.allocated_nodes,
+        signal,
+        job.run_attempt,
+    )
+    .await;
 }
 
-/// Send CancelJob RPC to an explicit set of nodes for a job with a specific
-/// signal. Callers that already know which nodes ran the job (e.g. a dispatch
-/// loop) should use this instead of `send_cancel_to_agents` so the cancel
-/// isn't at the mercy of `job.allocated_nodes` having been mutated in the
-/// meantime (e.g. cleared by a requeue-on-eviction side effect).
-///
-/// Fire-and-forget: each node's cancel runs on its own task and this returns
-/// immediately. Use `cancel_job_on_nodes` when the cancel must be delivered
-/// before subsequent work (e.g. a requeue that could re-dispatch the job).
+/// Send CancelJob RPC to explicit nodes; `run_attempt` (0 = unfenced) stops it
+/// from killing a later run of the same job_id. Fire-and-forget.
 pub async fn send_cancel_to_nodes(
     cluster: &Arc<ClusterManager>,
     job_id: spur_core::job::JobId,
     node_names: &[String],
     signal: i32,
+    run_attempt: u32,
 ) {
     let term = cluster.current_term();
     for agent_addr in cancel_agent_addrs(cluster, job_id, node_names) {
-        tokio::spawn(cancel_one_agent(agent_addr, job_id, signal, term));
+        tokio::spawn(cancel_one_agent(
+            agent_addr,
+            job_id,
+            signal,
+            term,
+            run_attempt,
+        ));
     }
 }
 
@@ -1985,11 +2006,18 @@ pub async fn cancel_job_on_nodes(
     job_id: spur_core::job::JobId,
     node_names: &[String],
     signal: i32,
+    run_attempt: u32,
 ) {
     let term = cluster.current_term();
     let mut set = tokio::task::JoinSet::new();
     for agent_addr in cancel_agent_addrs(cluster, job_id, node_names) {
-        set.spawn(cancel_one_agent(agent_addr, job_id, signal, term));
+        set.spawn(cancel_one_agent(
+            agent_addr,
+            job_id,
+            signal,
+            term,
+            run_attempt,
+        ));
     }
     while set.join_next().await.is_some() {}
 }
@@ -2112,6 +2140,7 @@ async fn cancel_one_agent(
     job_id: spur_core::job::JobId,
     signal: i32,
     term: u64,
+    run_attempt: u32,
 ) {
     let attempt = async {
         match SlurmAgentClient::connect(agent_addr.clone())
@@ -2126,6 +2155,7 @@ async fn cancel_one_agent(
                         job_id,
                         signal,
                         term,
+                        run_attempt,
                     })
                     .await
                 {

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -307,6 +307,9 @@ async fn process_assignment(
     }
 
     if spec.srun_job && srun_step_dispatch {
+        // Same one-shot read as the batch path below: this iteration is the
+        // only place that can advance a Pending job's run_attempt.
+        let prospective_run_attempt = job.run_attempt.saturating_add(1);
         match register_allocation_on_nodes(
             cluster.clone(),
             job_id,
@@ -314,6 +317,7 @@ async fn process_assignment(
             &spec,
             per_node_allocs.clone(),
             allocated_nodelist.clone(),
+            prospective_run_attempt,
         )
         .await
         {
@@ -1102,6 +1106,7 @@ struct AllocationRegisterParams {
     allocated_nodelist: String,
     allocated: spur_core::resource::ResourceAllocations,
     work_dir: String,
+    run_attempt: u32,
 }
 
 /// Register a srun-only allocation on a node agent without launching a batch process.
@@ -1133,6 +1138,7 @@ async fn register_allocation_to_agent(
             mpi: params.mpi.clone(),
             work_dir: params.work_dir.clone(),
             user: params.user.clone(),
+            run_attempt: params.run_attempt,
         })
         .await?;
 
@@ -1153,6 +1159,7 @@ async fn register_allocation_on_nodes(
     spec: &spur_core::job::JobSpec,
     per_node_allocs: std::collections::HashMap<String, spur_core::resource::ResourceAllocations>,
     allocated_nodelist: String,
+    run_attempt: u32,
 ) -> AllocationRegisterOutcome {
     let mut successes = 0u32;
     let mut failures = 0u32;
@@ -1198,6 +1205,7 @@ async fn register_allocation_on_nodes(
             allocated_nodelist: allocated_nodelist.clone(),
             allocated,
             work_dir: spec.work_dir.clone(),
+            run_attempt,
         };
         set.spawn(async move {
             let result = register_allocation_to_agent(&agent_addr, &params).await;

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -638,9 +638,13 @@ pub(crate) async fn try_preempt(
                 mode = ?mode,
                 "preempting lower-priority job"
             );
+            // Reserve before the free lands whenever this mode will kill, so the
+            // scheduler never sees a window where resources look free early.
+            if matches!(mode, PreemptMode::Cancel | PreemptMode::Requeue) {
+                crate::server::note_pending_kill_for_job(cluster, candidate);
+            }
             match cluster.preempt_job(candidate.job_id, mode) {
                 Ok(PreemptOutcome::Killed) => {
-                    crate::server::note_pending_kill_for_job(cluster, candidate);
                     // Signal 0 = graceful cancel (SIGTERM then SIGKILL).
                     send_cancel_to_agents(cluster, candidate, 0).await;
                 }
@@ -1760,13 +1764,15 @@ async fn enforce_time_limits(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>
                 "grace period expired — force-killing job"
             );
 
+            // Reserve before the free, so the scheduler never sees the gap
+            // where resources look free but the agent hasn't been told.
+            crate::server::note_pending_kill_for_job(&cluster, job);
             if let Err(e) = cluster.complete_job(job.job_id, -1, spur_core::job::JobState::Timeout)
             {
                 warn!(job_id = job.job_id, error = %e, "failed to mark job as timed out");
                 continue;
             }
 
-            crate::server::note_pending_kill_for_job(&cluster, job);
             send_cancel_to_agents(&cluster, job, 9).await; // SIGKILL
         }
     }
@@ -4432,8 +4438,9 @@ mod tests {
         async fn pending_kill_reservation_inflates_node_alloc_resources() {
             let dir = TempDir::new().unwrap();
             let cm = test_cluster(&dir).await;
-            register_node_at(&cm, "n1", unreachable_addr().await);
-            register_node_at(&cm, "n2", unreachable_addr().await);
+            let placeholder: std::net::SocketAddr = "127.0.0.1:1".parse().unwrap();
+            register_node_at(&cm, "n1", placeholder);
+            register_node_at(&cm, "n2", placeholder);
 
             let mut nodes: Vec<_> = ["n1", "n2"]
                 .iter()

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -6,16 +6,20 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use chrono::Utc;
+use prost::Message;
 use tracing::{debug, error, info, warn};
 
+use spur_core::allocation::{
+    AgentCommandKind as CoreAgentCommandKind, AgentCommandRecord, AgentCommandState, AllocationKey,
+};
 use spur_core::node::{Node, NodeSource};
 use spur_core::partition::requested_partition_names;
 use spur_core::task_launch::batch_dispatched_multi_node_pmix;
 use spur_proto::proto::slurm_agent_client::SlurmAgentClient;
 use spur_proto::proto::slurm_controller_client::SlurmControllerClient;
 use spur_proto::proto::{
-    AgentCancelJobRequest, AgentSuspendJobRequest, JobSpec as ProtoJobSpec, LaunchJobRequest,
-    RegisterJobAllocationRequest, SubmitJobRequest,
+    AgentCancelJobRequest, AgentSuspendJobRequest, JobSpec as ProtoJobSpec, LaunchFailureKind,
+    LaunchJobRequest, LaunchJobResponse, RegisterJobAllocationRequest, SubmitJobRequest,
 };
 use spur_sched::backfill::{self, BackfillScheduler};
 use spur_sched::traits::{ClusterState, Scheduler};
@@ -28,6 +32,8 @@ use crate::raft::RaftHandle;
 /// awaits delivery. Best-effort cleanup must not stall eviction on an
 /// unreachable agent.
 const CANCEL_RPC_TIMEOUT: Duration = Duration::from_secs(5);
+const AGENT_COMMAND_ACK_TIMEOUT: Duration =
+    Duration::from_secs(crate::cluster::AGENT_COMMAND_ACK_TIMEOUT_SECS);
 
 fn node_comm_socket(node: &Node) -> Option<String> {
     let host = node.comm_addr()?;
@@ -37,22 +43,6 @@ fn node_comm_socket(node: &Node) -> Option<String> {
 fn node_comm_http_url(node: &Node) -> Option<String> {
     let host = node.comm_addr()?;
     Some(spur_net::format_comm_http_url(host, node.port))
-}
-
-/// Inflate each node's `alloc_resources` by its pending-kill amount, so a
-/// resource whose prior occupant's kill isn't confirmed released stays out.
-fn apply_pending_kill_reservations(
-    nodes: &mut [Node],
-    pending_kill: &std::collections::HashMap<String, spur_core::resource::ResourceAllocations>,
-) {
-    if pending_kill.is_empty() {
-        return;
-    }
-    for node in nodes {
-        if let Some(resources) = pending_kill.get(&node.name) {
-            node.alloc_resources.add(resources);
-        }
-    }
 }
 
 /// Spawn the time-limit enforcement watchdog and power manager alongside the scheduler loop.
@@ -136,6 +126,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
         // Finalize never-satisfiable deps before pending_jobs() so they drop
         // out of this cycle instead of sitting PENDING forever.
         cluster.cancel_unsatisfiable_dependency_jobs();
+        cluster.recover_incomplete_dispatches();
 
         // Free completed stage-in capacity before classification selects new
         // stage candidates. Real agent-side data movement is a follow-up;
@@ -147,9 +138,6 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
         }
         cluster.evict_expired_terminal_jobs();
 
-        // Held out of scheduling until a heartbeat confirms release.
-        let pending_kill = cluster.pending_kill_reservations();
-
         // Classify once, apply reasons, and stage only candidates admitted by
         // that classification. Run before the empty-check so reasons stay fresh
         // even with nothing schedulable.
@@ -159,7 +147,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
         }
         let hit_depth_limit = pending.len() > max_jobs;
 
-        let mut nodes = cluster.schedulable_nodes();
+        let nodes = cluster.schedulable_nodes();
         let partitions = cluster.get_partitions();
         let reservations = cluster.get_reservations();
 
@@ -167,9 +155,6 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
             debug!("no nodes registered, skipping scheduling cycle");
             continue;
         }
-
-        // A kill RPC can be lost, so don't trust alloc_resources alone here.
-        apply_pending_kill_reservations(&mut nodes, &pending_kill);
 
         let cycle_start = Instant::now();
 
@@ -330,14 +315,19 @@ async fn process_assignment(
         }
     }
 
-    let dispatch_attempt = match cluster.begin_dispatch_attempt(job_id) {
+    let dispatch_attempt = match cluster.prepare_dispatch(
+        job_id,
+        assignment.nodes.clone(),
+        resources.clone(),
+        assignment.per_node_alloc.clone(),
+        srun_step_dispatch,
+    ) {
         Ok(attempt) => attempt,
         Err(e) => {
-            debug!(job_id, error = %e, "job left Pending before dispatch");
+            debug!(job_id, error = %e, "job could not prepare durable dispatch");
             return false;
         }
     };
-
     if spec.srun_job && srun_step_dispatch {
         match register_allocation_on_nodes(
             cluster.clone(),
@@ -350,33 +340,23 @@ async fn process_assignment(
         )
         .await
         {
-            AllocationRegisterOutcome::AllFailed => {
-                if let Err(e) = cluster.reserve_pending_dispatch(
-                    job_id,
-                    &dispatch_nodes,
-                    &per_node_allocs,
-                    dispatch_attempt,
-                ) {
+            AllocationRegisterOutcome::AllFailed { cleanup_nodes } => {
+                if let Err(e) = cluster.abort_dispatch(job_id, dispatch_attempt, &cleanup_nodes) {
                     error!(job_id, error = %e, "failed to reserve failed registration cleanup");
                     return false;
                 }
-                cancel_job_on_nodes(&cluster, job_id, &dispatch_nodes, 9, dispatch_attempt).await;
+                cancel_job_on_nodes(&cluster, job_id, &cleanup_nodes, 9, dispatch_attempt).await;
                 if let Err(e) = cluster.requeue_job(job_id) {
                     error!(job_id, error = %e, "failed to requeue after registration failure");
                 }
                 return false;
             }
-            AllocationRegisterOutcome::PartialFailed { succeeded_nodes } => {
-                if let Err(e) = cluster.reserve_pending_dispatch(
-                    job_id,
-                    &succeeded_nodes,
-                    &per_node_allocs,
-                    dispatch_attempt,
-                ) {
+            AllocationRegisterOutcome::PartialFailed { cleanup_nodes } => {
+                if let Err(e) = cluster.abort_dispatch(job_id, dispatch_attempt, &cleanup_nodes) {
                     error!(job_id, error = %e, "failed to reserve partial registration cleanup");
                     return false;
                 }
-                cancel_job_on_nodes(&cluster, job_id, &succeeded_nodes, 9, dispatch_attempt).await;
+                cancel_job_on_nodes(&cluster, job_id, &cleanup_nodes, 9, dispatch_attempt).await;
                 if let Err(e) = cluster.requeue_job(job_id) {
                     error!(job_id, error = %e, "failed to requeue after partial registration");
                 }
@@ -402,6 +382,9 @@ async fn process_assignment(
                     node = %name,
                     "node missing while building peer list"
                 );
+                if let Err(error) = cluster.abort_dispatch(job_id, dispatch_attempt, &[]) {
+                    error!(job_id, error = %error, "failed to abort unstarted dispatch");
+                }
                 return false;
             };
             let Some(addr) = node_comm_socket(&n) else {
@@ -410,6 +393,9 @@ async fn process_assignment(
                     node = %name,
                     "no comm address for peer list"
                 );
+                if let Err(error) = cluster.abort_dispatch(job_id, dispatch_attempt, &[]) {
+                    error!(job_id, error = %error, "failed to abort unstarted dispatch");
+                }
                 return false;
             };
             addrs.push(addr);
@@ -494,12 +480,7 @@ async fn process_assignment(
         // start_job failure here (e.g. the job was cancelled out from
         // under us between assignment and this point) doesn't leave
         // orphans.
-        if let Err(hold_err) = cluster.reserve_pending_dispatch(
-            job_id,
-            &dispatch_nodes,
-            &per_node_allocs,
-            dispatch_attempt,
-        ) {
+        if let Err(hold_err) = cluster.abort_dispatch(job_id, dispatch_attempt, &dispatch_nodes) {
             error!(job_id, error = %hold_err, "failed to reserve failed-dispatch cleanup");
             return false;
         }
@@ -922,6 +903,8 @@ enum DispatchError {
     /// The agent rejected the dispatch because the controller-allocated resources
     /// are already in use locally — the controller's view of this node is stale.
     ResourcesUnavailable,
+    /// The request may have reached the agent, but no definitive response arrived.
+    DeliveryUncertain(anyhow::Error),
     Other(anyhow::Error),
 }
 
@@ -932,9 +915,20 @@ impl std::fmt::Display for DispatchError {
             Self::ResourcesUnavailable => {
                 write!(f, "agent rejected job: allocated resources unavailable")
             }
+            Self::DeliveryUncertain(e) => write!(f, "agent delivery outcome is unknown: {e:#}"),
             Self::Other(e) => write!(f, "{e:#}"),
         }
     }
+}
+
+fn delivery_outcome_is_uncertain(status: &tonic::Status) -> bool {
+    matches!(
+        status.code(),
+        tonic::Code::Cancelled
+            | tonic::Code::Unknown
+            | tonic::Code::DeadlineExceeded
+            | tonic::Code::Unavailable
+    )
 }
 
 impl<E: Into<anyhow::Error>> From<E> for DispatchError {
@@ -943,16 +937,7 @@ impl<E: Into<anyhow::Error>> From<E> for DispatchError {
     }
 }
 
-/// Send a LaunchJob RPC to a node agent.
-async fn dispatch_to_agent(
-    agent_addr: &str,
-    params: &AgentDispatchParams<'_>,
-) -> Result<LaunchOutcome, DispatchError> {
-    let mut client = SlurmAgentClient::connect(agent_addr.to_string())
-        .await?
-        .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
-        .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE);
-
+fn build_launch_request(params: &AgentDispatchParams<'_>) -> anyhow::Result<LaunchJobRequest> {
     let spec = params.spec;
 
     // The scheduler distributes GPUs per node (a --gpus total may be uneven
@@ -1068,26 +1053,40 @@ async fn dispatch_to_agent(
         initial_winsize: None,
     };
 
+    Ok(LaunchJobRequest {
+        job_id: params.job_id,
+        spec: Some(proto_spec),
+        allocated: Some(crate::server::allocations_to_proto(params.allocated)),
+        peer_nodes: params.peer_nodes.to_vec(),
+        task_offset: params.task_offset,
+        target_node: params.target_node.to_string(),
+        array_job_id: spec.array_job_id.unwrap_or(0),
+        array_task_id: spec.array_task_id.unwrap_or(0),
+        run_attempt: params.run_attempt,
+        pmix_plan,
+        task_fanout: params.task_fanout,
+        pmix_prepared: params.pmix_prepared,
+        term: params.term,
+    })
+}
+
+/// Send a LaunchJob RPC to a node agent.
+async fn dispatch_to_agent(
+    agent_addr: &str,
+    params: &AgentDispatchParams<'_>,
+) -> Result<LaunchOutcome, DispatchError> {
+    let mut client = SlurmAgentClient::connect(agent_addr.to_string())
+        .await
+        .map_err(DispatchError::from)?
+        .max_decoding_message_size(spur_proto::MAX_GRPC_MESSAGE_SIZE)
+        .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE);
+
     let response = client
-        .launch_job(LaunchJobRequest {
-            job_id: params.job_id,
-            spec: Some(proto_spec),
-            allocated: Some(crate::server::allocations_to_proto(params.allocated)),
-            peer_nodes: params.peer_nodes.to_vec(),
-            task_offset: params.task_offset,
-            target_node: params.target_node.to_string(),
-            // Controller-assigned at array expansion; consumed agent-side.
-            array_job_id: spec.array_job_id.unwrap_or(0),
-            array_task_id: spec.array_task_id.unwrap_or(0),
-            run_attempt: params.run_attempt,
-            pmix_plan,
-            task_fanout: params.task_fanout,
-            pmix_prepared: params.pmix_prepared,
-            term: params.term,
-        })
+        .launch_job(build_launch_request(params)?)
         .await
         .map_err(|s| match s.code() {
             tonic::Code::ResourceExhausted => DispatchError::ResourcesUnavailable,
+            _ if delivery_outcome_is_uncertain(&s) => DispatchError::DeliveryUncertain(s.into()),
             _ => DispatchError::Other(s.into()),
         })?;
 
@@ -1145,8 +1144,8 @@ fn build_pmix_plan_proto(
 /// Outcome of parallel RegisterJobAllocation RPCs for a standalone srun job.
 pub(crate) enum AllocationRegisterOutcome {
     AllSucceeded,
-    AllFailed,
-    PartialFailed { succeeded_nodes: Vec<String> },
+    AllFailed { cleanup_nodes: Vec<String> },
+    PartialFailed { cleanup_nodes: Vec<String> },
 }
 
 /// Parameters for registering a srun-only allocation on a single node agent.
@@ -1164,6 +1163,132 @@ struct AllocationRegisterParams {
     term: u64,
 }
 
+fn build_register_allocation_request(
+    params: &AllocationRegisterParams,
+) -> RegisterJobAllocationRequest {
+    RegisterJobAllocationRequest {
+        job_id: params.job_id,
+        partition: params.partition.clone(),
+        nodelist: params.allocated_nodelist.clone(),
+        uid: params.uid,
+        gid: params.gid,
+        cpus: params.allocated.cpus,
+        memory_mb: params.allocated.memory_mb,
+        gpu_devices: params
+            .allocated
+            .device_ids("gpu")
+            .into_iter()
+            .map(|id| id.to_string())
+            .collect(),
+        allocated: Some(crate::server::allocations_to_proto(&params.allocated)),
+        mpi: params.mpi.clone(),
+        work_dir: params.work_dir.clone(),
+        user: params.user.clone(),
+        run_attempt: params.run_attempt,
+        term: params.term,
+    }
+}
+
+pub(crate) fn durable_agent_command_payload(
+    cluster: &ClusterManager,
+    command: &AgentCommandRecord,
+) -> anyhow::Result<Vec<u8>> {
+    let job = cluster
+        .get_job(command.key.job_id)
+        .ok_or_else(|| anyhow::anyhow!("job {} no longer exists", command.key.job_id))?;
+    if job.run_attempt != command.key.run_attempt {
+        anyhow::bail!("agent command targets a superseded run");
+    }
+    let allocated = job
+        .per_node_alloc
+        .get(&command.key.node)
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("command node has no allocation slice"))?;
+    let term = cluster.current_term();
+
+    match command.kind {
+        CoreAgentCommandKind::Launch => {
+            let node_index = job
+                .allocated_nodes
+                .iter()
+                .position(|node| node == &command.key.node)
+                .ok_or_else(|| anyhow::anyhow!("command node is not in the allocation"))?;
+            let peer_nodes = job
+                .allocated_nodes
+                .iter()
+                .map(|name| {
+                    cluster
+                        .get_node(name)
+                        .and_then(|node| node_comm_socket(&node))
+                        .ok_or_else(|| anyhow::anyhow!("node {name} has no communication address"))
+                })
+                .collect::<anyhow::Result<Vec<_>>>()?;
+            let peer_hosts = job
+                .allocated_nodes
+                .iter()
+                .map(|name| {
+                    cluster
+                        .get_node(name)
+                        .and_then(|node| node.comm_addr().map(str::to_string))
+                        .ok_or_else(|| anyhow::anyhow!("node {name} has no communication host"))
+                })
+                .collect::<anyhow::Result<Vec<_>>>()?;
+            let tasks_per_node = job
+                .spec
+                .tasks_per_node
+                .unwrap_or_else(|| (job.spec.num_tasks / job.spec.num_nodes.max(1)).max(1));
+            let mut spec = job.spec.clone();
+            let task_fanout = spec.srun_job;
+            if task_fanout {
+                spec.srun_job = false;
+            }
+            let config = cluster.config();
+            let pmix_prepared = batch_dispatched_multi_node_pmix(
+                spec.mpi.as_deref(),
+                spec.num_nodes,
+                spec.script.as_deref(),
+            );
+            let request = build_launch_request(&AgentDispatchParams {
+                job_id: job.job_id,
+                spec: &spec,
+                peer_nodes: &peer_nodes,
+                peer_hosts: &peer_hosts,
+                node_index: node_index as u32,
+                task_offset: node_index as u32 * tasks_per_node,
+                target_node: &command.key.node,
+                allocated: &allocated,
+                allocated_nodelist: &job.allocated_nodes.join(","),
+                run_attempt: job.run_attempt,
+                term,
+                pmix_tmpdir: &config.mpi.pmix_tmpdir,
+                task_fanout,
+                modex_connect_timeout_secs: config.mpi.modex_connect_timeout_secs,
+                modex_fence_timeout_secs: config.mpi.modex_fence_timeout_secs,
+                modex_verify_timeout_secs: config.mpi.modex_verify_timeout_secs,
+                pmix_prepared,
+            })?;
+            Ok(request.encode_to_vec())
+        }
+        CoreAgentCommandKind::Register => {
+            let request = build_register_allocation_request(&AllocationRegisterParams {
+                job_id: job.job_id,
+                partition: job.spec.partition.clone().unwrap_or_default(),
+                uid: job.spec.uid,
+                gid: job.spec.gid,
+                user: job.spec.user.clone(),
+                mpi: job.spec.mpi.clone().unwrap_or_default(),
+                allocated_nodelist: job.allocated_nodes.join(","),
+                allocated,
+                work_dir: job.spec.work_dir.clone(),
+                run_attempt: job.run_attempt,
+                term,
+            });
+            Ok(request.encode_to_vec())
+        }
+        CoreAgentCommandKind::Release => Ok(Vec::new()),
+    }
+}
+
 /// Register a srun-only allocation on a node agent without launching a batch process.
 async fn register_allocation_to_agent(
     agent_addr: &str,
@@ -1175,30 +1300,11 @@ async fn register_allocation_to_agent(
         .max_encoding_message_size(spur_proto::MAX_GRPC_REQUEST_SIZE);
 
     client
-        .register_job_allocation(RegisterJobAllocationRequest {
-            job_id: params.job_id,
-            partition: params.partition.clone(),
-            nodelist: params.allocated_nodelist.clone(),
-            uid: params.uid,
-            gid: params.gid,
-            cpus: params.allocated.cpus,
-            memory_mb: params.allocated.memory_mb,
-            gpu_devices: params
-                .allocated
-                .device_ids("gpu")
-                .into_iter()
-                .map(|id| id.to_string())
-                .collect(),
-            allocated: Some(crate::server::allocations_to_proto(&params.allocated)),
-            mpi: params.mpi.clone(),
-            work_dir: params.work_dir.clone(),
-            user: params.user.clone(),
-            run_attempt: params.run_attempt,
-            term: params.term,
-        })
+        .register_job_allocation(build_register_allocation_request(params))
         .await
         .map_err(|s| match s.code() {
             tonic::Code::ResourceExhausted => DispatchError::ResourcesUnavailable,
+            _ if delivery_outcome_is_uncertain(&s) => DispatchError::DeliveryUncertain(s.into()),
             _ => DispatchError::Other(s.into()),
         })?;
 
@@ -1208,6 +1314,31 @@ async fn register_allocation_to_agent(
     );
 
     Ok(())
+}
+
+async fn wait_for_agent_commands(
+    cluster: &ClusterManager,
+    command_ids: &[u64],
+) -> Option<Vec<spur_core::allocation::AgentCommandRecord>> {
+    let wait = async {
+        loop {
+            let commands = cluster.agent_commands(command_ids);
+            if commands.len() == command_ids.len()
+                && commands
+                    .iter()
+                    .all(|command| command.state != AgentCommandState::Pending)
+            {
+                return commands;
+            }
+            tokio::select! {
+                _ = cluster.wait_for_agent_command_update() => {}
+                _ = tokio::time::sleep(Duration::from_millis(50)) => {}
+            }
+        }
+    };
+    tokio::time::timeout(AGENT_COMMAND_ACK_TIMEOUT, wait)
+        .await
+        .ok()
 }
 
 /// Register a srun-only allocation on every assigned node.
@@ -1223,11 +1354,74 @@ async fn register_allocation_on_nodes(
 ) -> AllocationRegisterOutcome {
     let mut successes = 0u32;
     let mut failures = 0u32;
-    let mut succeeded_nodes: Vec<String> = Vec::new();
+    let mut cleanup_nodes: Vec<String> = Vec::new();
     let total = dispatch_nodes.len() as u32;
     let term = cluster.current_term();
 
+    if dispatch_nodes
+        .iter()
+        .all(|node| cluster.node_supports_command_polling(node))
+    {
+        let commands: Vec<_> = dispatch_nodes
+            .iter()
+            .map(|node_name| {
+                (
+                    AllocationKey::new(job_id, run_attempt, node_name.clone()),
+                    CoreAgentCommandKind::Register,
+                    Vec::new(),
+                )
+            })
+            .collect();
+        let committed = match cluster.begin_allocation_launch_commands(
+            job_id,
+            run_attempt,
+            commands,
+        ) {
+            Ok(commands) => commands,
+            Err(error) => {
+                error!(job_id, error = %error, "failed to commit allocation registration commands");
+                return AllocationRegisterOutcome::AllFailed {
+                    cleanup_nodes: Vec::new(),
+                };
+            }
+        };
+        let command_ids: Vec<_> = committed.iter().map(|command| command.command_id).collect();
+        let Some(results) = wait_for_agent_commands(&cluster, &command_ids).await else {
+            error!(
+                job_id,
+                "timed out waiting for allocation registration acknowledgements"
+            );
+            return AllocationRegisterOutcome::AllFailed {
+                cleanup_nodes: dispatch_nodes,
+            };
+        };
+        let succeeded_nodes: Vec<_> = results
+            .iter()
+            .filter(|command| command.state == AgentCommandState::Succeeded)
+            .map(|command| command.key.node.clone())
+            .collect();
+        if succeeded_nodes.len() == dispatch_nodes.len() {
+            return AllocationRegisterOutcome::AllSucceeded;
+        }
+        if succeeded_nodes.is_empty() {
+            return AllocationRegisterOutcome::AllFailed {
+                cleanup_nodes: Vec::new(),
+            };
+        }
+        return AllocationRegisterOutcome::PartialFailed {
+            cleanup_nodes: succeeded_nodes,
+        };
+    }
+
+    if let Err(error) = cluster.begin_allocation_launch(job_id, run_attempt) {
+        error!(job_id, error = %error, "failed to commit legacy allocation registration intent");
+        return AllocationRegisterOutcome::AllFailed {
+            cleanup_nodes: Vec::new(),
+        };
+    }
+
     let mut set = tokio::task::JoinSet::new();
+    let mut attempted_nodes = Vec::new();
     for node_name in &dispatch_nodes {
         let node_info = cluster.get_node(node_name);
         let agent_addr = match node_info {
@@ -1255,6 +1449,7 @@ async fn register_allocation_on_nodes(
         };
 
         let result_node = node_name.clone();
+        attempted_nodes.push(result_node.clone());
         let allocated = per_node_allocs.get(node_name).cloned().unwrap_or_default();
         let params = AllocationRegisterParams {
             job_id,
@@ -1279,7 +1474,7 @@ async fn register_allocation_on_nodes(
         match result {
             Ok((node_name, Ok(()))) => {
                 successes += 1;
-                succeeded_nodes.push(node_name);
+                cleanup_nodes.push(node_name);
             }
             Ok((node_name, Err(e))) => {
                 error!(
@@ -1288,13 +1483,17 @@ async fn register_allocation_on_nodes(
                     error = %e,
                     "allocation registration on agent failed"
                 );
-                if matches!(e, DispatchError::ResourcesUnavailable) {
+                if matches!(&e, DispatchError::ResourcesUnavailable) {
                     cluster.cool_down_node(&node_name);
+                }
+                if matches!(&e, DispatchError::DeliveryUncertain(_)) {
+                    cleanup_nodes.push(node_name);
                 }
                 failures += 1;
             }
             Err(e) => {
                 error!(job_id, error = %e, "allocation registration task panicked");
+                cleanup_nodes = attempted_nodes.clone();
                 failures += 1;
             }
         }
@@ -1302,13 +1501,13 @@ async fn register_allocation_on_nodes(
 
     if successes == 0 && total > 0 {
         error!(job_id, failures, "all allocation registrations failed");
-        AllocationRegisterOutcome::AllFailed
+        AllocationRegisterOutcome::AllFailed { cleanup_nodes }
     } else if failures > 0 {
         warn!(
             job_id,
             successes, failures, "partial allocation registration failure"
         );
-        AllocationRegisterOutcome::PartialFailed { succeeded_nodes }
+        AllocationRegisterOutcome::PartialFailed { cleanup_nodes }
     } else {
         AllocationRegisterOutcome::AllSucceeded
     }
@@ -1334,9 +1533,14 @@ enum DispatchConfirmOutcome {
 fn abort_pending_pmix_dispatch(
     cluster: &ClusterManager,
     job_id: spur_core::job::JobId,
+    run_attempt: u32,
     detail: String,
 ) -> DispatchConfirmOutcome {
     let _ = cluster.set_job_launch_failure_detail(job_id, detail);
+    if let Err(e) = cluster.abort_dispatch(job_id, run_attempt, &[]) {
+        error!(job_id, error = %e, "failed to abort PMIx dispatch");
+        return DispatchConfirmOutcome::Aborted;
+    }
     if let Err(e) = cluster.backoff_pending_job_after_dispatch_failure(job_id) {
         error!(job_id, error = %e, "failed to back off after PMIx dispatch failure");
     }
@@ -1407,7 +1611,7 @@ async fn confirm_dispatch_on_nodes(
 ) -> DispatchConfirmOutcome {
     let mut successes = 0u32;
     let mut failures = 0u32;
-    let mut succeeded_nodes: Vec<String> = Vec::new();
+    let mut cleanup_nodes: Vec<String> = Vec::new();
     let mut prolog_failed: Vec<(String, String)> = Vec::new();
     let total = dispatch_nodes.len() as u32;
 
@@ -1475,7 +1679,7 @@ async fn confirm_dispatch_on_nodes(
                 node_agents.len(),
                 dispatch_nodes.len()
             );
-            return abort_pending_pmix_dispatch(&cluster, job_id, detail);
+            return abort_pending_pmix_dispatch(&cluster, job_id, run_attempt, detail);
         }
 
         if let Some(detail) = pmix_dispatch::multi_node_pmix_unsupported(
@@ -1485,6 +1689,10 @@ async fn confirm_dispatch_on_nodes(
         ) {
             error!(job_id, "{detail}");
             let _ = cluster.set_job_launch_failure_detail(job_id, detail.clone());
+            if let Err(e) = cluster.abort_dispatch(job_id, run_attempt, &[]) {
+                error!(job_id, error = %e, "failed to abort unsupported PMIx dispatch");
+                return DispatchConfirmOutcome::Aborted;
+            }
             if let Err(e) = cluster.hold_job_for_launch_failure(job_id, Some(&detail)) {
                 error!(job_id, error = %e, "failed to hold job for unsupported multi-node PMIx");
             }
@@ -1506,6 +1714,7 @@ async fn confirm_dispatch_on_nodes(
                 allocated: &allocated,
                 allocated_nodelist: &allocated_nodelist,
                 run_attempt,
+                term,
                 pmix_tmpdir: &pmix_tmpdir,
                 task_fanout,
                 modex_connect_timeout_secs,
@@ -1518,12 +1727,12 @@ async fn confirm_dispatch_on_nodes(
                 Ok(None) => {
                     let detail = format!("job is not configured for PMIx on node {node_name}");
                     error!(job_id, node = %node_name, "{detail}");
-                    return abort_pending_pmix_dispatch(&cluster, job_id, detail);
+                    return abort_pending_pmix_dispatch(&cluster, job_id, run_attempt, detail);
                 }
                 Err(detail) => {
                     let detail = format!("invalid PMIx launch plan for node {node_name}: {detail}");
                     error!(job_id, node = %node_name, "{detail}");
-                    return abort_pending_pmix_dispatch(&cluster, job_id, detail);
+                    return abort_pending_pmix_dispatch(&cluster, job_id, run_attempt, detail);
                 }
             };
             prepare_nodes.push(PmixPrepareNode {
@@ -1540,6 +1749,7 @@ async fn confirm_dispatch_on_nodes(
             return abort_pending_pmix_dispatch(
                 &cluster,
                 job_id,
+                run_attempt,
                 format!("PMIx prepare failed: {detail}"),
             );
         }
@@ -1550,71 +1760,154 @@ async fn confirm_dispatch_on_nodes(
         ));
     }
 
-    let mut set = tokio::task::JoinSet::new();
-    for (node_idx, (node_name, agent_addr)) in node_agents.iter().enumerate() {
-        let spec = spec.clone();
-        let peer_addrs = peer_addrs.clone();
-        let peer_hosts = peer_hosts.clone();
-        let task_offset = node_idx as u32 * tasks_per_node;
-        let node_index = node_idx as u32;
-        let is_primary = task_offset == 0;
-        let target_node = node_name.clone();
-        let result_node = node_name.clone();
-        let allocated = per_node_allocs.get(node_name).cloned().unwrap_or_default();
-        let allocated_nodelist = allocated_nodelist.clone();
-        let pmix_tmpdir = pmix_tmpdir.clone();
-        let agent_addr = agent_addr.clone();
-        set.spawn(async move {
-            let result = dispatch_to_agent(
-                &agent_addr,
-                &AgentDispatchParams {
-                    job_id,
-                    spec: &spec,
-                    peer_nodes: &peer_addrs,
-                    peer_hosts: &peer_hosts,
-                    node_index,
-                    task_offset,
-                    target_node: &target_node,
-                    allocated: &allocated,
-                    allocated_nodelist: &allocated_nodelist,
-                    run_attempt,
-                    term,
-                    pmix_tmpdir: &pmix_tmpdir,
-                    task_fanout,
-                    modex_connect_timeout_secs,
-                    modex_fence_timeout_secs,
-                    modex_verify_timeout_secs,
-                    pmix_prepared: needs_pmix_prepare,
-                },
-            )
-            .await;
-            (result_node, is_primary, result)
-        });
-    }
-
-    while let Some(result) = set.join_next().await {
-        match result {
-            Ok((node_name, is_primary, Ok(outcome))) => {
-                successes += 1;
-                succeeded_nodes.push(node_name);
-                if is_primary {
-                    primary_outcome = Some(outcome);
-                }
-            }
-            Ok((node_name, _, Err(e))) => {
-                error!(job_id, node = %node_name, error = %e, "dispatch confirmation failed");
-                failures += 1;
-                match e {
-                    DispatchError::PrologFailed(reason) => {
-                        prolog_failed.push((node_name, reason));
+    let durable_delivery = failures == 0
+        && dispatch_nodes
+            .iter()
+            .all(|node| cluster.node_supports_command_polling(node));
+    if durable_delivery {
+        let commands: Vec<_> = dispatch_nodes
+            .iter()
+            .map(|node_name| {
+                (
+                    AllocationKey::new(job_id, run_attempt, node_name.clone()),
+                    CoreAgentCommandKind::Launch,
+                    Vec::new(),
+                )
+            })
+            .collect();
+        let committed =
+            match cluster.begin_allocation_launch_commands(job_id, run_attempt, commands) {
+                Ok(commands) => commands,
+                Err(error) => {
+                    error!(job_id, error = %error, "failed to commit launch commands");
+                    if let Err(abort_error) =
+                        cluster.abort_dispatch(job_id, run_attempt, &dispatch_nodes)
+                    {
+                        error!(job_id, error = %abort_error, "failed to abort uncertain dispatch");
                     }
-                    DispatchError::ResourcesUnavailable => cluster.cool_down_node(&node_name),
-                    DispatchError::Other(_) => {}
+                    return DispatchConfirmOutcome::Aborted;
+                }
+            };
+        let command_ids: Vec<_> = committed.iter().map(|command| command.command_id).collect();
+        let results = match wait_for_agent_commands(&cluster, &command_ids).await {
+            Some(results) => results,
+            None => {
+                warn!(
+                    job_id,
+                    "timed out waiting for durable launch acknowledgements"
+                );
+                cluster.agent_commands(&command_ids)
+            }
+        };
+        for result in results {
+            if result.state == AgentCommandState::Succeeded {
+                successes += 1;
+                cleanup_nodes.push(result.key.node.clone());
+                if result.key.node == dispatch_nodes[0] {
+                    if let Ok(response) =
+                        LaunchJobResponse::decode(result.response_payload.as_slice())
+                    {
+                        primary_outcome = Some(LaunchOutcome {
+                            stdout_path: response.stdout_path,
+                            stderr_path: response.stderr_path,
+                        });
+                    }
+                }
+                continue;
+            }
+
+            failures += 1;
+            if let Ok(response) = LaunchJobResponse::decode(result.response_payload.as_slice()) {
+                if response.failure_kind == LaunchFailureKind::LaunchFailureProlog as i32 {
+                    prolog_failed.push((result.key.node.clone(), response.error));
                 }
             }
-            Err(e) => {
-                error!(job_id, error = %e, "dispatch confirmation task panicked");
-                failures += 1;
+            error!(
+                job_id,
+                node = %result.key.node,
+                error = %result.error,
+                "durable dispatch command failed"
+            );
+        }
+        failures += total.saturating_sub(successes + failures);
+    } else {
+        if let Err(error) = cluster.begin_allocation_launch(job_id, run_attempt) {
+            error!(job_id, error = %error, "failed to commit legacy launch intent");
+            if let Err(abort_error) = cluster.abort_dispatch(job_id, run_attempt, &dispatch_nodes) {
+                error!(job_id, error = %abort_error, "failed to abort uncertain dispatch");
+            }
+            return DispatchConfirmOutcome::Aborted;
+        }
+        let mut set = tokio::task::JoinSet::new();
+        let mut attempted_nodes = Vec::new();
+        for (node_idx, (node_name, agent_addr)) in node_agents.iter().enumerate() {
+            let spec = spec.clone();
+            let peer_addrs = peer_addrs.clone();
+            let peer_hosts = peer_hosts.clone();
+            let task_offset = node_idx as u32 * tasks_per_node;
+            let node_index = node_idx as u32;
+            let is_primary = task_offset == 0;
+            let target_node = node_name.clone();
+            let result_node = node_name.clone();
+            attempted_nodes.push(result_node.clone());
+            let allocated = per_node_allocs.get(node_name).cloned().unwrap_or_default();
+            let allocated_nodelist = allocated_nodelist.clone();
+            let pmix_tmpdir = pmix_tmpdir.clone();
+            let agent_addr = agent_addr.clone();
+            set.spawn(async move {
+                let result = dispatch_to_agent(
+                    &agent_addr,
+                    &AgentDispatchParams {
+                        job_id,
+                        spec: &spec,
+                        peer_nodes: &peer_addrs,
+                        peer_hosts: &peer_hosts,
+                        node_index,
+                        task_offset,
+                        target_node: &target_node,
+                        allocated: &allocated,
+                        allocated_nodelist: &allocated_nodelist,
+                        run_attempt,
+                        term,
+                        pmix_tmpdir: &pmix_tmpdir,
+                        task_fanout,
+                        modex_connect_timeout_secs,
+                        modex_fence_timeout_secs,
+                        modex_verify_timeout_secs,
+                        pmix_prepared: needs_pmix_prepare,
+                    },
+                )
+                .await;
+                (result_node, is_primary, result)
+            });
+        }
+
+        while let Some(result) = set.join_next().await {
+            match result {
+                Ok((node_name, is_primary, Ok(outcome))) => {
+                    successes += 1;
+                    cleanup_nodes.push(node_name);
+                    if is_primary {
+                        primary_outcome = Some(outcome);
+                    }
+                }
+                Ok((node_name, _, Err(error))) => {
+                    error!(job_id, node = %node_name, error = %error, "dispatch confirmation failed");
+                    failures += 1;
+                    match error {
+                        DispatchError::PrologFailed(reason) => {
+                            prolog_failed.push((node_name, reason));
+                        }
+                        DispatchError::ResourcesUnavailable => cluster.cool_down_node(&node_name),
+                        DispatchError::DeliveryUncertain(_) => cleanup_nodes.push(node_name),
+                        DispatchError::Other(_) => {}
+                    }
+                }
+                Err(error) => {
+                    error!(job_id, error = %error, "dispatch confirmation task panicked");
+                    cleanup_nodes = attempted_nodes.clone();
+                    failures += 1;
+                }
             }
         }
     }
@@ -1650,15 +1943,17 @@ async fn confirm_dispatch_on_nodes(
     };
     let _ = cluster.set_job_launch_failure_detail(job_id, confirmation_detail.clone());
 
-    // Stop whatever DID launch (only succeeded_nodes hold anything) before the
-    // job settles back to Pending, or the launched process would be orphaned.
-    if let Err(e) =
-        cluster.reserve_pending_dispatch(job_id, &succeeded_nodes, &per_node_allocs, run_attempt)
-    {
+    if durable_delivery {
+        cleanup_nodes = dispatch_nodes.clone();
+    }
+
+    // A committed polled command or a direct RPC with a lost response may still
+    // mutate the agent after this decision, so both remain charged for cleanup.
+    if let Err(e) = cluster.abort_dispatch(job_id, run_attempt, &cleanup_nodes) {
         error!(job_id, error = %e, "failed to reserve aborted dispatch cleanup");
         return DispatchConfirmOutcome::Aborted;
     }
-    cancel_job_on_nodes(&cluster, job_id, &succeeded_nodes, 9, run_attempt).await;
+    cancel_job_on_nodes(&cluster, job_id, &cleanup_nodes, 9, run_attempt).await;
 
     // Drain before deciding the job's fate, so the failing node is already out
     // of the candidate set on the next scheduling attempt. The drain is issued
@@ -2121,6 +2416,11 @@ fn cancel_agent_addrs(
 ) -> Vec<String> {
     let mut addrs = Vec::with_capacity(node_names.len());
     for node_name in node_names {
+        if cluster.node_supports_command_polling(node_name)
+            && cluster.has_pending_kill(job_id, node_name)
+        {
+            continue;
+        }
         match cluster.get_node(node_name) {
             Some(ref n) => {
                 if let Some(url) = node_comm_http_url(n) {
@@ -2602,6 +2902,19 @@ mod tests {
         use spur_core::node::NodeSource;
         use std::sync::atomic::{AtomicU32, Ordering};
         use tempfile::TempDir;
+
+        #[test]
+        fn retryable_agent_status_has_an_uncertain_delivery_outcome() {
+            assert!(delivery_outcome_is_uncertain(&tonic::Status::unavailable(
+                "response lost"
+            )));
+            assert!(delivery_outcome_is_uncertain(
+                &tonic::Status::deadline_exceeded("response lost")
+            ));
+            assert!(!delivery_outcome_is_uncertain(
+                &tonic::Status::resource_exhausted("rejected")
+            ));
+        }
         use tonic::transport::server::TcpIncoming;
         use tonic::transport::Server;
 
@@ -2624,6 +2937,7 @@ mod tests {
             /// register_job_allocation returns a ResourceExhausted status,
             /// the srun/salloc equivalent of `reject_resources`.
             reject_registration: bool,
+            uncertain_registration: bool,
             /// Records each `LaunchJobRequest.task_fanout` this agent receives,
             /// so tests can assert on it without a real spurd behind the RPC.
             fanout_calls: Option<Arc<std::sync::Mutex<Vec<bool>>>>,
@@ -2755,6 +3069,9 @@ mod tests {
                     return Err(tonic::Status::resource_exhausted(
                         "controller-allocated resources unavailable on this node",
                     ));
+                }
+                if self.uncertain_registration {
+                    return Err(tonic::Status::unavailable("registration outcome lost"));
                 }
                 Ok(tonic::Response::new(Default::default()))
             }
@@ -2888,6 +3205,7 @@ mod tests {
                 launch_delay,
                 reject_resources: false,
                 reject_registration: false,
+                uncertain_registration: false,
                 fanout_calls: capture.then(|| fanout_calls.clone()),
             };
             tokio::spawn(async move {
@@ -2907,10 +3225,12 @@ mod tests {
             let addr = incoming.local_addr().unwrap();
             let agent = MockAgent {
                 cancel_calls: Arc::new(AtomicU32::new(0)),
+                release_pmix_calls: Arc::new(AtomicU32::new(0)),
                 reject_launch_as: None,
                 launch_delay: Duration::ZERO,
                 reject_resources: true,
                 reject_registration: false,
+                uncertain_registration: false,
                 fanout_calls: None,
             };
             tokio::spawn(async move {
@@ -2930,10 +3250,36 @@ mod tests {
             let addr = incoming.local_addr().unwrap();
             let agent = MockAgent {
                 cancel_calls: Arc::new(AtomicU32::new(0)),
+                release_pmix_calls: Arc::new(AtomicU32::new(0)),
                 reject_launch_as: None,
                 launch_delay: Duration::ZERO,
                 reject_resources: false,
                 reject_registration: true,
+                uncertain_registration: false,
+                fanout_calls: None,
+            };
+            tokio::spawn(async move {
+                let _ = Server::builder()
+                    .add_service(
+                        spur_proto::proto::slurm_agent_server::SlurmAgentServer::new(agent),
+                    )
+                    .serve_with_incoming(incoming)
+                    .await;
+            });
+            addr
+        }
+
+        async fn spawn_mock_agent_with_uncertain_registration() -> std::net::SocketAddr {
+            let incoming = TcpIncoming::bind("127.0.0.1:0".parse().unwrap()).unwrap();
+            let addr = incoming.local_addr().unwrap();
+            let agent = MockAgent {
+                cancel_calls: Arc::new(AtomicU32::new(0)),
+                release_pmix_calls: Arc::new(AtomicU32::new(0)),
+                reject_launch_as: None,
+                launch_delay: Duration::ZERO,
+                reject_resources: false,
+                reject_registration: false,
+                uncertain_registration: true,
                 fanout_calls: None,
             };
             tokio::spawn(async move {
@@ -3084,6 +3430,10 @@ mod tests {
                 version: String::new(),
                 labels: HashMap::new(),
                 source: NodeSource::NativeHost,
+                agent_session_id: String::new(),
+                node_boot_id: String::new(),
+                recovery_complete: true,
+                supports_command_polling: false,
             });
             let n = name.to_string();
             wait_for(
@@ -3586,6 +3936,68 @@ mod tests {
             let job_id = submit_and_wait(&cm, batch_spec("no-comm-addr", 1));
             let outcome = confirm_dispatch_pending_job(&cm, job_id, &["n1"]).await;
             assert!(matches!(outcome, DispatchConfirmOutcome::Aborted));
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn pmix_prelaunch_failure_releases_prepared_allocation() {
+            use spur_core::allocation::AllocationPhase;
+
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+
+            let (addr, _) = spawn_mock_agent().await;
+            register_node_at(&cm, "n1", addr);
+            register_node_without_comm_addr(&cm, "n2");
+
+            let mut spec = batch_spec("pmix-prelaunch-fail", 2);
+            spec.mpi = Some(spur_core::mpi::MPI_PMIX.into());
+            let job_id = submit_and_wait(&cm, spec.clone());
+            let nodes = vec!["n1".to_string(), "n2".to_string()];
+            let per_node_allocs = HashMap::from([
+                ("n1".into(), ResourceAllocations::with_scalar(1, 0)),
+                ("n2".into(), ResourceAllocations::with_scalar(1, 0)),
+            ]);
+            let run_attempt = cm
+                .prepare_dispatch(
+                    job_id,
+                    nodes.clone(),
+                    ResourceAllocations::with_scalar(2, 0),
+                    per_node_allocs.clone(),
+                    false,
+                )
+                .unwrap();
+
+            assert_eq!(cm.get_node("n1").unwrap().alloc_resources.cpus, 1);
+            assert_eq!(cm.get_node("n2").unwrap().alloc_resources.cpus, 1);
+
+            let outcome = confirm_dispatch_on_nodes(
+                cm.clone(),
+                job_id,
+                nodes,
+                spec,
+                Vec::new(),
+                per_node_allocs,
+                "n1,n2".into(),
+                1,
+                run_attempt,
+                false,
+            )
+            .await;
+
+            assert!(matches!(outcome, DispatchConfirmOutcome::Aborted));
+            let records = cm.allocation_records();
+            assert!(records
+                .values()
+                .filter(|record| {
+                    record.key.job_id == job_id && record.key.run_attempt == run_attempt
+                })
+                .all(|record| record.phase == AllocationPhase::Released));
+            assert_eq!(cm.get_node("n1").unwrap().alloc_resources.cpus, 0);
+            assert_eq!(cm.get_node("n2").unwrap().alloc_resources.cpus, 0);
+            let job = cm.get_job(job_id).unwrap();
+            assert!(job.allocated_nodes.is_empty());
+            assert!(job.allocated_resources.is_none());
+            assert!(job.per_node_alloc.is_empty());
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -4220,8 +4632,7 @@ mod tests {
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-        async fn process_assignment_cancels_dispatched_nodes_when_start_job_fails_after_confirmation(
-        ) {
+        async fn process_assignment_rejects_incomplete_allocation_before_dispatch() {
             use spur_core::job::JobState;
 
             let dir = TempDir::new().unwrap();
@@ -4233,15 +4644,6 @@ mod tests {
 
             let job_id = submit_and_wait(&cm, batch_spec("start-job-inconsistent", 2));
 
-            // A malformed assignment: confirm_dispatch_on_nodes tolerates a
-            // missing per_node_alloc entry (falls back to a default
-            // allocation), but start_job validates every assigned node has
-            // one and rejects the whole call otherwise. This is what a
-            // scheduler/assignment bug producing inconsistent data — or the
-            // job being touched by another path between assignment and this
-            // call — looks like from here: both nodes already launched real
-            // work by the time start_job is rejected, so both must be torn
-            // back down rather than left running under a job stuck Pending.
             let mut bad_assignment = assignment(job_id, &["n1", "n2"]);
             bad_assignment.per_node_alloc.remove("n2");
 
@@ -4254,15 +4656,17 @@ mod tests {
             assert_eq!(
                 cm.get_job(job_id).unwrap().state,
                 JobState::Pending,
-                "a start_job failure must not leave the job Running with no confirmed nodes"
+                "an invalid assignment must leave the job Pending"
             );
-            wait_for(
-                "n1 cancelled after start_job rejected the assignment",
-                || cancel1.load(Ordering::SeqCst) >= 1,
+            assert_eq!(
+                cancel1.load(Ordering::SeqCst),
+                0,
+                "validation must reject before mutating n1"
             );
-            wait_for(
-                "n2 cancelled after start_job rejected the assignment",
-                || cancel2.load(Ordering::SeqCst) >= 1,
+            assert_eq!(
+                cancel2.load(Ordering::SeqCst),
+                0,
+                "validation must reject before mutating n2"
             );
         }
 
@@ -4469,11 +4873,42 @@ mod tests {
                 0,
             )
             .await;
-            assert!(matches!(outcome, AllocationRegisterOutcome::AllFailed));
+            assert!(matches!(
+                outcome,
+                AllocationRegisterOutcome::AllFailed { .. }
+            ));
             assert!(
                 cm.nodes_on_dispatch_cooldown().contains("n1"),
                 "a resources-unavailable reject on the srun registration path must cool the node too"
             );
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn uncertain_registration_remains_reserved_for_cleanup() {
+            let dir = TempDir::new().unwrap();
+            let cm = test_cluster(&dir).await;
+
+            let addr = spawn_mock_agent_with_uncertain_registration().await;
+            register_node_at(&cm, "n1", addr);
+
+            let mut spec = batch_spec("srun-uncertain-registration", 1);
+            spec.srun_job = true;
+            let job_id = submit_and_wait(&cm, spec.clone());
+            let outcome = register_allocation_on_nodes(
+                cm,
+                job_id,
+                vec!["n1".into()],
+                &spec,
+                HashMap::from([("n1".into(), ResourceAllocations::with_scalar(4, 8000))]),
+                "n1".into(),
+                0,
+            )
+            .await;
+
+            let AllocationRegisterOutcome::AllFailed { cleanup_nodes } = outcome else {
+                panic!("expected AllFailed");
+            };
+            assert_eq!(cleanup_nodes, vec!["n1".to_string()]);
         }
 
         // A partial registration failure must report only the nodes that
@@ -4496,6 +4931,15 @@ mod tests {
                 ("n1".into(), ResourceAllocations::with_scalar(4, 8000)),
                 ("n2".into(), ResourceAllocations::with_scalar(4, 8000)),
             ]);
+            let run_attempt = cm
+                .prepare_dispatch(
+                    job_id,
+                    vec!["n1".into(), "n2".into()],
+                    ResourceAllocations::with_scalar(8, 16000),
+                    per_node_allocs.clone(),
+                    true,
+                )
+                .unwrap();
             let outcome = register_allocation_on_nodes(
                 cm.clone(),
                 job_id,
@@ -4503,15 +4947,15 @@ mod tests {
                 &spec,
                 per_node_allocs.clone(),
                 "n1,n2".into(),
-                0,
+                run_attempt,
             )
             .await;
-            let AllocationRegisterOutcome::PartialFailed { succeeded_nodes } = outcome else {
+            let AllocationRegisterOutcome::PartialFailed { cleanup_nodes } = outcome else {
                 panic!("expected PartialFailed");
             };
-            assert_eq!(succeeded_nodes, vec!["n1".to_string()]);
+            assert_eq!(cleanup_nodes, vec!["n1".to_string()]);
 
-            cm.reserve_pending_dispatch(job_id, &succeeded_nodes, &per_node_allocs, 0)
+            cm.abort_dispatch(job_id, run_attempt, &cleanup_nodes)
                 .unwrap();
             let reserved = cm.pending_kill_reservations();
             assert!(
@@ -4521,36 +4965,6 @@ mod tests {
             assert!(
                 !reserved.contains_key("n2"),
                 "a node that never registered anything must not be held"
-            );
-        }
-
-        // A pending-kill reservation must not look free to the scheduler.
-        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-        async fn pending_kill_reservation_inflates_node_alloc_resources() {
-            let dir = TempDir::new().unwrap();
-            let cm = test_cluster(&dir).await;
-            let placeholder: std::net::SocketAddr = "127.0.0.1:1".parse().unwrap();
-            register_node_at(&cm, "n1", placeholder);
-            register_node_at(&cm, "n2", placeholder);
-
-            let mut nodes: Vec<_> = ["n1", "n2"]
-                .iter()
-                .map(|n| cm.get_node(n).unwrap())
-                .collect();
-            assert_eq!(nodes[0].alloc_resources.cpus, 0);
-
-            let mut pending_kill = std::collections::HashMap::new();
-            pending_kill.insert("n1".to_string(), ResourceAllocations::with_scalar(2, 4000));
-
-            apply_pending_kill_reservations(&mut nodes, &pending_kill);
-
-            assert_eq!(
-                nodes[0].alloc_resources.cpus, 2,
-                "n1 inflated by its pending-kill reservation"
-            );
-            assert_eq!(
-                nodes[1].alloc_resources.cpus, 0,
-                "n2 has no pending-kill entry, untouched"
             );
         }
     }

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -39,9 +39,8 @@ fn node_comm_http_url(node: &Node) -> Option<String> {
     Some(spur_net::format_comm_http_url(host, node.port))
 }
 
-/// Inflate each node's `alloc_resources` by any pending-kill amount for it, so
-/// the scheduler doesn't place a new job on a resource whose prior occupant's
-/// kill hasn't been confirmed released yet.
+/// Inflate each node's `alloc_resources` by its pending-kill amount, so a
+/// resource whose prior occupant's kill isn't confirmed released stays out.
 fn apply_pending_kill_reservations(
     nodes: &mut [Node],
     pending_kill: &std::collections::HashMap<String, spur_core::resource::ResourceAllocations>,
@@ -146,8 +145,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
         cluster.enforce_reservation_end_times();
         cluster.evict_expired_terminal_jobs();
 
-        // Pruned on every read regardless of whether this cycle schedules
-        // anything, so an idle cluster doesn't accumulate expired entries.
+        // Pruned on every read so an idle cluster doesn't accumulate expired entries.
         let pending_kill = cluster.pending_kill_reservations();
 
         // Classify once, apply reasons, and stage only candidates admitted by
@@ -168,9 +166,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
             continue;
         }
 
-        // Keep a resource excluded from placement until the agent confirms it
-        // released a cancelled/evicted job, even though the controller's own
-        // alloc_resources already counts it free — a kill RPC can be lost.
+        // A kill RPC can be lost, so don't trust alloc_resources alone here.
         apply_pending_kill_reservations(&mut nodes, &pending_kill);
 
         let cycle_start = Instant::now();
@@ -4354,9 +4350,7 @@ mod tests {
             );
         }
 
-        // A node with a pending-kill reservation must not look free to the
-        // scheduler even though `alloc_resources` itself already shows it as
-        // free — the whole point of the confirm-before-free gate.
+        // A pending-kill reservation must not look free to the scheduler.
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn pending_kill_reservation_inflates_node_alloc_resources() {
             let dir = TempDir::new().unwrap();

--- a/crates/spurctld/src/scheduler_loop.rs
+++ b/crates/spurctld/src/scheduler_loop.rs
@@ -146,6 +146,10 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
         cluster.enforce_reservation_end_times();
         cluster.evict_expired_terminal_jobs();
 
+        // Pruned on every read regardless of whether this cycle schedules
+        // anything, so an idle cluster doesn't accumulate expired entries.
+        let pending_kill = cluster.pending_kill_reservations();
+
         // Classify once, apply reasons, and stage only candidates admitted by
         // that classification. Run before the empty-check so reasons stay fresh
         // even with nothing schedulable.
@@ -167,7 +171,7 @@ pub async fn run(cluster: Arc<ClusterManager>, raft: Arc<RaftHandle>) {
         // Keep a resource excluded from placement until the agent confirms it
         // released a cancelled/evicted job, even though the controller's own
         // alloc_resources already counts it free — a kill RPC can be lost.
-        apply_pending_kill_reservations(&mut nodes, &cluster.pending_kill_reservations());
+        apply_pending_kill_reservations(&mut nodes, &pending_kill);
 
         let cycle_start = Instant::now();
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -299,7 +299,12 @@ impl ControllerService {
                         node = %node_owned,
                         "node's heartbeat repeatedly omitted a job the controller binds here — evicting"
                     );
-                    match cluster.evict_job(fresh.job_id, spur_core::job::PendingReason::NodeDown) {
+                    match cluster.evict_job(
+                        fresh.job_id,
+                        spur_core::job::PendingReason::NodeDown,
+                        fresh.run_attempt,
+                    ) {
+                        Ok(finalized) if finalized.is_empty() => {}
                         Ok(finalized) => {
                             note_pending_kill_for_job(&cluster, &fresh);
                             cluster.complete_evicted_steps(&finalized);
@@ -452,9 +457,20 @@ fn should_kill_reported_job(cluster: &ClusterManager, job_id: u32, node: &str) -
 }
 
 /// Reserve `job`'s resources on each allocated node. Call before sending the kill.
-fn note_pending_kill_for_job(cluster: &ClusterManager, job: &spur_core::job::Job) {
+pub(crate) fn note_pending_kill_for_job(cluster: &ClusterManager, job: &spur_core::job::Job) {
+    let node_count = job.allocated_nodes.len().max(1) as u32;
     for node in &job.allocated_nodes {
-        let resources = job.per_node_alloc.get(node).cloned().unwrap_or_default();
+        let resources = job.per_node_alloc.get(node).cloned().unwrap_or_else(|| {
+            job.allocated_resources.as_ref().map_or_else(
+                spur_core::resource::ResourceAllocations::default,
+                |total| {
+                    spur_core::resource::ResourceAllocations::with_scalar(
+                        total.cpus / node_count,
+                        total.memory_mb / node_count as u64,
+                    )
+                },
+            )
+        });
         cluster.note_pending_kill(job.job_id, node, resources);
     }
 }

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -292,6 +292,7 @@ impl ControllerService {
                         warn!(job_id = job.job_id, error = %e, "failed to evict phantom binding");
                         continue;
                     }
+                    note_pending_kill_for_job(&cluster, &job);
                     crate::scheduler_loop::send_cancel_to_agents(&cluster, &job, 9).await;
                 }
             });
@@ -437,6 +438,16 @@ fn should_kill_reported_job(cluster: &ClusterManager, job_id: u32, node: &str) -
     }
 }
 
+/// Record a pending-kill reservation for each of `job`'s allocated nodes, so
+/// new dispatch avoids those resources until the agent confirms it released
+/// them or the reservation's TTL expires. Call right before sending the kill.
+fn note_pending_kill_for_job(cluster: &ClusterManager, job: &spur_core::job::Job) {
+    for node in &job.allocated_nodes {
+        let resources = job.per_node_alloc.get(node).cloned().unwrap_or_default();
+        cluster.note_pending_kill(job.job_id, node, resources);
+    }
+}
+
 #[tonic::async_trait]
 impl SlurmController for ControllerService {
     async fn submit_job(
@@ -577,6 +588,7 @@ impl SlurmController for ControllerService {
 
         // Send cancel signal to agents so the process is actually killed
         if let Some(job) = job {
+            note_pending_kill_for_job(&self.cluster, &job);
             let cluster = self.cluster.clone();
             tokio::spawn(async move {
                 crate::scheduler_loop::send_cancel_to_agents(&cluster, &job, 0).await;

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -265,6 +265,8 @@ impl ControllerService {
         }
 
         let reported_ids: HashSet<u32> = reported.iter().map(|r| r.job_id).collect();
+        self.cluster
+            .clear_confirmed_pending_kills(node, &reported_ids);
         let active = self.cluster.active_jobs_on_node(node);
         // Sweep entries for jobs that left the active set by another path,
         // else one that's never re-reported leaks its streak entry.
@@ -299,6 +301,9 @@ impl ControllerService {
                         node = %node_owned,
                         "node's heartbeat repeatedly omitted a job the controller binds here — evicting"
                     );
+                    // Reserve before the free; a no-op eviction below self-heals
+                    // once this node's next heartbeat stops reporting the job.
+                    note_pending_kill_for_job(&cluster, &fresh);
                     match cluster.evict_job(
                         fresh.job_id,
                         spur_core::job::PendingReason::NodeDown,
@@ -306,7 +311,6 @@ impl ControllerService {
                     ) {
                         Ok(finalized) if finalized.is_empty() => {}
                         Ok(finalized) => {
-                            note_pending_kill_for_job(&cluster, &fresh);
                             cluster.complete_evicted_steps(&finalized);
                             crate::scheduler_loop::send_cancel_to_agents(&cluster, &fresh, 9).await;
                         }
@@ -609,13 +613,18 @@ impl SlurmController for ControllerService {
         // Snapshot before cancelling so we still have allocated_nodes after.
         let job = self.cluster.get_job(job_id);
 
+        // Reserve before the free lands, so the scheduler never sees a window
+        // where the resources look free but the agent hasn't been told yet.
+        if let Some(job) = &job {
+            note_pending_kill_for_job(&self.cluster, job);
+        }
+
         self.cluster
             .cancel_job(job_id, &req.user)
             .map_err(cluster_err_to_status)?;
 
         // Send cancel signal to agents so the process is actually killed
         if let Some(job) = job {
-            note_pending_kill_for_job(&self.cluster, &job);
             let cluster = self.cluster.clone();
             tokio::spawn(async move {
                 crate::scheduler_loop::send_cancel_to_agents(&cluster, &job, 0).await;
@@ -3956,6 +3965,37 @@ mod tests {
         assert!(
             evicted,
             "a single-node job's persistent phantom report must evict it"
+        );
+    }
+
+    // A heartbeat that stops reporting a job is real confirmation of release —
+    // the pending-kill reservation must clear then, not wait out the full TTL.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reconcile_clears_pending_kill_once_heartbeat_confirms_release() {
+        use spur_core::resource::ResourceAllocations;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+
+        svc.cluster
+            .note_pending_kill(1, "n1", ResourceAllocations::with_scalar(2, 4000));
+        svc.cluster
+            .note_pending_kill(2, "n1", ResourceAllocations::with_scalar(1, 1000));
+        assert_eq!(svc.cluster.pending_kill_reservations()["n1"].cpus, 3);
+
+        // n1's heartbeat still reports job 2, but no longer job 1.
+        svc.reconcile_reported_allocations(
+            "n1",
+            &[RunningJobStatus {
+                job_id: 2,
+                ..Default::default()
+            }],
+        );
+
+        assert_eq!(
+            svc.cluster.pending_kill_reservations()["n1"].cpus,
+            1,
+            "job 1's reservation must clear once the heartbeat confirms it's gone"
         );
     }
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -625,9 +625,10 @@ impl SlurmController for ControllerService {
             note_pending_kill_for_job(&self.cluster, job);
         }
 
-        self.cluster
-            .cancel_job(job_id, &req.user)
-            .map_err(cluster_err_to_status)?;
+        if let Err(e) = self.cluster.cancel_job(job_id, &req.user) {
+            self.cluster.clear_pending_kill_for_job(job_id);
+            return Err(cluster_err_to_status(e));
+        }
 
         // Send cancel signal to agents so the process is actually killed
         if let Some(job) = job {

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -299,10 +299,9 @@ impl ControllerService {
                         node = %node_owned,
                         "node's heartbeat repeatedly omitted a job the controller binds here — evicting"
                     );
-                    // Reserve before evict_job frees the resources, not after.
-                    note_pending_kill_for_job(&cluster, &fresh);
-                    match cluster.evict_job(fresh.job_id) {
+                    match cluster.evict_job(fresh.job_id, spur_core::job::PendingReason::NodeDown) {
                         Ok(finalized) => {
+                            note_pending_kill_for_job(&cluster, &fresh);
                             cluster.complete_evicted_steps(&finalized);
                             crate::scheduler_loop::send_cancel_to_agents(&cluster, &fresh, 9).await;
                         }
@@ -591,11 +590,8 @@ impl SlurmController for ControllerService {
         let req = request.into_inner();
         let job_id = req.job_id;
 
-        // Snapshot for allocated_nodes and reserve before cancel_job frees them.
+        // Snapshot before cancelling so we still have allocated_nodes after.
         let job = self.cluster.get_job(job_id);
-        if let Some(ref job) = job {
-            note_pending_kill_for_job(&self.cluster, job);
-        }
 
         self.cluster
             .cancel_job(job_id, &req.user)
@@ -603,6 +599,7 @@ impl SlurmController for ControllerService {
 
         // Send cancel signal to agents so the process is actually killed
         if let Some(job) = job {
+            note_pending_kill_for_job(&self.cluster, &job);
             let cluster = self.cluster.clone();
             tokio::spawn(async move {
                 crate::scheduler_loop::send_cancel_to_agents(&cluster, &job, 0).await;
@@ -3624,6 +3621,18 @@ mod tests {
             stale,
             vec![12, 999],
             "terminal and unknown ids are reclaimed; Pending/Running (bound)/Completing/Suspended/Preempted are spared"
+        );
+
+        // Same jobs, queried against a node NONE of them are bound to: Running/
+        // Completing/Suspended must now be killed (unbound), Pending/Preempted spared.
+        let unbound: Vec<u32> = [10, 11, 13, 14, 15]
+            .into_iter()
+            .filter(|&job_id| should_kill_reported_job(&cluster, job_id, "n2"))
+            .collect();
+        assert_eq!(
+            unbound,
+            vec![11, 13, 14],
+            "Running/Completing/Suspended are killed when reported by a node they aren't bound to"
         );
     }
 

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -228,8 +228,26 @@ impl ControllerService {
         Err(self.not_leader_status())
     }
 
-    /// Reconcile `node`'s reported held jobs against the controller's record.
-    /// Spawned, best-effort; called from the (leader-gated) heartbeat handler.
+    fn validate_agent_identity(&self, hostname: &str, node_token: &str) -> Result<(), Status> {
+        if !matches!(
+            self.cluster.config().admission.mode,
+            spur_core::config::AdmissionMode::Token
+        ) {
+            return Ok(());
+        }
+        if node_token.is_empty() {
+            return Err(Status::unauthenticated("node token required"));
+        }
+        let identity = spur_core::admission::verify_node_token(node_token, self.jwt_key.as_bytes())
+            .map_err(|e| Status::unauthenticated(e.to_string()))?;
+        if identity.hostname != hostname {
+            return Err(Status::permission_denied("node token hostname mismatch"));
+        }
+        Ok(())
+    }
+
+    /// Legacy agents report job ids only. Unknown jobs may be killed, but an
+    /// omission is never interpreted as proof that an allocation was released.
     fn reconcile_reported_allocations(&self, node: &str, reported: &[RunningJobStatus]) {
         let kill = reported
             .iter()
@@ -268,69 +286,110 @@ impl ControllerService {
                 }
             });
         }
+    }
 
-        let reported_ids: HashSet<u32> = reported.iter().map(|r| r.job_id).collect();
-        {
-            let cluster = self.cluster.clone();
-            let node_owned = node.to_string();
-            let reported_ids = reported_ids.clone();
-            tokio::spawn(async move {
-                if let Err(e) = cluster.clear_confirmed_pending_kills(&node_owned, &reported_ids) {
-                    warn!(node = %node_owned, error = %e, "failed to persist pending-kill release confirmation");
-                }
-            });
-        }
-        let active = self.cluster.active_jobs_on_node(node);
-        // Sweep entries for jobs that left the active set by another path,
-        // else one that's never re-reported leaks its streak entry.
-        let active_ids: HashSet<spur_core::job::JobId> = active.iter().map(|j| j.job_id).collect();
-        self.cluster.prune_phantom_streaks_not_in(node, &active_ids);
+    fn reconcile_allocation_inventory(
+        &self,
+        node: &str,
+        agent_session_id: &str,
+        node_boot_id: &str,
+        agent_recovery_complete: bool,
+        supports_command_polling: bool,
+        inventory: Vec<AgentAllocationStatus>,
+    ) -> Result<(), Status> {
+        use spur_core::allocation::{AllocationKey, AllocationPhase};
 
-        let mut phantom = Vec::new();
-        for job in active {
-            if reported_ids.contains(&job.job_id) {
-                self.cluster.note_node_reported_job(job.job_id, node);
-            } else if job.allocated_nodes.len() == 1 // evict_job fails the whole job
-                && self.cluster.note_node_omitted_job(job.job_id, node)
+        let mut reported = HashMap::new();
+        for status in inventory {
+            let key = AllocationKey::new(status.job_id, status.run_attempt, node);
+            let resources = status
+                .resources
+                .map(proto_to_allocations)
+                .unwrap_or_default();
+            if reported
+                .insert(
+                    key,
+                    (
+                        resources,
+                        status.process_present || status.cgroup_present,
+                        status.last_command_id,
+                        AgentAllocationPhase::try_from(status.phase).ok(),
+                    ),
+                )
+                .is_some()
             {
-                phantom.push(job);
+                return Err(Status::invalid_argument(
+                    "allocation inventory contains a duplicate key",
+                ));
             }
         }
-        if !phantom.is_empty() {
-            let cluster = self.cluster.clone();
-            let node_owned = node.to_string();
-            tokio::spawn(async move {
-                for job in phantom {
-                    // Re-fetch: the snapshot may be stale by now — a fresh
-                    // run_attempt means a legitimate requeue, not a phantom.
-                    let Some(fresh) = cluster.get_job(job.job_id) else {
-                        continue;
-                    };
-                    if fresh.state.is_terminal() || fresh.run_attempt != job.run_attempt {
-                        continue;
-                    }
-                    warn!(
-                        job_id = fresh.job_id,
-                        node = %node_owned,
-                        "node's heartbeat repeatedly omitted a job the controller binds here — evicting"
-                    );
-                    match cluster.evict_job(
-                        fresh.job_id,
-                        spur_core::job::PendingReason::NodeDown,
-                        fresh.run_attempt,
-                    ) {
-                        Ok(finalized) if finalized.is_empty() => {}
-                        Ok(finalized) => {
-                            cluster.complete_evicted_steps(&finalized);
-                            crate::scheduler_loop::send_cancel_to_agents(&cluster, &fresh, 9).await;
-                        }
-                        Err(e) => {
-                            warn!(job_id = fresh.job_id, error = %e, "failed to evict phantom binding");
-                        }
+
+        let expected = self.cluster.allocation_records_on_node(node);
+        let expected_keys: HashSet<_> = expected.iter().map(|record| record.key.clone()).collect();
+        let mut evict = HashSet::new();
+        let mut cleanup = Vec::new();
+        let mut reconciled = agent_recovery_complete;
+
+        for record in expected {
+            if record.phase == AllocationPhase::Releasing {
+                reconciled = false;
+                cleanup.push(record.key.clone());
+                continue;
+            }
+            match reported.get(&record.key) {
+                Some((resources, present, command_id, _))
+                    if resources == &record.resources
+                        && *present
+                        && (record.phase == AllocationPhase::Launching
+                            || *command_id == record.last_command_id
+                            || record.agent_session_id.is_none()) => {}
+                None if matches!(
+                    record.phase,
+                    AllocationPhase::Prepared | AllocationPhase::Launching
+                ) => {}
+                _ => {
+                    reconciled = false;
+                    cleanup.push(record.key.clone());
+                    if record.phase == AllocationPhase::Active {
+                        evict.insert((record.key.job_id, record.key.run_attempt));
                     }
                 }
-            });
+            }
         }
+
+        for key in reported.keys() {
+            if !expected_keys.contains(key) {
+                reconciled = false;
+                cleanup.push(key.clone());
+            }
+        }
+
+        for (job_id, run_attempt) in evict {
+            warn!(
+                job_id,
+                run_attempt,
+                node,
+                "agent inventory cannot prove the controller allocation; evicting the run"
+            );
+            let finalized = self
+                .cluster
+                .evict_job(job_id, spur_core::job::PendingReason::NodeDown, run_attempt)
+                .map_err(|error| Status::internal(error.to_string()))?;
+            self.cluster.complete_evicted_steps(&finalized);
+        }
+        self.cluster
+            .enqueue_recovery_releases(cleanup)
+            .map_err(|error| Status::internal(error.to_string()))?;
+        self.cluster
+            .update_agent_recovery(
+                node,
+                agent_session_id,
+                node_boot_id,
+                reconciled,
+                supports_command_polling,
+            )
+            .map_err(|error| Status::internal(error.to_string()))?;
+        Ok(())
     }
 
     /// Reads never require the leader (every node applies the committed log),
@@ -602,6 +661,18 @@ impl SlurmController for ControllerService {
         let req = request.into_inner();
         let job_id = req.job_id;
 
+        if req.run_attempt != 0
+            && self
+                .cluster
+                .get_job(job_id)
+                .is_some_and(|job| job.run_attempt != req.run_attempt)
+        {
+            return Err(Status::failed_precondition(format!(
+                "job {job_id} run attempt {} is no longer current",
+                req.run_attempt
+            )));
+        }
+
         self.cluster
             .check_cancel_allowed(job_id, &req.user)
             .map_err(cluster_err_to_status)?;
@@ -646,7 +717,7 @@ impl SlurmController for ControllerService {
         let req = request.into_inner();
         let job = self
             .cluster
-            .finish_srun_job(req.job_id, req.exit_code, &req.user)
+            .finish_srun_job(req.job_id, req.exit_code, &req.user, req.run_attempt)
             .map_err(|e| match e {
                 crate::cluster::SrunCompleteError::NotFound(id) => {
                     Status::not_found(format!("job {id} not found"))
@@ -659,6 +730,13 @@ impl SlurmController for ControllerService {
                         "job {id} does not use native step dispatch"
                     ))
                 }
+                crate::cluster::SrunCompleteError::StaleRun {
+                    job_id,
+                    expected,
+                    actual,
+                } => Status::failed_precondition(format!(
+                    "job {job_id} run attempt {expected} was superseded by attempt {actual}"
+                )),
                 crate::cluster::SrunCompleteError::AlreadyTerminal { job_id, state } => {
                     Status::failed_precondition(format!("job {job_id} is already {state:?}"))
                 }
@@ -1019,6 +1097,15 @@ impl SlurmController for ControllerService {
         if self.cluster.get_node(&req.hostname).is_none() {
             return Ok(Response::new(()));
         }
+        if !self.cluster.agent_session_matches(
+            &req.hostname,
+            &req.agent_session_id,
+            &req.node_boot_id,
+        ) {
+            return Err(Status::failed_precondition(
+                "agent session does not match the registered node",
+            ));
+        }
         let evicted = self
             .cluster
             .remove_node(
@@ -1203,6 +1290,11 @@ impl SlurmController for ControllerService {
 
         let req = request.into_inner();
         let resources = req.resources.map(proto_to_resource_set).unwrap_or_default();
+        let legacy_agent = req.agent_session_id.is_empty();
+        let recovery_complete = req.recovery_complete;
+        let supports_command_polling = !legacy_agent && req.supports_command_polling;
+        let agent_session_id = req.agent_session_id.clone();
+        let node_boot_id = req.node_boot_id.clone();
 
         let reject_loopback = self.cluster.config().network.reject_loopback_comm_addr;
         let advertised = req.address.clone();
@@ -1218,7 +1310,7 @@ impl SlurmController for ControllerService {
 
         let source = spur_core::node::node_source_from_registration(&req.version, &req.labels);
         self.cluster
-            .register_node(
+            .register_node_with_session(
                 // NodeName and NodeHostname are the same until agents can supply both.
                 req.hostname.clone(),
                 req.hostname.clone(),
@@ -1229,8 +1321,23 @@ impl SlurmController for ControllerService {
                 req.version,
                 source,
                 req.labels,
+                req.agent_session_id,
+                req.node_boot_id,
+                legacy_agent,
+                supports_command_polling,
             )
             .map_err(|e| Status::internal(e.to_string()))?;
+
+        if !legacy_agent {
+            self.reconcile_allocation_inventory(
+                &req.hostname,
+                &agent_session_id,
+                &node_boot_id,
+                recovery_complete,
+                supports_command_polling,
+                req.allocation_inventory,
+            )?;
+        }
 
         Ok(Response::new(RegisterAgentResponse {
             accepted: true,
@@ -1259,6 +1366,29 @@ impl SlurmController for ControllerService {
         }
 
         let req = request.into_inner();
+        if !req.reporting_node.is_empty() {
+            let node = self.cluster.get_node(&req.reporting_node).ok_or_else(|| {
+                Status::not_found(format!("node {} not found", req.reporting_node))
+            })?;
+            if node.agent_session_id.is_empty() {
+                if !req.agent_session_id.is_empty() || !req.node_boot_id.is_empty() {
+                    return Err(Status::failed_precondition(
+                        "completion report session does not match the legacy node registration",
+                    ));
+                }
+            } else {
+                self.validate_agent_identity(&req.reporting_node, &req.node_token)?;
+                if !self.cluster.agent_session_matches(
+                    &req.reporting_node,
+                    &req.agent_session_id,
+                    &req.node_boot_id,
+                ) {
+                    return Err(Status::failed_precondition(
+                        "completion report session does not match the registered node",
+                    ));
+                }
+            }
+        }
         let state = spur_core::job::JobState::from_proto_i32(req.state)
             .ok_or_else(|| Status::invalid_argument("invalid job state"))?;
 
@@ -1321,7 +1451,11 @@ impl SlurmController for ControllerService {
                             let job_id = req.job_id;
                             tokio::spawn(async move {
                                 crate::scheduler_loop::cancel_job_on_nodes(
-                                    &cluster, job_id, &missing, 15,
+                                    &cluster,
+                                    job_id,
+                                    &missing,
+                                    15,
+                                    req.run_attempt,
                                 )
                                 .await;
                             });
@@ -1381,19 +1515,22 @@ impl SlurmController for ControllerService {
 
         let req = request.into_inner();
 
-        if matches!(
-            self.cluster.config().admission.mode,
-            spur_core::config::AdmissionMode::Token
+        self.validate_agent_identity(&req.hostname, &req.node_token)?;
+
+        if self.cluster.get_node(&req.hostname).is_none() {
+            return Err(Status::not_found(format!(
+                "node {} not found — is the node registered?",
+                req.hostname
+            )));
+        }
+        if !self.cluster.agent_session_matches(
+            &req.hostname,
+            &req.agent_session_id,
+            &req.node_boot_id,
         ) {
-            if req.node_token.is_empty() {
-                return Err(Status::unauthenticated("node token required"));
-            }
-            let identity =
-                spur_core::admission::verify_node_token(&req.node_token, self.jwt_key.as_bytes())
-                    .map_err(|e| Status::unauthenticated(e.to_string()))?;
-            if identity.hostname != req.hostname {
-                return Err(Status::permission_denied("node token hostname mismatch"));
-            }
+            return Err(Status::failed_precondition(
+                "agent session does not match the registered node; re-register first",
+            ));
         }
 
         if self
@@ -1408,14 +1545,144 @@ impl SlurmController for ControllerService {
             {
                 info!(node = %req.hostname, "learned updated WireGuard mesh key from heartbeat");
             }
-            self.reconcile_reported_allocations(&req.hostname, &req.running_jobs);
+            if req.agent_session_id.is_empty() {
+                self.reconcile_reported_allocations(&req.hostname, &req.running_jobs);
+            } else {
+                self.reconcile_allocation_inventory(
+                    &req.hostname,
+                    &req.agent_session_id,
+                    &req.node_boot_id,
+                    req.recovery_complete,
+                    req.supports_command_polling,
+                    req.allocation_inventory,
+                )?;
+            }
             Ok(Response::new(HeartbeatResponse {}))
         } else {
             Err(Status::not_found(format!(
-                "node {} not found — is the node registered?",
+                "node {} disappeared",
                 req.hostname
             )))
         }
+    }
+
+    async fn poll_agent_commands(
+        &self,
+        request: Request<PollAgentCommandsRequest>,
+    ) -> Result<Response<PollAgentCommandsResponse>, Status> {
+        if let Err(status) = self.check_leader(&request) {
+            let proxy = &self.leader_proxy;
+            return match proxy.get_leader_client().await {
+                Ok(mut client) => {
+                    let mut forwarded = Request::new(request.into_inner());
+                    *forwarded.metadata_mut() = Self::forwarded_metadata();
+                    client.poll_agent_commands(forwarded).await
+                }
+                Err(error) => {
+                    warn!(error = %error, "failed to forward agent command poll to leader");
+                    Err(status)
+                }
+            };
+        }
+        if !self.raft.ensure_leader().await {
+            return Err(Status::unavailable(
+                "controller could not confirm leadership with a quorum",
+            ));
+        }
+
+        let req = request.into_inner();
+        self.validate_agent_identity(&req.hostname, &req.node_token)?;
+        let mut commands = self
+            .cluster
+            .pending_agent_commands(&req.hostname, &req.agent_session_id, &req.node_boot_id)
+            .map_err(|error| Status::failed_precondition(error.to_string()))?;
+        if commands.is_empty() {
+            tokio::select! {
+                _ = self.cluster.wait_for_agent_command_update() => {}
+                _ = tokio::time::sleep(std::time::Duration::from_secs(5)) => {}
+            }
+            if !self.raft.ensure_leader().await {
+                return Err(Status::unavailable(
+                    "controller lost quorum while polling agent commands",
+                ));
+            }
+            commands = self
+                .cluster
+                .pending_agent_commands(&req.hostname, &req.agent_session_id, &req.node_boot_id)
+                .map_err(|error| Status::failed_precondition(error.to_string()))?;
+        }
+        let commands = commands
+            .into_iter()
+            .map(|command| {
+                let payload = if command.payload.is_empty()
+                    && command.kind != spur_core::allocation::AgentCommandKind::Release
+                {
+                    crate::scheduler_loop::durable_agent_command_payload(&self.cluster, &command)
+                        .map_err(|error| Status::internal(error.to_string()))?
+                } else {
+                    command.payload.clone()
+                };
+                Ok(AgentCommand {
+                    command_id: command.command_id,
+                    job_id: command.key.job_id,
+                    run_attempt: command.key.run_attempt,
+                    node: command.key.node,
+                    kind: match command.kind {
+                        spur_core::allocation::AgentCommandKind::Launch => {
+                            AgentCommandKind::Launch as i32
+                        }
+                        spur_core::allocation::AgentCommandKind::Register => {
+                            AgentCommandKind::Register as i32
+                        }
+                        spur_core::allocation::AgentCommandKind::Release => {
+                            AgentCommandKind::Release as i32
+                        }
+                    },
+                    payload,
+                    signal: command.signal,
+                })
+            })
+            .collect::<Result<Vec<_>, Status>>()?;
+        Ok(Response::new(PollAgentCommandsResponse { commands }))
+    }
+
+    async fn acknowledge_agent_command(
+        &self,
+        request: Request<AcknowledgeAgentCommandRequest>,
+    ) -> Result<Response<()>, Status> {
+        if let Err(status) = self.check_leader(&request) {
+            let proxy = &self.leader_proxy;
+            return match proxy.get_leader_client().await {
+                Ok(mut client) => {
+                    let mut forwarded = Request::new(request.into_inner());
+                    *forwarded.metadata_mut() = Self::forwarded_metadata();
+                    client.acknowledge_agent_command(forwarded).await
+                }
+                Err(error) => {
+                    warn!(error = %error, "failed to forward agent command acknowledgement");
+                    Err(status)
+                }
+            };
+        }
+
+        let req = request.into_inner();
+        self.validate_agent_identity(&req.hostname, &req.node_token)?;
+        self.cluster
+            .acknowledge_agent_command(
+                req.command_id,
+                spur_core::allocation::AllocationKey::new(
+                    req.job_id,
+                    req.run_attempt,
+                    req.hostname,
+                ),
+                req.agent_session_id,
+                req.node_boot_id,
+                req.success,
+                req.response_payload,
+                req.error,
+            )
+            .map_err(|error| Status::internal(error.to_string()))?;
+        Ok(Response::new(()))
     }
 
     async fn create_token(
@@ -3013,6 +3280,7 @@ fn job_to_proto(job: &spur_core::job::Job) -> JobInfo {
         srun_step_dispatch: job.srun_step_dispatch,
         req_gpus: spur_core::job::effective_gpus(&job.spec, job.spec.num_nodes) as u32,
         req_gpus_detail: requested_gpus_detail(&job.spec),
+        run_attempt: job.run_attempt,
     }
 }
 
@@ -3845,9 +4113,8 @@ mod tests {
         }
     }
 
-    // evict_job is job-scoped, so one node's phantom must spare a multi-node job.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn reconcile_spares_a_multi_node_job_on_one_nodes_phantom_report() {
+    async fn legacy_heartbeat_omission_does_not_evict_a_multi_node_job() {
         use crate::raft::StateMachineApply;
         use spur_core::job::{JobSpec, JobState};
         use spur_core::resource::ResourceAllocations;
@@ -3891,7 +4158,6 @@ mod tests {
             run_attempt: 1,
         });
 
-        // n1's heartbeat never reports job 1; cross the phantom threshold.
         for _ in 0..3 {
             svc.reconcile_reported_allocations("n1", &[]);
         }
@@ -3901,14 +4167,12 @@ mod tests {
         assert_eq!(
             svc.cluster.get_job(1).unwrap().state,
             JobState::Running,
-            "a multi-node job must not be evicted over one node's phantom report"
+            "job-id omission is not physical cleanup evidence"
         );
     }
 
-    // The single-node counterpart: a persistent phantom report must still
-    // evict the job (this is the case D1 exists to fix).
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn reconcile_evicts_a_single_node_job_after_persistent_phantom_report() {
+    async fn legacy_heartbeat_omission_does_not_evict_a_single_node_job() {
         use crate::raft::StateMachineApply;
         use spur_core::job::{JobSpec, JobState};
         use spur_core::resource::ResourceAllocations;
@@ -3955,23 +4219,15 @@ mod tests {
             svc.reconcile_reported_allocations("n1", &[]);
         }
 
-        let mut evicted = false;
-        for _ in 0..200 {
-            if svc.cluster.get_job(1).unwrap().state.is_terminal() {
-                evicted = true;
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
-        }
-        assert!(
-            evicted,
-            "a single-node job's persistent phantom report must evict it"
+        assert_eq!(
+            svc.cluster.get_job(1).unwrap().state,
+            JobState::Running,
+            "job-id omission is not physical cleanup evidence"
         );
     }
 
-    // A heartbeat that stops reporting a job is the release confirmation.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn reconcile_clears_pending_kill_once_heartbeat_confirms_release() {
+    async fn legacy_heartbeat_omission_does_not_release_capacity() {
         use spur_core::resource::ResourceAllocations;
 
         let dir = tempfile::TempDir::new().unwrap();
@@ -3983,7 +4239,6 @@ mod tests {
             .note_pending_kill(2, "n1", ResourceAllocations::with_scalar(1, 1000), 102);
         assert_eq!(svc.cluster.pending_kill_reservations()["n1"].cpus, 3);
 
-        // n1's heartbeat still reports job 2, but no longer job 1.
         svc.reconcile_reported_allocations(
             "n1",
             &[RunningJobStatus {
@@ -3992,19 +4247,271 @@ mod tests {
             }],
         );
 
-        // The release confirmation is spawned off the heartbeat's critical path.
-        let mut cpus = svc.cluster.pending_kill_reservations()["n1"].cpus;
-        for _ in 0..200 {
-            if cpus == 1 {
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
-            cpus = svc.cluster.pending_kill_reservations()["n1"].cpus;
-        }
         assert_eq!(
-            cpus, 1,
-            "job 1's reservation must clear once the heartbeat confirms it's gone"
+            svc.cluster.pending_kill_reservations()["n1"].cpus,
+            3,
+            "omission alone must keep both release holds charged"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn completed_exact_inventory_recovers_through_eviction_cleanup_and_acknowledgement() {
+        use spur_core::allocation::{AgentCommandKind, AllocationKey, AllocationPhase};
+        use spur_core::job::{JobSpec, JobState};
+        use spur_core::node::{NodeSource, NodeState};
+        use spur_core::resource::{ResourceAllocations as CoreAllocations, ResourceSet};
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        svc.cluster
+            .register_node_with_session(
+                "n1".into(),
+                "n1".into(),
+                ResourceSet {
+                    cpus: 4,
+                    memory_mb: 8000,
+                    ..Default::default()
+                },
+                "127.0.0.1".into(),
+                6818,
+                String::new(),
+                String::new(),
+                NodeSource::NativeHost,
+                HashMap::new(),
+                "session-1".into(),
+                "boot-1".into(),
+                true,
+                true,
+            )
+            .unwrap();
+        let job_id = svc
+            .cluster
+            .submit_job(JobSpec {
+                name: "restart-recovery".into(),
+                user: "alice".into(),
+                num_nodes: 1,
+                num_tasks: 1,
+                cpus_per_task: 2,
+                work_dir: "/tmp".into(),
+                ..Default::default()
+            })
+            .unwrap()
+            .job_id;
+        let resources = CoreAllocations::with_scalar(2, 4000);
+        svc.cluster
+            .start_job(
+                job_id,
+                vec!["n1".into()],
+                resources.clone(),
+                HashMap::from([("n1".into(), resources.clone())]),
+            )
+            .unwrap();
+        let attempt = svc.cluster.get_job(job_id).unwrap().run_attempt;
+        let key = AllocationKey::new(job_id, attempt, "n1");
+
+        let unauthenticated = svc
+            .report_job_status(Request::new(ReportJobStatusRequest {
+                job_id,
+                state: JobState::Completed.to_proto_i32(),
+                exit_code: 0,
+                reporting_node: "n1".into(),
+                run_attempt: attempt,
+                ..Default::default()
+            }))
+            .await
+            .unwrap_err();
+        assert_eq!(unauthenticated.code(), tonic::Code::FailedPrecondition);
+        assert_eq!(
+            svc.cluster.allocation_records()[&key].phase,
+            AllocationPhase::Active
+        );
+
+        svc.reconcile_allocation_inventory(
+            "n1",
+            "session-1",
+            "boot-1",
+            true,
+            true,
+            vec![AgentAllocationStatus {
+                job_id,
+                run_attempt: attempt,
+                phase: AgentAllocationPhase::Active as i32,
+                resources: Some(allocations_to_proto(&resources)),
+                last_command_id: 0,
+                process_present: true,
+                cgroup_present: false,
+            }],
+        )
+        .unwrap();
+        assert_eq!(
+            svc.cluster.get_job(job_id).unwrap().state,
+            JobState::Running
+        );
+
+        svc.reconcile_allocation_inventory("n1", "session-1", "boot-1", true, true, Vec::new())
+            .unwrap();
+
+        assert_eq!(
+            svc.cluster.get_job(job_id).unwrap().state,
+            JobState::NodeFail
+        );
+        assert_eq!(
+            svc.cluster.get_node("n1").unwrap().state,
+            NodeState::Unknown
+        );
+        let record = svc.cluster.allocation_records()[&key].clone();
+        assert_eq!(record.phase, AllocationPhase::Releasing);
+        assert_eq!(svc.cluster.get_node("n1").unwrap().alloc_resources.cpus, 2);
+        let commands = svc
+            .cluster
+            .pending_agent_commands("n1", "session-1", "boot-1")
+            .unwrap();
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].kind, AgentCommandKind::Release);
+        assert_eq!(commands[0].key, key);
+
+        svc.cluster
+            .acknowledge_agent_command(
+                record.last_command_id,
+                key.clone(),
+                "session-1".into(),
+                "boot-1".into(),
+                false,
+                Vec::new(),
+                "process still present".into(),
+            )
+            .unwrap();
+        assert_eq!(
+            svc.cluster.allocation_records()[&key].phase,
+            AllocationPhase::Releasing
+        );
+
+        svc.reconcile_allocation_inventory("n1", "session-1", "boot-1", false, true, Vec::new())
+            .unwrap();
+        let replacement = svc
+            .cluster
+            .pending_agent_commands("n1", "session-1", "boot-1")
+            .unwrap();
+        assert_eq!(replacement.len(), 1);
+        assert!(replacement[0].command_id > record.last_command_id);
+        assert!(svc
+            .cluster
+            .agent_commands(&[record.last_command_id])
+            .is_empty());
+
+        svc.cluster
+            .acknowledge_agent_command(
+                replacement[0].command_id,
+                key.clone(),
+                "session-1".into(),
+                "boot-1".into(),
+                true,
+                Vec::new(),
+                String::new(),
+            )
+            .unwrap();
+        assert_eq!(
+            svc.cluster.allocation_records()[&key].phase,
+            AllocationPhase::Released
+        );
+        assert_eq!(svc.cluster.get_node("n1").unwrap().alloc_resources.cpus, 0);
+
+        svc.reconcile_allocation_inventory("n1", "session-1", "boot-1", true, true, Vec::new())
+            .unwrap();
+        let node = svc.cluster.get_node("n1").unwrap();
+        assert!(node.recovery_complete);
+        assert_eq!(node.state, NodeState::Idle);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stale_heartbeat_cannot_replace_the_registered_agent_session() {
+        use spur_core::node::NodeSource;
+        use spur_core::resource::ResourceSet;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        svc.cluster
+            .register_node_with_session(
+                "n1".into(),
+                "n1".into(),
+                ResourceSet {
+                    cpus: 4,
+                    memory_mb: 8000,
+                    ..Default::default()
+                },
+                "127.0.0.1".into(),
+                6818,
+                String::new(),
+                String::new(),
+                NodeSource::NativeHost,
+                HashMap::new(),
+                "new-session".into(),
+                "boot-1".into(),
+                true,
+                true,
+            )
+            .unwrap();
+
+        let error = svc
+            .heartbeat(Request::new(HeartbeatRequest {
+                hostname: "n1".into(),
+                agent_session_id: "old-session".into(),
+                node_boot_id: "boot-1".into(),
+                recovery_complete: true,
+                supports_command_polling: true,
+                ..Default::default()
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+        let node = svc.cluster.get_node("n1").unwrap();
+        assert_eq!(node.agent_session_id, "new-session");
+        assert_eq!(node.node_boot_id, "boot-1");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stale_agent_session_cannot_deregister_the_current_node() {
+        use spur_core::node::NodeSource;
+        use spur_core::resource::ResourceSet;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        svc.cluster
+            .register_node_with_session(
+                "n1".into(),
+                "n1".into(),
+                ResourceSet {
+                    cpus: 4,
+                    memory_mb: 8000,
+                    ..Default::default()
+                },
+                "127.0.0.1".into(),
+                6818,
+                String::new(),
+                String::new(),
+                NodeSource::NativeHost,
+                HashMap::new(),
+                "new-session".into(),
+                "boot-1".into(),
+                true,
+                true,
+            )
+            .unwrap();
+
+        let error = svc
+            .deregister_agent(Request::new(DeregisterAgentRequest {
+                hostname: "n1".into(),
+                node_token: String::new(),
+                reason: "old daemon stopped".into(),
+                agent_session_id: "old-session".into(),
+                node_boot_id: "boot-1".into(),
+            }))
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+        assert!(svc.cluster.get_node("n1").is_some());
     }
 
     // An unauthorized cancel must not plant a reservation against a job it
@@ -4058,6 +4565,7 @@ mod tests {
                 job_id: 1,
                 signal: 0,
                 user: "mallory".into(),
+                run_attempt: 0,
             }))
             .await;
         assert!(result.is_err(), "an unauthorized cancel must be rejected");

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -230,10 +230,13 @@ impl ControllerService {
 
     /// Reconcile `node`'s heartbeat-reported held jobs against the controller's
     /// own record. Kills a reported job the controller considers terminal, has
-    /// no record of, or has running elsewhere without this node bound to it —
-    /// never fabricating a binding. Separately, evicts a job the controller
-    /// still believes is allocated on `node` if the node's report has omitted
-    /// it for several consecutive heartbeats. Spawned, best-effort; called only
+    /// no record of, or has running/suspended/completing elsewhere without
+    /// this node bound to it — never fabricating a binding. Separately, evicts
+    /// a single-node job the controller still believes is allocated on `node`
+    /// if the node's report has omitted it for several consecutive heartbeats
+    /// (a multi-node job is left alone here: `evict_job` fails the whole job,
+    /// so acting on one node's phantom would tear it down on every node,
+    /// including ones reporting it fine). Spawned, best-effort; called only
     /// from the heartbeat handler, which is already leader-gated.
     fn reconcile_reported_allocations(&self, node: &str, reported: &[RunningJobStatus]) {
         let kill = reported
@@ -270,11 +273,21 @@ impl ControllerService {
         }
 
         let reported_ids: HashSet<u32> = reported.iter().map(|r| r.job_id).collect();
+        let active = self.cluster.active_jobs_on_node(node);
+        // Sweep any miss-streak entries for jobs that left this node's active
+        // set by some other path (completed, cancelled, reattached) — the
+        // only other removal is a later heartbeat re-reporting the job, so
+        // without this a job that never gets re-reported leaks its entry.
+        let active_ids: HashSet<spur_core::job::JobId> = active.iter().map(|j| j.job_id).collect();
+        self.cluster.prune_phantom_streaks_not_in(node, &active_ids);
+
         let mut phantom = Vec::new();
-        for job in self.cluster.active_jobs_on_node(node) {
+        for job in active {
             if reported_ids.contains(&job.job_id) {
                 self.cluster.note_node_reported_job(job.job_id, node);
-            } else if self.cluster.note_node_omitted_job(job.job_id, node) {
+            } else if job.allocated_nodes.len() == 1
+                && self.cluster.note_node_omitted_job(job.job_id, node)
+            {
                 phantom.push(job);
             }
         }
@@ -283,17 +296,36 @@ impl ControllerService {
             let node_owned = node.to_string();
             tokio::spawn(async move {
                 for job in phantom {
+                    // Re-fetch and re-check the epoch: the snapshot above may
+                    // be stale by the time this runs — a NodeFail->Pending
+                    // ->Running requeue on a fresh run_attempt must not be
+                    // force-failed by a phantom detected against the earlier
+                    // run, and the (possibly stale) snapshot must not be used
+                    // for the kill that follows.
+                    let Some(fresh) = cluster.get_job(job.job_id) else {
+                        continue;
+                    };
+                    if fresh.state.is_terminal() || fresh.run_attempt != job.run_attempt {
+                        continue;
+                    }
                     warn!(
-                        job_id = job.job_id,
+                        job_id = fresh.job_id,
                         node = %node_owned,
                         "node's heartbeat repeatedly omitted a job the controller binds here — evicting"
                     );
-                    if let Err(e) = cluster.evict_job(job.job_id) {
-                        warn!(job_id = job.job_id, error = %e, "failed to evict phantom binding");
-                        continue;
+                    // Reserve before freeing: evict_job's WAL apply frees the
+                    // resources immediately, so the reservation must already
+                    // be in place before that happens, not after.
+                    note_pending_kill_for_job(&cluster, &fresh);
+                    match cluster.evict_job(fresh.job_id) {
+                        Ok(finalized) => {
+                            cluster.complete_evicted_steps(&finalized);
+                            crate::scheduler_loop::send_cancel_to_agents(&cluster, &fresh, 9).await;
+                        }
+                        Err(e) => {
+                            warn!(job_id = fresh.job_id, error = %e, "failed to evict phantom binding");
+                        }
                     }
-                    note_pending_kill_for_job(&cluster, &job);
-                    crate::scheduler_loop::send_cancel_to_agents(&cluster, &job, 9).await;
                 }
             });
         }
@@ -421,19 +453,24 @@ fn is_k0s_admin(cache: &crate::association_cache::AssociationCache, caller: &str
 }
 
 /// Whether a job `node` reports holding should be killed there: the controller
-/// has no record of it, considers it terminal, or is Running but not bound to
-/// `node` — never fabricating a binding to justify sparing it. Only `Running`
-/// carries the "should already be bound to specific nodes" expectation;
-/// Pending (register-before-persist: the agent can hold an allocation before
-/// the controller's own dispatch-confirmation WAL write lands) and the other
-/// active states (Completing/Suspended/Preempted) are always spared.
+/// has no record of it, considers it terminal, or is Running/Suspended
+/// /Completing but not bound to `node` — never fabricating a binding to
+/// justify sparing it. Those three states carry the "should already be bound
+/// to specific nodes" expectation (a suspend/completing transition doesn't
+/// touch `allocated_nodes`); Pending (register-before-persist: the agent can
+/// hold an allocation before the controller's own dispatch-confirmation WAL
+/// write lands) and Preempted (never an observable persisted state — it
+/// transitions to Pending atomically within one WAL apply) are always spared.
 fn should_kill_reported_job(cluster: &ClusterManager, job_id: u32, node: &str) -> bool {
+    use spur_core::job::JobState;
     match cluster.job_state(job_id) {
         None => true,
         Some(state) if state.is_terminal() => true,
-        Some(spur_core::job::JobState::Running) => !cluster
-            .get_job(job_id)
-            .is_some_and(|j| j.allocated_nodes.iter().any(|n| n == node)),
+        Some(JobState::Running) | Some(JobState::Suspended) | Some(JobState::Completing) => {
+            !cluster
+                .get_job(job_id)
+                .is_some_and(|j| j.allocated_nodes.iter().any(|n| n == node))
+        }
         Some(_) => false,
     }
 }
@@ -579,8 +616,14 @@ impl SlurmController for ControllerService {
         let req = request.into_inner();
         let job_id = req.job_id;
 
-        // Snapshot the job before cancelling so we have allocated_nodes
+        // Snapshot the job before cancelling so we have allocated_nodes, and
+        // reserve the pending-kill hold before cancel_job's WAL apply frees
+        // the resources — reserving after would leave a window where the
+        // scheduler could see them free with no reservation in place yet.
         let job = self.cluster.get_job(job_id);
+        if let Some(ref job) = job {
+            note_pending_kill_for_job(&self.cluster, job);
+        }
 
         self.cluster
             .cancel_job(job_id, &req.user)
@@ -588,7 +631,6 @@ impl SlurmController for ControllerService {
 
         // Send cancel signal to agents so the process is actually killed
         if let Some(job) = job {
-            note_pending_kill_for_job(&self.cluster, &job);
             let cluster = self.cluster.clone();
             tokio::spawn(async move {
                 crate::scheduler_loop::send_cancel_to_agents(&cluster, &job, 0).await;
@@ -3796,6 +3838,132 @@ mod tests {
             control_plane_replicas: 1,
             jwt_key: String::new(),
         }
+    }
+
+    // D1 phantom eviction is job-scoped (`evict_job` fails the whole job), so
+    // it must never fire for a multi-node job on just one node's phantom
+    // report — that would tear down nodes that are reporting the job fine.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reconcile_spares_a_multi_node_job_on_one_nodes_phantom_report() {
+        use crate::raft::StateMachineApply;
+        use spur_core::job::{JobSpec, JobState};
+        use spur_core::resource::ResourceAllocations;
+        use spur_core::wal::WalOperation;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let apply = |op: &WalOperation| {
+            <crate::cluster::ClusterManager as StateMachineApply>::apply_operation(
+                &svc.cluster,
+                op,
+            );
+        };
+
+        apply(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(JobSpec {
+                name: "multi-node".into(),
+                user: "alice".into(),
+                num_nodes: 2,
+                num_tasks: 2,
+                cpus_per_task: 1,
+                work_dir: "/tmp".into(),
+                ..Default::default()
+            }),
+        });
+        apply(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
+        let res = ResourceAllocations::with_scalar(1, 1000);
+        let per_node: std::collections::HashMap<_, _> =
+            [("n1".to_string(), res.clone()), ("n2".to_string(), res)].into();
+        apply(&WalOperation::JobStart {
+            job_id: 1,
+            nodes: vec!["n1".into(), "n2".into()],
+            resources: ResourceAllocations::with_scalar(2, 2000),
+            per_node_alloc: per_node,
+            srun_step_dispatch: false,
+            run_attempt: 1,
+        });
+
+        // n1's heartbeat never reports job 1; cross the phantom threshold.
+        for _ in 0..3 {
+            svc.reconcile_reported_allocations("n1", &[]);
+        }
+        // Give the (would-be) spawned eviction a chance to run.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        assert_eq!(
+            svc.cluster.get_job(1).unwrap().state,
+            JobState::Running,
+            "a multi-node job must not be evicted over one node's phantom report"
+        );
+    }
+
+    // The single-node counterpart: a persistent phantom report must still
+    // evict the job (this is the case D1 exists to fix).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reconcile_evicts_a_single_node_job_after_persistent_phantom_report() {
+        use crate::raft::StateMachineApply;
+        use spur_core::job::{JobSpec, JobState};
+        use spur_core::resource::ResourceAllocations;
+        use spur_core::wal::WalOperation;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let apply = |op: &WalOperation| {
+            <crate::cluster::ClusterManager as StateMachineApply>::apply_operation(
+                &svc.cluster,
+                op,
+            );
+        };
+
+        apply(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(JobSpec {
+                name: "single-node".into(),
+                user: "alice".into(),
+                num_nodes: 1,
+                num_tasks: 1,
+                cpus_per_task: 1,
+                work_dir: "/tmp".into(),
+                ..Default::default()
+            }),
+        });
+        apply(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
+        let res = ResourceAllocations::with_scalar(1, 1000);
+        let per_node: std::collections::HashMap<_, _> = [("n1".to_string(), res)].into();
+        apply(&WalOperation::JobStart {
+            job_id: 1,
+            nodes: vec!["n1".into()],
+            resources: ResourceAllocations::with_scalar(1, 1000),
+            per_node_alloc: per_node,
+            srun_step_dispatch: false,
+            run_attempt: 1,
+        });
+
+        for _ in 0..3 {
+            svc.reconcile_reported_allocations("n1", &[]);
+        }
+
+        let mut evicted = false;
+        for _ in 0..200 {
+            if svc.cluster.get_job(1).unwrap().state.is_terminal() {
+                evicted = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+        assert!(
+            evicted,
+            "a single-node job's persistent phantom report must evict it"
+        );
     }
 
     // A step must NOT be created when the target node is allocated but unregistered: address

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -251,13 +251,15 @@ impl ControllerService {
                         node = %node_owned,
                         "agent holds a job the controller doesn't bind here — reclaiming its allocation"
                     );
-                    // Signal 0 = graceful release, no-op on an unknown id. Not
-                    // epoch-gated — a requeue racing this send is still possible.
+                    // Signal 0 = graceful release, no-op on an unknown id. 0 for
+                    // an unknown/terminal id too — nothing to fence against.
+                    let run_attempt = cluster.get_job(job_id).map_or(0, |j| j.run_attempt);
                     crate::scheduler_loop::cancel_job_on_nodes(
                         &cluster,
                         job_id,
                         std::slice::from_ref(&node_owned),
                         0,
+                        run_attempt,
                     )
                     .await;
                 }
@@ -610,11 +612,15 @@ impl SlurmController for ControllerService {
         let req = request.into_inner();
         let job_id = req.job_id;
 
+        self.cluster
+            .check_cancel_allowed(job_id, &req.user)
+            .map_err(cluster_err_to_status)?;
+
         // Snapshot before cancelling so we still have allocated_nodes after.
         let job = self.cluster.get_job(job_id);
 
-        // Reserve before the free lands, so the scheduler never sees a window
-        // where the resources look free but the agent hasn't been told yet.
+        // Reserve before the free lands (the check above already gated this
+        // on the request being authorized against a live job).
         if let Some(job) = &job {
             note_pending_kill_for_job(&self.cluster, job);
         }
@@ -3997,6 +4003,67 @@ mod tests {
             1,
             "job 1's reservation must clear once the heartbeat confirms it's gone"
         );
+    }
+
+    // An unauthorized cancel must not plant a reservation against a job it
+    // never touched — that would let anyone withhold another job's resources.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn unauthorized_cancel_reserves_nothing() {
+        use crate::raft::StateMachineApply;
+        use spur_core::job::{JobSpec, JobState};
+        use spur_core::resource::ResourceAllocations;
+        use spur_core::wal::WalOperation;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let svc = test_service(&dir).await;
+        let apply = |op: &WalOperation| {
+            <crate::cluster::ClusterManager as StateMachineApply>::apply_operation(
+                &svc.cluster,
+                op,
+            );
+        };
+
+        apply(&WalOperation::JobSubmit {
+            job_id: 1,
+            spec: Box::new(JobSpec {
+                name: "owned-by-alice".into(),
+                user: "alice".into(),
+                num_nodes: 1,
+                num_tasks: 1,
+                cpus_per_task: 1,
+                work_dir: "/tmp".into(),
+                ..Default::default()
+            }),
+        });
+        apply(&WalOperation::job_state_change(
+            1,
+            JobState::Pending,
+            JobState::Running,
+        ));
+        let per_node: std::collections::HashMap<_, _> =
+            [("n1".to_string(), ResourceAllocations::with_scalar(2, 4000))].into();
+        apply(&WalOperation::JobStart {
+            job_id: 1,
+            nodes: vec!["n1".into()],
+            resources: ResourceAllocations::with_scalar(2, 4000),
+            per_node_alloc: per_node,
+            srun_step_dispatch: false,
+            run_attempt: 1,
+        });
+
+        let result = svc
+            .cancel_job(Request::new(CancelJobRequest {
+                job_id: 1,
+                signal: 0,
+                user: "mallory".into(),
+            }))
+            .await;
+        assert!(result.is_err(), "an unauthorized cancel must be rejected");
+        assert!(
+            svc.cluster.pending_kill_reservations().is_empty(),
+            "the rejected cancel must not have reserved n1's resources"
+        );
+        assert_eq!(svc.cluster.get_job(1).unwrap().state, JobState::Running);
     }
 
     // A step must NOT be created when the target node is allocated but unregistered: address

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -228,16 +228,8 @@ impl ControllerService {
         Err(self.not_leader_status())
     }
 
-    /// Reconcile `node`'s heartbeat-reported held jobs against the controller's
-    /// own record. Kills a reported job the controller considers terminal, has
-    /// no record of, or has running/suspended/completing elsewhere without
-    /// this node bound to it — never fabricating a binding. Separately, evicts
-    /// a single-node job the controller still believes is allocated on `node`
-    /// if the node's report has omitted it for several consecutive heartbeats
-    /// (a multi-node job is left alone here: `evict_job` fails the whole job,
-    /// so acting on one node's phantom would tear it down on every node,
-    /// including ones reporting it fine). Spawned, best-effort; called only
-    /// from the heartbeat handler, which is already leader-gated.
+    /// Reconcile `node`'s reported held jobs against the controller's record.
+    /// Spawned, best-effort; called from the (leader-gated) heartbeat handler.
     fn reconcile_reported_allocations(&self, node: &str, reported: &[RunningJobStatus]) {
         let kill = reported
             .iter()
@@ -274,10 +266,8 @@ impl ControllerService {
 
         let reported_ids: HashSet<u32> = reported.iter().map(|r| r.job_id).collect();
         let active = self.cluster.active_jobs_on_node(node);
-        // Sweep any miss-streak entries for jobs that left this node's active
-        // set by some other path (completed, cancelled, reattached) — the
-        // only other removal is a later heartbeat re-reporting the job, so
-        // without this a job that never gets re-reported leaks its entry.
+        // Sweep entries for jobs that left the active set by another path,
+        // else one that's never re-reported leaks its streak entry.
         let active_ids: HashSet<spur_core::job::JobId> = active.iter().map(|j| j.job_id).collect();
         self.cluster.prune_phantom_streaks_not_in(node, &active_ids);
 
@@ -285,7 +275,7 @@ impl ControllerService {
         for job in active {
             if reported_ids.contains(&job.job_id) {
                 self.cluster.note_node_reported_job(job.job_id, node);
-            } else if job.allocated_nodes.len() == 1
+            } else if job.allocated_nodes.len() == 1 // evict_job fails the whole job
                 && self.cluster.note_node_omitted_job(job.job_id, node)
             {
                 phantom.push(job);
@@ -296,12 +286,8 @@ impl ControllerService {
             let node_owned = node.to_string();
             tokio::spawn(async move {
                 for job in phantom {
-                    // Re-fetch and re-check the epoch: the snapshot above may
-                    // be stale by the time this runs — a NodeFail->Pending
-                    // ->Running requeue on a fresh run_attempt must not be
-                    // force-failed by a phantom detected against the earlier
-                    // run, and the (possibly stale) snapshot must not be used
-                    // for the kill that follows.
+                    // Re-fetch: the snapshot may be stale by now — a fresh
+                    // run_attempt means a legitimate requeue, not a phantom.
                     let Some(fresh) = cluster.get_job(job.job_id) else {
                         continue;
                     };
@@ -313,9 +299,7 @@ impl ControllerService {
                         node = %node_owned,
                         "node's heartbeat repeatedly omitted a job the controller binds here — evicting"
                     );
-                    // Reserve before freeing: evict_job's WAL apply frees the
-                    // resources immediately, so the reservation must already
-                    // be in place before that happens, not after.
+                    // Reserve before evict_job frees the resources, not after.
                     note_pending_kill_for_job(&cluster, &fresh);
                     match cluster.evict_job(fresh.job_id) {
                         Ok(finalized) => {
@@ -452,15 +436,8 @@ fn is_k0s_admin(cache: &crate::association_cache::AssociationCache, caller: &str
     caller.is_empty() || caller == "root" || cache.is_admin(caller)
 }
 
-/// Whether a job `node` reports holding should be killed there: the controller
-/// has no record of it, considers it terminal, or is Running/Suspended
-/// /Completing but not bound to `node` — never fabricating a binding to
-/// justify sparing it. Those three states carry the "should already be bound
-/// to specific nodes" expectation (a suspend/completing transition doesn't
-/// touch `allocated_nodes`); Pending (register-before-persist: the agent can
-/// hold an allocation before the controller's own dispatch-confirmation WAL
-/// write lands) and Preempted (never an observable persisted state — it
-/// transitions to Pending atomically within one WAL apply) are always spared.
+/// Whether a job `node` reports holding should be killed there: unknown,
+/// terminal, or Running/Suspended/Completing but unbound — never fabricating.
 fn should_kill_reported_job(cluster: &ClusterManager, job_id: u32, node: &str) -> bool {
     use spur_core::job::JobState;
     match cluster.job_state(job_id) {
@@ -475,9 +452,7 @@ fn should_kill_reported_job(cluster: &ClusterManager, job_id: u32, node: &str) -
     }
 }
 
-/// Record a pending-kill reservation for each of `job`'s allocated nodes, so
-/// new dispatch avoids those resources until the agent confirms it released
-/// them or the reservation's TTL expires. Call right before sending the kill.
+/// Reserve `job`'s resources on each allocated node. Call before sending the kill.
 fn note_pending_kill_for_job(cluster: &ClusterManager, job: &spur_core::job::Job) {
     for node in &job.allocated_nodes {
         let resources = job.per_node_alloc.get(node).cloned().unwrap_or_default();
@@ -616,10 +591,7 @@ impl SlurmController for ControllerService {
         let req = request.into_inner();
         let job_id = req.job_id;
 
-        // Snapshot the job before cancelling so we have allocated_nodes, and
-        // reserve the pending-kill hold before cancel_job's WAL apply frees
-        // the resources — reserving after would leave a window where the
-        // scheduler could see them free with no reservation in place yet.
+        // Snapshot for allocated_nodes and reserve before cancel_job frees them.
         let job = self.cluster.get_job(job_id);
         if let Some(ref job) = job {
             note_pending_kill_for_job(&self.cluster, job);
@@ -3559,9 +3531,7 @@ mod tests {
         assert_eq!(status.message(), "partition 'gpu' not found");
     }
 
-    /// Terminal and unknown ids are killed. Pending (mid-dispatch) and the
-    /// other active states are always spared; a Running job bound to the
-    /// reporting node is spared too.
+    /// Terminal and unknown ids are killed; Pending and a bound Running job are spared.
     #[tokio::test]
     async fn should_kill_reported_job_selects_only_terminal_or_unbound() {
         use crate::raft::StateMachineApply;
@@ -3840,9 +3810,7 @@ mod tests {
         }
     }
 
-    // D1 phantom eviction is job-scoped (`evict_job` fails the whole job), so
-    // it must never fire for a multi-node job on just one node's phantom
-    // report — that would tear down nodes that are reporting the job fine.
+    // evict_job is job-scoped, so one node's phantom must spare a multi-node job.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn reconcile_spares_a_multi_node_job_on_one_nodes_phantom_report() {
         use crate::raft::StateMachineApply;

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -251,9 +251,12 @@ impl ControllerService {
                         node = %node_owned,
                         "agent holds a job the controller doesn't bind here — reclaiming its allocation"
                     );
-                    // Signal 0 = graceful release, no-op on an unknown id. 0 for
-                    // an unknown/terminal id too — nothing to fence against.
-                    let run_attempt = cluster.get_job(job_id).map_or(0, |j| j.run_attempt);
+                    // A requeue may have advanced the controller job to a newer
+                    // run while this node still holds the cancelled one.
+                    let run_attempt = cluster
+                        .pending_kill_run_attempt(job_id, &node_owned)
+                        .or_else(|| cluster.get_job(job_id).map(|j| j.run_attempt))
+                        .unwrap_or(0);
                     crate::scheduler_loop::cancel_job_on_nodes(
                         &cluster,
                         job_id,
@@ -267,8 +270,16 @@ impl ControllerService {
         }
 
         let reported_ids: HashSet<u32> = reported.iter().map(|r| r.job_id).collect();
-        self.cluster
-            .clear_confirmed_pending_kills(node, &reported_ids);
+        {
+            let cluster = self.cluster.clone();
+            let node_owned = node.to_string();
+            let reported_ids = reported_ids.clone();
+            tokio::spawn(async move {
+                if let Err(e) = cluster.clear_confirmed_pending_kills(&node_owned, &reported_ids) {
+                    warn!(node = %node_owned, error = %e, "failed to persist pending-kill release confirmation");
+                }
+            });
+        }
         let active = self.cluster.active_jobs_on_node(node);
         // Sweep entries for jobs that left the active set by another path,
         // else one that's never re-reported leaks its streak entry.
@@ -303,9 +314,6 @@ impl ControllerService {
                         node = %node_owned,
                         "node's heartbeat repeatedly omitted a job the controller binds here — evicting"
                     );
-                    // Reserve before the free; a no-op eviction below self-heals
-                    // once this node's next heartbeat stops reporting the job.
-                    note_pending_kill_for_job(&cluster, &fresh);
                     match cluster.evict_job(
                         fresh.job_id,
                         spur_core::job::PendingReason::NodeDown,
@@ -458,33 +466,9 @@ fn should_kill_reported_job(cluster: &ClusterManager, job_id: u32, node: &str) -
                 .get_job(job_id)
                 .is_some_and(|j| j.allocated_nodes.iter().any(|n| n == node))
         }
+        Some(JobState::Pending) => cluster.has_pending_kill(job_id, node),
         Some(_) => false,
     }
-}
-
-/// Reserve `job`'s resources on each node. Returns the attempt token, so a
-/// later failure can roll back only this reservation via `clear_pending_kill_for_job`.
-pub(crate) fn note_pending_kill_for_job(
-    cluster: &ClusterManager,
-    job: &spur_core::job::Job,
-) -> u64 {
-    let attempt = cluster.new_pending_kill_attempt();
-    let node_count = job.allocated_nodes.len().max(1) as u32;
-    for node in &job.allocated_nodes {
-        let resources = job.per_node_alloc.get(node).cloned().unwrap_or_else(|| {
-            job.allocated_resources.as_ref().map_or_else(
-                spur_core::resource::ResourceAllocations::default,
-                |total| {
-                    spur_core::resource::ResourceAllocations::with_scalar(
-                        total.cpus / node_count,
-                        total.memory_mb / node_count as u64,
-                    )
-                },
-            )
-        });
-        cluster.note_pending_kill(job.job_id, node, resources, attempt);
-    }
-    attempt
 }
 
 #[tonic::async_trait]
@@ -625,16 +609,7 @@ impl SlurmController for ControllerService {
         // Snapshot before cancelling so we still have allocated_nodes after.
         let job = self.cluster.get_job(job_id);
 
-        // Reserve before the free lands (the check above already gated this
-        // on the request being authorized against a live job).
-        let attempt = job
-            .as_ref()
-            .map(|job| note_pending_kill_for_job(&self.cluster, job));
-
         if let Err(e) = self.cluster.cancel_job(job_id, &req.user) {
-            if let Some(attempt) = attempt {
-                self.cluster.clear_pending_kill_for_job(job_id, attempt);
-            }
             return Err(cluster_err_to_status(e));
         }
 
@@ -3573,7 +3548,7 @@ mod tests {
     async fn should_kill_reported_job_selects_only_terminal_or_unbound() {
         use crate::raft::StateMachineApply;
         use spur_core::job::{JobSpec, JobState};
-        use spur_core::wal::WalOperation;
+        use spur_core::wal::{PendingKillReservation, WalOperation};
 
         let dir = tempfile::TempDir::new().unwrap();
         let cluster =
@@ -3653,18 +3628,29 @@ mod tests {
         assert_eq!(cluster.job_state(14), Some(JobState::Suspended));
         assert_eq!(cluster.job_state(15), Some(JobState::Preempted));
 
+        apply(&WalOperation::PendingKillReserve {
+            reservations: vec![PendingKillReservation {
+                job_id: 10,
+                node: "n1".into(),
+                resources: res.clone(),
+                attempt: 101,
+                run_attempt: 1,
+            }],
+        });
+
         let stale: Vec<u32> = [10, 11, 12, 13, 14, 15, 999]
             .into_iter()
             .filter(|&job_id| should_kill_reported_job(&cluster, job_id, "n1"))
             .collect();
         assert_eq!(
             stale,
-            vec![12, 999],
-            "terminal and unknown ids are reclaimed; Pending/Running (bound)/Completing/Suspended/Preempted are spared"
+            vec![10, 12, 999],
+            "a Pending job is reclaimed only while an unconfirmed prior-run hold exists"
         );
 
         // Same jobs, queried against a node NONE of them are bound to: Running/
-        // Completing/Suspended must now be killed (unbound), Pending/Preempted spared.
+        // Completing/Suspended must now be killed (unbound); the release hold
+        // is scoped to n1, so Pending remains spared on n2.
         let unbound: Vec<u32> = [10, 11, 13, 14, 15]
             .into_iter()
             .filter(|&job_id| should_kill_reported_job(&cluster, job_id, "n2"))
@@ -3983,8 +3969,7 @@ mod tests {
         );
     }
 
-    // A heartbeat that stops reporting a job is real confirmation of release —
-    // the pending-kill reservation must clear then, not wait out the full TTL.
+    // A heartbeat that stops reporting a job is the release confirmation.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn reconcile_clears_pending_kill_once_heartbeat_confirms_release() {
         use spur_core::resource::ResourceAllocations;
@@ -4007,9 +3992,17 @@ mod tests {
             }],
         );
 
+        // The release confirmation is spawned off the heartbeat's critical path.
+        let mut cpus = svc.cluster.pending_kill_reservations()["n1"].cpus;
+        for _ in 0..200 {
+            if cpus == 1 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            cpus = svc.cluster.pending_kill_reservations()["n1"].cpus;
+        }
         assert_eq!(
-            svc.cluster.pending_kill_reservations()["n1"].cpus,
-            1,
+            cpus, 1,
             "job 1's reservation must clear once the heartbeat confirms it's gone"
         );
     }

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -462,8 +462,13 @@ fn should_kill_reported_job(cluster: &ClusterManager, job_id: u32, node: &str) -
     }
 }
 
-/// Reserve `job`'s resources on each allocated node. Call before sending the kill.
-pub(crate) fn note_pending_kill_for_job(cluster: &ClusterManager, job: &spur_core::job::Job) {
+/// Reserve `job`'s resources on each node. Returns the attempt token, so a
+/// later failure can roll back only this reservation via `clear_pending_kill_for_job`.
+pub(crate) fn note_pending_kill_for_job(
+    cluster: &ClusterManager,
+    job: &spur_core::job::Job,
+) -> u64 {
+    let attempt = cluster.new_pending_kill_attempt();
     let node_count = job.allocated_nodes.len().max(1) as u32;
     for node in &job.allocated_nodes {
         let resources = job.per_node_alloc.get(node).cloned().unwrap_or_else(|| {
@@ -477,8 +482,9 @@ pub(crate) fn note_pending_kill_for_job(cluster: &ClusterManager, job: &spur_cor
                 },
             )
         });
-        cluster.note_pending_kill(job.job_id, node, resources);
+        cluster.note_pending_kill(job.job_id, node, resources, attempt);
     }
+    attempt
 }
 
 #[tonic::async_trait]
@@ -621,12 +627,14 @@ impl SlurmController for ControllerService {
 
         // Reserve before the free lands (the check above already gated this
         // on the request being authorized against a live job).
-        if let Some(job) = &job {
-            note_pending_kill_for_job(&self.cluster, job);
-        }
+        let attempt = job
+            .as_ref()
+            .map(|job| note_pending_kill_for_job(&self.cluster, job));
 
         if let Err(e) = self.cluster.cancel_job(job_id, &req.user) {
-            self.cluster.clear_pending_kill_for_job(job_id);
+            if let Some(attempt) = attempt {
+                self.cluster.clear_pending_kill_for_job(job_id, attempt);
+            }
             return Err(cluster_err_to_status(e));
         }
 
@@ -3985,9 +3993,9 @@ mod tests {
         let svc = test_service(&dir).await;
 
         svc.cluster
-            .note_pending_kill(1, "n1", ResourceAllocations::with_scalar(2, 4000));
+            .note_pending_kill(1, "n1", ResourceAllocations::with_scalar(2, 4000), 101);
         svc.cluster
-            .note_pending_kill(2, "n1", ResourceAllocations::with_scalar(1, 1000));
+            .note_pending_kill(2, "n1", ResourceAllocations::with_scalar(1, 1000), 102);
         assert_eq!(svc.cluster.pending_kill_reservations()["n1"].cpus, 3);
 
         // n1's heartbeat still reports job 2, but no longer job 1.

--- a/crates/spurctld/src/server.rs
+++ b/crates/spurctld/src/server.rs
@@ -228,38 +228,74 @@ impl ControllerService {
         Err(self.not_leader_status())
     }
 
-    /// Re-send a terminal-job cancel to a node still reporting it on heartbeat,
-    /// freeing an allocation whose terminal cancel never landed. Spawned, best-effort.
-    fn reclaim_stale_agent_jobs(&self, node: &str, reported: &[RunningJobStatus]) {
-        let stale = stale_reported_jobs(&self.cluster, reported);
-        if stale.is_empty() {
-            return;
-        }
-        let cluster = self.cluster.clone();
-        let node = node.to_string();
-        tokio::spawn(async move {
-            for job_id in stale {
-                // Re-check: a requeue since the snapshot above would otherwise
-                // send an unguarded cancel into the job's new run.
-                if !is_still_terminal(&cluster, job_id) {
-                    continue;
+    /// Reconcile `node`'s heartbeat-reported held jobs against the controller's
+    /// own record. Kills a reported job the controller considers terminal, has
+    /// no record of, or has running elsewhere without this node bound to it —
+    /// never fabricating a binding. Separately, evicts a job the controller
+    /// still believes is allocated on `node` if the node's report has omitted
+    /// it for several consecutive heartbeats. Spawned, best-effort; called only
+    /// from the heartbeat handler, which is already leader-gated.
+    fn reconcile_reported_allocations(&self, node: &str, reported: &[RunningJobStatus]) {
+        let kill = reported
+            .iter()
+            .filter(|r| should_kill_reported_job(&self.cluster, r.job_id, node))
+            .map(|r| r.job_id)
+            .collect::<Vec<_>>();
+        if !kill.is_empty() {
+            let cluster = self.cluster.clone();
+            let node_owned = node.to_string();
+            tokio::spawn(async move {
+                for job_id in kill {
+                    // Re-check: a requeue or reattach since the snapshot above
+                    // would otherwise send an unguarded cancel into a live job.
+                    if !should_kill_reported_job(&cluster, job_id, &node_owned) {
+                        continue;
+                    }
+                    warn!(
+                        job_id,
+                        node = %node_owned,
+                        "agent holds a job the controller doesn't bind here — reclaiming its allocation"
+                    );
+                    // Signal 0 = graceful release, no-op on an unknown id. Not
+                    // epoch-gated — a requeue racing this send is still possible.
+                    crate::scheduler_loop::cancel_job_on_nodes(
+                        &cluster,
+                        job_id,
+                        std::slice::from_ref(&node_owned),
+                        0,
+                    )
+                    .await;
                 }
-                warn!(
-                    job_id,
-                    node = %node,
-                    "agent still holds a terminal job — re-sending cancel to reclaim its allocation"
-                );
-                // Signal 0 = graceful release, no-op on an unknown id. Not
-                // epoch-gated — a requeue racing this send is still possible.
-                crate::scheduler_loop::cancel_job_on_nodes(
-                    &cluster,
-                    job_id,
-                    std::slice::from_ref(&node),
-                    0,
-                )
-                .await;
+            });
+        }
+
+        let reported_ids: HashSet<u32> = reported.iter().map(|r| r.job_id).collect();
+        let mut phantom = Vec::new();
+        for job in self.cluster.active_jobs_on_node(node) {
+            if reported_ids.contains(&job.job_id) {
+                self.cluster.note_node_reported_job(job.job_id, node);
+            } else if self.cluster.note_node_omitted_job(job.job_id, node) {
+                phantom.push(job);
             }
-        });
+        }
+        if !phantom.is_empty() {
+            let cluster = self.cluster.clone();
+            let node_owned = node.to_string();
+            tokio::spawn(async move {
+                for job in phantom {
+                    warn!(
+                        job_id = job.job_id,
+                        node = %node_owned,
+                        "node's heartbeat repeatedly omitted a job the controller binds here — evicting"
+                    );
+                    if let Err(e) = cluster.evict_job(job.job_id) {
+                        warn!(job_id = job.job_id, error = %e, "failed to evict phantom binding");
+                        continue;
+                    }
+                    crate::scheduler_loop::send_cancel_to_agents(&cluster, &job, 9).await;
+                }
+            });
+        }
     }
 
     /// Reads never require the leader (every node applies the committed log),
@@ -383,19 +419,22 @@ fn is_k0s_admin(cache: &crate::association_cache::AssociationCache, caller: &str
     caller.is_empty() || caller == "root" || cache.is_admin(caller)
 }
 
-/// Whether the controller still considers `job_id` terminal right now — guards
-/// the spawned reclaim loop against a requeue landing after its stale snapshot.
-fn is_still_terminal(cluster: &ClusterManager, job_id: u32) -> bool {
-    cluster.job_state(job_id).is_some_and(|s| s.is_terminal())
-}
-
-/// Reported ids the controller's own record marks terminal. Non-terminal (incl.
-/// Pending mid-dispatch) and unknown ids are spared, so no live job is reclaimed.
-fn stale_reported_jobs(cluster: &ClusterManager, reported: &[RunningJobStatus]) -> Vec<u32> {
-    reported
-        .iter()
-        .filter_map(|r| is_still_terminal(cluster, r.job_id).then_some(r.job_id))
-        .collect()
+/// Whether a job `node` reports holding should be killed there: the controller
+/// has no record of it, considers it terminal, or is Running but not bound to
+/// `node` — never fabricating a binding to justify sparing it. Only `Running`
+/// carries the "should already be bound to specific nodes" expectation;
+/// Pending (register-before-persist: the agent can hold an allocation before
+/// the controller's own dispatch-confirmation WAL write lands) and the other
+/// active states (Completing/Suspended/Preempted) are always spared.
+fn should_kill_reported_job(cluster: &ClusterManager, job_id: u32, node: &str) -> bool {
+    match cluster.job_state(job_id) {
+        None => true,
+        Some(state) if state.is_terminal() => true,
+        Some(spur_core::job::JobState::Running) => !cluster
+            .get_job(job_id)
+            .is_some_and(|j| j.allocated_nodes.iter().any(|n| n == node)),
+        Some(_) => false,
+    }
 }
 
 #[tonic::async_trait]
@@ -1331,7 +1370,7 @@ impl SlurmController for ControllerService {
             {
                 info!(node = %req.hostname, "learned updated WireGuard mesh key from heartbeat");
             }
-            self.reclaim_stale_agent_jobs(&req.hostname, &req.running_jobs);
+            self.reconcile_reported_allocations(&req.hostname, &req.running_jobs);
             Ok(Response::new(HeartbeatResponse {}))
         } else {
             Err(Status::not_found(format!(
@@ -3466,10 +3505,11 @@ mod tests {
         assert_eq!(status.message(), "partition 'gpu' not found");
     }
 
-    /// Only a controller-terminal job is stale; Pending (mid-dispatch), Running,
-    /// and unknown ids are all spared.
+    /// Terminal and unknown ids are killed. Pending (mid-dispatch) and the
+    /// other active states are always spared; a Running job bound to the
+    /// reporting node is spared too.
     #[tokio::test]
-    async fn stale_reported_jobs_selects_only_terminal_jobs() {
+    async fn should_kill_reported_job_selects_only_terminal_or_unbound() {
         use crate::raft::StateMachineApply;
         use spur_core::job::{JobSpec, JobState};
         use spur_core::wal::WalOperation;
@@ -3552,26 +3592,21 @@ mod tests {
         assert_eq!(cluster.job_state(14), Some(JobState::Suspended));
         assert_eq!(cluster.job_state(15), Some(JobState::Preempted));
 
-        let reported: Vec<RunningJobStatus> = [10, 11, 12, 13, 14, 15, 999]
+        let stale: Vec<u32> = [10, 11, 12, 13, 14, 15, 999]
             .into_iter()
-            .map(|job_id| RunningJobStatus {
-                job_id,
-                ..Default::default()
-            })
+            .filter(|&job_id| should_kill_reported_job(&cluster, job_id, "n1"))
             .collect();
-
-        let stale = stale_reported_jobs(&cluster, &reported);
         assert_eq!(
             stale,
-            vec![12],
-            "only the terminal job is reclaimed; Pending/Running/Completing/Suspended/Preempted/unknown are spared"
+            vec![12, 999],
+            "terminal and unknown ids are reclaimed; Pending/Running (bound)/Completing/Suspended/Preempted are spared"
         );
     }
 
     /// GATE: a job requeued (Timeout -> Pending) between the reclaim snapshot
     /// and the spawned loop's send must fail the re-check, not just the snapshot.
     #[tokio::test]
-    async fn is_still_terminal_false_after_requeue_race() {
+    async fn should_kill_reported_job_false_after_requeue_race() {
         use crate::raft::StateMachineApply;
         use spur_core::job::{JobSpec, JobState};
         use spur_core::wal::WalOperation;
@@ -3622,7 +3657,10 @@ mod tests {
             JobState::Running,
             JobState::Timeout,
         ));
-        assert!(is_still_terminal(&cluster, 77), "snapshot sees Timeout");
+        assert!(
+            should_kill_reported_job(&cluster, 77, "n1"),
+            "snapshot sees Timeout"
+        );
 
         // Concurrent requeue lands before the reclaim loop's re-check.
         apply(&WalOperation::job_state_change(
@@ -3632,7 +3670,7 @@ mod tests {
         ));
 
         assert!(
-            !is_still_terminal(&cluster, 77),
+            !should_kill_reported_job(&cluster, 77, "n1"),
             "re-check must skip a job requeued since the snapshot"
         );
     }

--- a/crates/spurd/Cargo.toml
+++ b/crates/spurd/Cargo.toml
@@ -21,6 +21,7 @@ spur-devices = { path = "../spur-devices" }
 tokio = { workspace = true }
 tonic = { workspace = true }
 prost-types = { workspace = true }
+prost = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 clap = { workspace = true }
@@ -34,6 +35,7 @@ libc = "0.2"
 hostname = "0.4.2"
 tokio-stream = "0.1"
 shlex = "2"
+uuid = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -398,7 +398,10 @@ impl AgentService {
                     if let Some(ref cgroup) = c.cgroup {
                         crate::executor::cleanup_cgroup(cgroup);
                     }
-                    allocation.lock().await.release_job(c.job_id);
+                    allocation
+                        .lock()
+                        .await
+                        .release_job_if_attempt(c.job_id, c.run_attempt);
                     cleanup_completed_job_mpi(c.job_id, &c.mpi, &mpi_host).await;
                 }
 
@@ -522,14 +525,16 @@ fn reconcile_orphaned_allocations(
 struct LaunchReservationGuard {
     allocation: Arc<Mutex<NodeAllocation>>,
     job_id: u32,
+    run_attempt: u32,
     armed: bool,
 }
 
 impl LaunchReservationGuard {
-    fn new(allocation: Arc<Mutex<NodeAllocation>>, job_id: u32) -> Self {
+    fn new(allocation: Arc<Mutex<NodeAllocation>>, job_id: u32, run_attempt: u32) -> Self {
         Self {
             allocation,
             job_id,
+            run_attempt,
             armed: true,
         }
     }
@@ -545,12 +550,18 @@ impl Drop for LaunchReservationGuard {
             return;
         }
         let job_id = self.job_id;
+        let run_attempt = self.run_attempt;
+        // Drop can't await; try_lock succeeds inline on this uncontended path,
+        // else release off-thread so the reservation is never left stranded.
         if let Ok(mut alloc) = self.allocation.try_lock() {
-            alloc.release_job(job_id);
+            alloc.release_job_if_attempt(job_id, run_attempt);
         } else if let Ok(handle) = tokio::runtime::Handle::try_current() {
             let allocation = self.allocation.clone();
             handle.spawn(async move {
-                allocation.lock().await.release_job(job_id);
+                allocation
+                    .lock()
+                    .await
+                    .release_job_if_attempt(job_id, run_attempt);
             });
         }
     }
@@ -1262,12 +1273,18 @@ impl SlurmAgent for AgentService {
             };
 
         let (alloc_result, allocated_device_ids) = self
-            .allocate_local_resources(job_id, &spec, req.allocated.as_ref())
+            .allocate_local_resources_for_attempt(
+                job_id,
+                &spec,
+                req.allocated.as_ref(),
+                run_attempt,
+            )
             .await?;
 
         // Release the reservation on any exit before commit, including a
         // cancelled launch future; disarmed once committed to `running`.
-        let mut reservation_guard = LaunchReservationGuard::new(self.allocation.clone(), job_id);
+        let mut reservation_guard =
+            LaunchReservationGuard::new(self.allocation.clone(), job_id, run_attempt);
 
         let injection = {
             let reg = self.device_registry.lock().await;
@@ -1402,7 +1419,10 @@ impl SlurmAgent for AgentService {
                 // in flight — committing now would resurrect a demoted leader's write.
                 let stale_term = self.check_term(req.term).is_err();
                 if stale_term {
-                    self.allocation.lock().await.release_job(job_id);
+                    self.allocation
+                        .lock()
+                        .await
+                        .release_job_if_attempt(job_id, run_attempt);
                 }
 
                 // Reservation reclaimed (launch exceeded the TTL) or term superseded:
@@ -1589,7 +1609,10 @@ impl SlurmAgent for AgentService {
         // commit order) so this can't free a job that just became running.
         let jobs = self.running.lock().await;
         if !jobs.contains_key(&job_id) {
-            self.allocation.lock().await.release_job(job_id);
+            self.allocation
+                .lock()
+                .await
+                .release_job_if_attempt(job_id, req.run_attempt);
         }
         drop(jobs);
 
@@ -1762,7 +1785,13 @@ impl SlurmAgent for AgentService {
         {
             let mut alloc = self.allocation.lock().await;
             alloc
-                .allocate_for_job(req.job_id, cpus, memory_mb, &controller_gpu_ids)
+                .allocate_for_job_with_attempt(
+                    req.job_id,
+                    cpus,
+                    memory_mb,
+                    &controller_gpu_ids,
+                    req.run_attempt,
+                )
                 .map_err(|e| match e {
                     AllocError::GpusUnavailable => Status::resource_exhausted(
                         "controller-allocated GPUs unavailable on this node",
@@ -2504,7 +2533,10 @@ impl AgentService {
             }
         };
         if dropped {
-            self.allocation.lock().await.release_job(job_id);
+            self.allocation
+                .lock()
+                .await
+                .release_job_if_attempt(job_id, expected_run_attempt);
             if let Err(e) = self.mpi_host.stop_pmix_server(job_id) {
                 warn!(job_id, error = %e, "PMIx stop failed on job drop");
             }
@@ -2512,11 +2544,23 @@ impl AgentService {
     }
 
     /// Record controller-allocated GPUs and allocate local CPU/memory resources.
+    #[cfg(test)]
     async fn allocate_local_resources(
         &self,
         job_id: u32,
         spec: &JobSpec,
         allocated: Option<&ResourceAllocations>,
+    ) -> Result<(AllocationResult, Vec<u32>), Status> {
+        self.allocate_local_resources_for_attempt(job_id, spec, allocated, 0)
+            .await
+    }
+
+    async fn allocate_local_resources_for_attempt(
+        &self,
+        job_id: u32,
+        spec: &JobSpec,
+        allocated: Option<&ResourceAllocations>,
+        run_attempt: u32,
     ) -> Result<(AllocationResult, Vec<u32>), Status> {
         let controller_gpu_ids: Vec<u32> = allocated
             .and_then(|a| a.devices.get("gpu"))
@@ -2545,11 +2589,12 @@ impl AgentService {
         } else {
             0
         };
-        let result = match alloc.allocate_for_job(
+        let result = match alloc.allocate_for_job_with_attempt(
             job_id,
             cpus,
             spec.memory_per_node_mb,
             &controller_gpu_ids,
+            run_attempt,
         ) {
             Ok(result) => result,
             Err(AllocError::GpusUnavailable) => {
@@ -2571,11 +2616,12 @@ impl AgentService {
                         alloc.release_job(*owner);
                     }
                 }
-                match alloc.allocate_for_job(
+                match alloc.allocate_for_job_with_attempt(
                     job_id,
                     cpus,
                     spec.memory_per_node_mb,
                     &controller_gpu_ids,
+                    run_attempt,
                 ) {
                     Ok(result) => result,
                     Err(_) => {
@@ -4761,6 +4807,53 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn stale_cancel_keeps_a_newer_launch_reservation() {
+        let svc = AgentService::new(
+            test_reporter_with_gpus(&[0]),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        {
+            let mut alloc = svc.allocation.lock().await;
+            alloc
+                .allocate_for_job_with_attempt(7, 1, 0, &[0], 2)
+                .unwrap();
+        }
+
+        svc.cancel_job(Request::new(AgentCancelJobRequest {
+            job_id: 7,
+            signal: 9,
+            term: 0,
+            run_attempt: 1,
+        }))
+        .await
+        .expect("stale cancel");
+
+        assert_eq!(
+            svc.free_gpu_count().await,
+            0,
+            "a stale cancel must not free a newer launch reservation"
+        );
+
+        svc.cancel_job(Request::new(AgentCancelJobRequest {
+            job_id: 7,
+            signal: 9,
+            term: 0,
+            run_attempt: 2,
+        }))
+        .await
+        .expect("current cancel");
+
+        assert_eq!(
+            svc.free_gpu_count().await,
+            1,
+            "the matching cancel must still release the launch reservation"
+        );
+    }
+
     // A cancel meant for an old run must not kill the job_id's re-dispatched
     // replacement, even for the very first signal (not just the grace escalation).
     #[tokio::test]
@@ -4955,7 +5048,7 @@ mod tests {
                 .await
                 .allocate_for_job(9, 1, 0, &[0])
                 .unwrap();
-            let guard = LaunchReservationGuard::new(svc.allocation.clone(), 9);
+            let guard = LaunchReservationGuard::new(svc.allocation.clone(), 9, 0);
             assert_eq!(svc.free_gpu_count().await, 0, "reserved under guard");
             drop(guard);
         }
@@ -4973,7 +5066,7 @@ mod tests {
                 .allocate_for_job(10, 1, 0, &[0])
                 .unwrap();
             svc.allocation.lock().await.commit_job(10);
-            let mut guard = LaunchReservationGuard::new(svc.allocation.clone(), 10);
+            let mut guard = LaunchReservationGuard::new(svc.allocation.clone(), 10, 0);
             guard.disarm();
             drop(guard);
         }

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -312,10 +312,17 @@ impl AgentService {
         }
     }
 
-    /// Reject a term older than the highest seen; 0 (legacy/unset) always passes.
+    /// Reject a term older than the highest seen. 0 (legacy/unset) passes only
+    /// before any real term has been observed — once fencing starts, it can't stop.
     fn check_term(&self, term: u64) -> Result<(), Status> {
         if term == 0 {
-            return Ok(());
+            return if self.highest_term_seen.load(Ordering::Acquire) == 0 {
+                Ok(())
+            } else {
+                Err(Status::failed_precondition(
+                    "unfenced request rejected after a real controller term was observed",
+                ))
+            };
         }
         let prev = self.highest_term_seen.fetch_max(term, Ordering::AcqRel);
         if term < prev {
@@ -1391,16 +1398,21 @@ impl SlurmAgent for AgentService {
                 let committed = self.allocation.lock().await.commit_job(job_id);
                 reservation_guard.disarm();
 
-                // reconcile reclaimed the reservation mid-launch (launch exceeded
-                // the TTL). Don't track a job with no backing allocation — kill,
-                // reap, and clean up its cgroup/rootfs/spool (mirroring the
-                // monitor loop's completion teardown, which never runs since the
-                // job never enters `running`), then fail the launch.
-                if !committed {
+                // A newer-term request raced past our check while this launch was
+                // in flight — committing now would resurrect a demoted leader's write.
+                let stale_term = self.check_term(req.term).is_err();
+                if stale_term {
+                    self.allocation.lock().await.release_job(job_id);
+                }
+
+                // Reservation reclaimed (launch exceeded the TTL) or term superseded:
+                // kill, reap, and clean up rather than track a job with no backing.
+                if !committed || stale_term {
                     drop(jobs);
                     warn!(
                         job_id,
-                        "reservation reclaimed during launch; aborting to avoid running unbacked"
+                        stale_term,
+                        "reservation reclaimed or superseded during launch; aborting to avoid running unbacked"
                     );
                     if let Err(e) = self.mpi_host.stop_pmix_server(job_id) {
                         warn!(job_id, error = %e, "PMIx stop failed after reclaimed reservation");
@@ -1424,9 +1436,14 @@ impl SlurmAgent for AgentService {
                             crate::executor::cleanup_cgroup(cg);
                         }
                     });
+                    let error = if stale_term {
+                        "controller term superseded during launch"
+                    } else {
+                        "reservation reclaimed during launch"
+                    };
                     return Ok(Response::new(LaunchJobResponse {
                         success: false,
-                        error: "reservation reclaimed during launch".into(),
+                        error: error.into(),
                         stdout_path: String::new(),
                         stderr_path: String::new(),
                         failure_kind: LaunchFailureKind::LaunchFailureUnspecified as i32,
@@ -3230,6 +3247,18 @@ mod tests {
         ))
     }
 
+    /// An executable script at a temp path that sleeps `millis` then exits 0,
+    /// widening the window for a concurrent term change during launch.
+    fn delayed_hook_script(millis: u64) -> tempfile::TempPath {
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        writeln!(f, "#!/bin/bash\nsleep {}\nexit 0", millis as f64 / 1000.0).unwrap();
+        let path = f.into_temp_path();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+
     /// An executable script at a temp path that exits with `code`.
     fn failing_hook_script(code: i32) -> tempfile::TempPath {
         use std::io::Write;
@@ -3330,6 +3359,57 @@ mod tests {
             resp.error.contains("No such file or directory"),
             "the cause chain must survive into the reported error, got {:?}",
             resp.error
+        );
+    }
+
+    // A newer-term request racing past our check while the launch is still in
+    // flight must abort the commit, not resurrect a demoted leader's write.
+    #[tokio::test]
+    async fn a_term_superseded_mid_launch_aborts_before_committing() {
+        let prolog = delayed_hook_script(200);
+        let svc = Arc::new(AgentService::new(
+            test_reporter(),
+            HooksConfig {
+                prolog: Some(prolog.to_str().unwrap().to_string()),
+                ..Default::default()
+            },
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        ));
+
+        let svc_launch = svc.clone();
+        let launch = tokio::spawn(async move {
+            svc_launch
+                .launch_job(Request::new(LaunchJobRequest {
+                    job_id: 42,
+                    term: 5,
+                    spec: Some(JobSpec {
+                        name: "term-race".into(),
+                        script: "#!/bin/bash\ntrue\n".into(),
+                        num_tasks: 1,
+                        num_nodes: 1,
+                        cpus_per_task: 1,
+                        work_dir: std::env::temp_dir().to_string_lossy().into_owned(),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                }))
+                .await
+                .unwrap()
+                .into_inner()
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        svc.check_term(6).expect("a higher term is accepted");
+
+        let resp = launch.await.unwrap();
+        assert!(
+            !resp.success,
+            "a superseded term must not commit the launch"
+        );
+        assert!(
+            !svc.running.lock().await.contains_key(&42),
+            "the job must never land in `running` under a stale term"
         );
     }
 
@@ -4531,6 +4611,8 @@ mod tests {
             spur_core::config::MemlockLimit::Unlimited,
         );
 
+        svc.check_term(0)
+            .expect("legacy zero passes before any real term is seen");
         svc.check_term(5).expect("first real term is accepted");
         let err = svc.check_term(3).expect_err("stale term must be rejected");
         assert_eq!(err.code(), tonic::Code::FailedPrecondition);
@@ -4539,7 +4621,10 @@ mod tests {
             svc.check_term(5).is_err(),
             "term below the new high-water mark is still rejected"
         );
-        svc.check_term(0).expect("legacy zero is always accepted");
+        assert!(
+            svc.check_term(0).is_err(),
+            "a delayed unfenced request must not bypass an already-established term"
+        );
     }
 
     // The heartbeat's held-job source must report an allocation-only (srun/salloc)

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1762,9 +1762,7 @@ impl SlurmAgent for AgentService {
                 memory_mb,
                 nodelist: req.nodelist,
                 mpi: req.mpi,
-                // srun allocation-only jobs use their own cancel lifecycle;
-                // epoch 0 leaves the stale-report guard disabled for them.
-                run_attempt: 0,
+                run_attempt: req.run_attempt,
             },
         );
         drop(jobs);
@@ -4474,6 +4472,31 @@ mod tests {
             0,
             "committed+tracked allocation must survive reconcile"
         );
+    }
+
+    // Interactive (srun/salloc) allocations must carry the controller's real
+    // run_attempt, not a hardcoded 0 that disables the stale-report guard.
+    #[tokio::test]
+    async fn register_job_allocation_stores_requested_run_attempt() {
+        let svc = AgentService::new(
+            test_reporter_with_gpus(&[0]),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        svc.register_job_allocation(Request::new(RegisterJobAllocationRequest {
+            job_id: 91,
+            cpus: 1,
+            run_attempt: 3,
+            ..Default::default()
+        }))
+        .await
+        .expect("register");
+
+        let running = svc.running.lock().await;
+        let tracked = running.get(&91).expect("job tracked");
+        assert_eq!(tracked.run_attempt, 3);
     }
 
     // The heartbeat's held-job source must report an allocation-only (srun/salloc)

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1574,28 +1574,13 @@ impl SlurmAgent for AgentService {
         self.check_term(req.term)?;
         let job_id = req.job_id;
 
-        // 0 = no tracked run to compare against (unknown/terminal id at the
-        // sender); otherwise a mismatch means this targets a superseded run.
-        if req.run_attempt != 0 {
-            let tracked = self
-                .running
-                .lock()
-                .await
-                .get(&job_id)
-                .map(|t| t.run_attempt);
-            if tracked.is_some_and(|current| current != req.run_attempt) {
-                info!(
-                    job_id,
-                    req.run_attempt, "cancel targets a superseded run, ignoring"
-                );
-                return Ok(Response::new(()));
-            }
-        }
-
+        // run_attempt (0 = unfenced) is checked inside the signal call itself,
+        // under the same lock that selects the tracked job.
         if req.signal > 0 {
-            self.send_explicit_signal(job_id, req.signal).await;
+            self.send_explicit_signal(job_id, req.signal, req.run_attempt)
+                .await;
         } else {
-            self.graceful_cancel(job_id).await;
+            self.graceful_cancel(job_id, req.run_attempt).await;
         }
 
         // The signal paths only act on a running job; release a still-launching
@@ -2630,21 +2615,31 @@ impl AgentService {
     }
 
     /// Send a user-specified signal to a running job.
-    async fn send_explicit_signal(&self, job_id: u32, signal: i32) {
+    async fn send_explicit_signal(&self, job_id: u32, signal: i32, expected_run_attempt: u32) {
         let is_allocation_only = {
             let jobs = self.running.lock().await;
-            jobs.get(&job_id)
-                .is_some_and(|tracked| tracked.job.is_allocation_only())
+            let Some(tracked) = jobs.get(&job_id) else {
+                return;
+            };
+            if expected_run_attempt != 0 && tracked.run_attempt != expected_run_attempt {
+                return;
+            }
+            tracked.job.is_allocation_only()
         };
         if is_allocation_only {
             self.drop_tracked_job(job_id).await;
             return;
         }
 
+        // Re-checked: a newer run could have replaced the tracked job between
+        // the lock above and this one.
         let jobs = self.running.lock().await;
         let Some(tracked) = jobs.get(&job_id) else {
             return;
         };
+        if expected_run_attempt != 0 && tracked.run_attempt != expected_run_attempt {
+            return;
+        }
         let sig =
             nix::sys::signal::Signal::try_from(signal).unwrap_or(nix::sys::signal::Signal::SIGTERM);
         info!(job_id, signal, "sending explicit signal to job");
@@ -2667,24 +2662,32 @@ impl AgentService {
     }
 
     /// SIGTERM now, escalate to SIGKILL after a 5-second grace period.
-    async fn graceful_cancel(&self, job_id: u32) {
+    async fn graceful_cancel(&self, job_id: u32, expected_run_attempt: u32) {
         let is_allocation_only = {
             let jobs = self.running.lock().await;
-            jobs.get(&job_id)
-                .is_some_and(|tracked| tracked.job.is_allocation_only())
+            let Some(tracked) = jobs.get(&job_id) else {
+                return;
+            };
+            if expected_run_attempt != 0 && tracked.run_attempt != expected_run_attempt {
+                return;
+            }
+            tracked.job.is_allocation_only()
         };
         if is_allocation_only {
             self.drop_tracked_job(job_id).await;
             return;
         }
 
-        // Epoch of the run we're cancelling; the delayed SIGKILL below must not
-        // touch a newer run that reused this job_id after a requeue.
+        // Re-checked here (the tracked job may have changed since the lock
+        // above); reused below so the delayed SIGKILL is fenced the same way.
         let cancel_attempt = {
             let jobs = self.running.lock().await;
             let Some(tracked) = jobs.get(&job_id) else {
                 return;
             };
+            if expected_run_attempt != 0 && tracked.run_attempt != expected_run_attempt {
+                return;
+            }
             info!(job_id, "graceful cancel: SIGTERM → 5s grace → SIGKILL");
             let _ = tracked.job.kill_signal(nix::sys::signal::Signal::SIGTERM);
             tracked.run_attempt
@@ -5006,7 +5009,7 @@ mod tests {
         let job_id = 900;
         svc.insert_test_job(job_id, TrackedJob::dummy(0)).await;
 
-        svc.graceful_cancel(job_id).await;
+        svc.graceful_cancel(job_id, 0).await;
 
         assert!(
             wait_job_reaped(&svc, job_id, 5_000).await,
@@ -5061,7 +5064,7 @@ mod tests {
         };
         svc.insert_test_job(job_id, tracked).await;
 
-        svc.graceful_cancel(job_id).await;
+        svc.graceful_cancel(job_id, 0).await;
 
         // 5s grace + up to 2s monitor tick + buffer
         assert!(
@@ -5126,7 +5129,7 @@ mod tests {
         svc.insert_test_job(job_id, run1).await;
 
         // Cancel epoch 1 (SIGTERM; trapped, survives) and spawn the grace timer.
-        svc.graceful_cancel(job_id).await;
+        svc.graceful_cancel(job_id, 0).await;
 
         // Simulate requeue + re-dispatch: same job_id, newer epoch.
         let (run2, pid2) = spawn_trap(2);
@@ -5242,7 +5245,7 @@ mod tests {
             "process should run after SIGCONT, got {state}"
         );
 
-        svc.send_explicit_signal(job_id, 9).await; // cleanup
+        svc.send_explicit_signal(job_id, 9, 0).await; // cleanup
     }
 
     #[tokio::test]
@@ -5258,7 +5261,7 @@ mod tests {
         let job_id = 902;
         svc.insert_test_job(job_id, TrackedJob::dummy(0)).await;
 
-        svc.send_explicit_signal(job_id, 9).await; // SIGKILL
+        svc.send_explicit_signal(job_id, 9, 0).await; // SIGKILL
 
         assert!(
             wait_job_reaped(&svc, job_id, 5_000).await,

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1574,6 +1574,24 @@ impl SlurmAgent for AgentService {
         self.check_term(req.term)?;
         let job_id = req.job_id;
 
+        // 0 = no tracked run to compare against (unknown/terminal id at the
+        // sender); otherwise a mismatch means this targets a superseded run.
+        if req.run_attempt != 0 {
+            let tracked = self
+                .running
+                .lock()
+                .await
+                .get(&job_id)
+                .map(|t| t.run_attempt);
+            if tracked.is_some_and(|current| current != req.run_attempt) {
+                info!(
+                    job_id,
+                    req.run_attempt, "cancel targets a superseded run, ignoring"
+                );
+                return Ok(Response::new(()));
+            }
+        }
+
         if req.signal > 0 {
             self.send_explicit_signal(job_id, req.signal).await;
         } else {
@@ -4664,7 +4682,7 @@ mod tests {
         );
 
         assert!(
-            reporter.held_job_ids().is_empty(),
+            reporter.held_job_ids().await.is_empty(),
             "reporter sees no jobs before registration"
         );
 
@@ -4682,7 +4700,7 @@ mod tests {
         .expect("register");
 
         assert_eq!(
-            reporter.held_job_ids(),
+            reporter.held_job_ids().await,
             vec![77],
             "reporter's heartbeat must observe the agent-registered allocation-only job"
         );
@@ -4714,6 +4732,7 @@ mod tests {
             job_id: 7,
             signal: 9,
             term: 0,
+            run_attempt: 0,
         }))
         .await
         .expect("cancel_job");
@@ -4722,6 +4741,94 @@ mod tests {
             svc.free_gpu_count().await,
             1,
             "cancel must release a launching (never-committed) reservation"
+        );
+    }
+
+    // A cancel meant for an old run must not kill the job_id's re-dispatched
+    // replacement, even for the very first signal (not just the grace escalation).
+    #[tokio::test]
+    async fn cancel_job_ignores_a_request_for_a_superseded_run() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        svc.start_monitor("http://127.0.0.1:1".into());
+
+        fn spawn_sleeper(run_attempt: u32) -> (TrackedJob, i32) {
+            let child = tokio::process::Command::new("/bin/sleep")
+                .arg("30")
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .process_group(0)
+                .spawn()
+                .expect("spawn sleep process");
+            let pid = child.id().expect("pid") as i32;
+            let t = TrackedJob {
+                job: executor::RunningJob::Managed {
+                    child,
+                    cgroup_path: None,
+                },
+                rootfs_mode: crate::container::RootfsMode::Extracted,
+                stdout_path: "/dev/null".into(),
+                stderr_path: "/dev/null".into(),
+                has_pid_namespace: false,
+                has_user_namespace: false,
+                has_mount_namespace: false,
+                _pty_master: None,
+                work_dir: "/tmp".into(),
+                uid: 0,
+                gid: 0,
+                user: "testuser".into(),
+                partition: String::new(),
+                gpu_devices: Vec::new(),
+                cpus: 1,
+                memory_mb: 0,
+                nodelist: String::new(),
+                mpi: String::new(),
+                run_attempt,
+            };
+            (t, pid)
+        }
+
+        let job_id = 903;
+        let (run2, pid2) = spawn_sleeper(2);
+        svc.insert_test_job(job_id, run2).await;
+
+        // A stray cancel for old run 1 must not touch live run 2; wait out a
+        // real (unguarded) kill before asserting the process survived.
+        svc.cancel_job(Request::new(AgentCancelJobRequest {
+            job_id,
+            signal: 9,
+            term: 0,
+            run_attempt: 1,
+        }))
+        .await
+        .unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        assert!(
+            svc.running.lock().await.contains_key(&job_id),
+            "a cancel for a superseded run must not reap the current run"
+        );
+        assert!(
+            matches!(proc_state(pid2), 'S' | 'R' | 'D'),
+            "a cancel for a superseded run must not kill the current run"
+        );
+
+        // A cancel for the current run must still work.
+        svc.cancel_job(Request::new(AgentCancelJobRequest {
+            job_id,
+            signal: 9,
+            term: 0,
+            run_attempt: 2,
+        }))
+        .await
+        .unwrap();
+        assert!(
+            wait_job_reaped(&svc, job_id, 2_000).await,
+            "a cancel matching the current run must still kill it"
         );
     }
 

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -2488,8 +2488,22 @@ impl SlurmAgent for AgentService {
 }
 
 impl AgentService {
-    async fn drop_tracked_job(&self, job_id: u32) {
-        if self.running.lock().await.remove(&job_id).is_some() {
+    // expected_run_attempt (0 = unfenced) must still match at remove time — a
+    // newer run can replace the tracked entry between the caller's own check and here.
+    async fn drop_tracked_job(&self, job_id: u32, expected_run_attempt: u32) {
+        let dropped = {
+            let mut jobs = self.running.lock().await;
+            match jobs.entry(job_id) {
+                std::collections::hash_map::Entry::Occupied(e)
+                    if expected_run_attempt == 0 || e.get().run_attempt == expected_run_attempt =>
+                {
+                    e.remove();
+                    true
+                }
+                _ => false,
+            }
+        };
+        if dropped {
             self.allocation.lock().await.release_job(job_id);
             if let Err(e) = self.mpi_host.stop_pmix_server(job_id) {
                 warn!(job_id, error = %e, "PMIx stop failed on job drop");
@@ -2627,7 +2641,7 @@ impl AgentService {
             tracked.job.is_allocation_only()
         };
         if is_allocation_only {
-            self.drop_tracked_job(job_id).await;
+            self.drop_tracked_job(job_id, expected_run_attempt).await;
             return;
         }
 
@@ -2674,7 +2688,7 @@ impl AgentService {
             tracked.job.is_allocation_only()
         };
         if is_allocation_only {
-            self.drop_tracked_job(job_id).await;
+            self.drop_tracked_job(job_id, expected_run_attempt).await;
             return;
         }
 
@@ -4832,6 +4846,36 @@ mod tests {
         assert!(
             wait_job_reaped(&svc, job_id, 2_000).await,
             "a cancel matching the current run must still kill it"
+        );
+    }
+
+    // drop_tracked_job (the allocation-only cancel path) must not remove a
+    // replacement run inserted after the caller's own epoch check passed.
+    #[tokio::test]
+    async fn drop_tracked_job_ignores_a_request_for_a_superseded_run() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        let job_id = 904;
+        let mut run2 = TrackedJob::dummy(0);
+        run2.job = executor::RunningJob::AllocationOnly;
+        run2.run_attempt = 2;
+        svc.insert_test_job(job_id, run2).await;
+
+        svc.drop_tracked_job(job_id, 1).await;
+        assert!(
+            svc.running.lock().await.contains_key(&job_id),
+            "a drop targeting a superseded run must not remove the current run"
+        );
+
+        svc.drop_tracked_job(job_id, 2).await;
+        assert!(
+            !svc.running.lock().await.contains_key(&job_id),
+            "a drop matching the current run must still remove it"
         );
     }
 

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -4,10 +4,11 @@
 //! gRPC server implementing the SlurmAgent service.
 //! Receives job launch/cancel requests from spurctld.
 
-use std::collections::HashMap;
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
 
+use prost::Message;
 use tokio::sync::Mutex;
 use tonic::{Request, Response, Status};
 use tracing::{error, info, warn};
@@ -193,6 +194,7 @@ async fn step_cancel_requested(
         .is_some_and(|step| step.cancel_requested)
 }
 
+#[derive(Clone)]
 pub struct AgentService {
     pub reporter: Arc<NodeReporter>,
     /// In-memory only: starts empty on every spurd start/restart, regardless
@@ -211,6 +213,152 @@ pub struct AgentService {
     active_steps: Arc<Mutex<HashMap<(u32, u32), ActiveStep>>>,
     /// Highest Raft term seen, so a demoted leader's request is rejected.
     highest_term_seen: Arc<std::sync::atomic::AtomicU64>,
+    applied_commands: Arc<Mutex<HashMap<u64, AppliedCommandResult>>>,
+    shutting_down: Arc<AtomicBool>,
+    step_lifecycle: Arc<StdMutex<HashMap<(u32, u32), usize>>>,
+}
+
+#[derive(Clone)]
+struct AppliedCommandResult {
+    success: bool,
+    response_payload: Vec<u8>,
+    error: String,
+}
+
+struct StepLifecycleGuard {
+    step_lifecycle: Arc<StdMutex<HashMap<(u32, u32), usize>>>,
+    key: (u32, u32),
+}
+
+impl StepLifecycleGuard {
+    fn new(
+        step_lifecycle: Arc<StdMutex<HashMap<(u32, u32), usize>>>,
+        job_id: u32,
+        run_attempt: u32,
+    ) -> Self {
+        let key = (job_id, run_attempt);
+        let mut steps = step_lifecycle
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *steps.entry(key).or_default() += 1;
+        drop(steps);
+        Self {
+            step_lifecycle,
+            key,
+        }
+    }
+}
+
+impl Drop for StepLifecycleGuard {
+    fn drop(&mut self) {
+        let mut steps = self
+            .step_lifecycle
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let Some(count) = steps.get_mut(&self.key) else {
+            return;
+        };
+        *count -= 1;
+        if *count == 0 {
+            steps.remove(&self.key);
+        }
+    }
+}
+
+fn has_active_steps(
+    active_steps: &StdMutex<HashMap<(u32, u32), usize>>,
+    job_id: u32,
+    run_attempt: u32,
+) -> bool {
+    active_steps
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&(job_id, run_attempt))
+        .is_some_and(|count| *count > 0)
+}
+
+async fn wait_for_active_steps(
+    active_steps: &StdMutex<HashMap<(u32, u32), usize>>,
+    job_id: u32,
+    run_attempt: u32,
+) {
+    while has_active_steps(active_steps, job_id, run_attempt) {
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    }
+}
+
+async fn settle_residual_allocation(
+    active_steps: &StdMutex<HashMap<(u32, u32), usize>>,
+    job_id: u32,
+    run_attempt: u32,
+) -> anyhow::Result<()> {
+    executor::terminate_residual_allocation(job_id, run_attempt).await?;
+    wait_for_active_steps(active_steps, job_id, run_attempt).await;
+    executor::terminate_residual_allocation(job_id, run_attempt).await
+}
+
+fn allocation_owned_by_different_attempt(
+    allocation: &NodeAllocation,
+    job_id: u32,
+    run_attempt: u32,
+) -> bool {
+    run_attempt != 0
+        && allocation
+            .owned_allocations()
+            .into_iter()
+            .any(|owner| owner.job_id == job_id && owner.run_attempt != run_attempt)
+}
+
+async fn settle_current_allocation(
+    allocation: &Mutex<NodeAllocation>,
+    active_steps: &StdMutex<HashMap<(u32, u32), usize>>,
+    job_id: u32,
+    run_attempt: u32,
+) -> anyhow::Result<bool> {
+    let allocation = allocation.lock().await;
+    if allocation_owned_by_different_attempt(&allocation, job_id, run_attempt) {
+        return Ok(false);
+    }
+    settle_residual_allocation(active_steps, job_id, run_attempt).await?;
+    Ok(true)
+}
+
+async fn release_settled_allocation(
+    allocation: &Mutex<NodeAllocation>,
+    job_id: u32,
+    run_attempt: u32,
+) -> bool {
+    let mut allocation = allocation.lock().await;
+    if allocation_owned_by_different_attempt(&allocation, job_id, run_attempt) {
+        return false;
+    }
+    allocation.release_job_if_attempt(job_id, run_attempt);
+    crate::executor::cleanup_job_spool(job_id);
+    true
+}
+
+fn core_allocations(resources: &ResourceAllocations) -> spur_core::resource::ResourceAllocations {
+    spur_core::resource::ResourceAllocations {
+        cpus: resources.cpus,
+        memory_mb: resources.memory_mb,
+        devices: resources
+            .devices
+            .iter()
+            .map(|(name, devices)| {
+                (
+                    name.clone(),
+                    devices
+                        .devices
+                        .iter()
+                        .map(|device| spur_core::resource::AllocatedDevice {
+                            device_id: device.device_id,
+                            count: device.count,
+                        })
+                        .collect(),
+                )
+            })
+            .collect(),
+    }
 }
 
 impl AgentService {
@@ -246,12 +394,11 @@ impl AgentService {
         mpi: MpiConfig,
         running: RunningJobs,
     ) -> Self {
-        let allocation = NodeAllocation::new(
-            hostname::get()
-                .map(|h| h.to_string_lossy().to_string())
-                .unwrap_or_else(|_| "unknown".into()),
+        let allocation = Arc::new(Mutex::new(NodeAllocation::new(
+            reporter.hostname.clone(),
             &reporter.resources,
-        );
+        )));
+        reporter.set_allocation_source(allocation.clone());
 
         // Load SPANK plugins from plugstack.conf if available
         let plugstack_path = std::env::var("SPUR_PLUGSTACK")
@@ -300,7 +447,7 @@ impl AgentService {
         Self {
             reporter,
             running,
-            allocation: Arc::new(Mutex::new(allocation)),
+            allocation,
             spank: Arc::new(spank),
             mpi_host: Arc::new(MpiPluginHost::new(mpi)),
             hooks: Arc::new(hooks),
@@ -309,6 +456,9 @@ impl AgentService {
             k0s: Arc::new(crate::cluster::K0sAgent::from_config(cluster)),
             active_steps: Arc::new(Mutex::new(HashMap::new())),
             highest_term_seen: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            applied_commands: Arc::new(Mutex::new(HashMap::new())),
+            shutting_down: Arc::new(AtomicBool::new(false)),
+            step_lifecycle: Arc::new(StdMutex::new(HashMap::new())),
         }
     }
 
@@ -333,9 +483,105 @@ impl AgentService {
         Ok(())
     }
 
+    async fn has_different_local_attempt(&self, job_id: u32, run_attempt: u32) -> bool {
+        if run_attempt == 0 {
+            return false;
+        }
+        if self
+            .running
+            .lock()
+            .await
+            .get(&job_id)
+            .is_some_and(|tracked| tracked.run_attempt != run_attempt)
+        {
+            return true;
+        }
+        self.allocation
+            .lock()
+            .await
+            .owned_allocations()
+            .into_iter()
+            .any(|allocation| allocation.job_id == job_id && allocation.run_attempt != run_attempt)
+    }
+
     /// Handle to the RPC-driven k0s component owner. spurd `main()` spawns its supervise loop.
     pub fn k0s(&self) -> Arc<crate::cluster::K0sAgent> {
         self.k0s.clone()
+    }
+
+    pub async fn shutdown_jobs(&self) -> anyhow::Result<()> {
+        if self.shutting_down.swap(true, Ordering::AcqRel) {
+            return Ok(());
+        }
+
+        let mut cleanup_failures = HashMap::new();
+        let tracked: Vec<_> = self.running.lock().await.drain().collect();
+        for (job_id, mut tracked) in tracked {
+            let _ = tracked.job.kill_signal(nix::sys::signal::Signal::SIGKILL);
+            let cgroup = tracked.job.take_cgroup();
+            let rootfs_mode = tracked.rootfs_mode.clone();
+            let mpi = tracked.mpi.clone();
+            let run_attempt = tracked.run_attempt;
+            reap_killed_job(tracked.job).await;
+            crate::container::cleanup_rootfs(job_id, &rootfs_mode);
+            if let Some(ref cgroup) = cgroup {
+                crate::executor::cleanup_cgroup(cgroup);
+            }
+            crate::executor::cleanup_job_cgroup(job_id);
+            cleanup_completed_job_mpi(job_id, &mpi, &self.mpi_host).await;
+            if let Err(error) =
+                settle_residual_allocation(&self.step_lifecycle, job_id, run_attempt).await
+            {
+                warn!(job_id, run_attempt, error = %error, "job cleanup incomplete during shutdown");
+                cleanup_failures.insert((job_id, run_attempt), error.to_string());
+                continue;
+            }
+            self.allocation
+                .lock()
+                .await
+                .release_job_if_attempt(job_id, run_attempt);
+            crate::executor::cleanup_job_spool(job_id);
+        }
+
+        let remaining = self.allocation.lock().await.owned_allocations();
+        for owner in remaining {
+            if let Err(error) = self.mpi_host.stop_pmix_server(owner.job_id) {
+                warn!(job_id = owner.job_id, error = %error, "PMIx stop failed during shutdown");
+            }
+            crate::executor::cleanup_job_cgroup(owner.job_id);
+            if let Err(error) =
+                settle_residual_allocation(&self.step_lifecycle, owner.job_id, owner.run_attempt)
+                    .await
+            {
+                warn!(
+                    job_id = owner.job_id,
+                    run_attempt = owner.run_attempt,
+                    error = %error,
+                    "allocation cleanup incomplete during shutdown"
+                );
+                cleanup_failures.insert((owner.job_id, owner.run_attempt), error.to_string());
+                continue;
+            }
+            cleanup_failures.remove(&(owner.job_id, owner.run_attempt));
+            self.allocation
+                .lock()
+                .await
+                .release_job_if_attempt(owner.job_id, owner.run_attempt);
+            crate::executor::cleanup_job_spool(owner.job_id);
+        }
+
+        if cleanup_failures.is_empty() {
+            Ok(())
+        } else {
+            let failures = cleanup_failures
+                .into_iter()
+                .map(|((job_id, run_attempt), error)| {
+                    format!("job {job_id} attempt {run_attempt}: {error}")
+                })
+                .collect::<Vec<_>>()
+                .join("; ");
+            anyhow::bail!("local cleanup is incomplete: {}", failures)
+        }
     }
 
     /// Spawn a background task to monitor running jobs and report completions.
@@ -345,6 +591,8 @@ impl AgentService {
         let spank = self.spank.clone();
         let mpi_host = self.mpi_host.clone();
         let hooks = self.hooks.clone();
+        let step_lifecycle = self.step_lifecycle.clone();
+        let reporter = self.reporter.clone();
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(2));
             loop {
@@ -393,15 +641,14 @@ impl AgentService {
 
                 for c in &completed {
                     jobs.remove(&c.job_id);
-                    crate::container::cleanup_rootfs(c.job_id, &c.rootfs_mode);
-                    crate::executor::cleanup_job_spool(c.job_id);
-                    if let Some(ref cgroup) = c.cgroup {
-                        crate::executor::cleanup_cgroup(cgroup);
-                    }
                     allocation
                         .lock()
                         .await
-                        .release_job_if_attempt(c.job_id, c.run_attempt);
+                        .begin_release(c.job_id, c.run_attempt);
+                    crate::container::cleanup_rootfs(c.job_id, &c.rootfs_mode);
+                    if let Some(ref cgroup) = c.cgroup {
+                        crate::executor::cleanup_cgroup(cgroup);
+                    }
                     cleanup_completed_job_mpi(c.job_id, &c.mpi, &mpi_host).await;
                 }
 
@@ -416,9 +663,7 @@ impl AgentService {
                 // completions if the RPC times out.
                 drop(jobs);
 
-                let local_hostname = hostname::get()
-                    .map(|h| h.to_string_lossy().to_string())
-                    .unwrap_or_else(|_| "localhost".into());
+                let local_hostname = reporter.hostname.clone();
 
                 let mut drain_jobs: std::collections::HashSet<u32> =
                     std::collections::HashSet::new();
@@ -476,24 +721,373 @@ impl AgentService {
                     } else {
                         None
                     };
-                    report_completion(
-                        &controller_addr,
+                    let physically_released = settle_current_allocation(
+                        &allocation,
+                        &step_lifecycle,
                         c.job_id,
-                        c.exit_code,
-                        c.signal,
                         c.run_attempt,
-                        &local_hostname,
-                        drain.as_ref(),
                     )
-                    .await;
+                    .await
+                    .map_err(|error| {
+                        warn!(
+                            job_id = c.job_id,
+                            run_attempt = c.run_attempt,
+                            error = %error,
+                            "job completion waits for residual process cleanup"
+                        );
+                    })
+                    .unwrap_or(false);
+                    let reported = physically_released
+                        && report_completion(
+                            &controller_addr,
+                            CompletionReport {
+                                job_id: c.job_id,
+                                exit_code: c.exit_code,
+                                signal: c.signal,
+                                run_attempt: c.run_attempt,
+                                reporting_node: &local_hostname,
+                                drain: drain.as_ref(),
+                                agent_session_id: reporter.agent_session_id(),
+                                node_boot_id: reporter.node_boot_id(),
+                                node_token: &reporter.node_token(),
+                            },
+                        )
+                        .await;
+                    if reported {
+                        release_settled_allocation(&allocation, c.job_id, c.run_attempt).await;
+                        continue;
+                    }
+
+                    let retry_controller = controller_addr.clone();
+                    let retry_node = local_hostname.clone();
+                    let retry_allocation = allocation.clone();
+                    let retry_drain = drain.clone();
+                    let retry_step_lifecycle = step_lifecycle.clone();
+                    let retry_reporter = reporter.clone();
+                    let job_id = c.job_id;
+                    let exit_code = c.exit_code;
+                    let signal = c.signal;
+                    let run_attempt = c.run_attempt;
+                    tokio::spawn(async move {
+                        let mut retry = tokio::time::interval(tokio::time::Duration::from_secs(2));
+                        loop {
+                            retry.tick().await;
+                            match settle_current_allocation(
+                                &retry_allocation,
+                                &retry_step_lifecycle,
+                                job_id,
+                                run_attempt,
+                            )
+                            .await
+                            {
+                                Ok(true) => {}
+                                Ok(false) => {
+                                    info!(
+                                        job_id,
+                                        run_attempt,
+                                        "stopping completion retry for a superseded attempt"
+                                    );
+                                    break;
+                                }
+                                Err(error) => {
+                                    warn!(
+                                        job_id,
+                                        run_attempt,
+                                        error = %error,
+                                        "residual process cleanup still incomplete"
+                                    );
+                                    continue;
+                                }
+                            }
+                            if !report_completion(
+                                &retry_controller,
+                                CompletionReport {
+                                    job_id,
+                                    exit_code,
+                                    signal,
+                                    run_attempt,
+                                    reporting_node: &retry_node,
+                                    drain: retry_drain.as_ref(),
+                                    agent_session_id: retry_reporter.agent_session_id(),
+                                    node_boot_id: retry_reporter.node_boot_id(),
+                                    node_token: &retry_reporter.node_token(),
+                                },
+                            )
+                            .await
+                            {
+                                continue;
+                            }
+                            release_settled_allocation(&retry_allocation, job_id, run_attempt)
+                                .await;
+                            break;
+                        }
+                    });
                 }
             }
         });
     }
+
+    pub async fn command_loop(&self) {
+        let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(1));
+        loop {
+            interval.tick().await;
+            let channel = match spur_client::connect_channel(&self.reporter.controller_addr).await {
+                Ok(channel) => channel,
+                Err(error) => {
+                    tracing::debug!(error = %error, "agent command poll connection failed");
+                    continue;
+                }
+            };
+            let mut client = spur_proto::controller_client(channel);
+            let poll = PollAgentCommandsRequest {
+                hostname: self.reporter.hostname.clone(),
+                node_token: self.reporter.node_token(),
+                agent_session_id: self.reporter.agent_session_id().to_string(),
+                node_boot_id: self.reporter.node_boot_id().to_string(),
+            };
+            let commands = match client.poll_agent_commands(poll).await {
+                Ok(response) => response.into_inner().commands,
+                Err(error) => {
+                    tracing::debug!(error = %error, "agent command poll failed");
+                    continue;
+                }
+            };
+            let pending_ids: HashSet<_> =
+                commands.iter().map(|command| command.command_id).collect();
+            self.applied_commands
+                .lock()
+                .await
+                .retain(|command_id, _| pending_ids.contains(command_id));
+
+            for command in commands {
+                let result = self.apply_or_replay_command(&command).await;
+
+                let acknowledgement = AcknowledgeAgentCommandRequest {
+                    hostname: self.reporter.hostname.clone(),
+                    node_token: self.reporter.node_token(),
+                    agent_session_id: self.reporter.agent_session_id().to_string(),
+                    node_boot_id: self.reporter.node_boot_id().to_string(),
+                    command_id: command.command_id,
+                    job_id: command.job_id,
+                    run_attempt: command.run_attempt,
+                    success: result.success,
+                    response_payload: result.response_payload,
+                    error: result.error,
+                };
+                match client.acknowledge_agent_command(acknowledgement).await {
+                    Ok(_) => {
+                        self.applied_commands
+                            .lock()
+                            .await
+                            .remove(&command.command_id);
+                    }
+                    Err(error) => {
+                        warn!(
+                            command_id = command.command_id,
+                            error = %error,
+                            "agent command acknowledgement failed"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    async fn apply_or_replay_command(&self, command: &AgentCommand) -> AppliedCommandResult {
+        let cached = {
+            let applied = self.applied_commands.lock().await;
+            applied.get(&command.command_id).cloned()
+        };
+        if let Some(result) = cached {
+            return result;
+        }
+
+        let result = self.apply_polled_command(command).await;
+        if result.success
+            && matches!(
+                AgentCommandKind::try_from(command.kind),
+                Ok(AgentCommandKind::Launch | AgentCommandKind::Register)
+            )
+        {
+            let _ = self.allocation.lock().await.set_last_command_id(
+                command.job_id,
+                command.run_attempt,
+                command.command_id,
+            );
+        }
+        self.applied_commands
+            .lock()
+            .await
+            .insert(command.command_id, result.clone());
+        result
+    }
+
+    async fn apply_polled_command(&self, command: &AgentCommand) -> AppliedCommandResult {
+        if command.node != self.reporter.hostname {
+            return AppliedCommandResult {
+                success: false,
+                response_payload: Vec::new(),
+                error: "command targets a different node".into(),
+            };
+        }
+
+        match AgentCommandKind::try_from(command.kind) {
+            Ok(AgentCommandKind::Launch) => {
+                let request = match LaunchJobRequest::decode(command.payload.as_slice()) {
+                    Ok(request)
+                        if request.job_id == command.job_id
+                            && request.run_attempt == command.run_attempt =>
+                    {
+                        request
+                    }
+                    Ok(_) => {
+                        return AppliedCommandResult {
+                            success: false,
+                            response_payload: Vec::new(),
+                            error: "launch payload identity does not match command".into(),
+                        }
+                    }
+                    Err(error) => {
+                        return AppliedCommandResult {
+                            success: false,
+                            response_payload: Vec::new(),
+                            error: format!("invalid launch payload: {error}"),
+                        }
+                    }
+                };
+                match <Self as SlurmAgent>::launch_job(self, Request::new(request)).await {
+                    Ok(response) => {
+                        let response = response.into_inner();
+                        AppliedCommandResult {
+                            success: response.success,
+                            error: response.error.clone(),
+                            response_payload: response.encode_to_vec(),
+                        }
+                    }
+                    Err(error) => AppliedCommandResult {
+                        success: false,
+                        response_payload: Vec::new(),
+                        error: error.to_string(),
+                    },
+                }
+            }
+            Ok(AgentCommandKind::Register) => {
+                let request = match RegisterJobAllocationRequest::decode(command.payload.as_slice())
+                {
+                    Ok(request)
+                        if request.job_id == command.job_id
+                            && request.run_attempt == command.run_attempt =>
+                    {
+                        request
+                    }
+                    Ok(_) => {
+                        return AppliedCommandResult {
+                            success: false,
+                            response_payload: Vec::new(),
+                            error: "registration payload identity does not match command".into(),
+                        }
+                    }
+                    Err(error) => {
+                        return AppliedCommandResult {
+                            success: false,
+                            response_payload: Vec::new(),
+                            error: format!("invalid registration payload: {error}"),
+                        }
+                    }
+                };
+                match <Self as SlurmAgent>::register_job_allocation(self, Request::new(request))
+                    .await
+                {
+                    Ok(response) => AppliedCommandResult {
+                        success: true,
+                        response_payload: response.into_inner().encode_to_vec(),
+                        error: String::new(),
+                    },
+                    Err(error) => AppliedCommandResult {
+                        success: false,
+                        response_payload: Vec::new(),
+                        error: error.to_string(),
+                    },
+                }
+            }
+            Ok(AgentCommandKind::Release) => {
+                match self
+                    .apply_release_command(command.job_id, command.run_attempt, command.signal)
+                    .await
+                {
+                    Ok(()) => AppliedCommandResult {
+                        success: true,
+                        response_payload: Vec::new(),
+                        error: String::new(),
+                    },
+                    Err(error) => AppliedCommandResult {
+                        success: false,
+                        response_payload: Vec::new(),
+                        error: error.to_string(),
+                    },
+                }
+            }
+            _ => AppliedCommandResult {
+                success: false,
+                response_payload: Vec::new(),
+                error: "unknown agent command kind".into(),
+            },
+        }
+    }
+
+    async fn apply_release_command(
+        &self,
+        job_id: u32,
+        run_attempt: u32,
+        signal: i32,
+    ) -> anyhow::Result<()> {
+        if self.has_different_local_attempt(job_id, run_attempt).await {
+            anyhow::bail!(
+                "job {job_id} attempt {run_attempt} was superseded by a local allocation"
+            );
+        }
+        if signal > 0 {
+            self.send_explicit_signal(job_id, signal, run_attempt).await;
+        } else {
+            self.graceful_cancel(job_id, run_attempt).await;
+        }
+
+        loop {
+            let running = self
+                .running
+                .lock()
+                .await
+                .get(&job_id)
+                .is_some_and(|job| run_attempt == 0 || job.run_attempt == run_attempt);
+            if !running {
+                settle_residual_allocation(&self.step_lifecycle, job_id, run_attempt).await?;
+                self.allocation
+                    .lock()
+                    .await
+                    .release_job_if_attempt(job_id, run_attempt);
+                return Ok(());
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        }
+    }
 }
 
+#[derive(Clone)]
 struct DrainRequest {
     reason: String,
+}
+
+#[derive(Clone, Copy)]
+struct CompletionReport<'a> {
+    job_id: u32,
+    exit_code: i32,
+    signal: i32,
+    run_attempt: u32,
+    reporting_node: &'a str,
+    drain: Option<&'a DrainRequest>,
+    agent_session_id: &'a str,
+    node_boot_id: &'a str,
+    node_token: &'a str,
 }
 
 /// Reclaim a launch reservation that never commits within this bound. Sized
@@ -817,15 +1411,18 @@ fn inject_script_args(script: &str, args: &[String]) -> Result<String, Status> {
     Ok(format!("{set_line}\n{script}"))
 }
 
-async fn report_completion(
-    controller_addr: &str,
-    job_id: u32,
-    exit_code: i32,
-    signal: i32,
-    run_attempt: u32,
-    reporting_node: &str,
-    drain: Option<&DrainRequest>,
-) {
+async fn report_completion(controller_addr: &str, report: CompletionReport<'_>) -> bool {
+    let CompletionReport {
+        job_id,
+        exit_code,
+        signal,
+        run_attempt,
+        reporting_node,
+        drain,
+        agent_session_id,
+        node_boot_id,
+        node_token,
+    } = report;
     // Wire `state` is derived from `exit_code` alone (advisory): a signaled job
     // reports Completed/0 because the controller's validator requires
     // state<->exit_code agreement. The controller rederives the true Failed /
@@ -854,6 +1451,9 @@ async fn report_completion(
             drain_reason: drain.as_ref().map(|d| d.reason.clone()).unwrap_or_default(),
             reporting_node: reporting_node.to_string(),
             run_attempt,
+            agent_session_id: agent_session_id.to_string(),
+            node_boot_id: node_boot_id.to_string(),
+            node_token: node_token.to_string(),
         };
         spur_proto::controller_client(channel)
             .report_job_status(req)
@@ -871,25 +1471,34 @@ async fn report_completion(
     .await;
 
     match result {
-        Ok(_) => info!(
-            job_id,
-            exit_code,
-            controller = %controller_addr,
-            "reported completion to controller"
-        ),
-        Err(e) if e.retryable() => error!(
-            job_id,
-            exit_code,
-            attempts = CONTROLLER_RPC_ATTEMPTS,
-            error = %e,
-            "gave up reporting completion to controller"
-        ),
-        Err(e) => error!(
-            job_id,
-            exit_code,
-            error = %e,
-            "ReportJobStatus failed with non-retryable error"
-        ),
+        Ok(_) => {
+            info!(
+                job_id,
+                exit_code,
+                controller = %controller_addr,
+                "reported completion to controller"
+            );
+            true
+        }
+        Err(e) if e.retryable() => {
+            error!(
+                job_id,
+                exit_code,
+                attempts = CONTROLLER_RPC_ATTEMPTS,
+                error = %e,
+                "gave up reporting completion to controller"
+            );
+            false
+        }
+        Err(e) => {
+            error!(
+                job_id,
+                exit_code,
+                error = %e,
+                "ReportJobStatus failed with non-retryable error"
+            );
+            false
+        }
     }
 }
 
@@ -979,6 +1588,9 @@ impl SlurmAgent for AgentService {
     ) -> Result<Response<LaunchJobResponse>, Status> {
         let req = request.into_inner();
         self.check_term(req.term)?;
+        if self.shutting_down.load(Ordering::Acquire) {
+            return Err(Status::unavailable("agent is shutting down"));
+        }
         let job_id = req.job_id;
         let peer_nodes = req.peer_nodes;
         let task_offset = req.task_offset;
@@ -1019,9 +1631,7 @@ impl SlurmAgent for AgentService {
             (spec.num_tasks / spec.num_nodes.max(1)).max(1)
         };
         let node_rank = task_offset / tasks_per_node.max(1);
-        let hostname = hostname::get()
-            .map(|h| h.to_string_lossy().to_string())
-            .unwrap_or_else(|_| "localhost".into());
+        let hostname = self.reporter.hostname.clone();
         let mut senv = SpurEnv::new();
         senv.extend(&spec.environment);
 
@@ -1406,6 +2016,35 @@ impl SlurmAgent for AgentService {
 
         match executor::launch_job(&launch_cfg, (*self.spank).as_ref()).await {
             Ok(mut result) => {
+                if let Err(error) =
+                    executor::write_recovery_manifest(job_id, run_attempt, &result.job)
+                {
+                    let error = format!("failed to record launched process: {error:#}");
+                    let controller = self.reporter.controller_addr.clone();
+                    let node_name = self.reporter.hostname.clone();
+                    let drain_reason = error.clone();
+                    tokio::spawn(async move {
+                        request_node_drain(&controller, &node_name, &drain_reason, job_id).await;
+                    });
+                    let _ = result.job.kill_signal(nix::sys::signal::Signal::SIGKILL);
+                    let cgroup = result.job.take_cgroup();
+                    let cleanup_rootfs = rootfs_mode.clone();
+                    tokio::spawn(async move {
+                        reap_killed_job(result.job).await;
+                        crate::container::cleanup_rootfs(job_id, &cleanup_rootfs);
+                        crate::executor::cleanup_job_spool(job_id);
+                        if let Some(ref cgroup) = cgroup {
+                            crate::executor::cleanup_cgroup(cgroup);
+                        }
+                    });
+                    return Ok(Response::new(LaunchJobResponse {
+                        success: false,
+                        error,
+                        stdout_path: String::new(),
+                        stderr_path: String::new(),
+                        failure_kind: LaunchFailureKind::LaunchFailureUnspecified as i32,
+                    }));
+                }
                 pmix_guard.as_mut().map(PmixLaunchGuard::disarm);
                 let mut jobs = self.running.lock().await;
                 // Commit the reservation: the job now has a tracked process, so
@@ -1418,7 +2057,8 @@ impl SlurmAgent for AgentService {
                 // A newer-term request raced past our check while this launch was
                 // in flight — committing now would resurrect a demoted leader's write.
                 let stale_term = self.check_term(req.term).is_err();
-                if stale_term {
+                let shutting_down = self.shutting_down.load(Ordering::Acquire);
+                if stale_term || shutting_down {
                     self.allocation
                         .lock()
                         .await
@@ -1427,11 +2067,12 @@ impl SlurmAgent for AgentService {
 
                 // Reservation reclaimed (launch exceeded the TTL) or term superseded:
                 // kill, reap, and clean up rather than track a job with no backing.
-                if !committed || stale_term {
+                if !committed || stale_term || shutting_down {
                     drop(jobs);
                     warn!(
                         job_id,
                         stale_term,
+                        shutting_down,
                         "reservation reclaimed or superseded during launch; aborting to avoid running unbacked"
                     );
                     if let Err(e) = self.mpi_host.stop_pmix_server(job_id) {
@@ -1456,7 +2097,9 @@ impl SlurmAgent for AgentService {
                             crate::executor::cleanup_cgroup(cg);
                         }
                     });
-                    let error = if stale_term {
+                    let error = if shutting_down {
+                        "agent is shutting down"
+                    } else if stale_term {
                         "controller term superseded during launch"
                     } else {
                         "reservation reclaimed during launch"
@@ -1594,27 +2237,28 @@ impl SlurmAgent for AgentService {
         self.check_term(req.term)?;
         let job_id = req.job_id;
 
-        // run_attempt (0 = unfenced) is checked inside the signal call itself,
-        // under the same lock that selects the tracked job.
-        if req.signal > 0 {
+        if self
+            .has_different_local_attempt(job_id, req.run_attempt)
+            .await
+        {
+            return Ok(Response::new(()));
+        }
+        let requires_synchronous_cleanup = self
+            .running
+            .lock()
+            .await
+            .get(&job_id)
+            .is_none_or(|tracked| tracked.job.is_allocation_only());
+        if requires_synchronous_cleanup {
+            self.apply_release_command(job_id, req.run_attempt, req.signal)
+                .await
+                .map_err(|error| Status::internal(error.to_string()))?;
+        } else if req.signal > 0 {
             self.send_explicit_signal(job_id, req.signal, req.run_attempt)
                 .await;
         } else {
             self.graceful_cancel(job_id, req.run_attempt).await;
         }
-
-        // The signal paths only act on a running job; release a still-launching
-        // reservation so a cancel-during-eviction doesn't strand it until the
-        // TTL. Hold the running lock across the release (matching launch_job's
-        // commit order) so this can't free a job that just became running.
-        let jobs = self.running.lock().await;
-        if !jobs.contains_key(&job_id) {
-            self.allocation
-                .lock()
-                .await
-                .release_job_if_attempt(job_id, req.run_attempt);
-        }
-        drop(jobs);
 
         if let Err(err) = self.mpi_host.release_prepared_pmix(job_id) {
             warn!(job_id, error = %err, "PMIx prepare release on cancel failed");
@@ -1752,6 +2396,9 @@ impl SlurmAgent for AgentService {
     ) -> Result<Response<RegisterJobAllocationResponse>, Status> {
         let req = request.into_inner();
         self.check_term(req.term)?;
+        if self.shutting_down.load(Ordering::Acquire) {
+            return Err(Status::unavailable("agent is shutting down"));
+        }
         if req.job_id == 0 {
             return Err(Status::invalid_argument("job_id is required"));
         }
@@ -1776,6 +2423,9 @@ impl SlurmAgent for AgentService {
         // insert (running → allocation, as in commit) so the job is never
         // committed-but-absent-from-running, which the reclaim reads as stale.
         let mut jobs = self.running.lock().await;
+        if self.shutting_down.load(Ordering::Acquire) {
+            return Err(Status::unavailable("agent is shutting down"));
+        }
         if jobs.contains_key(&req.job_id) {
             return Err(Status::already_exists(format!(
                 "job {} already registered on this node",
@@ -1801,6 +2451,13 @@ impl SlurmAgent for AgentService {
                         req.job_id
                     )),
                 })?;
+            if let Some(resources) = allocated {
+                let _ = alloc.set_exact_resources(
+                    req.job_id,
+                    req.run_attempt,
+                    core_allocations(resources),
+                );
+            }
             let _ = alloc.commit_job(req.job_id);
         }
 
@@ -1887,15 +2544,22 @@ impl SlurmAgent for AgentService {
         // node already confirmed via LaunchJob (confirm_dispatch_on_nodes) — so a
         // miss is a wrong job/node pairing, not a launch race. The one uncovered
         // case is a spurd restart mid-job, which starts `running` empty.
-        let (gpu_devices, partition, cpus, memory_mb, nodelist, job_mpi) = {
+        let (
+            gpu_devices,
+            partition,
+            cpus,
+            memory_mb,
+            nodelist,
+            job_mpi,
+            run_attempt,
+            _active_step_guard,
+        ) = {
             let jobs = self.running.lock().await;
             let tracked = jobs.get(&job_id).ok_or_else(|| {
                 Status::not_found(format!("job {} not running on this node", job_id))
             })?;
             let nodelist = if tracked.nodelist.is_empty() {
-                hostname::get()
-                    .map(|h| h.to_string_lossy().to_string())
-                    .unwrap_or_else(|_| "localhost".into())
+                self.reporter.hostname.clone()
             } else {
                 tracked.nodelist.clone()
             };
@@ -1906,6 +2570,8 @@ impl SlurmAgent for AgentService {
                 tracked.memory_mb,
                 nodelist,
                 tracked.mpi.clone(),
+                tracked.run_attempt,
+                StepLifecycleGuard::new(self.step_lifecycle.clone(), job_id, tracked.run_attempt),
             )
         };
 
@@ -2140,35 +2806,78 @@ impl SlurmAgent for AgentService {
             "RunCommand: executing step"
         );
 
-        use std::process::Stdio;
+        cmd.stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true);
 
+        let jobs = self.running.lock().await;
+        if self.shutting_down.load(Ordering::Acquire) {
+            return Err(Status::unavailable("agent is shutting down"));
+        }
+        let tracked = jobs
+            .get(&job_id)
+            .filter(|tracked| tracked.run_attempt == run_attempt)
+            .ok_or_else(|| {
+                Status::failed_precondition(format!(
+                    "job {job_id} run attempt changed before step launch"
+                ))
+            })?;
+        let cgroup = executor::setup_step_cgroup(job_id, tracked.cpus, tracked.memory_mb)
+            .map_err(|error| Status::internal(format!("step cgroup setup failed: {error}")))?;
         let mut child = cmd
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
             .spawn()
-            .map_err(|e| Status::internal(format!("command failed: {}", e)))?;
-        if let Some(pid) = child.id() {
-            let cancel_now = {
-                let mut steps = self.active_steps.lock().await;
-                if let Some(step) = steps.get_mut(&step_key) {
-                    step.pid = Some(pid);
-                    step.cancel_requested
-                } else {
-                    false
-                }
-            };
-            if cancel_now {
-                signal_step_process_group(pid, nix::sys::signal::Signal::SIGTERM as i32);
-                let _ = child.kill().await;
-                let _ = child.wait_with_output().await;
-                return Ok(Response::new(cancelled_step_response()));
-            }
+            .map_err(|error| Status::internal(format!("command failed: {error}")))?;
+        let pid = child
+            .id()
+            .ok_or_else(|| Status::internal("step process exited before its pid was recorded"))?;
+
+        if cgroup
+            .as_deref()
+            .is_some_and(|path| !executor::attach_process_to_cgroup(path, pid))
+        {
+            drop(jobs);
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            return Err(Status::internal("failed to attach step process to cgroup"));
         }
 
-        let output = match child.wait_with_output().await {
-            Ok(output) => output,
-            Err(e) => return Err(Status::internal(format!("command failed: {}", e))),
+        if let Err(error) = executor::write_process_recovery_manifest(
+            job_id,
+            run_attempt,
+            pid as i32,
+            cgroup.as_deref(),
+        ) {
+            drop(jobs);
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            return Err(Status::internal(format!(
+                "failed to record step process for recovery: {error}"
+            )));
+        }
+
+        let cancel_now = {
+            let mut steps = self.active_steps.lock().await;
+            if let Some(step) = steps.get_mut(&step_key) {
+                step.pid = Some(pid);
+                step.cancel_requested
+            } else {
+                false
+            }
         };
+        drop(jobs);
+
+        if cancel_now {
+            signal_step_process_group(pid, nix::sys::signal::Signal::SIGTERM as i32);
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            executor::remove_process_recovery_manifest(job_id, run_attempt, pid as i32);
+            return Ok(Response::new(cancelled_step_response()));
+        }
+
+        let output = child.wait_with_output().await;
+        executor::remove_process_recovery_manifest(job_id, run_attempt, pid as i32);
+        let output =
+            output.map_err(|error| Status::internal(format!("command failed: {error}")))?;
 
         if let Some(ref task_epilog) = self.hooks.task_epilog {
             let ctx = spur_core::hooks::HookContext {
@@ -2577,82 +3286,43 @@ impl AgentService {
             )));
         }
 
-        // Hold running across the reclaim (running-then-allocation, as in commit)
-        // so a concurrent commit can't make a live owner look stale.
-        let running = self.running.lock().await;
-        let live: std::collections::HashSet<u32> = running.keys().copied().collect();
-
         let mut alloc = self.allocation.lock().await;
 
-        let cpus = if spec.cpus_per_task > 0 {
-            spec.cpus_per_task
-        } else {
-            0
-        };
+        let cpus = allocated.map_or(spec.cpus_per_task, |resources| resources.cpus);
+        let memory_mb = allocated.map_or(spec.memory_per_node_mb, |resources| resources.memory_mb);
         let result = match alloc.allocate_for_job_with_attempt(
             job_id,
             cpus,
-            spec.memory_per_node_mb,
+            memory_mb,
             &controller_gpu_ids,
             run_attempt,
         ) {
             Ok(result) => result,
             Err(AllocError::GpusUnavailable) => {
-                // A conflicting owner absent from the live set is stale (the
-                // controller only re-launches after freeing it); reclaim and retry.
-                let stale: Vec<u32> = alloc
-                    .conflicting_owners(&controller_gpu_ids)
-                    .into_iter()
-                    .filter(|owner| !live.contains(owner))
-                    .collect();
-                if !stale.is_empty() {
-                    warn!(
-                        job_id,
-                        reclaimed = ?stale,
-                        requested = ?controller_gpu_ids,
-                        "reclaiming stale GPU owners no longer running, then retrying dispatch"
-                    );
-                    for owner in &stale {
-                        alloc.release_job(*owner);
-                    }
-                }
-                match alloc.allocate_for_job_with_attempt(
-                    job_id,
-                    cpus,
-                    spec.memory_per_node_mb,
-                    &controller_gpu_ids,
-                    run_attempt,
-                ) {
-                    Ok(result) => result,
-                    Err(_) => {
-                        warn!(
-                            job_id,
-                            requested = ?controller_gpu_ids,
-                            already_allocated = ?alloc.allocated_gpu_ids(),
-                            "rejecting dispatch: controller-allocated GPUs already in use in the \
-                             local allocation table by a still-running or launching job"
-                        );
-                        return Err(Status::resource_exhausted(
-                            "controller-allocated GPUs unavailable on this node",
-                        ));
-                    }
-                }
-            }
-            Err(AllocError::DuplicateJob) => {
-                // A launch is already in flight for this job id (reserved, not
-                // yet committed or released). This is a concurrent duplicate,
-                // not resource exhaustion. A stale reservation from a prior,
-                // already-torn-down run is superseded inside allocate_for_job
-                // and does not reach here.
                 warn!(
                     job_id,
-                    "rejecting duplicate launch: a launch is already in flight for this job"
+                    requested = ?controller_gpu_ids,
+                    already_allocated = ?alloc.allocated_gpu_ids(),
+                    "rejecting dispatch because controller-allocated GPUs are locally owned"
+                );
+                return Err(Status::resource_exhausted(
+                    "controller-allocated GPUs unavailable on this node",
+                ));
+            }
+            Err(AllocError::DuplicateJob) => {
+                warn!(
+                    job_id,
+                    "rejecting duplicate launch while an allocation is still owned"
                 );
                 return Err(Status::already_exists(format!(
-                    "job {job_id} already has a launch in flight on this node"
+                    "job {job_id} already owns an allocation on this node"
                 )));
             }
         };
+
+        if let Some(resources) = allocated {
+            let _ = alloc.set_exact_resources(job_id, run_attempt, core_allocations(resources));
+        }
 
         let gpu_ids = controller_gpu_ids;
         Ok((result, gpu_ids))
@@ -3326,6 +3996,70 @@ mod tests {
             String::new(),
             new_running_jobs(),
         ))
+    }
+
+    #[tokio::test]
+    async fn configured_node_name_is_the_local_allocation_identity() {
+        let reporter = test_reporter();
+        let service = AgentService::new(
+            reporter.clone(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        assert_eq!(service.allocation.lock().await.node_name, reporter.hostname);
+    }
+
+    #[tokio::test]
+    async fn first_polled_command_does_not_relock_the_command_cache() {
+        use std::future::Future;
+        use std::task::{Context, Poll, Waker};
+
+        let service = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        let command = AgentCommand {
+            command_id: 7,
+            job_id: 9,
+            run_attempt: 1,
+            node: "different-node".into(),
+            kind: AgentCommandKind::Launch as i32,
+            ..Default::default()
+        };
+
+        let mut future = std::pin::pin!(service.apply_or_replay_command(&command));
+        let mut context = Context::from_waker(Waker::noop());
+        let Poll::Ready(result) = Future::poll(future.as_mut(), &mut context) else {
+            panic!("an uncontended command cache path must complete in one poll");
+        };
+
+        assert!(!result.success);
+        assert_eq!(service.applied_commands.lock().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn stale_completion_cleanup_refuses_a_newer_local_attempt() {
+        let resources = ResourceSet {
+            cpus: 4,
+            memory_mb: 8192,
+            ..Default::default()
+        };
+        let mut local = NodeAllocation::new("test-node".into(), &resources);
+        local
+            .allocate_for_job_with_attempt(9, 1, 64, &[], 2)
+            .unwrap();
+        local.commit_job(9);
+        let allocation = Mutex::new(local);
+        let steps = StdMutex::new(HashMap::new());
+
+        assert!(!settle_current_allocation(&allocation, &steps, 9, 1)
+            .await
+            .unwrap());
+        assert!(allocation.lock().await.owns_attempt(9, 2));
     }
 
     /// An executable script at a temp path that sleeps `millis` then exits 0,
@@ -4372,10 +5106,8 @@ mod tests {
         );
     }
 
-    // A conflicting owner no longer in `running` is stale and must be reclaimed
-    // so the dispatch succeeds instead of stranding the node.
     #[tokio::test]
-    async fn dispatch_reclaims_stale_gpu_owner_not_running() {
+    async fn dispatch_rejects_unreleased_gpu_owner_not_running() {
         let svc = AgentService::new(
             test_reporter_with_gpus(&[0]),
             HooksConfig::default(),
@@ -4417,9 +5149,10 @@ mod tests {
             .allocate_local_resources(100, &spec, Some(&allocated))
             .await;
         assert!(
-            res.is_ok(),
-            "dispatch must reclaim the stale owner's GPU and succeed, got {res:?}"
+            matches!(res, Err(ref status) if status.code() == tonic::Code::ResourceExhausted),
+            "dispatch must not infer cleanup from an in-memory omission, got {res:?}"
         );
+        assert_eq!(svc.free_gpu_count().await, 0);
     }
 
     // A conflicting owner still in `running` must never be reclaimed (that would
@@ -4538,10 +5271,8 @@ mod tests {
         }
     }
 
-    // A dispatch spanning two GPUs each held by a distinct stale owner must
-    // reclaim both and succeed.
     #[tokio::test]
-    async fn dispatch_reclaims_multiple_stale_owners() {
+    async fn dispatch_rejects_multiple_unreleased_owners() {
         let svc = AgentService::new(
             test_reporter_with_gpus(&[0, 1]),
             HooksConfig::default(),
@@ -4567,9 +5298,10 @@ mod tests {
             .allocate_local_resources(100, &spec, Some(&gpu_alloc_request(&[0, 1])))
             .await;
         assert!(
-            res.is_ok(),
-            "both stale owners must be reclaimed, got {res:?}"
+            matches!(res, Err(ref status) if status.code() == tonic::Code::ResourceExhausted),
+            "dispatch must preserve every unreleased owner, got {res:?}"
         );
+        assert_eq!(svc.free_gpu_count().await, 0);
     }
 
     // A dispatch spanning a stale GPU and a still-running GPU must reject: the
@@ -4805,6 +5537,100 @@ mod tests {
             1,
             "cancel must release a launching (never-committed) reservation"
         );
+    }
+
+    #[tokio::test]
+    async fn shutdown_kills_tracked_process_and_releases_local_allocation() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        let job_id = 907;
+        let run_attempt = 3;
+        let mut tracked = TrackedJob::dummy(0);
+        tracked.run_attempt = run_attempt;
+        let pid = tracked.job.pid().unwrap() as i32;
+        {
+            let mut allocation = svc.allocation.lock().await;
+            allocation
+                .allocate_for_job_with_attempt(job_id, 1, 0, &[], run_attempt)
+                .unwrap();
+            assert!(allocation.commit_job(job_id));
+        }
+        svc.insert_test_job(job_id, tracked).await;
+
+        svc.shutdown_jobs().await.unwrap();
+
+        assert!(svc.running.lock().await.is_empty());
+        assert!(svc.allocation.lock().await.owned_allocations().is_empty());
+        assert!(!std::path::Path::new(&format!("/proc/{pid}")).exists());
+        assert!(svc.shutting_down.load(Ordering::Acquire));
+    }
+
+    #[tokio::test]
+    async fn release_command_kills_a_manifested_process_after_agent_restart() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        let job_id = 908;
+        let run_attempt = 4;
+        let mut child = std::process::Command::new(std::env::current_exe().unwrap())
+            .arg("release_command_residual_child_process")
+            .arg("--ignored")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+        executor::write_process_recovery_manifest(job_id, run_attempt, child.id() as i32, None)
+            .unwrap();
+
+        svc.apply_release_command(job_id, run_attempt, 9)
+            .await
+            .unwrap();
+        let status = child.wait().unwrap();
+
+        assert!(!status.success());
+        assert!(svc.running.lock().await.is_empty());
+        assert!(svc.allocation.lock().await.owned_allocations().is_empty());
+    }
+
+    #[tokio::test]
+    async fn release_command_waits_for_the_complete_step_lifecycle() {
+        let svc = AgentService::new(
+            test_reporter(),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+        let job_id = 909;
+        let run_attempt = 5;
+        let guard = StepLifecycleGuard::new(svc.step_lifecycle.clone(), job_id, run_attempt);
+        let release_service = svc.clone();
+        let release = tokio::spawn(async move {
+            release_service
+                .apply_release_command(job_id, run_attempt, 9)
+                .await
+        });
+
+        tokio::task::yield_now().await;
+        assert!(!release.is_finished());
+        drop(guard);
+
+        release.await.unwrap().unwrap();
+    }
+
+    #[test]
+    #[ignore]
+    fn release_command_residual_child_process() {
+        loop {
+            std::thread::park();
+        }
     }
 
     #[tokio::test]

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -208,6 +208,10 @@ pub struct AgentService {
     k0s: Arc<crate::cluster::K0sAgent>,
     /// In-flight srun steps keyed by `(job_id, step_id)`.
     active_steps: Arc<Mutex<HashMap<(u32, u32), ActiveStep>>>,
+    /// Highest Raft term seen on LaunchJob/CancelJob/RegisterJobAllocation, so
+    /// a demoted former leader's request (carrying an older term) is rejected
+    /// instead of acted on.
+    highest_term_seen: Arc<std::sync::atomic::AtomicU64>,
 }
 
 impl AgentService {
@@ -305,7 +309,25 @@ impl AgentService {
             device_registry,
             k0s: Arc::new(crate::cluster::K0sAgent::from_config(cluster)),
             active_steps: Arc::new(Mutex::new(HashMap::new())),
+            highest_term_seen: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         }
+    }
+
+    /// Reject a request carrying a Raft term older than the highest already
+    /// seen (a demoted former leader), else record it as the new high-water
+    /// mark. Term 0 is a legacy/unset sentinel and is always accepted.
+    fn check_term(&self, term: u64) -> Result<(), Status> {
+        use std::sync::atomic::Ordering;
+        if term == 0 {
+            return Ok(());
+        }
+        let prev = self.highest_term_seen.fetch_max(term, Ordering::AcqRel);
+        if term < prev {
+            return Err(Status::failed_precondition(format!(
+                "stale controller term {term} (highest seen {prev}); a newer leader has taken over"
+            )));
+        }
+        Ok(())
     }
 
     /// Handle to the RPC-driven k0s component owner. spurd `main()` spawns its supervise loop.
@@ -942,6 +964,7 @@ impl SlurmAgent for AgentService {
         request: Request<LaunchJobRequest>,
     ) -> Result<Response<LaunchJobResponse>, Status> {
         let req = request.into_inner();
+        self.check_term(req.term)?;
         let job_id = req.job_id;
         let peer_nodes = req.peer_nodes;
         let task_offset = req.task_offset;
@@ -1535,6 +1558,7 @@ impl SlurmAgent for AgentService {
         request: Request<AgentCancelJobRequest>,
     ) -> Result<Response<()>, Status> {
         let req = request.into_inner();
+        self.check_term(req.term)?;
         let job_id = req.job_id;
 
         if req.signal > 0 {
@@ -1687,6 +1711,7 @@ impl SlurmAgent for AgentService {
         request: Request<RegisterJobAllocationRequest>,
     ) -> Result<Response<RegisterJobAllocationResponse>, Status> {
         let req = request.into_inner();
+        self.check_term(req.term)?;
         if req.job_id == 0 {
             return Err(Status::invalid_argument("job_id is required"));
         }
@@ -4499,6 +4524,29 @@ mod tests {
         assert_eq!(tracked.run_attempt, 3);
     }
 
+    // A request carrying a Raft term below the highest already seen is a
+    // demoted former leader and must be rejected; a higher term raises the
+    // high-water mark; term 0 (legacy/unset) is always accepted.
+    #[test]
+    fn check_term_rejects_stale_and_accepts_legacy_zero() {
+        let svc = AgentService::new(
+            test_reporter_with_gpus(&[0]),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        svc.check_term(5).expect("first real term is accepted");
+        let err = svc.check_term(3).expect_err("stale term must be rejected");
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+        svc.check_term(7).expect("a higher term is accepted");
+        assert!(
+            svc.check_term(5).is_err(),
+            "term below the new high-water mark is still rejected"
+        );
+        svc.check_term(0).expect("legacy zero is always accepted");
+    }
+
     // The heartbeat's held-job source must report an allocation-only (srun/salloc)
     // job so the controller can reconcile it — the strand this fix addresses.
     #[tokio::test]
@@ -4585,6 +4633,7 @@ mod tests {
         svc.cancel_job(Request::new(AgentCancelJobRequest {
             job_id: 7,
             signal: 9,
+            term: 0,
         }))
         .await
         .expect("cancel_job");

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -1612,6 +1612,7 @@ impl SlurmAgent for AgentService {
         request: Request<AgentSuspendJobRequest>,
     ) -> Result<Response<()>, Status> {
         let req = request.into_inner();
+        self.check_term(req.term)?;
         self.suspend_signal(req.job_id, req.resume).await;
         Ok(Response::new(()))
     }
@@ -4637,6 +4638,36 @@ mod tests {
             1,
             "cancel must release a launching (never-committed) reservation"
         );
+    }
+
+    // A demoted leader's stale SuspendJob must be rejected like LaunchJob/CancelJob/
+    // RegisterJobAllocation already are.
+    #[tokio::test]
+    async fn suspend_job_rejects_a_stale_term() {
+        let svc = AgentService::new(
+            test_reporter_with_gpus(&[0]),
+            HooksConfig::default(),
+            Arc::new(Mutex::new(DeviceRegistry::new())),
+            spur_core::config::MemlockLimit::Unlimited,
+        );
+
+        svc.suspend_job(Request::new(AgentSuspendJobRequest {
+            job_id: 1,
+            resume: false,
+            term: 5,
+        }))
+        .await
+        .expect("first real term is accepted");
+
+        let err = svc
+            .suspend_job(Request::new(AgentSuspendJobRequest {
+                job_id: 1,
+                resume: false,
+                term: 3,
+            }))
+            .await
+            .expect_err("a stale term must be rejected");
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
     }
 
     // A launch that aborts before entering `running` must tear down its PMI

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -208,9 +208,7 @@ pub struct AgentService {
     k0s: Arc<crate::cluster::K0sAgent>,
     /// In-flight srun steps keyed by `(job_id, step_id)`.
     active_steps: Arc<Mutex<HashMap<(u32, u32), ActiveStep>>>,
-    /// Highest Raft term seen on LaunchJob/CancelJob/RegisterJobAllocation, so
-    /// a demoted former leader's request (carrying an older term) is rejected
-    /// instead of acted on.
+    /// Highest Raft term seen, so a demoted leader's request is rejected.
     highest_term_seen: Arc<std::sync::atomic::AtomicU64>,
 }
 
@@ -313,9 +311,7 @@ impl AgentService {
         }
     }
 
-    /// Reject a request carrying a Raft term older than the highest already
-    /// seen (a demoted former leader), else record it as the new high-water
-    /// mark. Term 0 is a legacy/unset sentinel and is always accepted.
+    /// Reject a term older than the highest seen; 0 (legacy/unset) always passes.
     fn check_term(&self, term: u64) -> Result<(), Status> {
         use std::sync::atomic::Ordering;
         if term == 0 {
@@ -4524,9 +4520,7 @@ mod tests {
         assert_eq!(tracked.run_attempt, 3);
     }
 
-    // A request carrying a Raft term below the highest already seen is a
-    // demoted former leader and must be rejected; a higher term raises the
-    // high-water mark; term 0 (legacy/unset) is always accepted.
+    // A term below the highest seen is a demoted leader and must be rejected.
     #[test]
     fn check_term_rejects_stale_and_accepts_legacy_zero() {
         let svc = AgentService::new(

--- a/crates/spurd/src/agent_server.rs
+++ b/crates/spurd/src/agent_server.rs
@@ -5,6 +5,7 @@
 //! Receives job launch/cancel requests from spurctld.
 
 use std::collections::HashMap;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use tokio::sync::Mutex;
@@ -313,7 +314,6 @@ impl AgentService {
 
     /// Reject a term older than the highest seen; 0 (legacy/unset) always passes.
     fn check_term(&self, term: u64) -> Result<(), Status> {
-        use std::sync::atomic::Ordering;
         if term == 0 {
             return Ok(());
         }

--- a/crates/spurd/src/executor.rs
+++ b/crates/spurd/src/executor.rs
@@ -4,6 +4,7 @@
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::os::fd::{FromRawFd, OwnedFd, RawFd};
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -11,6 +12,7 @@ use std::process::Stdio;
 use anyhow::{bail, Context};
 use nix::sys::signal::{self, SaFlags, SigAction, SigHandler, SigSet, Signal};
 use nix::unistd::Pid;
+use serde::{Deserialize, Serialize};
 use tokio::process::Command;
 use tracing::{debug, info, warn};
 
@@ -111,6 +113,17 @@ const CGROUP_ROOT: &str = "/sys/fs/cgroup/spur";
 /// wrapper). Deliberately off the user's work_dir so these root-side writes
 /// never hit an NFS root_squash mount. Mirrors Slurm's SlurmdSpoolDir.
 const SPOOL_ROOT: &str = "/var/spool/spur";
+const RECOVERY_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RecoveryManifest {
+    schema_version: u32,
+    job_id: JobId,
+    run_attempt: u32,
+    pid: i32,
+    start_time: u64,
+    cgroup_path: Option<PathBuf>,
+}
 
 pub struct ContainerLaunchConfig {
     pub config: ContainerConfig,
@@ -440,6 +453,15 @@ impl RunningJob {
         match self {
             RunningJob::Managed { cgroup_path, .. } => cgroup_path.take(),
             RunningJob::Forked { cgroup_path, .. } => cgroup_path.take(),
+            RunningJob::AllocationOnly => None,
+        }
+    }
+
+    fn cgroup_path(&self) -> Option<&Path> {
+        match self {
+            RunningJob::Managed { cgroup_path, .. } | RunningJob::Forked { cgroup_path, .. } => {
+                cgroup_path.as_deref()
+            }
             RunningJob::AllocationOnly => None,
         }
     }
@@ -961,6 +983,14 @@ fn setup_cgroup(
     Ok(Some(cgroup_path))
 }
 
+pub fn setup_step_cgroup(
+    job_id: JobId,
+    cpus: u32,
+    memory_mb: u64,
+) -> anyhow::Result<Option<PathBuf>> {
+    setup_cgroup(job_id, cpus, memory_mb, &[])
+}
+
 /// Move a process into a cgroup. Returns true if successful.
 fn move_to_cgroup(cgroup_path: &Path, pid: u32) -> bool {
     let procs_file = cgroup_path.join("cgroup.procs");
@@ -974,6 +1004,10 @@ fn move_to_cgroup(cgroup_path: &Path, pid: u32) -> bool {
     } else {
         true
     }
+}
+
+pub fn attach_process_to_cgroup(cgroup_path: &Path, pid: u32) -> bool {
+    move_to_cgroup(cgroup_path, pid)
 }
 
 /// Whether the job's cgroup recorded an OOM kill (cgroup-v2 `memory.events`).
@@ -1003,6 +1037,336 @@ pub fn cleanup_cgroup(cgroup_path: &Path) {
     if let Err(e) = std::fs::remove_dir(cgroup_path) {
         warn!(error = %e, path = %cgroup_path.display(), "failed to remove cgroup");
     }
+}
+
+pub fn cleanup_job_cgroup(job_id: JobId) {
+    let path = Path::new(CGROUP_ROOT).join(format!("job_{job_id}"));
+    if path.exists() {
+        cleanup_cgroup(&path);
+    }
+}
+
+fn recovery_manifests_for_allocation(
+    root: &Path,
+    job_id: JobId,
+    run_attempt: u32,
+) -> anyhow::Result<Vec<(PathBuf, RecoveryManifest)>> {
+    let mut manifests = Vec::new();
+    for entry in std::fs::read_dir(root)? {
+        let entry = entry?;
+        if entry
+            .path()
+            .extension()
+            .and_then(|extension| extension.to_str())
+            != Some("json")
+        {
+            continue;
+        }
+        let bytes = std::fs::read(entry.path())?;
+        let manifest: RecoveryManifest = serde_json::from_slice(&bytes)?;
+        if manifest.schema_version != RECOVERY_SCHEMA_VERSION {
+            anyhow::bail!(
+                "unsupported recovery manifest schema {}",
+                manifest.schema_version
+            );
+        }
+        if manifest.job_id == job_id && (run_attempt == 0 || manifest.run_attempt == run_attempt) {
+            manifests.push((entry.path(), manifest));
+        }
+    }
+    Ok(manifests)
+}
+
+fn signal_residual_cgroup(cgroup: &Path) -> anyhow::Result<()> {
+    if !cgroup.exists() {
+        return Ok(());
+    }
+    let kill = cgroup.join("cgroup.kill");
+    if kill.exists() {
+        std::fs::write(&kill, "1")
+            .with_context(|| format!("kill residual cgroup {}", cgroup.display()))?;
+        return Ok(());
+    }
+    let pids = std::fs::read_to_string(cgroup.join("cgroup.procs"))
+        .with_context(|| format!("read residual cgroup {}", cgroup.display()))?;
+    for pid in pids.lines().filter_map(|value| value.trim().parse().ok()) {
+        kill_process_tree(pid, Signal::SIGKILL);
+    }
+    Ok(())
+}
+
+fn cgroup_is_empty(cgroup: &Path) -> anyhow::Result<bool> {
+    if !cgroup.exists() {
+        return Ok(true);
+    }
+    let processes = std::fs::read_to_string(cgroup.join("cgroup.procs"))
+        .with_context(|| format!("read residual cgroup {}", cgroup.display()))?;
+    Ok(processes.trim().is_empty())
+}
+
+pub async fn terminate_residual_allocation(job_id: JobId, run_attempt: u32) -> anyhow::Result<()> {
+    let root = prepare_recovery_root()?;
+    let manifests = recovery_manifests_for_allocation(&root, job_id, run_attempt)?;
+    let cgroup = Path::new(CGROUP_ROOT).join(format!("job_{job_id}"));
+
+    for _ in 0..100 {
+        signal_residual_cgroup(&cgroup)?;
+        for (_, manifest) in &manifests {
+            if process_identity_is_live(manifest.pid, manifest.start_time) {
+                kill_process_tree(manifest.pid, Signal::SIGKILL);
+            }
+        }
+
+        let processes_gone = manifests
+            .iter()
+            .all(|(_, manifest)| !process_identity_is_live(manifest.pid, manifest.start_time));
+        if processes_gone && cgroup_is_empty(&cgroup)? {
+            if cgroup.exists() {
+                std::fs::remove_dir(&cgroup)
+                    .with_context(|| format!("remove residual cgroup {}", cgroup.display()))?;
+            }
+            cleanup_job_spool_files(job_id);
+            for (path, _) in manifests {
+                let _ = std::fs::remove_file(path);
+            }
+            return Ok(());
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+
+    anyhow::bail!("residual processes for job {job_id} attempt {run_attempt} are still present")
+}
+
+pub fn recover_residual_job_cgroups() -> anyhow::Result<usize> {
+    let root = Path::new(CGROUP_ROOT);
+    let entries = match std::fs::read_dir(root) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(error) => return Err(error).context("scan Spur job cgroups"),
+    };
+
+    let mut recovered = 0;
+    for entry in entries {
+        let entry = entry.context("read Spur cgroup entry")?;
+        let name = entry.file_name();
+        if !name.to_string_lossy().starts_with("job_") {
+            continue;
+        }
+        let path = entry.path();
+        if path.join("cgroup.kill").exists() {
+            std::fs::write(path.join("cgroup.kill"), "1")
+                .with_context(|| format!("kill residual cgroup {}", path.display()))?;
+        } else {
+            cleanup_cgroup(&path);
+        }
+        let remaining = std::fs::read_to_string(path.join("cgroup.procs")).unwrap_or_default();
+        if !remaining.trim().is_empty() {
+            anyhow::bail!("residual cgroup {} still has processes", path.display());
+        }
+        if path.exists() {
+            std::fs::remove_dir(&path)
+                .with_context(|| format!("remove residual cgroup {}", path.display()))?;
+        }
+        recovered += 1;
+    }
+    Ok(recovered)
+}
+
+fn recovery_root() -> PathBuf {
+    if nix::unistd::geteuid().is_root() {
+        PathBuf::from(SPOOL_ROOT).join("recovery")
+    } else {
+        std::env::temp_dir().join(format!("spur-recovery-{}", nix::unistd::geteuid().as_raw()))
+    }
+}
+
+fn prepare_recovery_root() -> anyhow::Result<PathBuf> {
+    let root = recovery_root();
+    prepare_recovery_root_at(&root)?;
+    Ok(root)
+}
+
+fn prepare_recovery_root_at(root: &Path) -> anyhow::Result<()> {
+    std::fs::create_dir_all(root)
+        .with_context(|| format!("create recovery spool {}", root.display()))?;
+    std::fs::set_permissions(root, std::fs::Permissions::from_mode(0o700))?;
+    let metadata = std::fs::symlink_metadata(root)?;
+    if !metadata.file_type().is_dir()
+        || metadata.uid() != nix::unistd::geteuid().as_raw()
+        || metadata.mode() & 0o077 != 0
+    {
+        anyhow::bail!("recovery spool {} is not private to spurd", root.display());
+    }
+    Ok(())
+}
+
+fn proc_start_time(pid: i32) -> Option<u64> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let after_name = stat.rsplit_once(") ")?.1;
+    after_name.split_whitespace().nth(19)?.parse().ok()
+}
+
+fn process_identity_is_live(pid: i32, start_time: u64) -> bool {
+    let Some(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok() else {
+        return false;
+    };
+    let Some(after_name) = stat.rsplit_once(") ").map(|(_, fields)| fields) else {
+        return false;
+    };
+    let fields: Vec<_> = after_name.split_whitespace().collect();
+    fields.first() != Some(&"Z")
+        && fields.get(19).and_then(|value| value.parse::<u64>().ok()) == Some(start_time)
+}
+
+pub fn write_recovery_manifest(
+    job_id: JobId,
+    run_attempt: u32,
+    job: &RunningJob,
+) -> anyhow::Result<()> {
+    let Some(pid) = job.pid().map(|pid| pid as i32) else {
+        return Ok(());
+    };
+    write_process_recovery_manifest(job_id, run_attempt, pid, job.cgroup_path())
+}
+
+#[cfg(test)]
+fn write_recovery_manifest_at(
+    root: &Path,
+    job_id: JobId,
+    run_attempt: u32,
+    job: &RunningJob,
+) -> anyhow::Result<()> {
+    let Some(pid) = job.pid().map(|pid| pid as i32) else {
+        return Ok(());
+    };
+    write_process_recovery_manifest_at(root, job_id, run_attempt, pid, job.cgroup_path())
+}
+
+pub fn write_process_recovery_manifest(
+    job_id: JobId,
+    run_attempt: u32,
+    pid: i32,
+    cgroup_path: Option<&Path>,
+) -> anyhow::Result<()> {
+    let root = prepare_recovery_root()?;
+    write_process_recovery_manifest_at(&root, job_id, run_attempt, pid, cgroup_path)
+}
+
+fn recovery_manifest_path(root: &Path, job_id: JobId, run_attempt: u32, pid: i32) -> PathBuf {
+    root.join(format!("job_{job_id}_{run_attempt}_{pid}.json"))
+}
+
+fn write_process_recovery_manifest_at(
+    root: &Path,
+    job_id: JobId,
+    run_attempt: u32,
+    pid: i32,
+    cgroup_path: Option<&Path>,
+) -> anyhow::Result<()> {
+    let start_time = proc_start_time(pid)
+        .ok_or_else(|| anyhow::anyhow!("job process {pid} disappeared before it was recorded"))?;
+    prepare_recovery_root_at(root)?;
+    let path = recovery_manifest_path(root, job_id, run_attempt, pid);
+    let temporary = root.join(format!(".job_{job_id}_{run_attempt}_{pid}.tmp"));
+    let manifest = RecoveryManifest {
+        schema_version: RECOVERY_SCHEMA_VERSION,
+        job_id,
+        run_attempt,
+        pid,
+        start_time,
+        cgroup_path: cgroup_path.map(Path::to_path_buf),
+    };
+    let bytes = serde_json::to_vec(&manifest)?;
+    std::fs::write(&temporary, bytes)
+        .with_context(|| format!("write recovery manifest {}", temporary.display()))?;
+    std::fs::set_permissions(&temporary, std::fs::Permissions::from_mode(0o600))?;
+    std::fs::rename(&temporary, &path)
+        .with_context(|| format!("install recovery manifest {}", path.display()))?;
+    Ok(())
+}
+
+pub fn remove_process_recovery_manifest(job_id: JobId, run_attempt: u32, pid: i32) {
+    let _ = std::fs::remove_file(recovery_manifest_path(
+        &recovery_root(),
+        job_id,
+        run_attempt,
+        pid,
+    ));
+}
+
+fn remove_recovery_manifests(job_id: JobId) {
+    let root = recovery_root();
+    let Ok(entries) = std::fs::read_dir(&root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if entry.path().extension().and_then(|value| value.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(bytes) = std::fs::read(entry.path()) else {
+            continue;
+        };
+        let Ok(manifest) = serde_json::from_slice::<RecoveryManifest>(&bytes) else {
+            continue;
+        };
+        if manifest.job_id == job_id {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+
+pub fn recover_residual_allocations() -> anyhow::Result<usize> {
+    let mut recovered = recover_residual_job_cgroups()?;
+    let root = prepare_recovery_root()?;
+    recovered += recover_manifests_at(&root)?;
+    Ok(recovered)
+}
+
+fn recover_manifests_at(root: &Path) -> anyhow::Result<usize> {
+    prepare_recovery_root_at(root)?;
+    let mut recovered = 0;
+    for entry in std::fs::read_dir(root)? {
+        let entry = entry?;
+        if entry
+            .path()
+            .extension()
+            .and_then(|extension| extension.to_str())
+            != Some("json")
+        {
+            continue;
+        }
+        let bytes = std::fs::read(entry.path())?;
+        let manifest: RecoveryManifest = serde_json::from_slice(&bytes)?;
+        if manifest.schema_version != RECOVERY_SCHEMA_VERSION {
+            anyhow::bail!(
+                "unsupported recovery manifest schema {}",
+                manifest.schema_version
+            );
+        }
+        if let Some(cgroup) = &manifest.cgroup_path {
+            let expected = Path::new(CGROUP_ROOT).join(format!("job_{}", manifest.job_id));
+            if cgroup != &expected {
+                anyhow::bail!("recovery manifest has an invalid cgroup path");
+            }
+            if cgroup.exists() {
+                cleanup_cgroup(cgroup);
+            }
+        }
+        if process_identity_is_live(manifest.pid, manifest.start_time) {
+            kill_process_tree(manifest.pid, Signal::SIGKILL);
+        }
+        if process_identity_is_live(manifest.pid, manifest.start_time) {
+            anyhow::bail!(
+                "residual process {} for job {} is still alive",
+                manifest.pid,
+                manifest.job_id
+            );
+        }
+        cleanup_job_spool_files(manifest.job_id);
+        let _ = std::fs::remove_file(entry.path());
+        recovered += 1;
+    }
+    Ok(recovered)
 }
 
 /// Recursively signal a process and all its descendants (children first).
@@ -1373,6 +1737,11 @@ pub(crate) fn write_job_scratch(
 /// batchdir after completion. Tries both candidate roots since the fallback
 /// location isn't recorded.
 pub fn cleanup_job_spool(job_id: JobId) {
+    cleanup_job_spool_files(job_id);
+    remove_recovery_manifests(job_id);
+}
+
+fn cleanup_job_spool_files(job_id: JobId) {
     for base in [PathBuf::from(SPOOL_ROOT), std::env::temp_dir().join("spur")] {
         let _ = std::fs::remove_dir_all(base.join(format!("job{}", job_id)));
     }
@@ -2070,6 +2439,127 @@ mod tests {
         write_job_scratch(&dir.join("spur_job.sh"), "x", uid, gid).unwrap();
         cleanup_job_spool(job_id);
         assert!(!dir.exists());
+    }
+
+    #[test]
+    fn recovery_manifest_records_exact_process_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        let job = RunningJob::Forked {
+            pid: std::process::id() as i32,
+            _pidfd: None,
+            cgroup_path: None,
+            reaped: false,
+        };
+        write_recovery_manifest_at(dir.path(), 41, 3, &job).unwrap();
+
+        let path = recovery_manifest_path(dir.path(), 41, 3, std::process::id() as i32);
+        let bytes = std::fs::read(path).unwrap();
+        let manifest: RecoveryManifest = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(manifest.job_id, 41);
+        assert_eq!(manifest.run_attempt, 3);
+        assert_eq!(manifest.pid, std::process::id() as i32);
+        assert_eq!(manifest.start_time, proc_start_time(manifest.pid).unwrap());
+    }
+
+    #[test]
+    fn recovery_manifest_kills_the_recorded_process_before_clearing() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut child = std::process::Command::new(std::env::current_exe().unwrap())
+            .arg("recovery_manifest_child_process")
+            .arg("--ignored")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .unwrap();
+        let job = RunningJob::Forked {
+            pid: child.id() as i32,
+            _pidfd: None,
+            cgroup_path: None,
+            reaped: false,
+        };
+        write_recovery_manifest_at(dir.path(), 42, 4, &job).unwrap();
+        let manifest_path = recovery_manifest_path(dir.path(), 42, 4, child.id() as i32);
+
+        let first_recovery = recover_manifests_at(dir.path());
+        let status = child.wait().unwrap();
+        let recovered = match first_recovery {
+            Ok(recovered) => recovered,
+            Err(_) => recover_manifests_at(dir.path()).unwrap(),
+        };
+
+        assert_eq!(recovered, 1);
+        assert!(!status.success());
+        assert!(!manifest_path.exists());
+    }
+
+    #[test]
+    fn recovery_processes_every_manifest_for_one_job() {
+        let dir = tempfile::tempdir().unwrap();
+        prepare_recovery_root_at(dir.path()).unwrap();
+        let current_pid = std::process::id() as i32;
+        let manifests = [
+            RecoveryManifest {
+                schema_version: RECOVERY_SCHEMA_VERSION,
+                job_id: 44,
+                run_attempt: 6,
+                pid: current_pid,
+                start_time: proc_start_time(current_pid).unwrap() + 1,
+                cgroup_path: None,
+            },
+            RecoveryManifest {
+                schema_version: RECOVERY_SCHEMA_VERSION,
+                job_id: 44,
+                run_attempt: 6,
+                pid: i32::MAX,
+                start_time: 1,
+                cgroup_path: None,
+            },
+        ];
+        for manifest in &manifests {
+            let path = recovery_manifest_path(
+                dir.path(),
+                manifest.job_id,
+                manifest.run_attempt,
+                manifest.pid,
+            );
+            std::fs::write(path, serde_json::to_vec(manifest).unwrap()).unwrap();
+        }
+
+        assert_eq!(recover_manifests_at(dir.path()).unwrap(), 2);
+        assert!(std::fs::read_dir(dir.path()).unwrap().next().is_none());
+    }
+
+    #[test]
+    fn recovery_manifest_does_not_signal_a_reused_pid() {
+        let dir = tempfile::tempdir().unwrap();
+        prepare_recovery_root_at(dir.path()).unwrap();
+        let pid = std::process::id() as i32;
+        let manifest = RecoveryManifest {
+            schema_version: RECOVERY_SCHEMA_VERSION,
+            job_id: 43,
+            run_attempt: 5,
+            pid,
+            start_time: proc_start_time(pid).unwrap() + 1,
+            cgroup_path: None,
+        };
+        std::fs::write(
+            dir.path().join("job_43.json"),
+            serde_json::to_vec(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(recover_manifests_at(dir.path()).unwrap(), 1);
+        assert!(proc_start_time(pid).is_some());
+        assert!(!dir.path().join("job_43.json").exists());
+    }
+
+    #[test]
+    #[ignore]
+    fn recovery_manifest_child_process() {
+        loop {
+            std::thread::park();
+        }
     }
 
     // send_fds/recv_fds are process-agnostic: they pass fds over any Unix

--- a/crates/spurd/src/main.rs
+++ b/crates/spurd/src/main.rs
@@ -285,17 +285,6 @@ async fn main() -> anyhow::Result<()> {
         running_jobs.clone(),
     ));
 
-    // Register with controller
-    reporter.register().await?;
-
-    // Start heartbeat loop
-    let hb_reporter = reporter.clone();
-    tokio::spawn(async move {
-        hb_reporter.heartbeat_loop().await;
-    });
-
-    // Start agent gRPC server (receives job launches + cluster-component RPCs from spurctld).
-    // Pass the [cluster] config so the K0sAgent uses the operator's k0s version + install path.
     let memlock = match config.as_ref() {
         Some(c) => c.rlimits.memlock_limit()?,
         None => spur_core::config::MemlockLimit::Unlimited,
@@ -316,6 +305,50 @@ async fn main() -> anyhow::Result<()> {
         running_jobs,
     );
 
+    match executor::recover_residual_allocations() {
+        Ok(recovered) => {
+            if recovered > 0 {
+                warn!(
+                    recovered,
+                    "removed residual job cgroups before registration"
+                );
+            }
+            reporter.mark_recovery_complete();
+        }
+        Err(error) => {
+            warn!(error = %error, "node remains unschedulable while residual jobs are cleaned");
+            let recovery_reporter = reporter.clone();
+            tokio::spawn(async move {
+                let mut retry = tokio::time::interval(std::time::Duration::from_secs(2));
+                loop {
+                    retry.tick().await;
+                    match executor::recover_residual_allocations() {
+                        Ok(_) => {
+                            recovery_reporter.mark_recovery_complete();
+                            if let Err(error) = recovery_reporter.register().await {
+                                warn!(error = %error, "failed to publish completed node recovery");
+                                continue;
+                            }
+                            break;
+                        }
+                        Err(error) => {
+                            warn!(error = %error, "residual job cleanup still incomplete");
+                        }
+                    }
+                }
+            });
+        }
+    }
+
+    // Register with controller
+    reporter.register().await?;
+
+    // Start heartbeat loop
+    let hb_reporter = reporter.clone();
+    tokio::spawn(async move {
+        hb_reporter.heartbeat_loop().await;
+    });
+
     // the RPC-driven k0s component owner is idle until the controller sends
     // StartClusterComponent; k0s then runs under its OWN systemd unit — never as a spurd job/child —
     // so it survives spurd restart and stays out of the executor/monitor/time-limit job path. The
@@ -327,10 +360,15 @@ async fn main() -> anyhow::Result<()> {
     tokio::spawn(k0s.supervise());
 
     agent_service.start_monitor(args.controller.clone());
+    let command_service = agent_service.clone();
+    tokio::spawn(async move {
+        command_service.command_loop().await;
+    });
 
     let addr = args.listen.parse()?;
     info!(%addr, "agent gRPC server listening");
 
+    let shutdown_service = agent_service.clone();
     let server_future = tonic::transport::Server::builder()
         .add_service(spur_proto::agent_server(agent_service))
         .serve(addr);
@@ -340,17 +378,27 @@ async fn main() -> anyhow::Result<()> {
     tokio::select! {
         result = server_future => { result?; }
         _ = sigterm.recv() => {
-            info!("received SIGTERM, deregistering from controller");
-            let dereg_reporter = reporter.clone();
-            match tokio::time::timeout(
-                std::time::Duration::from_secs(5),
-                dereg_reporter.deregister("agent shutdown"),
-            )
-            .await
-            {
-                Ok(Ok(())) => {}
-                Ok(Err(e)) => warn!(error = %e, "deregistration failed"),
-                Err(_) => warn!("deregistration timed out"),
+            info!("received SIGTERM, cleaning local jobs before deregistration");
+            match shutdown_service.shutdown_jobs().await {
+                Ok(()) => {
+                    let dereg_reporter = reporter.clone();
+                    match tokio::time::timeout(
+                        std::time::Duration::from_secs(5),
+                        dereg_reporter.deregister("agent shutdown"),
+                    )
+                    .await
+                    {
+                        Ok(Ok(())) => {}
+                        Ok(Err(e)) => warn!(error = %e, "deregistration failed"),
+                        Err(_) => warn!("deregistration timed out"),
+                    }
+                }
+                Err(error) => {
+                    warn!(
+                        error = %error,
+                        "skipping deregistration because local cleanup is incomplete"
+                    );
+                }
             }
         }
     }

--- a/crates/spurd/src/reporter.rs
+++ b/crates/spurd/src/reporter.rs
@@ -1,14 +1,18 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 
 use anyhow::Context;
 use spur_core::resource::{GpuLinkType, GpuResource, ResourceSet};
 use spur_devices::{resolve_link_type, DeviceRegistry, LinkType};
-use spur_proto::proto::{RegisterAgentRequest, ResourceSet as ProtoResourceSet, RunningJobStatus};
+use spur_proto::proto::{
+    AgentAllocationPhase, AgentAllocationStatus, RegisterAgentRequest,
+    ResourceSet as ProtoResourceSet, RunningJobStatus,
+};
+use spur_sched::cons_tres::NodeAllocation;
 use tokio::sync::Mutex;
 use tracing::{debug, info, warn};
 
@@ -21,8 +25,8 @@ pub trait HeldJobs: Send + Sync {
 
 #[tonic::async_trait]
 impl<T: Send> HeldJobs for Mutex<HashMap<u32, T>> {
-    // Awaits the lock rather than try_lock(): an empty result must mean "holds
-    // nothing", never "couldn't check" — the controller treats it as confirmed release.
+    // Awaiting the lock keeps inventory internally consistent with concurrent
+    // launch and release mutations.
     async fn held_job_ids(&self) -> Vec<u32> {
         self.lock().await.keys().copied().collect()
     }
@@ -46,6 +50,10 @@ pub struct NodeReporter {
     /// Job ids this node holds, reported each heartbeat so the controller can
     /// reclaim allocations it no longer tracks. Shares the agent's running map.
     held_jobs: Arc<dyn HeldJobs>,
+    allocation_source: RwLock<Option<Arc<Mutex<NodeAllocation>>>>,
+    agent_session_id: String,
+    node_boot_id: String,
+    recovery_complete: AtomicBool,
 }
 
 impl NodeReporter {
@@ -72,7 +80,66 @@ impl NodeReporter {
             wg_iface,
             node_token: RwLock::new(String::new()),
             held_jobs,
+            allocation_source: RwLock::new(None),
+            agent_session_id: uuid::Uuid::new_v4().to_string(),
+            node_boot_id: std::fs::read_to_string("/proc/sys/kernel/random/boot_id")
+                .map(|value| value.trim().to_string())
+                .unwrap_or_default(),
+            recovery_complete: AtomicBool::new(false),
         }
+    }
+
+    pub fn set_allocation_source(&self, source: Arc<Mutex<NodeAllocation>>) {
+        *self.allocation_source.write().unwrap() = Some(source);
+    }
+
+    pub fn mark_recovery_complete(&self) {
+        self.recovery_complete.store(true, Ordering::Release);
+    }
+
+    pub fn agent_session_id(&self) -> &str {
+        &self.agent_session_id
+    }
+
+    pub fn node_boot_id(&self) -> &str {
+        &self.node_boot_id
+    }
+
+    pub fn node_token(&self) -> String {
+        self.node_token.read().unwrap().clone()
+    }
+
+    async fn allocation_inventory(&self) -> Vec<AgentAllocationStatus> {
+        let held: HashSet<u32> = self.held_job_ids().await.into_iter().collect();
+        let source = self.allocation_source.read().unwrap().clone();
+        let Some(source) = source else {
+            return Vec::new();
+        };
+        let allocations = source.lock().await.owned_allocations();
+        allocations
+            .into_iter()
+            .map(|allocation| {
+                let process_present = held.contains(&allocation.job_id);
+                let phase = if allocation.releasing {
+                    AgentAllocationPhase::Releasing
+                } else if allocation.launching {
+                    AgentAllocationPhase::Launching
+                } else if process_present {
+                    AgentAllocationPhase::Active
+                } else {
+                    AgentAllocationPhase::Releasing
+                };
+                AgentAllocationStatus {
+                    job_id: allocation.job_id,
+                    run_attempt: allocation.run_attempt,
+                    phase: phase as i32,
+                    resources: Some(allocations_to_proto(&allocation.exact_resources)),
+                    last_command_id: allocation.last_command_id,
+                    process_present,
+                    cgroup_present: process_present,
+                }
+            })
+            .collect()
     }
 
     /// This node's current WireGuard mesh public key (empty if the interface has no key / no mesh).
@@ -93,6 +160,7 @@ impl NodeReporter {
             .context("failed to connect to spurctld for registration")?;
         let mut client = spur_proto::controller_client(channel);
 
+        let allocation_inventory = self.allocation_inventory().await;
         let resp = client
             .register_agent(RegisterAgentRequest {
                 hostname: self.hostname.clone(),
@@ -103,6 +171,11 @@ impl NodeReporter {
                 wg_pubkey: self.wg_pubkey(),
                 labels: self.labels.clone(),
                 join_token: self.join_token.clone(),
+                agent_session_id: self.agent_session_id.clone(),
+                node_boot_id: self.node_boot_id.clone(),
+                allocation_inventory,
+                recovery_complete: self.recovery_complete.load(Ordering::Acquire),
+                supports_command_polling: true,
             })
             .await
             .context("registration failed")?;
@@ -133,6 +206,8 @@ impl NodeReporter {
                 hostname: self.hostname.clone(),
                 node_token: current_token,
                 reason: reason.to_string(),
+                agent_session_id: self.agent_session_id.clone(),
+                node_boot_id: self.node_boot_id.clone(),
             })
             .await
             .context("deregistration RPC failed")?;
@@ -161,6 +236,7 @@ impl NodeReporter {
                     ..Default::default()
                 })
                 .collect();
+            let allocation_inventory = self.allocation_inventory().await;
 
             match spur_client::connect_channel(&self.controller_addr).await {
                 Ok(channel) => {
@@ -173,6 +249,11 @@ impl NodeReporter {
                             running_jobs,
                             node_token: current_token,
                             wg_pubkey: self.wg_pubkey(),
+                            agent_session_id: self.agent_session_id.clone(),
+                            node_boot_id: self.node_boot_id.clone(),
+                            allocation_inventory,
+                            recovery_complete: self.recovery_complete.load(Ordering::Acquire),
+                            supports_command_polling: true,
                         })
                         .await
                     {
@@ -586,8 +667,7 @@ mod tests {
         assert_eq!(map.held_job_ids().await, vec![7]);
     }
 
-    // A brief lock hold (e.g. a concurrent launch/cancel) must not read as
-    // "holds nothing" — the controller treats an empty report as confirmed release.
+    // A brief lock hold must not turn a present local allocation into a false omission.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn held_job_ids_waits_out_contention_instead_of_reporting_empty() {
         let map: Arc<Mutex<HashMap<u32, u8>>> = Arc::new(Mutex::new(HashMap::from([(7, 0)])));

--- a/crates/spurd/src/reporter.rs
+++ b/crates/spurd/src/reporter.rs
@@ -14,16 +14,17 @@ use tracing::{debug, info, warn};
 
 /// Source of the job ids this node currently holds. The controller decides from
 /// its own authoritative state whether any reported id is stale.
+#[tonic::async_trait]
 pub trait HeldJobs: Send + Sync {
-    fn held_job_ids(&self) -> Vec<u32>;
+    async fn held_job_ids(&self) -> Vec<u32>;
 }
 
+#[tonic::async_trait]
 impl<T: Send> HeldJobs for Mutex<HashMap<u32, T>> {
-    fn held_job_ids(&self) -> Vec<u32> {
-        match self.try_lock() {
-            Ok(jobs) => jobs.keys().copied().collect(),
-            Err(_) => Vec::new(),
-        }
+    // Awaits the lock rather than try_lock(): an empty result must mean "holds
+    // nothing", never "couldn't check" — the controller treats it as confirmed release.
+    async fn held_job_ids(&self) -> Vec<u32> {
+        self.lock().await.keys().copied().collect()
     }
 }
 
@@ -81,8 +82,8 @@ impl NodeReporter {
     }
 
     /// Job ids this heartbeat would report, from the shared running map.
-    pub fn held_job_ids(&self) -> Vec<u32> {
-        self.held_jobs.held_job_ids()
+    pub async fn held_job_ids(&self) -> Vec<u32> {
+        self.held_jobs.held_job_ids().await
     }
 
     /// Register with the controller.
@@ -153,6 +154,7 @@ impl NodeReporter {
             let current_token = self.node_token.read().unwrap().clone();
             let running_jobs: Vec<RunningJobStatus> = self
                 .held_job_ids()
+                .await
                 .into_iter()
                 .map(|job_id| RunningJobStatus {
                     job_id,
@@ -576,11 +578,24 @@ mod tests {
         assert!(!should_reregister(&tonic::Status::internal("boom")));
     }
 
-    #[test]
-    fn held_job_ids_accepts_send_but_not_sync_values() {
+    #[tokio::test]
+    async fn held_job_ids_accepts_send_but_not_sync_values() {
         // Cell is Send but !Sync; this fails to compile if the bound re-tightens to Sync.
         let map: Mutex<HashMap<u32, std::cell::Cell<u8>>> =
             Mutex::new(HashMap::from([(7, std::cell::Cell::new(0))]));
-        assert_eq!(map.held_job_ids(), vec![7]);
+        assert_eq!(map.held_job_ids().await, vec![7]);
+    }
+
+    // A brief lock hold (e.g. a concurrent launch/cancel) must not read as
+    // "holds nothing" — the controller treats an empty report as confirmed release.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn held_job_ids_waits_out_contention_instead_of_reporting_empty() {
+        let map: Arc<Mutex<HashMap<u32, u8>>> = Arc::new(Mutex::new(HashMap::from([(7, 0)])));
+        let held = map.clone();
+        let guard = held.lock().await;
+        let reader = tokio::spawn(async move { map.held_job_ids().await });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        drop(guard);
+        assert_eq!(reader.await.unwrap(), vec![7]);
     }
 }

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -790,6 +790,8 @@ message AgentCancelJobRequest {
 message AgentSuspendJobRequest {
   uint32 job_id = 1;
   bool resume = 2;   // false = SIGSTOP (suspend), true = SIGCONT (resume)
+  // See LaunchJobRequest.term.
+  uint64 term = 3;
 }
 
 message NodeResourcesResponse {

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -242,6 +242,7 @@ message JobInfo {
   // "gpu:2/task".
   uint32 req_gpus = 55;
   string req_gpus_detail = 56;
+  uint32 run_attempt = 57;
 }
 
 message NodeInfo {
@@ -348,6 +349,8 @@ service SlurmController {
   // Agent registration
   rpc RegisterAgent(RegisterAgentRequest) returns (RegisterAgentResponse);
   rpc Heartbeat(HeartbeatRequest) returns (HeartbeatResponse);
+  rpc PollAgentCommands(PollAgentCommandsRequest) returns (PollAgentCommandsResponse);
+  rpc AcknowledgeAgentCommand(AcknowledgeAgentCommandRequest) returns (google.protobuf.Empty);
 
   // Admission token management
   rpc CreateToken(CreateTokenRequest) returns (CreateTokenResponse);
@@ -488,12 +491,14 @@ message CancelJobRequest {
   uint32 job_id = 1;
   int32 signal = 2;  // 0 = cancel, else signal number
   string user = 3;   // For authorization
+  uint32 run_attempt = 4; // 0 = target the current run (legacy/user-directed cancel)
 }
 
 message CompleteJobRequest {
   uint32 job_id = 1;
   int32 exit_code = 2;
   string user = 3;   // For authorization
+  uint32 run_attempt = 4; // 0 = legacy client without run fencing
 }
 
 message SuspendJobRequest {
@@ -563,6 +568,8 @@ message DeregisterAgentRequest {
   string hostname = 1;
   string node_token = 2;
   string reason = 3;
+  string agent_session_id = 4;
+  string node_boot_id = 5;
 }
 
 message GetPartitionsRequest {
@@ -660,6 +667,11 @@ message RegisterAgentRequest {
   string wg_pubkey = 6;      // WireGuard public key (for mesh setup)
   map<string, string> labels = 7;  // Node labels for partition routing (pool, rack, etc.)
   string join_token = 8;     // Admission token for token-based admission
+  string agent_session_id = 9;
+  string node_boot_id = 10;
+  repeated AgentAllocationStatus allocation_inventory = 11;
+  bool recovery_complete = 12;
+  bool supports_command_polling = 13;
 }
 
 message RegisterAgentResponse {
@@ -678,12 +690,75 @@ message HeartbeatRequest {
   // learns a key that appears/changes after registration (late mesh, spur0 recreated) and can
   // include the node in ApplyMesh without a spurd restart. Empty when the node has no mesh key.
   string wg_pubkey = 6;
+  string agent_session_id = 7;
+  string node_boot_id = 8;
+  repeated AgentAllocationStatus allocation_inventory = 9;
+  bool recovery_complete = 10;
+  bool supports_command_polling = 11;
 }
 
 message RunningJobStatus {
   uint32 job_id = 1;
   JobState state = 2;
   int32 exit_code = 3;
+}
+
+enum AgentAllocationPhase {
+  AGENT_ALLOCATION_PHASE_UNSPECIFIED = 0;
+  AGENT_ALLOCATION_PHASE_LAUNCHING = 1;
+  AGENT_ALLOCATION_PHASE_ACTIVE = 2;
+  AGENT_ALLOCATION_PHASE_RELEASING = 3;
+}
+
+message AgentAllocationStatus {
+  uint32 job_id = 1;
+  uint32 run_attempt = 2;
+  AgentAllocationPhase phase = 3;
+  ResourceAllocations resources = 4;
+  uint64 last_command_id = 5;
+  bool process_present = 6;
+  bool cgroup_present = 7;
+}
+
+enum AgentCommandKind {
+  AGENT_COMMAND_KIND_UNSPECIFIED = 0;
+  AGENT_COMMAND_KIND_LAUNCH = 1;
+  AGENT_COMMAND_KIND_REGISTER = 2;
+  AGENT_COMMAND_KIND_RELEASE = 3;
+}
+
+message AgentCommand {
+  uint64 command_id = 1;
+  uint32 job_id = 2;
+  uint32 run_attempt = 3;
+  string node = 4;
+  AgentCommandKind kind = 5;
+  bytes payload = 6;
+  int32 signal = 7;
+}
+
+message PollAgentCommandsRequest {
+  string hostname = 1;
+  string node_token = 2;
+  string agent_session_id = 3;
+  string node_boot_id = 4;
+}
+
+message PollAgentCommandsResponse {
+  repeated AgentCommand commands = 1;
+}
+
+message AcknowledgeAgentCommandRequest {
+  string hostname = 1;
+  string node_token = 2;
+  string agent_session_id = 3;
+  string node_boot_id = 4;
+  uint64 command_id = 5;
+  uint32 job_id = 6;
+  uint32 run_attempt = 7;
+  bool success = 8;
+  bytes response_payload = 9;
+  string error = 10;
 }
 
 message HeartbeatResponse {}
@@ -1162,6 +1237,9 @@ message ReportJobStatusRequest {
   // Echoed from LaunchJobRequest.run_attempt; controller drops this report if
   // older than the job's current epoch. 0 = unset (legacy), check off.
   uint32 run_attempt = 9;
+  string agent_session_id = 10;
+  string node_boot_id = 11;
+  string node_token = 12;
 }
 
 // ============================================================

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -785,6 +785,8 @@ message AgentCancelJobRequest {
   int32 signal = 2;
   // See LaunchJobRequest.term.
   uint64 term = 3;
+  // 0 = unfenced (unknown/terminal id, no tracked run to compare against).
+  uint32 run_attempt = 4;
 }
 
 message AgentSuspendJobRequest {

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -740,6 +740,10 @@ message LaunchJobRequest {
   bool task_fanout = 11;
   // When true, PMIx was prepared via PreparePmix; LaunchJob must not re-init the server.
   bool pmix_prepared = 12;
+  // Raft term of the controller issuing this dispatch. The agent rejects any
+  // of LaunchJob/AgentCancelJob/RegisterJobAllocation carrying a term lower
+  // than the highest it has already seen, fencing out a demoted leader.
+  uint64 term = 13;
 }
 
 // Why a launch was rejected, when the controller's response depends on it.
@@ -781,6 +785,8 @@ message LaunchJobResponse {
 message AgentCancelJobRequest {
   uint32 job_id = 1;
   int32 signal = 2;
+  // See LaunchJobRequest.term.
+  uint64 term = 3;
 }
 
 message AgentSuspendJobRequest {
@@ -1000,6 +1006,8 @@ message RegisterJobAllocationRequest {
   // Run epoch for this allocation; mirrors LaunchJobRequest.run_attempt so
   // interactive jobs get the same stale-report fencing as batch dispatch.
   uint32 run_attempt = 13;
+  // See LaunchJobRequest.term.
+  uint64 term = 14;
 }
 
 message RegisterJobAllocationResponse {}

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -740,9 +740,7 @@ message LaunchJobRequest {
   bool task_fanout = 11;
   // When true, PMIx was prepared via PreparePmix; LaunchJob must not re-init the server.
   bool pmix_prepared = 12;
-  // Raft term of the controller issuing this dispatch. The agent rejects any
-  // of LaunchJob/AgentCancelJob/RegisterJobAllocation carrying a term lower
-  // than the highest it has already seen, fencing out a demoted leader.
+  // Controller's Raft term; the agent rejects a lower one, fencing a demoted leader.
   uint64 term = 13;
 }
 

--- a/proto/slurm.proto
+++ b/proto/slurm.proto
@@ -997,6 +997,9 @@ message RegisterJobAllocationRequest {
   string mpi = 10;
   string work_dir = 11;
   string user = 12;  // Job owner; the agent gates exec/attach on it
+  // Run epoch for this allocation; mirrors LaunchJobRequest.run_attempt so
+  // interactive jobs get the same stale-report fencing as batch dispatch.
+  uint32 run_attempt = 13;
 }
 
 message RegisterJobAllocationResponse {}


### PR DESCRIPTION
## Summary

Prevents controller/worker reconciliation from freeing uncertain allocations or reusing node capacity while processes may still exist.

- Adds a durable per-node allocation lifecycle keyed by `(job_id, run_attempt, node)`. Placement is committed before agent mutation, every phase except `Released` remains charged, and a job becomes running only after all assigned nodes acknowledge launch.
- Delivers launch/register/release work to upgraded agents through a Raft-persisted outbox, while retaining the direct-RPC path for rolling upgrades. Controller terms, agent sessions, boot IDs, node tokens, command IDs, and run attempts fence stale work and reports.
- Makes `spurd` restart fail closed: recovery uses attempt-scoped PID/start-time manifests and cgroups, removes residual work before the node becomes schedulable, and acknowledges release only after processes, steps, manifests, and cgroups are gone.
- Covers partial multi-node dispatch, unreachable-node cancellation, PMIx pre-launch rollback, configured node names, command replay, and stale completion cleanup without allowing an old attempt to kill its replacement.

## Design

The controller is authoritative for which exact allocation is legitimate; the agent and kernel provide physical cleanup evidence. Heartbeat omission is never release evidence, and an unreachable or unclean node keeps its allocation charged until reconciliation proves cleanup.

No new step daemon or supervisor is introduced. After a `spurd` restart, residual workloads are intentionally terminated and the affected job fails rather than being adopted. Preserving workloads across restart would require a future durable per-job supervisor.

Persisted state additions use defaults or optional fields, protobuf changes only append fields and methods, and normal dispatch was live-tested in both rolling-upgrade orders with the previous agent/controller release.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --exclude spur-ffi --all-targets --locked`
- `cargo test --locked`

## Live lab verification

- Single-node batch launch, exact CPU charging, completion, and process/cgroup/spool cleanup
- Two-node batch launch, exact per-node charging, completion, and release on both nodes
- Active two-node job across a controller crash and WAL restart, followed by completion and release on both nodes
- Controller crash after durable allocation/command commit but before delivery: the unacknowledged attempt was safely aborted, retried once, completed, and released without duplicate work
- `spurd` crash during a batch job: residual process/cgroup/manifest cleanup on restart, job transition to `NODE_FAIL`, and capacity release only after cleanup acknowledgement
- Partial two-node dispatch with one unreachable agent: the uncertain node remained charged until it returned and reconciled
- Cancel with one node unreachable: the reachable node released immediately while the unreachable node stayed charged until cleanup and acknowledgement after rejoin
- Two-node standalone `srun` completion and release
- `spurd` crash during standalone `srun`: residual cleanup, terminal job state, and capacity release without a hung allocation
- Configured node name differing from the kernel hostname, including completion reporting and cleanup under the configured identity
- Durable polled-command launch and acknowledgement through the upgraded agent without deadlock
- Multi-node PMIx preparation failure, rollback of both prepared allocations, and no residual process/cgroup/spool state
- Current controller with the previous agent, and previous controller with the current agent: registration, launch, completion, accounting, and cleanup in both rolling-upgrade orders
- Full teardown of isolated services, listeners, state, spool, and cgroup roots while preserving the hosts' pre-existing services and artifacts

PMIx success was not run because the lab does not have OpenPMIx/Open MPI. GPU-specific live cases and multi-controller quorum failover were also not run in this CPU-only two-host lab; their state-machine paths remain covered by the locked test suite.
