### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Default owners for the entire repository.
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-* @powderluv @sgopinath1 @shiv-tyagi @yansun1996 @sajmera-pensando
+* @sgopinath1 @shiv-tyagi @yansun1996 @sajmera-pensando @biluriuday
 
 # CI workflows and test harness require maintainer review
 .github/workflows/** @shiv-tyagi


### PR DESCRIPTION
## Summary

Remove `@powderluv` from the default repository owners and add `@biluriuday`.

## Changes

- `.github/CODEOWNERS`: drop `@powderluv` from the `*` default owners line, add `@biluriuday`.

## Testing

No code change. CODEOWNERS syntax unchanged (single line edit).