### PR TITLE
build: compile OpenPMIx from source for MPI plugin in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,11 @@ FROM chef AS builder
 ARG SPUR_GIT_SHA
 ARG SPUR_GIT_DIRTY
 ARG BUILD_MPI_PLUGIN=0
+ARG OPENPMIX_VERSION=5.0.3
 # BUILD_MPI_PLUGIN=1 links against libpmix and installs a functional spur_mpi_pmix.so
 # into dist artifacts. Default 0 builds the stub plugin (not copied to dist).
+# AlmaLinux 8 has no openpmix-devel RPM; distro pmix-devel (PowerTools) is PMIx 2.x.
+# Build OpenPMIx from source so the plugin meets pmix_min_version (4.1.0+).
 ENV SPUR_GIT_SHA=$SPUR_GIT_SHA
 ENV SPUR_GIT_DIRTY=$SPUR_GIT_DIRTY
 
@@ -52,8 +55,21 @@ RUN cargo build --release --locked \
     --bin spur-k8s-operator
 
 RUN if [ "$BUILD_MPI_PLUGIN" = "1" ]; then \
-        dnf install -y openpmix-devel && dnf clean all; \
+        dnf install -y dnf-plugins-core && \
+        dnf config-manager --set-enabled powertools && \
+        dnf install -y gcc-c++ flex bison python3 libevent-devel hwloc-devel && \
+        curl -fsSL "https://github.com/openpmix/openpmix/releases/download/v${OPENPMIX_VERSION}/pmix-${OPENPMIX_VERSION}.tar.gz" \
+            | tar xz -C /tmp && \
+        cd "/tmp/pmix-${OPENPMIX_VERSION}" && \
+        ./configure --prefix=/usr/local && \
+        make -j"$(nproc)" && make install && \
+        printf '%s\n' /usr/local/lib /usr/local/lib64 > /etc/ld.so.conf.d/openpmix.conf && \
+        ldconfig && \
+        rm -rf "/tmp/pmix-${OPENPMIX_VERSION}" && \
+        dnf clean all; \
     fi && \
+    cd /build && \
+    PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/local/lib64/pkgconfig:${PKG_CONFIG_PATH:-}" \
     cargo build --release --locked -p spur-mpi-pmix
 
 RUN mkdir -p /dist/lib/spur && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,9 +57,11 @@ RUN cargo build --release --locked \
 RUN if [ "$BUILD_MPI_PLUGIN" = "1" ]; then \
         dnf install -y dnf-plugins-core && \
         dnf config-manager --set-enabled powertools && \
-        dnf install -y gcc-c++ flex bison python3 libevent-devel hwloc-devel && \
+        dnf install -y gcc-c++ flex bison python3 tar pkgconf-pkg-config libevent-devel hwloc-devel && \
         curl -fsSL "https://github.com/openpmix/openpmix/releases/download/v${OPENPMIX_VERSION}/pmix-${OPENPMIX_VERSION}.tar.gz" \
-            | tar xz -C /tmp && \
+            -o "/tmp/pmix-${OPENPMIX_VERSION}.tar.gz" && \
+        tar xzf "/tmp/pmix-${OPENPMIX_VERSION}.tar.gz" -C /tmp && \
+        rm -f "/tmp/pmix-${OPENPMIX_VERSION}.tar.gz" && \
         cd "/tmp/pmix-${OPENPMIX_VERSION}" && \
         ./configure --prefix=/usr/local && \
         make -j"$(nproc)" && make install && \


### PR DESCRIPTION
## Summary

Nightly and release builds with `BUILD_MPI_PLUGIN=1` fail in the Docker builder because AlmaLinux 8 has no `openpmix-devel` package. The distro `pmix-devel` RPM (PowerTools) ships PMIx 2.2.x, which is below Spur's `pmix_min_version` (4.1.0).

This change builds OpenPMIx 5.0.3 from source in the AlmaLinux 8 builder stage when `BUILD_MPI_PLUGIN=1`, then compiles `spur-mpi-pmix` against the installed `pkg-config` metadata. Nightly/release tarballs can include a functional `lib/spur/spur_mpi_pmix.so` again.

## Approach

- Add `OPENPMIX_VERSION` build arg (default `5.0.3`).
- Enable PowerTools and install build deps (`hwloc-devel`, `libevent-devel`, `python3`, etc.).
- Configure/install OpenPMIx to `/usr/local`, run `ldconfig`, then `cargo build -p spur-mpi-pmix` with `PKG_CONFIG_PATH` set.
- `cd /build` before the cargo step so removing the OpenPMIx source tree does not leave the shell in a deleted directory.

No changes to `spur-ci-infra` — nightly/release build entirely inside this Dockerfile on GitHub-hosted runners.

## Test plan

- [x] Local nightly-equivalent build:
  ```bash
  DOCKER_BUILDKIT=1 docker build --target dist --output type=local,dest=./dist \
    --build-arg BUILD_MPI_PLUGIN=1 \
    --build-arg SPUR_GIT_SHA=$(git rev-parse --short=8 HEAD) \
    --build-arg SPUR_GIT_DIRTY=false .
  ```
- [x] Verified `dist/lib/spur/spur_mpi_pmix.so` is produced
- [x] Verified `spur`, `spurctld`, `spurd`, `spur-k8s-operator` in `dist/bin/` (GLIBC_2.28)